### PR TITLE
Configure django-cors-headers for local development

### DIFF
--- a/backend/config/settings/base.py
+++ b/backend/config/settings/base.py
@@ -28,6 +28,7 @@ DJANGO_APPS = [
 ]
 
 THIRD_PARTY_APPS = [
+    'corsheaders',
     'rest_framework',
     'rest_framework_simplejwt',
     'rest_framework_simplejwt.token_blacklist',
@@ -50,6 +51,7 @@ INSTALLED_APPS = DJANGO_APPS + THIRD_PARTY_APPS + LOCAL_APPS
 
 MIDDLEWARE = [
     'django.middleware.security.SecurityMiddleware',
+    'corsheaders.middleware.CorsMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',

--- a/backend/config/settings/development.py
+++ b/backend/config/settings/development.py
@@ -18,6 +18,11 @@ SIMPLE_JWT = {
 # Print emails to the console instead of sending them
 EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
 
+# Allow the local Vite dev server to call the API
+CORS_ALLOWED_ORIGINS = [
+    'http://localhost:5173',
+]
+
 INSTALLED_APPS += ['debug_toolbar']  # noqa: F405
 
 MIDDLEWARE = ['debug_toolbar.middleware.DebugToolbarMiddleware'] + MIDDLEWARE  # noqa: F405

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -7,3 +7,4 @@ mysqlclient==2.2.*
 django-environ==0.11.*
 Pillow==10.*
 python-magic==0.4.*
+django-cors-headers==4.*


### PR DESCRIPTION
# 📝 Description
Fixes #147 

This PR fixes the local development CORS issue that was blocking frontend requests from `http://localhost:5173` to the Django backend.

Previously, the backend did not include CORS configuration, so browser preflight requests were failing before reaching the API. As a result, registration and login requests sent from the frontend were blocked by the browser, and the client could not access a meaningful backend error response.

To resolve this, this PR:
- adds `django-cors-headers` to the project dependencies
- registers `corsheaders` in `THIRD_PARTY_APPS`
- adds `corsheaders.middleware.CorsMiddleware` to the Django middleware stack
- allows `http://localhost:5173` in development via `CORS_ALLOWED_ORIGINS`

With these changes, the frontend can successfully communicate with the backend during local development without CORS preflight failures.

## Files changed
- `backend/config/settings/base.py`
  - added `corsheaders` to third-party apps
  - added `corsheaders.middleware.CorsMiddleware` to middleware
- `backend/config/settings/development.py`
  - added `CORS_ALLOWED_ORIGINS = ['http://localhost:5173']`
- `requirements/base.txt`
  - added `django-cors-headers`

## Why this change is needed
The frontend runs on a different origin (`localhost:5173`) than the backend (`localhost:8000`) in local development. Without explicit CORS configuration, the browser blocks these cross-origin requests. This PR enables the expected frontend-backend communication flow in the development environment.

# 📊 Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Refactoring
- [ ] Documentation
 
# ✅ Acceptance Criteria / Checklist
- [x] Project builds successfully
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, especially in hard-to-understand parts
- [x] I have performed a self-review of my code
- [ ] I have added/updated tests
- [x] New and existing unit tests pass locally with my changes

## Verification
- [x] `http://localhost:5173` is allowed in development CORS settings
- [x] frontend requests are no longer blocked by browser CORS preflight failure
- [x] registration from the frontend completes without CORS errors
- [x] login from the frontend completes without CORS errors



# ⏱️ Estimated Review Time
- [x] < 5 min
- [ ] 5-15 min
- [ ] > 15 min