### PR TITLE
feat: add production Django settings

### DIFF
--- a/backend/config/settings/production.py
+++ b/backend/config/settings/production.py
@@ -10,8 +10,12 @@ CORS_ALLOWED_ORIGINS = env.list('CORS_ALLOWED_ORIGINS')
 # ── Static files ──────────────────────────────────────────────────────────────
 
 # WhiteNoise serves Django's own static files (/static/) efficiently.
-# It must sit directly after SecurityMiddleware.
-MIDDLEWARE.insert(1, 'whitenoise.middleware.WhiteNoiseMiddleware')
+# Explicitly reconstruct the list so the position is clear and not tied to
+# the index of any particular middleware in base.py.
+MIDDLEWARE = [
+    'django.middleware.security.SecurityMiddleware',
+    'whitenoise.middleware.WhiteNoiseMiddleware',
+] + MIDDLEWARE[1:]
 STATICFILES_STORAGE = 'whitenoise.storage.CompressedManifestStaticFilesStorage'
 
 # ── Security headers ──────────────────────────────────────────────────────────


### PR DESCRIPTION
# 📝 Description
Fixes #277

Fills in `backend/config/settings/production.py` which previously contained only a comment. The development and test settings are completely untouched.

Key additions:
- `ALLOWED_HOSTS` and `CORS_ALLOWED_ORIGINS` read from environment variables
- WhiteNoise middleware inserted right after `SecurityMiddleware` for static file serving
- `SECURE_PROXY_SSL_HEADER` so Django correctly detects HTTPS behind the nginx reverse proxy
- `SESSION_COOKIE_SECURE`, `CSRF_COOKIE_SECURE`, `SECURE_HSTS_SECONDS` for browser security enforcement
- Optional Sentry error tracking initialised only when `SENTRY_DSN` env var is set

# 📊 Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Refactoring
- [ ] Documentation

# ✅ Acceptance Criteria / Checklist
- [x] Project builds successfully
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, especially in hard-to-understand parts
- [x] I have performed a self-review of my code
- [x] I have added/updated tests
- [x] New and existing unit tests pass locally with my changes

# 📸 Screenshots / Recordings
<!-- If applicable -->

# ⏱️ Estimated Review Time
- [x] < 5 min
- [ ] 5-15 min
- [ ] > 15 min
