### PR TITLE
feat: add CD workflow to auto-deploy main to production

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,38 @@
+name: Deploy to Production
+
+on:
+  workflow_run:
+    workflows: ["CI"]
+    types: [completed]
+    branches: [main]
+
+jobs:
+  deploy:
+    name: Deploy to Production
+    runs-on: ubuntu-latest
+    # Only deploy if CI passed
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+
+    steps:
+      - name: Deploy via SSH
+        uses: appleboy/ssh-action@v1
+        with:
+          host: ${{ secrets.DEPLOY_HOST }}
+          username: ${{ secrets.DEPLOY_USER }}
+          key: ${{ secrets.DEPLOY_SSH_KEY }}
+          script: |
+            # Ensure swap is active (survives reboots via /etc/fstab, but belt-and-suspenders)
+            swapon /swapfile 2>/dev/null || true
+
+            cd /opt/bounswe2026group4
+
+            # Pull latest code
+            git pull origin main
+
+            # Load production env vars (workaround for docker compose --env-file not reading correctly)
+            set -a && source .env.prod && set +a
+
+            # Rebuild and restart all services
+            docker compose -f docker-compose.prod.yml up -d --build
+
+            echo "Deploy complete at $(date)"


### PR DESCRIPTION
# 📝 Description
Fixes #303

Adds a GitHub Actions CD workflow (`.github/workflows/deploy.yml`) that automatically deploys to the production DigitalOcean server whenever CI passes on `main`.

**How it works:**
- Triggers via `workflow_run` after the existing `CI` workflow completes successfully on `main`
- SSHes into the Droplet using stored secrets (`DEPLOY_HOST`, `DEPLOY_USER`, `DEPLOY_SSH_KEY`)
- Pulls latest code, sources `.env.prod`, runs `docker compose up -d --build`
- Ensures swap is active before building to prevent OOM during React build

**Secrets required (already added):** `DEPLOY_HOST`, `DEPLOY_USER`, `DEPLOY_SSH_KEY`

# 📊 Type of Change
- [x] New feature

# ✅ Acceptance Criteria / Checklist
- [x] Project builds successfully
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code

# ⏱️ Estimated Review Time
- [x] < 5 min