### PR TITLE
fix: Mobile story map pins

### DIFF
--- a/mobile/src/features/stories/data/mappers/index.ts
+++ b/mobile/src/features/stories/data/mappers/index.ts
@@ -58,6 +58,58 @@ function asNumber(value: unknown) {
   return typeof value === 'number' && Number.isFinite(value) ? value : undefined;
 }
 
+function asStringId(value: unknown) {
+  if (typeof value === 'string' && value.length) {
+    return value;
+  }
+
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return String(value);
+  }
+
+  return undefined;
+}
+
+function asNumericValue(value: unknown) {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return value;
+  }
+
+  if (typeof value === 'string' && value.trim()) {
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : undefined;
+  }
+
+  return undefined;
+}
+
+function formatTimePeriod(story: Record<string, unknown>) {
+  const explicitTimePeriod = asString(story.timePeriod) || asString(story.time_period) || asString(story.period);
+
+  if (explicitTimePeriod) {
+    return explicitTimePeriod;
+  }
+
+  const timeType = asString(story.time_type) || asString(story.timeType);
+  const year = asNumericValue(story.year);
+  const yearStart = asNumericValue(story.year_start) ?? asNumericValue(story.yearStart);
+  const yearEnd = asNumericValue(story.year_end) ?? asNumericValue(story.yearEnd);
+
+  if (timeType === 'year_range' && yearStart !== undefined && yearEnd !== undefined) {
+    return `${yearStart}-${yearEnd}`;
+  }
+
+  if (timeType === 'decade' && year !== undefined) {
+    return `${year}s`;
+  }
+
+  if (year !== undefined) {
+    return String(year);
+  }
+
+  return '';
+}
+
 function getNarrativePreview(value: unknown) {
   if (typeof value === 'string') {
     return value;
@@ -120,35 +172,35 @@ export function mapStorySummary(value: unknown): StorySummaryEntity {
   const story = value as Record<string, unknown>;
   const locationRecord =
     story.location && typeof story.location === 'object' ? (story.location as Record<string, unknown>) : undefined;
+  const id = asStringId(story.id);
   const placeName =
     asString(story.placeName) ||
     asString(story.location_name) ||
     asString(story.locationName) ||
     asString(locationRecord?.name);
-  const timePeriod =
-    asString(story.timePeriod) || asString(story.time_period) || asString(story.period);
+  const timePeriod = formatTimePeriod(story);
   const previewText =
     asString(story.previewText) ||
     asString(story.preview_text) ||
     getNarrativePreview(story.narrative) ||
     asString(story.summary);
   const latitude =
-    asNumber(story.latitude) ??
-    asNumber(story.location_lat) ??
-    asNumber(story.locationLat) ??
-    asNumber(locationRecord?.latitude);
+    asNumericValue(story.latitude) ??
+    asNumericValue(story.location_lat) ??
+    asNumericValue(story.locationLat) ??
+    asNumericValue(locationRecord?.latitude);
   const longitude =
-    asNumber(story.longitude) ??
-    asNumber(story.location_lng) ??
-    asNumber(story.locationLng) ??
-    asNumber(locationRecord?.longitude);
+    asNumericValue(story.longitude) ??
+    asNumericValue(story.location_lng) ??
+    asNumericValue(story.locationLng) ??
+    asNumericValue(locationRecord?.longitude);
 
-  if (typeof story.id !== 'string' || typeof story.title !== 'string') {
+  if (!id || typeof story.title !== 'string') {
     throw new Error('Invalid story summary payload.');
   }
 
   return {
-    id: story.id,
+    id,
     title: story.title,
     previewText,
     placeName,


### PR DESCRIPTION
# 📝 Description
Fixes #301 

This PR fixes a bug in `mobile/src/features/stories/data/mappers/index.ts` where valid backend story map responses were not being mapped correctly in the mobile app.

The mapper previously expected:
- `id` as a string
- coordinates as numeric values
- preformatted time display fields

However, the backend returns:
- `id` as a number
- `location_lat` and `location_lng` as strings
- time data as raw fields such as `time_type`, `year`, `year_start`, and `year_end`

Because of this mismatch, valid map stories were rejected by the mapper and mobile map pins did not appear even though the backend endpoint returned them correctly.

This PR makes the mapper tolerant to backend response formats by:
- converting numeric IDs to strings
- parsing numeric string coordinates
- deriving a fallback `timePeriod` from backend time fields when needed

# 📊 Type of Change
- [x]  Bug fix
- [ ]  New feature
- [ ]  Refactoring
- [ ]  Documentation
 
# ✅ Acceptance Criteria / Checklist
- [x] Project builds successfully
- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, especially in hard-to-understand parts
- [x] I have performed a self-review of my code
- [ ] I have added/updated tests
- [x] New and existing unit tests pass locally with my changes

# 📸 Screenshots / Recordings
<!-- If applicable !-->

# ⏱️ Estimated Review Time
- [x] < 5 min
- [ ] 5-15 min
- [ ] > 15 min
