### PR TITLE
Fix/ Add contributor_name to StorySerializer

### DIFF
--- a/backend/apps/stories/serializers.py
+++ b/backend/apps/stories/serializers.py
@@ -7,12 +7,14 @@ from apps.stories.services import create_story, update_story
 
 class StorySerializer(serializers.ModelSerializer):
     user = serializers.PrimaryKeyRelatedField(read_only=True)
+    contributor_name = serializers.SerializerMethodField()
 
     class Meta:
         model = Story
         fields = [
             'id',
             'user',
+            'contributor_name',
             'title',
             'narrative',
             'location_lat',
@@ -33,11 +35,18 @@ class StorySerializer(serializers.ModelSerializer):
         read_only_fields = [
             'id',
             'user',
+            'contributor_name',
             'like_count',
             'save_count',
             'submitted_at',
             'updated_at',
         ]
+
+    def get_contributor_name(self, obj):
+        """Return the author's username, or None if they have chosen to post anonymously."""
+        if obj.contributor_visible and obj.user:
+            return obj.user.username
+        return None
 
     def validate_status(self, value):
         # Only moderation endpoints may set a story to removed — reject it here

--- a/backend/apps/stories/tests/test_serializers.py
+++ b/backend/apps/stories/tests/test_serializers.py
@@ -118,8 +118,9 @@ class TestStorySerializerFields:
     def test_serializer_contains_expected_fields(self, story):
         serializer = StorySerializer(story)
         expected = {
-            'id', 'user', 'title', 'narrative', 'location_lat', 'location_lng',
-            'location_name', 'region', 'time_type', 'year', 'year_start', 'year_end',
+            'id', 'user', 'contributor_name', 'title', 'narrative',
+            'location_lat', 'location_lng', 'location_name', 'region',
+            'time_type', 'year', 'year_start', 'year_end',
             'status', 'contributor_visible', 'like_count', 'save_count',
             'submitted_at', 'updated_at',
         }
@@ -131,6 +132,24 @@ class TestStorySerializerFields:
         assert serializer.is_valid(), serializer.errors
         assert 'like_count' not in serializer.validated_data
         assert 'save_count' not in serializer.validated_data
+
+    def test_contributor_name_returns_username_when_visible(self):
+        user = make_user()
+        story = make_story(user=user, contributor_visible=True)
+        data = StorySerializer(story).data
+        assert data['contributor_name'] == user.username
+
+    def test_contributor_name_is_none_when_not_visible(self):
+        user = make_user()
+        story = make_story(user=user, contributor_visible=False)
+        data = StorySerializer(story).data
+        assert data['contributor_name'] is None
+
+    def test_contributor_name_is_none_when_user_is_anonymized(self):
+        # Story whose author account was deleted — user FK is null
+        story = make_story(user=None, contributor_visible=True)
+        data = StorySerializer(story).data
+        assert data['contributor_name'] is None
 
 
 @pytest.mark.django_db

--- a/backend/apps/stories/views.py
+++ b/backend/apps/stories/views.py
@@ -114,7 +114,7 @@ class StoryListCreateView(generics.ListCreateAPIView):
     def get_queryset(self):
         # Guests and authenticated users can only browse published stories.
         # Draft and removed stories are not surfaced through this endpoint.
-        return Story.objects.filter(status=Story.STATUS_PUBLISHED)
+        return Story.objects.filter(status=Story.STATUS_PUBLISHED).select_related('user')
 
     def get_permissions(self):
         if self.request.method == 'POST':
@@ -126,7 +126,7 @@ class StoryListCreateView(generics.ListCreateAPIView):
 
 
 class StoryDetailView(generics.RetrieveUpdateAPIView):
-    queryset = Story.objects.all()
+    queryset = Story.objects.select_related('user')
     serializer_class = StorySerializer
     http_method_names = ['get', 'patch']
 


### PR DESCRIPTION
# 📝 Description
Fixes #269

This PR fixes a backend serialization issue that was causing problems on the frontend when rendering contributor information for stories.

Previously, the API only exposed user id field but did not expose a direct contributor name display field derived from the related user, which meant the frontend could not reliably access the contributor’s visible name from the story response. As a result, story author information was either missing or required extra handling on the client side, leading to a bug in the UI.

To resolve this, this PR introduces a new read-only serializer field, `contributor_name`, in `StorySerializer`. This field returns the author’s username only when the contributor is visible and the related user still exists. Otherwise, it returns `null`. This makes the API response safer, clearer, and directly usable by the frontend without requiring it to infer or reconstruct contributor identity logic.

In addition to the serializer change, the queryset in story list and detail views was updated to use `select_related('user')` in order to efficiently fetch the related user object needed for `contributor_name`, avoiding unnecessary extra queries.

This PR also adds serializer tests to verify the new behavior under different visibility and anonymization scenarios.

### Changes made
- Added `contributor_name` as a `SerializerMethodField` in `StorySerializer`
- Included `contributor_name` in serializer fields
- Marked `contributor_name` as read-only
- Implemented `get_contributor_name()` to:
  - return `user.username` when `contributor_visible=True`
  - return `null` when `contributor_visible=False`
  - return `null` when the related user is missing/anonymized
- Updated story list queryset to use `select_related('user')`
- Updated story detail queryset to use `select_related('user')`
- Added serializer tests covering:
  - expected field presence
  - visible contributor case
  - hidden contributor case
  - anonymized/deleted user case

### Why this fix is needed
The frontend was experiencing a bug because the contributor name was not being returned directly in the story payload. Even though the story had an associated user, the response shape was not convenient or stable enough for frontend consumption in contributor display logic.

By exposing `contributor_name` explicitly from the backend, we:
- make the API contract clearer
- reduce frontend-side conditional logic
- centralize visibility/anonymization rules in the backend
- ensure consistent behavior across all clients consuming the endpoint

# 📊 Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Refactoring
- [ ] Documentation
 
# ✅ Acceptance Criteria / Checklist
- [x] Project builds successfully
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, especially in hard-to-understand parts
- [x] I have performed a self-review of my code
- [x] I have added/updated tests
- [x] New and existing unit tests pass locally with my changes



# ⏱️ Estimated Review Time
- [ ] < 5 min
- [x] 5-15 min
- [ ] > 15 min