### PR TITLE
YAMLP template semicolon BUG FIX

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -34,6 +34,10 @@ body:
     id: meta
     attributes:
       label: Meta (optional)
-      description: Optional: effort estimate (S/M/L, hours), deadline (YYYY-MM-DD), priority.
-      placeholder: "Effort: S / Deadline: 2026-03-01 / Priority: P2"
+      description: |
+        Optional: effort estimate (S/M/L, hours), deadline (YYYY-MM-DD), priority.
+      placeholder: |
+        Effort: S 
+        Deadline: 2026-03-01 
+        Priority: P2
 

--- a/.github/ISSUE_TEMPLATE/documentation_update.yml
+++ b/.github/ISSUE_TEMPLATE/documentation_update.yml
@@ -34,6 +34,9 @@ body:
     id: meta
     attributes:
       label: Meta (optional)
-      description: Optional: effort estimate, deadline, priority, related PRs.
-      placeholder: "Effort: XS / Deadline: no-deadline"
+      description: |
+        Optional: effort estimate, deadline, priority, related PRs.
+      placeholder: |
+        Effort: XS
+        Deadline: no-deadline
 

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -34,6 +34,10 @@ body:
     id: meta
     attributes:
       label: Meta (optional)
-      description: Optional: effort (S/M/L/hours), deadline, priority, related links.
-      placeholder: "Effort: M / Deadline: no-deadline / Priority: P3"
+      description: |
+        Optional: effort (S/M/L/hours), deadline, priority, related links.
+      placeholder: |
+        Effort: M
+        Deadline: no-deadline 
+        Priority: P3
 

--- a/.github/ISSUE_TEMPLATE/quick_issue.yml
+++ b/.github/ISSUE_TEMPLATE/quick_issue.yml
@@ -36,5 +36,6 @@ body:
     attributes:
       label: Meta (optional)
       description: Optional effort, deadline, priority.
-      placeholder: "Effort: XS"
+      placeholder: |
+        Effort: XS
 

--- a/.github/ISSUE_TEMPLATE/refactor.yml
+++ b/.github/ISSUE_TEMPLATE/refactor.yml
@@ -34,6 +34,10 @@ body:
     id: meta
     attributes:
       label: Meta (optional)
-      description: Optional: effort, expected downtime, deadline, priority.
-      placeholder: "Effort: M / Deadline: 2026-02-28 / Priority: P3"
+      description: |
+        Optional: effort, expected downtime, deadline, priority.
+      placeholder: |
+        Effort: M
+        Deadline: 2026-02-28
+        Priority: P3
 

--- a/.github/ISSUE_TEMPLATE/task.yml
+++ b/.github/ISSUE_TEMPLATE/task.yml
@@ -34,6 +34,10 @@ body:
     id: meta
     attributes:
       label: Meta (optional)
-      description: Optional: effort, deadline, priority, notes.
-      placeholder: "Effort: S / Deadline: 2026-02-20 / Priority: P2"
+      description: |
+        Optional: effort, deadline, priority, notes.
+      placeholder: |
+        Effort: S
+        Deadline: 2026-02-20
+        Priority: P2
 


### PR DESCRIPTION
Fixed a bug where the YAML structure was corrupted due to a misplaced semicolon which would try to establish a key-value mapping. Where we tried to use the semicolon literary. Fixed by ıusing block scalar operator. Closes #26 