### PR TITLE
Feat/ Story Map Endpoint

### DIFF
--- a/backend/apps/stories/serializers.py
+++ b/backend/apps/stories/serializers.py
@@ -162,6 +162,31 @@ class FeedQuerySerializer(serializers.Serializer):
         return data
 
 
+class StoryMapSerializer(serializers.ModelSerializer):
+    """
+    Read-only serializer returning only the fields needed to render a map pin.
+
+    Intentionally minimal — the map view only needs coordinates, place name,
+    title, and time info to position a pin and show a preview tooltip.
+    Full story content is loaded separately when a pin is clicked.
+    """
+
+    class Meta:
+        model = Story
+        fields = [
+            'id',
+            'title',
+            'location_name',
+            'location_lat',
+            'location_lng',
+            'time_type',
+            'year',
+            'year_start',
+            'year_end',
+        ]
+        read_only_fields = fields
+
+
 class SearchQuerySerializer(serializers.Serializer):
     """Validates the q query parameter for the story search endpoint."""
 

--- a/backend/apps/stories/tests/test_serializers.py
+++ b/backend/apps/stories/tests/test_serializers.py
@@ -3,7 +3,7 @@ from decimal import Decimal
 import pytest
 
 from apps.stories.models import Story
-from apps.stories.serializers import SearchQuerySerializer, StoryFeedSerializer, StorySerializer
+from apps.stories.serializers import SearchQuerySerializer, StoryFeedSerializer, StoryMapSerializer, StorySerializer
 from apps.users.models import User
 
 
@@ -243,3 +243,61 @@ class TestSearchQuerySerializer:
     def test_single_character_passes(self):
         s = SearchQuerySerializer(data={'q': 'a'})
         assert s.is_valid(), s.errors
+
+
+# ── StoryMapSerializer ────────────────────────────────────────────────────────
+
+@pytest.mark.django_db
+class TestStoryMapSerializer:
+    MAP_FIELDS = {
+        'id', 'title', 'location_name', 'location_lat', 'location_lng',
+        'time_type', 'year', 'year_start', 'year_end',
+    }
+    EXCLUDED_FIELDS = {
+        'narrative', 'contributor_name', 'preview_text', 'status',
+        'like_count', 'save_count', 'submitted_at', 'updated_at',
+        'region', 'contributor_visible', 'user',
+    }
+
+    def _make_story(self, **kwargs):
+        user = make_user()
+        return make_story(user=user, **kwargs)
+
+    def test_contains_exactly_required_map_fields(self):
+        story = self._make_story()
+        data = StoryMapSerializer(story).data
+        assert set(data.keys()) == self.MAP_FIELDS
+
+    def test_excludes_heavy_fields(self):
+        story = self._make_story()
+        data = StoryMapSerializer(story).data
+        for field in self.EXCLUDED_FIELDS:
+            assert field not in data
+
+    def test_coordinates_are_present_and_correct(self):
+        story = self._make_story(
+            location_lat='41.015137', location_lng='28.979530',
+            location_name='Galata Bridge',
+        )
+        data = StoryMapSerializer(story).data
+        assert str(data['location_lat']) == '41.015137'
+        assert str(data['location_lng']) == '28.979530'
+        assert data['location_name'] == 'Galata Bridge'
+
+    def test_exact_year_story_has_year_set(self):
+        story = self._make_story(time_type=Story.TIME_EXACT, year=1923)
+        data = StoryMapSerializer(story).data
+        assert data['time_type'] == Story.TIME_EXACT
+        assert data['year'] == 1923
+        assert data['year_start'] is None
+        assert data['year_end'] is None
+
+    def test_year_range_story_has_year_start_and_end(self):
+        story = self._make_story(
+            time_type=Story.TIME_RANGE, year=None, year_start=1900, year_end=1950,
+        )
+        data = StoryMapSerializer(story).data
+        assert data['time_type'] == Story.TIME_RANGE
+        assert data['year'] is None
+        assert data['year_start'] == 1900
+        assert data['year_end'] == 1950

--- a/backend/apps/stories/tests/test_views.py
+++ b/backend/apps/stories/tests/test_views.py
@@ -10,6 +10,7 @@ from apps.users.models import RoleChoices, User
 
 FEED_URL = '/stories/feed/'
 LIST_URL = '/stories/'
+MAP_URL = '/stories/map/'
 SEARCH_URL = '/stories/search/'
 
 
@@ -340,3 +341,76 @@ class TestStorySearchView:
         make_story(title='Gone Story', status=Story.STATUS_REMOVED)
         response = client.get(SEARCH_URL + '?q=Gone')
         assert response.data['count'] == 0
+
+
+# ── GET /stories/map/ ─────────────────────────────────────────────────────────
+
+@pytest.mark.django_db
+class TestStoryMapView:
+    MAP_FIELDS = {
+        'id', 'title', 'location_name', 'location_lat', 'location_lng',
+        'time_type', 'year', 'year_start', 'year_end',
+    }
+
+    def test_returns_200_without_authentication(self, client):
+        response = client.get(MAP_URL)
+        assert response.status_code == status.HTTP_200_OK
+
+    def test_response_is_paginated(self, client):
+        make_story(status=Story.STATUS_PUBLISHED)
+        response = client.get(MAP_URL)
+        for key in ['count', 'next', 'previous', 'results']:
+            assert key in response.data
+
+    def test_result_contains_exactly_map_fields(self, client):
+        make_story(status=Story.STATUS_PUBLISHED)
+        response = client.get(MAP_URL)
+        assert response.data['count'] == 1
+        result = response.data['results'][0]
+        assert set(result.keys()) == self.MAP_FIELDS
+
+    def test_only_published_stories_appear(self, client):
+        make_story(title='Published', status=Story.STATUS_PUBLISHED)
+        make_story(title='Draft', status=Story.STATUS_DRAFT)
+        make_story(title='Removed', status=Story.STATUS_REMOVED)
+        response = client.get(MAP_URL)
+        assert response.data['count'] == 1
+        assert response.data['results'][0]['title'] == 'Published'
+
+    def test_empty_result_when_no_published_stories(self, client):
+        make_story(status=Story.STATUS_DRAFT)
+        response = client.get(MAP_URL)
+        assert response.data['count'] == 0
+        assert response.data['results'] == []
+
+    def test_year_from_filter_excludes_older_stories(self, client):
+        make_story(title='Old', time_type=Story.TIME_EXACT, year=1800)
+        make_story(title='New', time_type=Story.TIME_EXACT, year=2000)
+        response = client.get(MAP_URL + '?year_from=1900')
+        assert response.data['count'] == 1
+        assert response.data['results'][0]['title'] == 'New'
+
+    def test_year_to_filter_excludes_newer_stories(self, client):
+        make_story(title='Old', time_type=Story.TIME_EXACT, year=1800)
+        make_story(title='New', time_type=Story.TIME_EXACT, year=2000)
+        response = client.get(MAP_URL + '?year_to=1900')
+        assert response.data['count'] == 1
+        assert response.data['results'][0]['title'] == 'Old'
+
+    def test_location_filter_is_case_insensitive(self, client):
+        make_story(title='Istanbul Story', location_name='Galata Bridge')
+        make_story(title='Ankara Story', location_name='Atakule Tower')
+        response = client.get(MAP_URL + '?location=galata')
+        assert response.data['count'] == 1
+        assert response.data['results'][0]['title'] == 'Istanbul Story'
+
+    def test_invalid_year_range_returns_400(self, client):
+        response = client.get(MAP_URL + '?year_from=2000&year_to=1900')
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+    def test_narrative_not_exposed_in_results(self, client):
+        make_story(narrative='Secret text that should not appear.')
+        response = client.get(MAP_URL)
+        if response.data['count']:
+            result = response.data['results'][0]
+            assert 'narrative' not in result

--- a/backend/apps/stories/urls.py
+++ b/backend/apps/stories/urls.py
@@ -1,12 +1,13 @@
 from django.urls import path
 
-from apps.stories.views import StoryDetailView, StoryFeedView, StoryListCreateView, StorySearchView
+from apps.stories.views import StoryDetailView, StoryFeedView, StoryListCreateView, StoryMapView, StorySearchView
 
 app_name = 'stories'
 
 urlpatterns = [
     path('', StoryListCreateView.as_view(), name='story-list-create'),
-    path('<int:pk>/', StoryDetailView.as_view(), name='story-detail'),
     path('feed/', StoryFeedView.as_view(), name='story-feed'),
+    path('map/', StoryMapView.as_view(), name='story-map'),
     path('search/', StorySearchView.as_view(), name='story-search'),
+    path('<int:pk>/', StoryDetailView.as_view(), name='story-detail'),
 ]

--- a/backend/apps/stories/views.py
+++ b/backend/apps/stories/views.py
@@ -3,7 +3,7 @@ from rest_framework.permissions import AllowAny, IsAuthenticated
 from rest_framework.views import APIView
 
 from apps.stories.models import Story
-from apps.stories.serializers import FeedQuerySerializer, SearchQuerySerializer, StoryFeedSerializer, StorySerializer
+from apps.stories.serializers import FeedQuerySerializer, SearchQuerySerializer, StoryFeedSerializer, StoryMapSerializer, StorySerializer
 from apps.stories.services import get_story_feed, get_story_search
 from common.pagination import StoryPagination
 from common.permissions import IsOwnerOrAdmin
@@ -43,6 +43,41 @@ class StoryFeedView(APIView):
         paginator = StoryPagination()
         page = paginator.paginate_queryset(qs, request)
         serializer = StoryFeedSerializer(page, many=True)
+        return paginator.get_paginated_response(serializer.data)
+
+
+class StoryMapView(APIView):
+    """
+    GET /stories/map/
+
+    Returns a paginated list of published stories with only the fields needed
+    to render map pins: coordinates, place name, title, and time info.
+    Guests and authenticated users both have read access.
+
+    Query params:
+      year_from  — include stories from this year onwards
+      year_to    — include stories up to and including this year
+      location   — case-insensitive substring match against location_name
+      page       — page number (default 1)
+      page_size  — results per page (default 10, max 100)
+    """
+
+    permission_classes = [AllowAny]
+
+    def get(self, request):
+        query_serializer = FeedQuerySerializer(data=request.query_params)
+        query_serializer.is_valid(raise_exception=True)
+        params = query_serializer.validated_data
+
+        qs = get_story_feed(
+            year_from=params.get('year_from'),
+            year_to=params.get('year_to'),
+            location=params.get('location'),
+        )
+
+        paginator = StoryPagination()
+        page = paginator.paginate_queryset(qs, request)
+        serializer = StoryMapSerializer(page, many=True)
         return paginator.get_paginated_response(serializer.data)
 
 


### PR DESCRIPTION
# 📝 Description

Fixes #130

This PR introduces the initial **map data endpoint** for the story discovery experience by adding `GET /stories/map/` and a dedicated `StoryMapSerializer`.

The main purpose of this change is to provide a **lightweight and map-oriented response structure** for the frontend. Instead of returning full story objects, this endpoint exposes only the fields required to render story pins and basic preview information on the map. This helps avoid overfetching and keeps the response more efficient for map-based usage.

As part of this implementation:

* a new read-only `StoryMapSerializer` was added
* a new public endpoint `GET /stories/map/` was introduced
* the endpoint returns **only published stories**
* the response is **paginated**
* filtering support is included for:

  * `year_from`
  * `year_to`
  * `location`
* the response intentionally excludes heavy or unnecessary fields such as `narrative`, contributor-related metadata, and interaction counts

This PR also adds test coverage for both serializer and view behavior. The tests verify that:

* the serializer exposes exactly the intended map fields
* non-map/heavy fields are excluded
* coordinates and time-related fields are serialized correctly
* the endpoint is accessible without authentication
* the response is paginated
* only published stories appear in results
* empty responses behave correctly when there are no published stories
* year filters work as expected
* location filtering is case-insensitive
* invalid year ranges return `400 Bad Request`
* narrative content is not exposed in map responses

Overall, this PR establishes the backend contract needed for the map view and prepares the project for frontend integration of story pins and map-based story discovery.

# 📊 Type of Change

*  [ ] Bug fix
*  [x] New feature
*  [ ] Refactoring
*  [ ] Documentation

# ✅ Acceptance Criteria / Checklist

* [x] Project builds successfully
* [x] My code follows the style guidelines of this project
* [x] I have commented my code, especially in hard-to-understand parts
* [x] I have performed a self-review of my code
* [x] I have added/updated tests
* [x] New and existing unit tests pass locally with my changes



# ⏱️ Estimated Review Time

* [ ] < 5 min
* [x] 5-15 min
* [ ] > 15 min


