### PR TITLE
feat: make submit story always visible for better UX

### DIFF
--- a/frontend/src/components/AppLayout/AppLayout.jsx
+++ b/frontend/src/components/AppLayout/AppLayout.jsx
@@ -16,9 +16,6 @@ import { useAuth } from "@/hooks/useAuth";
 const publicLinks = [
   { to: "/map", label: "Map" },
   { to: "/", label: "Feed" },
-];
-
-const authLinks = [
   { to: "/submit-story", label: "Submit Story", icon: Plus },
 ];
 
@@ -52,9 +49,7 @@ function AppLayout() {
     navigate("/");
   };
 
-  const links = isAuthenticated
-    ? [...publicLinks, ...authLinks]
-    : publicLinks;
+  const links = publicLinks;
 
   return (
     <div className="min-h-screen">

--- a/frontend/src/components/AppLayout/__tests__/AppLayout.test.jsx
+++ b/frontend/src/components/AppLayout/__tests__/AppLayout.test.jsx
@@ -54,7 +54,12 @@ describe("AppLayout", () => {
     expect(screen.getAllByText("Login").length).toBeGreaterThan(0);
     expect(screen.getAllByText("Register").length).toBeGreaterThan(0);
     expect(screen.queryByText("Profile")).not.toBeInTheDocument();
-    expect(screen.queryByText("Submit Story")).not.toBeInTheDocument();
+  });
+
+  it("shows Submit Story link for unauthenticated users", () => {
+    renderWithRouter();
+
+    expect(screen.getAllByText("Submit Story").length).toBeGreaterThan(0);
   });
 
   it("shows username linking to profile, Logout, and Submit Story when authenticated", () => {

--- a/frontend/src/pages/LoginPage.jsx
+++ b/frontend/src/pages/LoginPage.jsx
@@ -88,7 +88,9 @@ function LoginPage() {
             </CardTitle>
           </div>
           <CardDescription>
-            Sign in to your account to explore and share local history stories
+            {location.state?.from?.pathname === "/submit-story"
+              ? "Log in to submit a story"
+              : "Sign in to your account to explore and share local history stories"}
           </CardDescription>
         </CardHeader>
 

--- a/frontend/src/pages/__tests__/LoginPage.test.jsx
+++ b/frontend/src/pages/__tests__/LoginPage.test.jsx
@@ -215,6 +215,45 @@ describe("LoginPage", () => {
     expect(signUpLink).toBeInTheDocument();
   });
 
+  it("shows contextual message when redirected from submit-story", () => {
+    render(
+      <ToastProvider>
+        <MemoryRouter initialEntries={[{ pathname: "/login", state: { from: { pathname: "/submit-story" } } }]}>
+          <Routes>
+            <Route path="/login" element={<LoginPage />} />
+          </Routes>
+        </MemoryRouter>
+        <Toaster />
+      </ToastProvider>
+    );
+
+    expect(screen.getByText("Log in to submit a story")).toBeInTheDocument();
+  });
+
+  it("navigates to /submit-story after login when redirected from submit-story", async () => {
+    const user = userEvent.setup();
+    mockLogin.mockResolvedValue({ access: "a", refresh: "b", user: { username: "alice" } });
+
+    render(
+      <ToastProvider>
+        <MemoryRouter initialEntries={[{ pathname: "/login", state: { from: { pathname: "/submit-story" } } }]}>
+          <Routes>
+            <Route path="/login" element={<LoginPage />} />
+          </Routes>
+        </MemoryRouter>
+        <Toaster />
+      </ToastProvider>
+    );
+
+    await user.type(screen.getByLabelText("Email"), "test@example.com");
+    await user.type(screen.getByLabelText("Password"), "password123");
+    await user.click(screen.getByRole("button", { name: /sign in/i }));
+
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith("/submit-story", { replace: true });
+    });
+  });
+
   it("shows success toast on successful login", async () => {
     const user = userEvent.setup();
     mockLogin.mockResolvedValue({ access: "a", refresh: "b", user: { username: "alice" } });


### PR DESCRIPTION
# 📝 Description
Fixes #313 
### What was done:
AppLayout.jsx:
  - Moved Submit Story from authLinks to publicLinks, it now appears in the nav for all users
  - Simplified links to always use publicLinks (no more conditional based on auth state)

  LoginPage.jsx:
  - Shows "Log in to submit a story" as the card description when location.state.from.pathname === '/submit-story'
  - The existing redirect-after-login logic (location.state?.from?.pathname) already handles redirecting back to /submit-story after successful login

  AppLayout.test.jsx:
  - Updated the unauthenticated test to no longer expect Submit Story to be absent
  - Added a new test asserting Submit Story is visible for unauthenticated users

  LoginPage.test.jsx:
  - Added test for contextual message when redirected from /submit-story
  - Added test verifying navigation to /submit-story after login when redirected from there

  The flow for unauthenticated users:
 click Submit Story → ProtectedRoute redirects to /login with state.from = /submit-story → LoginPage shows "Log in to submit a story" → after login, redirects to /submit-story.

# 📊 Type of Change
- [ ]  Bug fix
- [x]  New feature
- [ ]  Refactoring
- [ ]  Documentation
 
# ✅ Acceptance Criteria / Checklist
- [x] Project builds successfully
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, especially in hard-to-understand parts
- [x] I have performed a self-review of my code
- [x] I have added/updated tests
- [x] New and existing unit tests pass locally with my changes

# 📸 Screenshots / Recordings
<img width="1440" height="900" alt="Screenshot 2026-04-03 at 14 29 01" src="https://github.com/user-attachments/assets/639eb79f-d18f-41cc-84b0-7cc210c81514" />

# ⏱️ Estimated Review Time
- [x] < 5 min
- [ ] 5-15 min
- [ ] > 15 min
