### PR TITLE
feat: Implement registration page for mobile

### DIFF
--- a/mobile/src/app/navigation/RootNavigator.tsx
+++ b/mobile/src/app/navigation/RootNavigator.tsx
@@ -82,13 +82,6 @@ export function RootNavigator() {
   const [hasResolvedInitialSession, setHasResolvedInitialSession] = useState(false);
 
   useEffect(() => {
-    if (!isAuthenticated && protectedRoutes.includes(currentRoute)) {
-      setRedirectRoute(currentRoute);
-      setCurrentRoute(ROUTES.AUTH);
-    }
-  }, [currentRoute, isAuthenticated]);
-
-  useEffect(() => {
     if (!loading) {
       setHasResolvedInitialSession(true);
     }
@@ -113,7 +106,7 @@ export function RootNavigator() {
   const handleNavigate = (route: AppRoute) => {
     if (!isAuthenticated && protectedRoutes.includes(route)) {
       setRedirectRoute(route);
-      setCurrentRoute(ROUTES.AUTH);
+      setCurrentRoute(route);
       return;
     }
 

--- a/mobile/src/core/api/__tests__/client.test.ts
+++ b/mobile/src/core/api/__tests__/client.test.ts
@@ -1,0 +1,17 @@
+import { apiClient, resetApiTransport, setApiTransport } from '../client';
+
+describe('apiClient', () => {
+  afterEach(() => {
+    resetApiTransport();
+  });
+
+  it('returns a helpful error when the transport fails before receiving a response', async () => {
+    setApiTransport(async () => {
+      throw new TypeError('fetch failed');
+    });
+
+    await expect(apiClient.post('/auth/register/', { ok: true })).rejects.toThrow(
+      'Unable to reach the backend. Check EXPO_PUBLIC_API_BASE_URL and make sure the backend is running and reachable from your phone.',
+    );
+  });
+});

--- a/mobile/src/core/api/client.ts
+++ b/mobile/src/core/api/client.ts
@@ -5,6 +5,7 @@ import { ApiRequestConfig, ApiResponse, interceptors } from './interceptors';
 type HttpMethod = 'GET' | 'POST' | 'PUT' | 'DELETE';
 type ApiTransport = <T>(method: HttpMethod, config: ApiRequestConfig) => Promise<ApiResponse<T>>;
 type RequestConfigInput = Omit<ApiRequestConfig, 'url' | 'data'> & { token?: string };
+const REQUEST_TIMEOUT_MS = 15000;
 
 function buildUrl(path: string) {
   if (!env.apiBaseUrl) {
@@ -84,15 +85,35 @@ function parseResponseBody(raw: string, contentType: string | null) {
 }
 
 const defaultTransport: ApiTransport = async <T>(method: HttpMethod, config: ApiRequestConfig) => {
-  const response = await fetch(buildUrl(config.url ?? ''), {
-    method,
-    headers: {
-      Accept: 'application/json',
-      'Content-Type': 'application/json',
-      ...(config.headers ?? {}),
-    },
-    body: config.data ? JSON.stringify(config.data) : undefined,
-  });
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
+
+  let response: Response;
+
+  try {
+    response = await fetch(buildUrl(config.url ?? ''), {
+      method,
+      headers: {
+        Accept: 'application/json',
+        'Content-Type': 'application/json',
+        ...(config.headers ?? {}),
+      },
+      body: config.data ? JSON.stringify(config.data) : undefined,
+      signal: controller.signal,
+    });
+  } catch (error) {
+    clearTimeout(timeoutId);
+
+    if ((error as { name?: string }).name === 'AbortError') {
+      throw new AppError('Request timed out. Please check that your phone and computer are on the same Wi-Fi and try again.');
+    }
+
+    throw new AppError(
+      'Unable to reach the backend. Check EXPO_PUBLIC_API_BASE_URL and make sure the backend is running and reachable from your phone.',
+    );
+  }
+
+  clearTimeout(timeoutId);
 
   const raw = await response.text();
   const payload = parseResponseBody(raw, response.headers.get('content-type'));
@@ -132,6 +153,22 @@ async function request<T>(
 
     return (finalResponse.data ?? null) as T | null;
   } catch (error) {
+    const appError = error as AppError & { response?: ApiResponse<unknown> };
+
+    if (!appError.response) {
+      const normalizedError =
+        appError.name === 'AbortError'
+          ? new AppError(
+              'Request timed out. Please check that your phone and computer are on the same Wi-Fi and try again.',
+            )
+          : new AppError(
+              'Unable to reach the backend. Check EXPO_PUBLIC_API_BASE_URL and make sure the backend is running and reachable from your phone.',
+            );
+
+      await interceptors.runResponseError(normalizedError);
+      throw normalizedError;
+    }
+
     await interceptors.runResponseError(error);
     throw error;
   }

--- a/mobile/src/features/auth/application/services/index.ts
+++ b/mobile/src/features/auth/application/services/index.ts
@@ -1,11 +1,15 @@
 import { AuthRepositoryImpl } from '../../data/repositories';
 import { AuthSessionEntity } from '../../domain/entities';
+import { RegisterUserInput, RegisterUserResult } from '../../domain/repositories';
 
 const repository = new AuthRepositoryImpl();
 
 export const authService = {
   async login(email: string, password: string): Promise<AuthSessionEntity> {
     return repository.login(email, password);
+  },
+  async register(input: RegisterUserInput): Promise<RegisterUserResult> {
+    return repository.register(input);
   },
   async restore(): Promise<AuthSessionEntity | null> {
     return repository.restore();

--- a/mobile/src/features/auth/application/useCases/index.ts
+++ b/mobile/src/features/auth/application/useCases/index.ts
@@ -7,14 +7,11 @@ interface LoginInput {
 }
 
 export async function loginWithEmailPassword(input: LoginInput): Promise<Session> {
-  return authService.login({
-    email: input.email.trim().toLowerCase(),
-    password: input.password,
-  });
+  return authService.login(input.email.trim().toLowerCase(), input.password);
 }
 
 export async function restoreAuthSession() {
-  return authService.restoreSession();
+  return authService.restore();
 }
 
 export async function logoutCurrentUser(session: Session) {

--- a/mobile/src/features/auth/context/AuthContext.tsx
+++ b/mobile/src/features/auth/context/AuthContext.tsx
@@ -13,6 +13,7 @@ import { AuthUser, Session } from '../../../core/auth/session';
 import { interceptors } from '../../../core/api/interceptors';
 import { authService } from '../application/services';
 import { createInitialAuthState } from '../presentation/state/authUiState';
+import { RegisterUserInput, RegisterUserResult } from '../domain/repositories';
 
 interface LoginInput {
   email: string;
@@ -24,6 +25,7 @@ interface AuthContextValue {
   isAuthenticated: boolean;
   loading: boolean;
   login: (input: LoginInput) => Promise<Session>;
+  register: (input: RegisterUserInput) => Promise<RegisterUserResult>;
   logout: () => Promise<void>;
 }
 
@@ -131,6 +133,27 @@ export function AuthProvider({ children }: PropsWithChildren) {
     }
   }, []);
 
+  const register = useCallback(async (input: RegisterUserInput) => {
+    setState((current) => ({ ...current, isLoading: true, error: undefined }));
+
+    try {
+      const result = await authService.register(input);
+
+      setState((current) => ({
+        ...current,
+        isLoading: false,
+      }));
+
+      return result;
+    } catch (error) {
+      setState((current) => ({
+        ...current,
+        isLoading: false,
+      }));
+      throw error;
+    }
+  }, []);
+
   const logout = useCallback(async () => {
     const activeSession = sessionRef.current;
 
@@ -149,9 +172,10 @@ export function AuthProvider({ children }: PropsWithChildren) {
       isAuthenticated: Boolean(state.session?.accessToken),
       loading: state.isLoading,
       login,
+      register,
       logout,
     }),
-    [login, logout, state.isLoading, state.session],
+    [login, logout, register, state.isLoading, state.session],
   );
 
   return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;

--- a/mobile/src/features/auth/context/__tests__/AuthContext.test.tsx
+++ b/mobile/src/features/auth/context/__tests__/AuthContext.test.tsx
@@ -19,7 +19,7 @@ const loginResponse = {
 };
 
 function AuthHarness() {
-  const { user, isAuthenticated, loading, login, logout } = useAuth();
+  const { user, isAuthenticated, loading, login, register, logout } = useAuth();
 
   const handleRequest = async () => {
     try {
@@ -46,6 +46,18 @@ function AuthHarness() {
       <Pressable onPress={() => logout()}>
         <Text>logout</Text>
       </Pressable>
+      <Pressable
+        onPress={() =>
+          register({
+            username: 'traveler',
+            email: 'traveler@example.com',
+            password: 'Password1',
+            confirmPassword: 'Password1',
+          }).catch(() => undefined)
+        }
+      >
+        <Text>register</Text>
+      </Pressable>
       <Pressable onPress={handleRequest}>
         <Text>request</Text>
       </Pressable>
@@ -70,6 +82,22 @@ function installAuthTransport(options?: {
       return {
         status: 204,
         data: null as never,
+        config,
+      };
+    }
+
+    if (method === 'POST' && config.url === '/auth/register/') {
+      return {
+        status: 201,
+        data: {
+          message: 'Registration successful. Please verify your email.',
+          user: {
+            id: 2,
+            email: 'traveler@example.com',
+            username: 'traveler',
+            role: 'registered_user',
+          },
+        } as never,
         config,
       };
     }
@@ -146,6 +174,26 @@ describe('AuthProvider', () => {
     await waitFor(() => {
       expect(screen.getByText('guest')).toBeTruthy();
     });
+    expect(await storage.get(storageKeys.authSession)).toBeNull();
+  });
+
+  it('registers without creating a persisted session', async () => {
+    installAuthTransport();
+
+    render(
+      <AuthProvider>
+        <AuthHarness />
+      </AuthProvider>,
+    );
+
+    expect(await screen.findByText('guest')).toBeTruthy();
+    fireEvent.press(screen.getByText('register'));
+
+    await waitFor(() => {
+      expect(screen.getByText('ready')).toBeTruthy();
+    });
+
+    expect(screen.getByText('guest')).toBeTruthy();
     expect(await storage.get(storageKeys.authSession)).toBeNull();
   });
 

--- a/mobile/src/features/auth/data/repositories/index.ts
+++ b/mobile/src/features/auth/data/repositories/index.ts
@@ -1,4 +1,4 @@
-import { AuthRepository } from '../../domain/repositories';
+import { AuthRepository, RegisterUserInput, RegisterUserResult } from '../../domain/repositories';
 import { AuthSessionEntity } from '../../domain/entities';
 import { mapAuth } from '../mappers';
 import { authLocalSource, authRemoteSource } from '../sources';
@@ -14,6 +14,19 @@ export class AuthRepositoryImpl implements AuthRepository {
     await authLocalSource.setSession(session);
 
     return session;
+  }
+
+  async register(input: RegisterUserInput): Promise<RegisterUserResult> {
+    const response = await authRemoteSource.register({
+      username: input.username.trim(),
+      email: input.email.trim().toLowerCase(),
+      password: input.password,
+      password_confirmation: input.confirmPassword,
+    });
+
+    return {
+      message: response.message,
+    };
   }
 
   async restore(): Promise<AuthSessionEntity | null> {

--- a/mobile/src/features/auth/data/sources/index.ts
+++ b/mobile/src/features/auth/data/sources/index.ts
@@ -9,6 +9,13 @@ export interface LoginPayload {
   password: string;
 }
 
+export interface RegisterPayload {
+  username: string;
+  email: string;
+  password: string;
+  password_confirmation: string;
+}
+
 interface BackendUser {
   id: number;
   email: string;
@@ -20,6 +27,14 @@ interface LoginResponse {
   access: string;
   refresh: string;
   user: BackendUser;
+}
+
+export interface RegisterResponse {
+  message: string;
+  user: BackendUser & {
+    is_email_verified?: boolean;
+    date_joined?: string;
+  };
 }
 
 function mapBackendRole(role: BackendUser['role']): AppRole {
@@ -49,6 +64,15 @@ export const authRemoteSource = {
     }
 
     return toSession(response);
+  },
+  async register(payload: RegisterPayload): Promise<RegisterResponse> {
+    const response = await apiClient.post<RegisterResponse>(`${endpoints.auth}/register/`, payload);
+
+    if (!response) {
+      throw new Error('Registration did not return a response payload.');
+    }
+
+    return response;
   },
   async logout(session: Session): Promise<void> {
     await apiClient.post<void>(

--- a/mobile/src/features/auth/domain/repositories/index.ts
+++ b/mobile/src/features/auth/domain/repositories/index.ts
@@ -1,7 +1,19 @@
 import { AuthSessionEntity } from '../entities';
 
+export interface RegisterUserInput {
+  username: string;
+  email: string;
+  password: string;
+  confirmPassword: string;
+}
+
+export interface RegisterUserResult {
+  message: string;
+}
+
 export interface AuthRepository {
   login(email: string, password: string): Promise<AuthSessionEntity>;
+  register(input: RegisterUserInput): Promise<RegisterUserResult>;
   restore(): Promise<AuthSessionEntity | null>;
   logout(session?: AuthSessionEntity | null): Promise<void>;
   clear(): Promise<void>;

--- a/mobile/src/features/auth/presentation/components/AuthFormCard.tsx
+++ b/mobile/src/features/auth/presentation/components/AuthFormCard.tsx
@@ -1,0 +1,196 @@
+import React from 'react';
+import { Pressable, Text, View } from 'react-native';
+import { useAppTheme } from '../../../../core/hooks/useAppTheme';
+import { Button } from '../../../../shared/ui/Button';
+import { Input } from '../../../../shared/ui/Input';
+
+export type AuthMode = 'signIn' | 'register';
+
+export interface AuthFieldErrors {
+  username?: string;
+  email?: string;
+  password?: string;
+  confirmPassword?: string;
+}
+
+export interface PasswordRule {
+  id: string;
+  label: string;
+  passed: boolean;
+}
+
+interface AuthFormCardProps {
+  mode: AuthMode;
+  username: string;
+  email: string;
+  password: string;
+  confirmPassword: string;
+  fieldErrors: AuthFieldErrors;
+  error?: string;
+  successMessage?: string;
+  isLoading: boolean;
+  passwordRules: PasswordRule[];
+  onUsernameChange: (value: string) => void;
+  onEmailChange: (value: string) => void;
+  onPasswordChange: (value: string) => void;
+  onConfirmPasswordChange: (value: string) => void;
+  onSubmit: () => void;
+  onToggleMode: () => void;
+}
+
+export function AuthFormCard({
+  mode,
+  username,
+  email,
+  password,
+  confirmPassword,
+  fieldErrors,
+  error,
+  successMessage,
+  isLoading,
+  passwordRules,
+  onUsernameChange,
+  onEmailChange,
+  onPasswordChange,
+  onConfirmPasswordChange,
+  onSubmit,
+  onToggleMode,
+}: AuthFormCardProps) {
+  const { colors, spacing, typography } = useAppTheme();
+  const isRegister = mode === 'register';
+
+  return (
+    <View
+      style={{
+        padding: spacing.lg,
+        borderRadius: 20,
+        backgroundColor: colors.surface,
+        borderWidth: 1,
+        borderColor: colors.border,
+        gap: spacing.md,
+      }}
+    >
+      <View style={{ gap: spacing.xs }}>
+        <Text style={{ fontSize: typography.subtitle, fontWeight: '700', color: colors.text }}>
+          {isRegister ? 'Create account' : 'Sign in'}
+        </Text>
+        <Text style={{ fontSize: typography.body, color: colors.muted }}>
+          {isRegister
+            ? 'Create your account with the same fields and validation rules used on the web app.'
+            : 'Use your backend account email and password to start an authenticated session.'}
+        </Text>
+      </View>
+
+      {successMessage ? (
+        <View
+          style={{
+            borderWidth: 1,
+            borderColor: colors.primary,
+            backgroundColor: colors.infoSurface,
+            borderRadius: 12,
+            padding: spacing.md,
+          }}
+        >
+          <Text style={{ color: colors.primary, fontWeight: '600' }}>{successMessage}</Text>
+        </View>
+      ) : null}
+
+      {isRegister ? (
+        <View style={{ gap: spacing.sm }}>
+          <Text style={{ color: colors.text, fontWeight: '600' }}>Username</Text>
+          <Input
+            value={username}
+            onChangeText={onUsernameChange}
+            placeholder="your_username"
+            autoComplete="username"
+            textContentType="username"
+            autoCapitalize="none"
+            accessibilityLabel="Username"
+            editable={!isLoading}
+          />
+          {fieldErrors.username ? <Text style={{ color: colors.danger }}>{fieldErrors.username}</Text> : null}
+        </View>
+      ) : null}
+
+      <View style={{ gap: spacing.sm }}>
+        <Text style={{ color: colors.text, fontWeight: '600' }}>Email</Text>
+        <Input
+          value={email}
+          onChangeText={onEmailChange}
+          placeholder="you@example.com"
+          keyboardType="email-address"
+          textContentType="emailAddress"
+          autoComplete="email"
+          accessibilityLabel="Email address"
+          editable={!isLoading}
+        />
+        {fieldErrors.email ? <Text style={{ color: colors.danger }}>{fieldErrors.email}</Text> : null}
+      </View>
+
+      <View style={{ gap: spacing.sm }}>
+        <Text style={{ color: colors.text, fontWeight: '600' }}>Password</Text>
+        <Input
+          value={password}
+          onChangeText={onPasswordChange}
+          placeholder={isRegister ? 'Create a password' : 'Enter your password'}
+          secureTextEntry
+          textContentType="password"
+          autoComplete={isRegister ? 'new-password' : 'password'}
+          accessibilityLabel="Password"
+          editable={!isLoading}
+        />
+        {fieldErrors.password ? <Text style={{ color: colors.danger }}>{fieldErrors.password}</Text> : null}
+      </View>
+
+      {isRegister ? (
+        <>
+          <View style={{ gap: spacing.sm }}>
+            <Text style={{ color: colors.text, fontWeight: '600' }}>Confirm password</Text>
+            <Input
+              value={confirmPassword}
+              onChangeText={onConfirmPasswordChange}
+              placeholder="Repeat your password"
+              secureTextEntry
+              textContentType="password"
+              autoComplete="new-password"
+              accessibilityLabel="Confirm password"
+              editable={!isLoading}
+            />
+            {fieldErrors.confirmPassword ? (
+              <Text style={{ color: colors.danger }}>{fieldErrors.confirmPassword}</Text>
+            ) : null}
+          </View>
+
+          <View style={{ gap: spacing.xs }}>
+            {passwordRules.map((rule) => (
+              <Text
+                key={rule.id}
+                style={{
+                  color: rule.passed ? colors.primary : colors.muted,
+                  fontSize: typography.caption,
+                }}
+              >
+                {rule.passed ? '[x]' : '[ ]'} {rule.label}
+              </Text>
+            ))}
+          </View>
+        </>
+      ) : null}
+
+      {error ? <Text style={{ color: colors.danger }}>{error}</Text> : null}
+
+      <Button onPress={onSubmit} disabled={isLoading}>
+        {isLoading ? (isRegister ? 'Creating account...' : 'Signing in...') : isRegister ? 'Create account' : 'Sign in'}
+      </Button>
+
+      <Pressable disabled={isLoading} onPress={onToggleMode}>
+        <Text style={{ color: colors.muted, textAlign: 'center' }}>
+          {isRegister ? 'Already have an account? ' : "Don't have an account? "}
+          <Text style={{ color: colors.primary, fontWeight: '700' }}>
+            {isRegister ? 'Sign in' : 'Sign up'}
+          </Text>
+        </Text>
+      </Pressable>
+    </View>
+  );
+}

--- a/mobile/src/features/auth/presentation/screens/AuthScreen.tsx
+++ b/mobile/src/features/auth/presentation/screens/AuthScreen.tsx
@@ -4,7 +4,7 @@ import { useAppTheme } from '../../../../core/hooks/useAppTheme';
 import { validators } from '../../../../shared/forms/validators';
 import { useToast } from '../../../../shared/hooks/useToast';
 import { useAuth } from '../../context/AuthContext';
-import { AuthCard } from '../components/AuthCard';
+import { AuthFieldErrors, AuthFormCard, AuthMode, PasswordRule } from '../components/AuthFormCard';
 import { AuthUiState } from '../state/authUiState';
 
 interface AuthScreenProps {
@@ -17,29 +17,239 @@ const initialState: AuthUiState = {
   isLoading: false,
 };
 
-export function AuthScreen({ onAuthenticated }: AuthScreenProps) {
-  const { login, loading } = useAuth();
-  const { colors, spacing, typography } = useAppTheme();
-  const { toast } = useToast();
-  const [state, setState] = useState<AuthUiState>(initialState);
+const initialFieldErrors: AuthFieldErrors = {
+  username: undefined,
+  email: undefined,
+  password: undefined,
+  confirmPassword: undefined,
+};
 
-  const submit = async () => {
-    const email = state.email.trim();
-    const password = state.password;
+const passwordRules = [
+  {
+    id: 'length',
+    label: 'At least 8 characters',
+    test: (password: string) => password.length >= 8,
+  },
+  {
+    id: 'uppercase',
+    label: 'One uppercase letter',
+    test: (password: string) => /[A-Z]/.test(password),
+  },
+  {
+    id: 'lowercase',
+    label: 'One lowercase letter',
+    test: (password: string) => /[a-z]/.test(password),
+  },
+  {
+    id: 'number',
+    label: 'One number',
+    test: (password: string) => /[0-9]/.test(password),
+  },
+];
 
-    if (!validators.required(email) || !validators.required(password)) {
-      setState((current) => ({
-        ...current,
-        error: 'Email and password are required.',
-      }));
-      return;
+interface AuthFormState extends AuthUiState {
+  username: string;
+  confirmPassword: string;
+  successMessage?: string;
+  fieldErrors: AuthFieldErrors;
+}
+
+const initialFormState: AuthFormState = {
+  ...initialState,
+  username: '',
+  confirmPassword: '',
+  successMessage: undefined,
+  fieldErrors: initialFieldErrors,
+};
+
+function getPasswordError(password: string) {
+  if (password.length < 8) {
+    return 'Password must be at least 8 characters long.';
+  }
+
+  if (!/[A-Z]/.test(password)) {
+    return 'Password must contain at least one uppercase letter.';
+  }
+
+  if (!/[a-z]/.test(password)) {
+    return 'Password must contain at least one lowercase letter.';
+  }
+
+  if (!/[0-9]/.test(password)) {
+    return 'Password must contain at least one number.';
+  }
+
+  return undefined;
+}
+
+function extractRegisterErrors(error: unknown): {
+  error?: string;
+  fieldErrors: AuthFieldErrors;
+} {
+  const defaultError = 'Registration failed. Please try again.';
+  const response = (error as { response?: { data?: unknown } })?.response?.data;
+
+  if (!response || typeof response !== 'object') {
+    return { error: error instanceof Error ? error.message : defaultError, fieldErrors: initialFieldErrors };
+  }
+
+  const payload = response as Record<string, unknown>;
+  const nextFieldErrors: AuthFieldErrors = { ...initialFieldErrors };
+
+  const readMessage = (value: unknown) => {
+    if (Array.isArray(value) && typeof value[0] === 'string') {
+      return value[0];
     }
 
-    if (!validators.email(email)) {
+    return typeof value === 'string' ? value : undefined;
+  };
+
+  nextFieldErrors.username = readMessage(payload.username);
+  nextFieldErrors.email = readMessage(payload.email);
+  nextFieldErrors.password = readMessage(payload.password);
+  nextFieldErrors.confirmPassword = readMessage(payload.password_confirmation);
+
+  if (
+    nextFieldErrors.username ||
+    nextFieldErrors.email ||
+    nextFieldErrors.password ||
+    nextFieldErrors.confirmPassword
+  ) {
+    return { fieldErrors: nextFieldErrors };
+  }
+
+  const genericError =
+    readMessage(payload.non_field_errors) ??
+    readMessage(payload.detail) ??
+    readMessage(payload.message) ??
+    (error instanceof Error ? error.message : defaultError);
+
+  return {
+    error: genericError,
+    fieldErrors: nextFieldErrors,
+  };
+}
+
+export function AuthScreen({ onAuthenticated }: AuthScreenProps) {
+  const { login, register, loading } = useAuth();
+  const { colors, spacing, typography } = useAppTheme();
+  const { toast } = useToast();
+  const [mode, setMode] = useState<AuthMode>('signIn');
+  const [state, setState] = useState<AuthFormState>(initialFormState);
+
+  const isRegister = mode === 'register';
+  const visiblePasswordRules: PasswordRule[] = passwordRules.map((rule) => ({
+    id: rule.id,
+    label: rule.label,
+    passed: rule.test(state.password),
+  }));
+
+  const updateField =
+    (field: keyof AuthFormState) =>
+    (value: string) => {
       setState((current) => ({
         ...current,
-        error: 'Please enter a valid email address.',
+        [field]: value,
+        error: undefined,
+        successMessage: field === 'email' ? current.successMessage : undefined,
+        fieldErrors: {
+          ...current.fieldErrors,
+          [field]: undefined,
+          ...(field === 'password' ? { confirmPassword: undefined } : {}),
+        },
       }));
+    };
+
+  const toggleMode = () => {
+    setMode((current) => (current === 'signIn' ? 'register' : 'signIn'));
+    setState((current) => ({
+      ...initialFormState,
+      email: current.email,
+    }));
+  };
+
+  const validateSignIn = () => {
+    const email = state.email.trim();
+    const nextFieldErrors: AuthFieldErrors = {};
+
+    if (!validators.required(email)) {
+      nextFieldErrors.email = 'Email is required.';
+    } else if (!validators.email(email)) {
+      nextFieldErrors.email = 'Please enter a valid email address.';
+    }
+
+    if (!validators.required(state.password)) {
+      nextFieldErrors.password = 'Password is required.';
+    }
+
+    if (nextFieldErrors.email || nextFieldErrors.password) {
+      setState((current) => ({
+        ...current,
+        error: undefined,
+        fieldErrors: {
+          ...initialFieldErrors,
+          ...nextFieldErrors,
+        },
+      }));
+      return false;
+    }
+
+    return true;
+  };
+
+  const validateRegistration = () => {
+    const username = state.username.trim();
+    const email = state.email.trim();
+    const nextFieldErrors: AuthFieldErrors = {};
+
+    if (!validators.required(username)) {
+      nextFieldErrors.username = 'Username is required.';
+    }
+
+    if (!validators.required(email)) {
+      nextFieldErrors.email = 'Email is required.';
+    } else if (!validators.email(email)) {
+      nextFieldErrors.email = 'Enter a valid email address.';
+    }
+
+    if (!validators.required(state.password)) {
+      nextFieldErrors.password = 'Password is required.';
+    } else {
+      nextFieldErrors.password = getPasswordError(state.password);
+    }
+
+    if (!validators.required(state.confirmPassword)) {
+      nextFieldErrors.confirmPassword = 'Please confirm your password.';
+    } else if (state.password !== state.confirmPassword) {
+      nextFieldErrors.confirmPassword = 'Passwords do not match.';
+    }
+
+    if (
+      nextFieldErrors.username ||
+      nextFieldErrors.email ||
+      nextFieldErrors.password ||
+      nextFieldErrors.confirmPassword
+    ) {
+      setState((current) => ({
+        ...current,
+        error: undefined,
+        fieldErrors: {
+          ...initialFieldErrors,
+          ...nextFieldErrors,
+        },
+      }));
+      return false;
+    }
+
+    return true;
+  };
+
+  const submit = async () => {
+    if (isRegister) {
+      if (!validateRegistration()) {
+        return;
+      }
+    } else if (!validateSignIn()) {
       return;
     }
 
@@ -47,14 +257,53 @@ export function AuthScreen({ onAuthenticated }: AuthScreenProps) {
       ...current,
       isLoading: true,
       error: undefined,
+      successMessage: undefined,
+      fieldErrors: initialFieldErrors,
     }));
 
     try {
+      if (isRegister) {
+        const result = await register({
+          username: state.username.trim(),
+          email: state.email.trim(),
+          password: state.password,
+          confirmPassword: state.confirmPassword,
+        });
+
+        const successMessage = result.message || 'Account created successfully. Please sign in.';
+        toast.success('Account created! Sign in to continue.');
+        setMode('signIn');
+        setState({
+          ...initialFormState,
+          email: state.email.trim(),
+          successMessage,
+        });
+        return;
+      }
+
+      const email = state.email.trim();
+      const password = state.password;
       const session = await login({ email, password });
       toast.success(`Welcome back, ${session.user.username}.`);
       onAuthenticated?.();
-      setState(initialState);
+      setState(initialFormState);
     } catch (loginError) {
+      if (isRegister) {
+        const { error, fieldErrors } = extractRegisterErrors(loginError);
+
+        setState((current) => ({
+          ...current,
+          isLoading: false,
+          error,
+          fieldErrors,
+        }));
+
+        if (error) {
+          toast.error(error);
+        }
+        return;
+      }
+
       const message = loginError instanceof Error ? loginError.message : 'Unable to sign in right now.';
       setState((current) => ({
         ...current,
@@ -65,7 +314,7 @@ export function AuthScreen({ onAuthenticated }: AuthScreenProps) {
       return;
     }
 
-    setState(initialState);
+    setState(initialFormState);
   };
 
   return (
@@ -85,22 +334,32 @@ export function AuthScreen({ onAuthenticated }: AuthScreenProps) {
           <View style={{ gap: spacing.sm }}>
             <Text style={{ color: colors.primary, fontWeight: '700' }}>Local History Story Map</Text>
             <Text style={{ color: colors.text, fontSize: typography.title, fontWeight: '800' }}>
-              Sign in to the mobile app
+              {isRegister ? 'Create your mobile account' : 'Sign in to the mobile app'}
             </Text>
             <Text style={{ color: colors.muted, fontSize: typography.body }}>
-              Shared auth state restores persisted sessions, protects user-only screens, and
-              attaches your access token to authenticated API requests.
+              {isRegister
+                ? 'Create an account to explore, submit, and interact with local history stories from the mobile app.'
+                : 'Shared auth state restores persisted sessions, protects user-only screens, and attaches your access token to authenticated API requests.'}
             </Text>
           </View>
 
-          <AuthCard
+          <AuthFormCard
+            mode={mode}
+            username={state.username}
             email={state.email}
             password={state.password}
+            confirmPassword={state.confirmPassword}
+            fieldErrors={state.fieldErrors}
             error={state.error}
+            successMessage={state.successMessage}
             isLoading={state.isLoading || loading}
-            onEmailChange={(email) => setState((current) => ({ ...current, email }))}
-            onPasswordChange={(password) => setState((current) => ({ ...current, password }))}
+            passwordRules={visiblePasswordRules}
+            onUsernameChange={updateField('username')}
+            onEmailChange={updateField('email')}
+            onPasswordChange={updateField('password')}
+            onConfirmPasswordChange={updateField('confirmPassword')}
             onSubmit={submit}
+            onToggleMode={toggleMode}
           />
         </View>
       </ScrollView>

--- a/mobile/src/shared/ui/Button/Button.tsx
+++ b/mobile/src/shared/ui/Button/Button.tsx
@@ -8,6 +8,8 @@ interface ButtonProps extends PropsWithChildren {
 }
 
 export function Button({ children, onPress, disabled = false }: ButtonProps) {
+  const { colors, spacing } = useAppTheme();
+
   return (
     <Pressable
       onPress={disabled ? undefined : onPress}
@@ -19,7 +21,7 @@ export function Button({ children, onPress, disabled = false }: ButtonProps) {
         opacity: disabled ? 0.7 : 1,
       }}
     >
-      <Text style={{ color: isPrimary ? '#FFFFFF' : colors.text, fontWeight: '600' }}>
+      <Text style={{ color: '#FFFFFF', fontWeight: '600', textAlign: 'center' }}>
         {children ?? 'Button'}
       </Text>
     </Pressable>


### PR DESCRIPTION
# 📝 Description
Fixes #174 

Implemented the mobile registration flow by extending the existing authentication experience to support account creation.

This PR:
- adds a mobile sign-up UI consistent with the existing login screen
- adds username, email, password, and confirm password fields
- adds client-side validation for required fields, email format, password strength, and password match
- integrates the mobile app with the backend `/auth/register/` endpoint
- adds loading, success, and error handling for registration
- keeps protected-screen navigation behavior consistent for unauthenticated users
- improves API error handling for unreachable backend / timeout scenarios
- adds tests for auth registration flow and API failure normalization

# 📊 Type of Change
- [x]  Bug fix
- [x]  New feature
- [ ]  Refactoring
- [ ]  Documentation
 
# ✅ Acceptance Criteria / Checklist
- [ ] Project builds successfully
- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, especially in hard-to-understand parts
- [x] I have performed a self-review of my code
- [x] I have added/updated tests
- [ ] New and existing unit tests pass locally with my changes

Notes:
- Focused tests added and passing:
  - auth context registration flow
  - API client network failure normalization
  - root navigation protected-screen behavior
- Full project typecheck / all tests are not fully green yet because there are unrelated existing issues in the repo (for example story screen session typing expectations).

# 📸 Screenshots / Recordings

<p>
  <img src="https://github.com/user-attachments/assets/e4b628eb-99ab-43a0-9eee-1e7d65ec691c" width="300" alt="foto1" />
  <img src="https://github.com/user-attachments/assets/cd2f3da3-453a-438e-a22f-0d566e8aa4b3" width="300" alt="foto2" />
</p>


# ⏱️ Estimated Review Time
- [ ] < 5 min
- [x] 5-15 min
- [ ] > 15 min
