### PR TITLE
feat:profile-for-mobile

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,24 @@ docker compose up
 The API will be available at `http://localhost:8000`.
 The frontend will be available at `http://localhost:5173`.
 
+## Expo Go mobile development
+
+For Expo Go on a physical phone, set `mobile/.env` so the app points to your computer's LAN IP instead of `localhost`:
+
+```env
+EXPO_PUBLIC_API_BASE_URL=http://192.168.x.x:8000
+EXPO_PUBLIC_ENV=development
+```
+
+Then start Django on all interfaces:
+
+```bash
+cd backend
+python manage.py runserver 0.0.0.0:8000
+```
+
+The development settings now accept LAN hosts by default, which makes local Expo Go testing work without editing `ALLOWED_HOSTS` every time your IP changes.
+
 To stop:
 
 ```bash

--- a/mobile/README.md
+++ b/mobile/README.md
@@ -17,3 +17,27 @@ npm install
 ```bash
 npm run start
 ```
+
+## Expo Go with local backend
+
+1. Copy the example env file and set your computer's LAN IP:
+```bash
+cp .env.example .env
+```
+
+2. Update `EXPO_PUBLIC_API_BASE_URL` in `.env`:
+```env
+EXPO_PUBLIC_API_BASE_URL=http://192.168.x.x:8000
+```
+
+3. Start Django so Expo Go can reach it from your phone:
+```bash
+cd ../backend
+python manage.py runserver 0.0.0.0:8000
+```
+
+4. Make sure your phone and computer are on the same Wi-Fi, then run:
+```bash
+cd ../mobile
+npm run start
+```

--- a/mobile/src/app/navigation/RootNavigator.tsx
+++ b/mobile/src/app/navigation/RootNavigator.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { BackHandler, Pressable, ScrollView, StatusBar, Text, View } from 'react-native';
 import { Loader, Screen } from '../../shared';
 import { ROUTES } from './routes';
@@ -16,6 +16,7 @@ type AppRoute = (typeof ROUTES)[keyof typeof ROUTES];
 interface RouteSnapshot {
   route: AppRoute;
   storyId?: string | null;
+  userId?: string | null;
 }
 
 const protectedRoutes: AppRoute[] = [ROUTES.PROFILE, ROUTES.SUBMISSION];
@@ -87,13 +88,28 @@ function ScreenShell({
 }: {
   title: string;
   description: string;
-  children: React.ReactNode;
+  children: React.ReactNode | ((helpers: { scrollTo: (y: number) => void }) => React.ReactNode);
   framed?: boolean;
   scrollable?: boolean;
   fillContent?: boolean;
   hideHeader?: boolean;
 }) {
   const { colors, spacing, typography } = useAppTheme();
+  const scrollViewRef = useRef<ScrollView>(null);
+  const scrollTo = useCallback(
+    (y: number) => {
+      if (!scrollable) {
+        return;
+      }
+
+      scrollViewRef.current?.scrollTo({
+        y: Math.max(y - spacing.lg, 0),
+        animated: true,
+      });
+    },
+    [scrollable, spacing.lg],
+  );
+  const resolvedChildren = typeof children === 'function' ? children({ scrollTo }) : children;
 
   const innerContent = (
     <>
@@ -115,10 +131,10 @@ function ScreenShell({
             flex: fillContent ? 1 : undefined,
           }}
         >
-          {children}
+          {resolvedChildren}
         </View>
       ) : (
-        <View style={{ marginTop: hideHeader ? 0 : spacing.xl, flex: fillContent ? 1 : undefined }}>{children}</View>
+        <View style={{ marginTop: hideHeader ? 0 : spacing.xl, flex: fillContent ? 1 : undefined }}>{resolvedChildren}</View>
       )}
     </>
   );
@@ -126,6 +142,7 @@ function ScreenShell({
   if (scrollable) {
     return (
       <ScrollView
+        ref={scrollViewRef}
         style={{ flex: 1, backgroundColor: colors.background }}
         contentContainerStyle={{ padding: spacing.lg, paddingBottom: spacing.xl }}
         showsVerticalScrollIndicator={false}
@@ -147,6 +164,7 @@ export function RootNavigator() {
   const { colors, spacing } = useAppTheme();
   const [currentRoute, setCurrentRoute] = useState<AppRoute>(ROUTES.FEED);
   const [activeStoryId, setActiveStoryId] = useState<string | null>(null);
+  const [activeUserId, setActiveUserId] = useState<string | null>(null);
   const [hasResolvedInitialSession, setHasResolvedInitialSession] = useState(false);
   const [backStack, setBackStack] = useState<RouteSnapshot[]>([]);
 
@@ -154,8 +172,9 @@ export function RootNavigator() {
     () => ({
       route: currentRoute,
       storyId: currentRoute === ROUTES.STORY_DETAIL ? activeStoryId : null,
+      userId: currentRoute === ROUTES.USER_PROFILE ? activeUserId : null,
     }),
-    [activeStoryId, currentRoute],
+    [activeStoryId, activeUserId, currentRoute],
   );
   const [redirectTarget, setRedirectTarget] = useState<RouteSnapshot>({ route: ROUTES.PROFILE });
   const canGoBack = backStack.length > 0;
@@ -169,6 +188,7 @@ export function RootNavigator() {
   const restoreSnapshot = useCallback((snapshot: RouteSnapshot) => {
     setCurrentRoute(snapshot.route);
     setActiveStoryId(snapshot.route === ROUTES.STORY_DETAIL ? snapshot.storyId ?? null : null);
+    setActiveUserId(snapshot.route === ROUTES.USER_PROFILE ? snapshot.userId ?? null : null);
   }, []);
 
   const navigateToSnapshot = useCallback(
@@ -176,7 +196,8 @@ export function RootNavigator() {
       if (
         !options?.resetStack &&
         snapshot.route === currentSnapshot.route &&
-        snapshot.storyId === currentSnapshot.storyId
+        snapshot.storyId === currentSnapshot.storyId &&
+        snapshot.userId === currentSnapshot.userId
       ) {
         return;
       }
@@ -189,7 +210,8 @@ export function RootNavigator() {
 
           if (
             previous?.route === currentSnapshot.route &&
-            previous?.storyId === currentSnapshot.storyId
+            previous?.storyId === currentSnapshot.storyId &&
+            previous?.userId === currentSnapshot.userId
           ) {
             return current;
           }
@@ -283,7 +305,8 @@ export function RootNavigator() {
 
       if (
         previousSnapshot?.route === redirectTarget.route &&
-        previousSnapshot?.storyId === redirectTarget.storyId
+        previousSnapshot?.storyId === redirectTarget.storyId &&
+        previousSnapshot?.userId === redirectTarget.userId
       ) {
         nextStack.pop();
       }
@@ -299,6 +322,10 @@ export function RootNavigator() {
 
   const handleOpenStoryDetail = (storyId: string) => {
     navigateToSnapshot({ route: ROUTES.STORY_DETAIL, storyId });
+  };
+
+  const handleOpenUserProfile = (userId: string) => {
+    navigateToSnapshot({ route: ROUTES.USER_PROFILE, userId });
   };
 
   if (!hasResolvedInitialSession && loading) {
@@ -324,10 +351,23 @@ export function RootNavigator() {
         <ScreenShell
           title="Your profile"
           description={user?.username ? `Signed in as ${user.username}.` : 'Your account details.'}
+          framed={false}
+          fillContent
         >
-          <ProfileScreen />
+          <ProfileScreen mode="self" />
         </ScreenShell>
       </ProtectedScreen>
+    );
+  } else if (currentRoute === ROUTES.USER_PROFILE && activeUserId) {
+    content = (
+      <ScreenShell
+        title="User profile"
+        description="Public profile details."
+        framed={false}
+        fillContent
+      >
+        <ProfileScreen mode="public" userId={activeUserId} />
+      </ScreenShell>
     );
   } else if (currentRoute === ROUTES.SUBMISSION) {
     content = (
@@ -352,7 +392,12 @@ export function RootNavigator() {
         framed={false}
         scrollable
       >
-        <MapScreen onOpenStory={handleOpenStoryDetail} />
+        {({ scrollTo }) => (
+          <MapScreen
+            onOpenStory={handleOpenStoryDetail}
+            onMarkerPreviewRequested={(targetY) => scrollTo(targetY)}
+          />
+        )}
       </ScreenShell>
     );
   } else if (currentRoute === ROUTES.STORY_DETAIL && activeStoryId) {
@@ -362,6 +407,7 @@ export function RootNavigator() {
         session={user ? { role: user.role, user } : undefined}
         onRequestLogin={() => handleNavigate(ROUTES.AUTH)}
         onGoBack={handleBack}
+        onOpenContributorProfile={handleOpenUserProfile}
       />
     );
   } else {

--- a/mobile/src/app/navigation/__tests__/RootNavigator.test.tsx
+++ b/mobile/src/app/navigation/__tests__/RootNavigator.test.tsx
@@ -56,6 +56,7 @@ const feedResults = [
 
 const storyDetail = {
   id: 'story-001',
+  user: 12,
   title: 'Harbor Memory',
   narrative: ['A story about the harbor.', 'It still lives in local memory.'],
   location_name: 'Golden Horn',
@@ -69,6 +70,32 @@ const storyDetail = {
   like_count: 0,
   user_has_liked: false,
   comments: [],
+};
+
+const profileDetail = {
+  success: true,
+  data: {
+    id: 1,
+    username: 'Traveler',
+    email: 'traveler@example.com',
+    total_points: 12,
+    date_joined: '2026-01-15T10:00:00Z',
+    profile: {
+      bio: 'Collecting neighborhood memories.',
+      location: 'Istanbul',
+    },
+  },
+};
+
+const publicProfileDetail = {
+  id: 12,
+  username: 'Aylin',
+  total_points: 30,
+  published_story_count: 4,
+  date_joined: '2025-02-10T10:00:00Z',
+  bio: 'I write about harbor neighborhoods.',
+  location: 'Izmir',
+  birth_year: 1988,
 };
 
 function installAuthTransport() {
@@ -111,6 +138,39 @@ function installAuthTransport() {
       return {
         status: 200,
         data: { results: [] } as never,
+        config,
+      };
+    }
+
+    if (method === 'GET' && config.url === '/users/me/') {
+      return {
+        status: 200,
+        data: profileDetail as never,
+        config,
+      };
+    }
+
+    if (method === 'GET' && config.url === '/users/12/') {
+      return {
+        status: 200,
+        data: publicProfileDetail as never,
+        config,
+      };
+    }
+
+    if (method === 'GET' && config.url?.startsWith('/stories/?')) {
+      return {
+        status: 200,
+        data: {
+          count: feedResults.length,
+          next: null,
+          previous: null,
+          results: feedResults.map((story) => ({
+            ...story,
+            user: 1,
+            narrative: 'A story about the harbor.',
+          })),
+        } as never,
         config,
       };
     }
@@ -243,6 +303,25 @@ describe('RootNavigator auth flow', () => {
     await waitFor(() => {
       expect(screen.getByLabelText('Search stories')).toBeTruthy();
       expect(screen.getByLabelText('Read story: Harbor Memory')).toBeTruthy();
+    });
+  });
+
+  it('opens a public profile from the contributor name on story detail', async () => {
+    render(
+      <AppProviders>
+        <RootNavigator />
+      </AppProviders>,
+    );
+
+    await screen.findByLabelText('Read story: Harbor Memory');
+    fireEvent.press(screen.getByLabelText('Read story: Harbor Memory'));
+
+    expect(await screen.findByText('Harbor Memory')).toBeTruthy();
+    fireEvent.press(screen.getByLabelText('Open profile: Aylin'));
+
+    await waitFor(() => {
+      expect(screen.getByText('User profile')).toBeTruthy();
+      expect(screen.getByText('I write about harbor neighborhoods.')).toBeTruthy();
     });
   });
 });

--- a/mobile/src/app/navigation/__tests__/linking.test.ts
+++ b/mobile/src/app/navigation/__tests__/linking.test.ts
@@ -1,11 +1,24 @@
-import { getStoryIdFromPath, getStoryPath, linking } from '../linking';
+import {
+  getProfilePath,
+  getStoryIdFromPath,
+  getStoryPath,
+  getUserIdFromProfilePath,
+  getUserProfilePath,
+  linking,
+} from '../linking';
 
 describe('linking', () => {
-  it('defines the story detail route pattern', () => {
+  it('defines the profile and story route patterns', () => {
+    expect(linking.config.screens.Profile).toBe('profile');
+    expect(linking.config.screens.UserProfile).toBe('users/:id');
     expect(linking.config.screens.StoryDetail).toBe('stories/:id');
   });
 
-  it('builds and parses story paths', () => {
+  it('builds and parses profile and story paths', () => {
+    expect(getProfilePath()).toBe('/profile');
+    expect(getUserProfilePath('42')).toBe('/users/42');
+    expect(getUserIdFromProfilePath('/users/42')).toBe('42');
+    expect(getUserIdFromProfilePath('/profile')).toBeNull();
     expect(getStoryPath('story-001')).toBe('/stories/story-001');
     expect(getStoryIdFromPath('/stories/story-001')).toBe('story-001');
     expect(getStoryIdFromPath('/feed/story-001')).toBeNull();

--- a/mobile/src/app/navigation/linking.ts
+++ b/mobile/src/app/navigation/linking.ts
@@ -2,13 +2,29 @@ export const linking = {
   prefixes: [],
   config: {
     screens: {
+      Profile: 'profile',
+      UserProfile: 'users/:id',
       StoryDetail: 'stories/:id',
     },
   },
 };
 
+export function getProfilePath() {
+  return '/profile';
+}
+
+export function getUserProfilePath(userId: string) {
+  return `/users/${userId}`;
+}
+
 export function getStoryPath(storyId: string) {
   return `/stories/${storyId}`;
+}
+
+export function getUserIdFromProfilePath(path: string) {
+  const match = path.match(/^\/users\/([^/]+)$/);
+
+  return match?.[1] ?? null;
 }
 
 export function getStoryIdFromPath(path: string) {

--- a/mobile/src/app/navigation/routes.ts
+++ b/mobile/src/app/navigation/routes.ts
@@ -12,6 +12,7 @@ export const ROUTES = {
   NOTIFICATIONS: 'Notifications',
   REGISTER: 'register',
   PROFILE: 'Profile',
+  USER_PROFILE: 'UserProfile',
 } as const;
 
 export type AppRoute = (typeof ROUTES)[keyof typeof ROUTES];

--- a/mobile/src/core/api/client.ts
+++ b/mobile/src/core/api/client.ts
@@ -2,7 +2,7 @@ import { env } from '../../app/config/env';
 import { AppError } from '../errors/AppError';
 import { ApiRequestConfig, ApiResponse, interceptors } from './interceptors';
 
-type HttpMethod = 'GET' | 'POST' | 'PUT' | 'DELETE';
+type HttpMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE';
 type ApiTransport = <T>(method: HttpMethod, config: ApiRequestConfig) => Promise<ApiResponse<T>>;
 type RequestConfigInput = Omit<ApiRequestConfig, 'url' | 'data'> & { token?: string };
 const REQUEST_TIMEOUT_MS = 15000;
@@ -191,6 +191,12 @@ export const apiClient = {
     tokenOrConfig?: string | RequestConfigInput,
   ) =>
     request<T>('PUT', url, { ...normalizeConfig(tokenOrConfig), data }),
+  patch: async <T>(
+    url: string,
+    data?: unknown,
+    tokenOrConfig?: string | RequestConfigInput,
+  ) =>
+    request<T>('PATCH', url, { ...normalizeConfig(tokenOrConfig), data }),
   delete: async <T>(url: string, tokenOrConfig?: string | RequestConfigInput) =>
     request<T>('DELETE', url, normalizeConfig(tokenOrConfig)),
 };

--- a/mobile/src/features/auth/application/services/index.ts
+++ b/mobile/src/features/auth/application/services/index.ts
@@ -17,6 +17,9 @@ export const authService = {
   async logout(session?: AuthSessionEntity | null): Promise<void> {
     return repository.logout(session);
   },
+  async updateUser(user: AuthSessionEntity['user']): Promise<AuthSessionEntity | null> {
+    return repository.updateUser(user);
+  },
   async clear(): Promise<void> {
     return repository.clear();
   },

--- a/mobile/src/features/auth/context/AuthContext.tsx
+++ b/mobile/src/features/auth/context/AuthContext.tsx
@@ -27,6 +27,7 @@ interface AuthContextValue {
   login: (input: LoginInput) => Promise<Session>;
   register: (input: RegisterUserInput) => Promise<RegisterUserResult>;
   logout: () => Promise<void>;
+  updateUser: (user: Partial<AuthUser>) => Promise<void>;
 }
 
 const AuthContext = createContext<AuthContextValue | null>(null);
@@ -166,6 +167,31 @@ export function AuthProvider({ children }: PropsWithChildren) {
     navigationRef.redirectToPublic?.();
   }, []);
 
+  const updateUser = useCallback(async (userPatch: Partial<AuthUser>) => {
+    const activeSession = sessionRef.current;
+
+    if (!activeSession) {
+      return;
+    }
+
+    const nextUser = {
+      ...activeSession.user,
+      ...userPatch,
+    };
+
+    const nextSession = await authService.updateUser(nextUser);
+
+    if (!nextSession) {
+      return;
+    }
+
+    sessionRef.current = nextSession;
+    setState({
+      isLoading: false,
+      session: nextSession,
+    });
+  }, []);
+
   const value = useMemo<AuthContextValue>(
     () => ({
       user: state.session?.user ?? null,
@@ -174,8 +200,9 @@ export function AuthProvider({ children }: PropsWithChildren) {
       login,
       register,
       logout,
+      updateUser,
     }),
-    [login, logout, register, state.isLoading, state.session],
+    [login, logout, register, state.isLoading, state.session, updateUser],
   );
 
   return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;

--- a/mobile/src/features/auth/context/__tests__/AuthContext.test.tsx
+++ b/mobile/src/features/auth/context/__tests__/AuthContext.test.tsx
@@ -19,7 +19,7 @@ const loginResponse = {
 };
 
 function AuthHarness() {
-  const { user, isAuthenticated, loading, login, register, logout } = useAuth();
+  const { user, isAuthenticated, loading, login, register, logout, updateUser } = useAuth();
 
   const handleRequest = async () => {
     try {
@@ -45,6 +45,9 @@ function AuthHarness() {
       </Pressable>
       <Pressable onPress={() => logout()}>
         <Text>logout</Text>
+      </Pressable>
+      <Pressable onPress={() => updateUser({ username: 'Traveler Updated' })}>
+        <Text>update-user</Text>
       </Pressable>
       <Pressable
         onPress={() =>
@@ -175,6 +178,31 @@ describe('AuthProvider', () => {
       expect(screen.getByText('guest')).toBeTruthy();
     });
     expect(await storage.get(storageKeys.authSession)).toBeNull();
+  });
+
+  it('updates the stored auth user when profile data changes', async () => {
+    installAuthTransport();
+
+    render(
+      <AuthProvider>
+        <AuthHarness />
+      </AuthProvider>,
+    );
+
+    fireEvent.press(await screen.findByText('login'));
+
+    await waitFor(() => {
+      expect(screen.getByText('authenticated')).toBeTruthy();
+    });
+
+    fireEvent.press(screen.getByText('update-user'));
+
+    await waitFor(() => {
+      expect(screen.getByText('Traveler Updated')).toBeTruthy();
+    });
+
+    const storedSession = await storage.get<{ user?: { username?: string } }>(storageKeys.authSession);
+    expect(storedSession?.user?.username).toBe('Traveler Updated');
   });
 
   it('registers without creating a persisted session', async () => {

--- a/mobile/src/features/auth/data/repositories/index.ts
+++ b/mobile/src/features/auth/data/repositories/index.ts
@@ -54,6 +54,25 @@ export class AuthRepositoryImpl implements AuthRepository {
     }
   }
 
+  async updateUser(user: AuthSessionEntity['user']): Promise<AuthSessionEntity | null> {
+    const storedSession = await authLocalSource.getSession();
+
+    if (!storedSession) {
+      return null;
+    }
+
+    const nextSession: AuthSessionEntity = {
+      ...storedSession,
+      user: {
+        ...storedSession.user,
+        ...user,
+      },
+    };
+
+    await authLocalSource.setSession(nextSession);
+    return nextSession;
+  }
+
   async clear(): Promise<void> {
     await authLocalSource.clearSession();
   }

--- a/mobile/src/features/auth/domain/repositories/index.ts
+++ b/mobile/src/features/auth/domain/repositories/index.ts
@@ -16,5 +16,6 @@ export interface AuthRepository {
   register(input: RegisterUserInput): Promise<RegisterUserResult>;
   restore(): Promise<AuthSessionEntity | null>;
   logout(session?: AuthSessionEntity | null): Promise<void>;
+  updateUser(user: AuthSessionEntity['user']): Promise<AuthSessionEntity | null>;
   clear(): Promise<void>;
 }

--- a/mobile/src/features/map/presentation/components/MapCard.tsx
+++ b/mobile/src/features/map/presentation/components/MapCard.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { ActivityIndicator, Pressable, ScrollView, StyleSheet, Text, View } from 'react-native';
+import { ActivityIndicator, LayoutChangeEvent, Pressable, ScrollView, StyleSheet, Text, View } from 'react-native';
 import MapView, { Marker, Region } from 'react-native-maps';
 import { useAppTheme } from '../../../../core/hooks/useAppTheme';
 import { Button } from '../../../../shared/ui/Button';
@@ -13,6 +13,8 @@ interface MapCardProps {
   error?: string;
   onSelectMarker: (markerId: string) => void;
   onOpenStory: (storyId: string) => void;
+  onMarkerPress?: () => void;
+  onPreviewLayout?: (event: LayoutChangeEvent) => void;
 }
 
 const PREVIEW_MAX_LENGTH = 140;
@@ -25,6 +27,8 @@ export function MapCard({
   error,
   onSelectMarker,
   onOpenStory,
+  onMarkerPress,
+  onPreviewLayout,
 }: MapCardProps) {
   const { colors, spacing, typography } = useAppTheme();
   const selectedMarker = markers.find((marker) => marker.id === selectedMarkerId) ?? markers[0];
@@ -56,7 +60,10 @@ export function MapCard({
             <Marker
               key={marker.id}
               coordinate={{ latitude: marker.latitude, longitude: marker.longitude }}
-              onPress={() => onSelectMarker(marker.id)}
+              onPress={() => {
+                onSelectMarker(marker.id);
+                onMarkerPress?.();
+              }}
               testID="story-marker"
             >
               <View
@@ -154,7 +161,7 @@ export function MapCard({
         ) : null}
       </View>
 
-      <View style={{ padding: spacing.lg, gap: spacing.md }}>
+      <View testID="story-preview-panel" style={{ padding: spacing.lg, gap: spacing.md }} onLayout={onPreviewLayout}>
         <Text style={{ color: colors.text, fontSize: typography.subtitle, fontWeight: '800' }}>
           {selectedMarker?.isCluster ? `${selectedMarker.count} nearby stories` : 'Story preview'}
         </Text>

--- a/mobile/src/features/map/presentation/screens/MapScreen.tsx
+++ b/mobile/src/features/map/presentation/screens/MapScreen.tsx
@@ -1,5 +1,5 @@
-import React, { useEffect, useMemo, useState } from 'react';
-import { Text, View } from 'react-native';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
+import { LayoutChangeEvent, Text, View } from 'react-native';
 import { Region } from 'react-native-maps';
 import { useAppTheme } from '../../../../core/hooks/useAppTheme';
 import { StoryFilters } from '../../../stories/domain/repositories';
@@ -15,6 +15,7 @@ interface MapScreenProps {
   initialFilters?: StoryFilters;
   onOpenStory?: (storyId: string) => void;
   getMarkerGroups?: (filters?: StoryFilters) => Promise<MapMarkerGroup[]>;
+  onMarkerPreviewRequested?: (targetY: number) => void;
 }
 
 const EMPTY_FILTERS: StoryFilters = {};
@@ -30,11 +31,14 @@ export function MapScreen({
   initialFilters = EMPTY_FILTERS,
   onOpenStory,
   getMarkerGroups = mapService.getMarkerGroups,
+  onMarkerPreviewRequested,
 }: MapScreenProps) {
   const { colors, spacing, typography } = useAppTheme();
   const { filters, isHydrated } = useSearchFilters();
   const debouncedQuery = useDebounce(filters.query, 350);
   const [state, setState] = useState<MapUiState>(() => createInitialMapUiState(initialFilters));
+  const [mapCardTop, setMapCardTop] = useState(0);
+  const previewOffsetRef = useRef<number | null>(null);
 
   const activeFilters = useMemo<StoryFilters>(
     () => ({
@@ -109,6 +113,20 @@ export function MapScreen({
     return parts;
   }, [state.filters]);
 
+  function handlePreviewLayout(event: LayoutChangeEvent) {
+    previewOffsetRef.current = event.nativeEvent.layout.y;
+  }
+
+  function handleMarkerPreviewRequest() {
+    const previewOffset = previewOffsetRef.current;
+
+    if (previewOffset == null) {
+      return;
+    }
+
+    onMarkerPreviewRequested?.(mapCardTop + previewOffset);
+  }
+
   return (
     <View style={{ gap: spacing.md }}>
       <StorySearchControls helperText="Search by title or place." />
@@ -130,7 +148,11 @@ export function MapScreen({
         </Text>
       </View>
 
-      <View style={{ minHeight: 420 }}>
+      <View
+        testID="map-card-container"
+        style={{ minHeight: 420 }}
+        onLayout={(event) => setMapCardTop(event.nativeEvent.layout.y)}
+      >
         <MapCard
           region={ISTANBUL_REGION}
           markers={state.markers}
@@ -139,6 +161,8 @@ export function MapScreen({
           error={state.error}
           onSelectMarker={(markerId) => setState((current) => ({ ...current, selectedMarkerId: markerId }))}
           onOpenStory={(storyId) => onOpenStory?.(storyId)}
+          onMarkerPress={handleMarkerPreviewRequest}
+          onPreviewLayout={handlePreviewLayout}
         />
       </View>
     </View>

--- a/mobile/src/features/map/presentation/screens/__tests__/MapScreen.test.tsx
+++ b/mobile/src/features/map/presentation/screens/__tests__/MapScreen.test.tsx
@@ -119,6 +119,28 @@ describe('MapScreen', () => {
     expect(screen.getByText('Voices of the Ferry Pier')).toBeTruthy();
   });
 
+  it('requests scrolling to the preview when a marker is pressed', async () => {
+    const onMarkerPreviewRequested = jest.fn();
+
+    renderScreen(
+      <MapScreen
+        getMarkerGroups={async () => markerGroups}
+        onMarkerPreviewRequested={onMarkerPreviewRequested}
+      />,
+    );
+
+    await screen.findByText('The Day the Harbor Fell Silent');
+    fireEvent(screen.getByTestId('map-card-container'), 'layout', {
+      nativeEvent: { layout: { x: 0, y: 240, width: 100, height: 100 } },
+    });
+    fireEvent(screen.getByTestId('story-preview-panel'), 'layout', {
+      nativeEvent: { layout: { x: 0, y: 420, width: 100, height: 100 } },
+    });
+    fireEvent.press(screen.getAllByTestId('story-marker')[1]);
+
+    expect(onMarkerPreviewRequested).toHaveBeenCalledWith(660);
+  });
+
   it('refetches markers when filters change', async () => {
     const getMarkerGroups = jest.fn<Promise<MapMarkerGroup[]>, [any]>().mockResolvedValue(markerGroups);
 

--- a/mobile/src/features/profile/application/services/__tests__/userService.test.ts
+++ b/mobile/src/features/profile/application/services/__tests__/userService.test.ts
@@ -1,0 +1,171 @@
+import { resetApiTransport, setApiTransport } from '../../../../../core/api/client';
+import { interceptors } from '../../../../../core/api/interceptors';
+import { userService } from '../index';
+
+describe('userService', () => {
+  beforeEach(() => {
+    interceptors.clear();
+    resetApiTransport();
+  });
+
+  afterEach(() => {
+    resetApiTransport();
+  });
+
+  it('fetches the authenticated profile from /users/me/', async () => {
+    setApiTransport(async (method: any, config: any) => {
+      if (method === 'GET' && config.url === '/users/me/') {
+        return {
+          status: 200,
+          data: {
+            success: true,
+            data: {
+              id: 7,
+              username: 'Traveler',
+              email: 'traveler@example.com',
+              total_points: 5,
+              date_joined: '2026-01-15T10:00:00Z',
+              profile: {
+                bio: 'Collecting neighborhood memories.',
+                location: 'Istanbul',
+              },
+            },
+          } as never,
+          config,
+        };
+      }
+
+      if (method === 'GET' && config.url === '/users/7/') {
+        return {
+          status: 200,
+          data: {
+            id: 7,
+            username: 'Traveler',
+            total_points: 5,
+            published_story_count: 3,
+            location: 'Istanbul',
+            bio: 'Collecting neighborhood memories.',
+          } as never,
+          config,
+        };
+      }
+
+      throw new Error(`Unexpected request: ${method} ${config.url}`);
+    });
+
+    await expect(userService.getCurrentProfile()).resolves.toMatchObject({
+      id: '7',
+      username: 'Traveler',
+      email: 'traveler@example.com',
+      location: 'Istanbul',
+      publishedStoryCount: 3,
+    });
+  });
+
+  it('fetches a public profile from /users/:id', async () => {
+    setApiTransport(async (method: any, config: any) => {
+      if (method === 'GET' && config.url === '/users/12/') {
+        return {
+          status: 200,
+          data: {
+            id: 12,
+            username: 'Aylin',
+            total_points: 9,
+            published_story_count: 4,
+            location: 'Izmir',
+            bio: 'Historian',
+            birth_year: 1988,
+          } as never,
+          config,
+        };
+      }
+
+      throw new Error(`Unexpected request: ${method} ${config.url}`);
+    });
+
+    await expect(userService.getPublicProfile('12')).resolves.toMatchObject({
+      id: '12',
+      username: 'Aylin',
+      publishedStoryCount: 4,
+      birthYear: 1988,
+    });
+  });
+
+  it('updates the authenticated profile via PATCH /users/me/', async () => {
+    setApiTransport(async (method: any, config: any) => {
+      if (method === 'PATCH' && config.url === '/users/me/') {
+        expect(config.data).toMatchObject({
+          username: 'Traveler Updated',
+          is_username_public: false,
+          profile: {
+            bio: 'Updated bio',
+            location: 'Ankara',
+            birth_date: '1994-01-01',
+            is_location_public: true,
+            is_birth_date_public: false,
+            is_photo_public: true,
+          },
+        });
+
+        return {
+          status: 200,
+          data: {
+            success: true,
+            data: {
+              id: 7,
+              username: 'Traveler Updated',
+              email: 'traveler@example.com',
+              total_points: 5,
+              is_username_public: false,
+              is_email_verified: true,
+              profile: {
+                bio: 'Updated bio',
+                location: 'Ankara',
+                birth_date: '1994-01-01',
+                is_location_public: true,
+                is_birth_date_public: false,
+                is_photo_public: true,
+              },
+            },
+          } as never,
+          config,
+        };
+      }
+
+      if (method === 'GET' && config.url === '/users/7/') {
+        return {
+          status: 200,
+          data: {
+            id: 7,
+            username: 'Traveler Updated',
+            total_points: 5,
+            published_story_count: 4,
+            location: 'Ankara',
+            bio: 'Updated bio',
+          } as never,
+          config,
+        };
+      }
+
+      throw new Error(`Unexpected request: ${method} ${config.url}`);
+    });
+
+    await expect(
+      userService.updateCurrentProfile({
+        username: 'Traveler Updated',
+        bio: 'Updated bio',
+        location: 'Ankara',
+        birthDate: '1994-01-01',
+        isUsernamePublic: false,
+        isLocationPublic: true,
+        isBirthDatePublic: false,
+        isPhotoPublic: true,
+      }),
+    ).resolves.toMatchObject({
+      username: 'Traveler Updated',
+      location: 'Ankara',
+      isUsernamePublic: false,
+      publishedStoryCount: 4,
+    });
+  });
+});

--- a/mobile/src/features/profile/application/services/index.ts
+++ b/mobile/src/features/profile/application/services/index.ts
@@ -1,1 +1,16 @@
-export const profileService = {};
+import { ProfileRepositoryImpl } from '../../data/repositories';
+import { ProfileEntity, UpdateProfileInput } from '../../domain/entities';
+
+const repository = new ProfileRepositoryImpl();
+
+export const userService = {
+  async getCurrentProfile(): Promise<ProfileEntity> {
+    return repository.getCurrentProfile();
+  },
+  async getPublicProfile(userId: string): Promise<ProfileEntity> {
+    return repository.getPublicProfile(userId);
+  },
+  async updateCurrentProfile(input: UpdateProfileInput): Promise<ProfileEntity> {
+    return repository.updateCurrentProfile(input);
+  },
+};

--- a/mobile/src/features/profile/data/repositories/index.ts
+++ b/mobile/src/features/profile/data/repositories/index.ts
@@ -1,1 +1,131 @@
-export class ProfileRepositoryImpl {}
+import { ProfileEntity, UpdateProfileInput } from '../../domain/entities';
+import { ProfileRepository } from '../../domain/repositories';
+import { profileRemoteSource } from '../sources';
+
+function asString(value: unknown) {
+  if (typeof value === 'string') {
+    return value;
+  }
+
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return String(value);
+  }
+
+  return '';
+}
+
+function asNumber(value: unknown) {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return value;
+  }
+
+  if (typeof value === 'string' && value.trim().length > 0) {
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : 0;
+  }
+
+  return 0;
+}
+
+function asNullableString(value: unknown) {
+  return typeof value === 'string' && value.length > 0 ? value : null;
+}
+
+function asNullableNumber(value: unknown) {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return value;
+  }
+
+  if (typeof value === 'string' && value.trim().length > 0) {
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : null;
+  }
+
+  return null;
+}
+
+function mapCurrentProfile(profile: Record<string, unknown>): ProfileEntity {
+  const nestedProfile =
+    profile.profile && typeof profile.profile === 'object'
+      ? (profile.profile as Record<string, unknown>)
+      : {};
+
+  return {
+    id: asString(profile.id),
+    username: asNullableString(profile.username),
+    email: asNullableString(profile.email),
+    totalPoints: asNumber(profile.total_points),
+    dateJoined: asString(profile.date_joined) || undefined,
+    bio: asNullableString(nestedProfile.bio),
+    location: asNullableString(nestedProfile.location),
+    birthDate: asNullableString(nestedProfile.birth_date),
+    profilePhoto: asNullableString(nestedProfile.profile_photo),
+    isUsernamePublic: Boolean(profile.is_username_public),
+    isEmailVerified: Boolean(profile.is_email_verified),
+    isLocationPublic: nestedProfile.is_location_public === undefined ? undefined : Boolean(nestedProfile.is_location_public),
+    isBirthDatePublic:
+      nestedProfile.is_birth_date_public === undefined ? undefined : Boolean(nestedProfile.is_birth_date_public),
+    isPhotoPublic: nestedProfile.is_photo_public === undefined ? undefined : Boolean(nestedProfile.is_photo_public),
+  };
+}
+
+function mergePublishedStoryCount(profile: ProfileEntity, publishedStoryCount?: number) {
+  return {
+    ...profile,
+    publishedStoryCount:
+      typeof publishedStoryCount === 'number' && Number.isFinite(publishedStoryCount)
+        ? publishedStoryCount
+        : profile.publishedStoryCount,
+  };
+}
+
+function mapPublicProfile(profile: Record<string, unknown>): ProfileEntity {
+  return {
+    id: asString(profile.id),
+    username: asNullableString(profile.username),
+    totalPoints: asNumber(profile.total_points),
+    dateJoined: asString(profile.date_joined) || undefined,
+    publishedStoryCount: asNumber(profile.published_story_count),
+    bio: asNullableString(profile.bio),
+    location: asNullableString(profile.location),
+    birthYear: asNullableNumber(profile.birth_year),
+    profilePhoto: asNullableString(profile.profile_photo),
+  };
+}
+
+export class ProfileRepositoryImpl implements ProfileRepository {
+  async getCurrentProfile(): Promise<ProfileEntity> {
+    const profile = await profileRemoteSource.getCurrentProfile();
+    const mappedProfile = mapCurrentProfile(profile);
+
+    try {
+      const publicProfile = await profileRemoteSource.getPublicProfile(mappedProfile.id);
+      return mergePublishedStoryCount(
+        mappedProfile,
+        asNumber(publicProfile.published_story_count),
+      );
+    } catch {
+      return mappedProfile;
+    }
+  }
+
+  async getPublicProfile(userId: string): Promise<ProfileEntity> {
+    const profile = await profileRemoteSource.getPublicProfile(userId);
+    return mapPublicProfile(profile);
+  }
+
+  async updateCurrentProfile(input: UpdateProfileInput): Promise<ProfileEntity> {
+    const profile = await profileRemoteSource.updateCurrentProfile(input);
+    const mappedProfile = mapCurrentProfile(profile);
+
+    try {
+      const publicProfile = await profileRemoteSource.getPublicProfile(mappedProfile.id);
+      return mergePublishedStoryCount(
+        mappedProfile,
+        asNumber(publicProfile.published_story_count),
+      );
+    } catch {
+      return mappedProfile;
+    }
+  }
+}

--- a/mobile/src/features/profile/data/sources/index.ts
+++ b/mobile/src/features/profile/data/sources/index.ts
@@ -1,2 +1,58 @@
-export const profileRemoteSource = {};
+import { apiClient } from '../../../../core/api/client';
+import { UpdateProfileInput } from '../../domain/entities';
+
+interface CurrentUserProfilePayload {
+  success?: boolean;
+  data?: unknown;
+}
+
+function unwrapCurrentUser(payload: CurrentUserProfilePayload | null) {
+  if (!payload?.data || typeof payload.data !== 'object') {
+    throw new Error('Profile response did not include user data.');
+  }
+
+  return payload.data as Record<string, unknown>;
+}
+
+function normalizePatchPayload(input: UpdateProfileInput) {
+  return {
+    username: input.username.trim(),
+    is_username_public: input.isUsernamePublic,
+    profile: {
+      bio: input.bio.trim(),
+      location: input.location.trim(),
+      birth_date: input.birthDate.trim() || null,
+      is_location_public: input.isLocationPublic,
+      is_birth_date_public: input.isBirthDatePublic,
+      is_photo_public: input.isPhotoPublic,
+    },
+  };
+}
+
+export const profileRemoteSource = {
+  async getCurrentProfile() {
+    const response = await apiClient.get<CurrentUserProfilePayload>('/users/me/');
+    return unwrapCurrentUser(response);
+  },
+
+  async getPublicProfile(userId: string) {
+    const response = await apiClient.get<Record<string, unknown>>(`/users/${userId}/`);
+
+    if (!response || typeof response !== 'object') {
+      throw new Error('Public profile response did not include profile data.');
+    }
+
+    return response;
+  },
+
+  async updateCurrentProfile(input: UpdateProfileInput) {
+    const response = await apiClient.patch<CurrentUserProfilePayload>(
+      '/users/me/',
+      normalizePatchPayload(input),
+    );
+
+    return unwrapCurrentUser(response);
+  },
+};
+
 export const profileLocalSource = {};

--- a/mobile/src/features/profile/domain/entities/index.ts
+++ b/mobile/src/features/profile/domain/entities/index.ts
@@ -1,3 +1,29 @@
 export interface ProfileEntity {
   id: string;
+  username: string | null;
+  email?: string | null;
+  totalPoints: number;
+  dateJoined?: string;
+  publishedStoryCount?: number;
+  bio?: string | null;
+  location?: string | null;
+  birthDate?: string | null;
+  birthYear?: number | null;
+  profilePhoto?: string | null;
+  isUsernamePublic?: boolean;
+  isEmailVerified?: boolean;
+  isLocationPublic?: boolean;
+  isBirthDatePublic?: boolean;
+  isPhotoPublic?: boolean;
+}
+
+export interface UpdateProfileInput {
+  username: string;
+  isUsernamePublic: boolean;
+  bio: string;
+  location: string;
+  birthDate: string;
+  isLocationPublic: boolean;
+  isBirthDatePublic: boolean;
+  isPhotoPublic: boolean;
 }

--- a/mobile/src/features/profile/domain/repositories/index.ts
+++ b/mobile/src/features/profile/domain/repositories/index.ts
@@ -1,3 +1,7 @@
+import { ProfileEntity, UpdateProfileInput } from '../entities';
+
 export interface ProfileRepository {
-  placeholder(): Promise<void>;
+  getCurrentProfile(): Promise<ProfileEntity>;
+  getPublicProfile(userId: string): Promise<ProfileEntity>;
+  updateCurrentProfile(input: UpdateProfileInput): Promise<ProfileEntity>;
 }

--- a/mobile/src/features/profile/presentation/screens/ProfileScreen.tsx
+++ b/mobile/src/features/profile/presentation/screens/ProfileScreen.tsx
@@ -1,26 +1,500 @@
-import React from 'react';
-import { Text, View } from 'react-native';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import { Pressable, ScrollView, Text, View } from 'react-native';
 import { useAppTheme } from '../../../../core/hooks/useAppTheme';
+import { Button, ErrorState, Input, Loader, Skeleton } from '../../../../shared';
+import { useAuth } from '../../../auth';
+import { userService } from '../../application/services';
+import { ProfileEntity, UpdateProfileInput } from '../../domain/entities';
 
-export function ProfileScreen() {
+type ProfileMode = 'self' | 'public';
+
+interface ProfileScreenProps {
+  mode?: ProfileMode;
+  userId?: string;
+  getCurrentProfile?: typeof userService.getCurrentProfile;
+  getPublicProfile?: typeof userService.getPublicProfile;
+  updateCurrentProfile?: typeof userService.updateCurrentProfile;
+}
+
+interface ProfileFormState {
+  username: string;
+  bio: string;
+  location: string;
+  birthDate: string;
+  isUsernamePublic: boolean;
+  isLocationPublic: boolean;
+  isBirthDatePublic: boolean;
+  isPhotoPublic: boolean;
+}
+
+function formatJoinedDate(value?: string) {
+  if (!value) {
+    return undefined;
+  }
+
+  const parsedDate = new Date(value);
+
+  if (Number.isNaN(parsedDate.getTime())) {
+    return undefined;
+  }
+
+  return parsedDate.toLocaleDateString('en-US', {
+    month: 'long',
+    year: 'numeric',
+  });
+}
+
+function createFormState(profile?: ProfileEntity | null): ProfileFormState {
+  return {
+    username: profile?.username ?? '',
+    bio: profile?.bio ?? '',
+    location: profile?.location ?? '',
+    birthDate: profile?.birthDate ?? '',
+    isUsernamePublic: profile?.isUsernamePublic ?? true,
+    isLocationPublic: profile?.isLocationPublic ?? true,
+    isBirthDatePublic: profile?.isBirthDatePublic ?? true,
+    isPhotoPublic: profile?.isPhotoPublic ?? true,
+  };
+}
+
+function areFormStatesEqual(left: ProfileFormState, right: ProfileFormState) {
+  return (
+    left.username === right.username &&
+    left.bio === right.bio &&
+    left.location === right.location &&
+    left.birthDate === right.birthDate &&
+    left.isUsernamePublic === right.isUsernamePublic &&
+    left.isLocationPublic === right.isLocationPublic &&
+    left.isBirthDatePublic === right.isBirthDatePublic &&
+    left.isPhotoPublic === right.isPhotoPublic
+  );
+}
+
+function LoadingState() {
+  const { colors, spacing } = useAppTheme();
+
+  return (
+    <View accessibilityLabel="Loading profile" style={{ flex: 1, gap: spacing.md }}>
+      <View
+        style={{
+          padding: spacing.lg,
+          borderRadius: 20,
+          borderWidth: 1,
+          borderColor: colors.border,
+          backgroundColor: colors.surface,
+          gap: spacing.md,
+        }}
+      >
+        <Skeleton width="50%" height={26} />
+        <Skeleton width="65%" />
+        <Skeleton width="42%" />
+        <Skeleton width="100%" height={72} />
+      </View>
+    </View>
+  );
+}
+
+function ToggleRow({
+  label,
+  value,
+  disabled = false,
+  onToggle,
+}: {
+  label: string;
+  value: boolean;
+  disabled?: boolean;
+  onToggle?: () => void;
+}) {
   const { colors, spacing, typography } = useAppTheme();
 
   return (
     <View
       style={{
+        flexDirection: 'row',
+        alignItems: 'center',
+        justifyContent: 'space-between',
+        gap: spacing.md,
+      }}
+    >
+      <Text style={{ flex: 1, color: colors.text, fontSize: typography.body }}>{label}</Text>
+      <Pressable
+        accessibilityRole="switch"
+        accessibilityState={{ checked: value, disabled }}
+        disabled={disabled}
+        onPress={disabled ? undefined : onToggle}
+        style={{
+          paddingHorizontal: spacing.md,
+          paddingVertical: spacing.sm,
+          borderRadius: 999,
+          borderWidth: 1,
+          borderColor: value ? colors.primary : colors.border,
+          backgroundColor: value ? colors.infoSurface : colors.surface,
+        }}
+      >
+        <Text style={{ color: value ? colors.primary : colors.text, fontWeight: '700' }}>
+          {value ? 'Public' : 'Private'}
+        </Text>
+      </Pressable>
+    </View>
+  );
+}
+
+function StatChip({ label, value }: { label: string; value: string }) {
+  const { colors, spacing, typography } = useAppTheme();
+
+  return (
+    <View
+      style={{
+        minWidth: 120,
         padding: spacing.md,
         borderRadius: 16,
         borderWidth: 1,
         borderColor: colors.border,
         backgroundColor: colors.background,
+        gap: spacing.xs,
       }}
     >
-      <Text style={{ color: colors.text, fontSize: typography.subtitle, fontWeight: '700' }}>
-        Profile screen placeholder
+      <Text style={{ color: colors.muted, fontSize: typography.caption, textTransform: 'uppercase' }}>
+        {label}
       </Text>
-      <Text style={{ marginTop: spacing.sm, color: colors.muted }}>
-        This area is now protected by the shared auth state and is ready for real profile data.
-      </Text>
+      <Text style={{ color: colors.text, fontSize: typography.subtitle, fontWeight: '800' }}>{value}</Text>
     </View>
+  );
+}
+
+export function ProfileScreen({
+  mode = 'self',
+  userId,
+  getCurrentProfile = userService.getCurrentProfile,
+  getPublicProfile = userService.getPublicProfile,
+  updateCurrentProfile = userService.updateCurrentProfile,
+}: ProfileScreenProps) {
+  const { user, updateUser } = useAuth();
+  const { colors, spacing, typography } = useAppTheme();
+  const isSelfMode = mode === 'self';
+  const [profile, setProfile] = useState<ProfileEntity | null>(null);
+  const [formState, setFormState] = useState<ProfileFormState>(createFormState());
+  const [isLoading, setIsLoading] = useState(true);
+  const [isSaving, setIsSaving] = useState(false);
+  const [isEditing, setIsEditing] = useState(false);
+  const [error, setError] = useState<string>();
+  const [saveMessage, setSaveMessage] = useState<string>();
+
+  const loadProfile = useCallback(async () => {
+    setIsLoading(true);
+    setError(undefined);
+    setSaveMessage(undefined);
+
+    try {
+      const nextProfile = isSelfMode
+        ? await getCurrentProfile()
+        : await getPublicProfile(userId ?? '');
+
+      setProfile(nextProfile);
+      setFormState(createFormState(nextProfile));
+      setIsEditing(false);
+    } catch (loadError) {
+      setError(loadError instanceof Error ? loadError.message : 'Unable to load this profile.');
+    } finally {
+      setIsLoading(false);
+    }
+  }, [getCurrentProfile, getPublicProfile, isSelfMode, userId]);
+
+  useEffect(() => {
+    if (!isSelfMode && !userId) {
+      setIsLoading(false);
+      setError('A user id is required to open this public profile.');
+      return;
+    }
+
+    void loadProfile();
+  }, [isSelfMode, loadProfile, userId]);
+
+  const handleSave = useCallback(async () => {
+    const payload: UpdateProfileInput = {
+      username: formState.username,
+      bio: formState.bio,
+      location: formState.location,
+      birthDate: formState.birthDate,
+      isUsernamePublic: formState.isUsernamePublic,
+      isLocationPublic: formState.isLocationPublic,
+      isBirthDatePublic: formState.isBirthDatePublic,
+      isPhotoPublic: formState.isPhotoPublic,
+    };
+
+    setIsSaving(true);
+    setError(undefined);
+    setSaveMessage(undefined);
+
+    try {
+      const updatedProfile = await updateCurrentProfile(payload);
+      setProfile(updatedProfile);
+      setFormState(createFormState(updatedProfile));
+      await updateUser({
+        username: updatedProfile.username ?? user?.username ?? '',
+      });
+      setSaveMessage('Profile updated successfully.');
+    } catch (saveError) {
+      setError(saveError instanceof Error ? saveError.message : 'Unable to save your profile.');
+    } finally {
+      setIsSaving(false);
+    }
+  }, [formState, updateCurrentProfile, updateUser, user?.username]);
+
+  const title = useMemo(() => {
+    if (isSelfMode) {
+      return 'Your profile';
+    }
+
+    return 'User profile';
+  }, [isSelfMode]);
+
+  const resolvedName = profile?.username || (isSelfMode ? user?.username : null) || 'Private user';
+  const joinedDate = formatJoinedDate(profile?.dateJoined);
+  const isDirty = useMemo(() => {
+    if (!profile) {
+      return false;
+    }
+
+    return !areFormStatesEqual(formState, createFormState(profile));
+  }, [formState, profile]);
+
+  if (isLoading) {
+    return <LoadingState />;
+  }
+
+  if (error && !profile) {
+    return (
+      <ErrorState
+        title="Profile unavailable"
+        message={error}
+        retryLabel="Try again"
+        onRetry={() => {
+          void loadProfile();
+        }}
+      />
+    );
+  }
+
+  if (!profile) {
+    return <Loader message="Loading profile..." />;
+  }
+
+  return (
+    <ScrollView
+      contentContainerStyle={{
+        paddingBottom: spacing.xl,
+        gap: spacing.lg,
+      }}
+      showsVerticalScrollIndicator={false}
+    >
+      <View
+        style={{
+          padding: spacing.lg,
+          borderRadius: 20,
+          borderWidth: 1,
+          borderColor: colors.border,
+          backgroundColor: colors.surface,
+          gap: spacing.md,
+        }}
+      >
+        <View
+          style={{
+            width: 56,
+            height: 56,
+            borderRadius: 28,
+            alignItems: 'center',
+            justifyContent: 'center',
+            backgroundColor: colors.infoSurface,
+          }}
+        >
+          <Text style={{ color: colors.primary, fontSize: typography.title, fontWeight: '800' }}>
+            {resolvedName.slice(0, 1).toUpperCase()}
+          </Text>
+        </View>
+
+        <View>
+          <Text style={{ color: colors.muted, fontSize: typography.caption, textTransform: 'uppercase' }}>{title}</Text>
+          <Text style={{ marginTop: spacing.xs, color: colors.text, fontSize: typography.title, fontWeight: '800' }}>
+            {resolvedName}
+          </Text>
+          {isSelfMode && profile.email ? (
+            <Text style={{ marginTop: spacing.xs, color: colors.muted }}>{profile.email}</Text>
+          ) : null}
+        </View>
+
+        <View style={{ flexDirection: 'row', flexWrap: 'wrap', gap: spacing.md }}>
+          {joinedDate ? <StatChip label="Joined" value={joinedDate} /> : null}
+          {isSelfMode ? <StatChip label="Points" value={String(profile.totalPoints)} /> : null}
+          <StatChip label="Stories" value={String(profile.publishedStoryCount ?? 0)} />
+          {profile.location ? <StatChip label="Location" value={profile.location} /> : null}
+          {profile.birthYear ? <StatChip label="Birth year" value={String(profile.birthYear)} /> : null}
+        </View>
+
+        {profile.bio ? (
+          <View
+            style={{
+              padding: spacing.md,
+              borderRadius: 16,
+              borderWidth: 1,
+              borderColor: colors.border,
+              backgroundColor: colors.background,
+            }}
+          >
+            <Text style={{ color: colors.muted, fontSize: typography.caption, textTransform: 'uppercase' }}>Bio</Text>
+            <Text style={{ marginTop: spacing.sm, color: colors.text }}>{profile.bio}</Text>
+          </View>
+        ) : null}
+      </View>
+
+      {isSelfMode ? (
+        <View
+          style={{
+            padding: spacing.lg,
+            borderRadius: 20,
+            borderWidth: 1,
+            borderColor: colors.border,
+            backgroundColor: colors.surface,
+            gap: spacing.md,
+          }}
+        >
+          <View
+            style={{
+              flexDirection: 'row',
+              alignItems: 'center',
+              justifyContent: 'space-between',
+              gap: spacing.md,
+            }}
+          >
+            <Text style={{ color: colors.text, fontSize: typography.subtitle, fontWeight: '800' }}>
+              Edit profile
+            </Text>
+            <Button
+              onPress={() => {
+                setSaveMessage(undefined);
+                setError(undefined);
+                setIsEditing((current) => {
+                  const nextValue = !current;
+
+                  if (!nextValue) {
+                    setFormState(createFormState(profile));
+                  }
+
+                  return nextValue;
+                });
+              }}
+              style={{ backgroundColor: colors.surface, borderWidth: 1, borderColor: colors.border }}
+            >
+              <Text style={{ color: colors.text, fontWeight: '700' }}>
+                {isEditing ? 'Cancel' : 'Edit profile'}
+              </Text>
+            </Button>
+          </View>
+
+          {saveMessage ? <Text style={{ color: colors.success }}>{saveMessage}</Text> : null}
+
+          {isEditing ? (
+            <>
+              <Input
+                accessibilityLabel="Username"
+                value={formState.username}
+                onChangeText={(value) => {
+                  setSaveMessage(undefined);
+                  setFormState((current) => ({ ...current, username: value }));
+                }}
+                placeholder="Username"
+              />
+              <Input
+                accessibilityLabel="Location"
+                value={formState.location}
+                onChangeText={(value) => {
+                  setSaveMessage(undefined);
+                  setFormState((current) => ({ ...current, location: value }));
+                }}
+                placeholder="Location"
+              />
+              <Input
+                accessibilityLabel="Birth date"
+                value={formState.birthDate}
+                onChangeText={(value) => {
+                  setSaveMessage(undefined);
+                  setFormState((current) => ({ ...current, birthDate: value }));
+                }}
+                placeholder="YYYY-MM-DD"
+              />
+              <Input
+                accessibilityLabel="Bio"
+                value={formState.bio}
+                onChangeText={(value) => {
+                  setSaveMessage(undefined);
+                  setFormState((current) => ({ ...current, bio: value }));
+                }}
+                placeholder="Tell people about yourself"
+                style={{ minHeight: 110, textAlignVertical: 'top' as const }}
+              />
+
+              <ToggleRow
+                label="Show username on your public profile"
+                value={formState.isUsernamePublic}
+                onToggle={() => {
+                  setSaveMessage(undefined);
+                  setFormState((current) => ({ ...current, isUsernamePublic: !current.isUsernamePublic }));
+                }}
+              />
+              <ToggleRow
+                label="Show location publicly"
+                value={formState.isLocationPublic}
+                onToggle={() => {
+                  setSaveMessage(undefined);
+                  setFormState((current) => ({ ...current, isLocationPublic: !current.isLocationPublic }));
+                }}
+              />
+              <ToggleRow
+                label="Show birth date publicly"
+                value={formState.isBirthDatePublic}
+                onToggle={() => {
+                  setSaveMessage(undefined);
+                  setFormState((current) => ({ ...current, isBirthDatePublic: !current.isBirthDatePublic }));
+                }}
+              />
+              <ToggleRow
+                label="Show profile photo publicly"
+                value={formState.isPhotoPublic}
+                onToggle={() => {
+                  setSaveMessage(undefined);
+                  setFormState((current) => ({ ...current, isPhotoPublic: !current.isPhotoPublic }));
+                }}
+              />
+
+              {error ? <Text style={{ color: colors.danger }}>{error}</Text> : null}
+
+              {isDirty || isSaving ? (
+                <Button onPress={() => void handleSave()} disabled={isSaving}>
+                  {isSaving ? 'Saving...' : 'Save changes'}
+                </Button>
+              ) : null}
+            </>
+          ) : null}
+        </View>
+      ) : (
+        <View
+          style={{
+            padding: spacing.lg,
+            borderRadius: 20,
+            borderWidth: 1,
+            borderColor: colors.border,
+            backgroundColor: colors.surface,
+            gap: spacing.sm,
+          }}
+        >
+          <Text style={{ color: colors.text, fontSize: typography.subtitle, fontWeight: '800' }}>
+            Stories
+          </Text>
+          <Text style={{ color: colors.muted }}>
+            Stories are intentionally out of scope for this profile version and will be added later.
+          </Text>
+        </View>
+      )}
+    </ScrollView>
   );
 }

--- a/mobile/src/features/profile/presentation/screens/__tests__/ProfileScreen.test.tsx
+++ b/mobile/src/features/profile/presentation/screens/__tests__/ProfileScreen.test.tsx
@@ -1,0 +1,126 @@
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react-native';
+import { ProfileScreen } from '../ProfileScreen';
+
+jest.mock('../../../../auth', () => ({
+  useAuth: () => ({
+    user: {
+      id: 7,
+      email: 'traveler@example.com',
+      username: 'Traveler',
+      role: 'user',
+    },
+  }),
+}));
+
+const selfProfile = {
+  id: '7',
+  username: 'Traveler',
+  email: 'traveler@example.com',
+  totalPoints: 12,
+  dateJoined: '2026-01-15T10:00:00Z',
+  bio: 'Collecting neighborhood memories.',
+  location: 'Istanbul',
+  birthDate: '1995-05-20',
+  isUsernamePublic: true,
+  isEmailVerified: true,
+  isLocationPublic: true,
+  isBirthDatePublic: false,
+  isPhotoPublic: true,
+};
+
+const publicProfile = {
+  id: '12',
+  username: 'Aylin',
+  totalPoints: 30,
+  publishedStoryCount: 4,
+  dateJoined: '2025-02-10T10:00:00Z',
+  bio: 'I write about harbor neighborhoods.',
+  location: 'Izmir',
+  birthYear: 1988,
+};
+
+describe('ProfileScreen', () => {
+  it('renders a loading state while profile data is being fetched', () => {
+    render(
+      <ProfileScreen
+        getCurrentProfile={() => new Promise(() => undefined)}
+      />,
+    );
+
+    expect(screen.getByLabelText('Loading profile')).toBeTruthy();
+  });
+
+  it('renders self profile data with edit controls', async () => {
+    render(
+      <ProfileScreen
+        mode="self"
+        getCurrentProfile={async () => selfProfile}
+      />,
+    );
+
+    expect(await screen.findByText('Traveler')).toBeTruthy();
+    expect(screen.getByText('traveler@example.com')).toBeTruthy();
+    expect(screen.getByText('Edit profile')).toBeTruthy();
+    expect(screen.getByDisplayValue('Traveler')).toBeTruthy();
+    expect(screen.getByDisplayValue('Istanbul')).toBeTruthy();
+    expect(screen.getByDisplayValue('Collecting neighborhood memories.')).toBeTruthy();
+    expect(screen.getByText('Save changes')).toBeTruthy();
+  });
+
+  it('saves changes in self mode', async () => {
+    const updateCurrentProfile = jest.fn(async () => ({
+      ...selfProfile,
+      username: 'Traveler Updated',
+    }));
+
+    render(
+      <ProfileScreen
+        mode="self"
+        getCurrentProfile={async () => selfProfile}
+        updateCurrentProfile={updateCurrentProfile}
+      />,
+    );
+
+    await screen.findByText('Edit profile');
+    fireEvent.changeText(screen.getByLabelText('Username'), 'Traveler Updated');
+    fireEvent.press(screen.getByText('Save changes'));
+
+    expect(updateCurrentProfile).toHaveBeenCalledWith(
+      expect.objectContaining({
+        username: 'Traveler Updated',
+      }),
+    );
+    expect(await screen.findByText('Profile updated successfully.')).toBeTruthy();
+  });
+
+  it('renders a public profile in read-only mode', async () => {
+    render(
+      <ProfileScreen
+        mode="public"
+        userId="12"
+        getPublicProfile={async () => publicProfile}
+      />,
+    );
+
+    expect(await screen.findByText('Aylin')).toBeTruthy();
+    expect(screen.getByText('4')).toBeTruthy();
+    expect(screen.queryByText('Edit profile')).toBeNull();
+    expect(screen.queryByText('Save changes')).toBeNull();
+    expect(screen.getByText('Stories are intentionally out of scope for this profile version and will be added later.')).toBeTruthy();
+  });
+
+  it('shows an error state when profile loading fails', async () => {
+    render(
+      <ProfileScreen
+        mode="self"
+        getCurrentProfile={async () => {
+          throw new Error('Network error');
+        }}
+      />,
+    );
+
+    expect(await screen.findByText('Profile unavailable')).toBeTruthy();
+    expect(screen.getByText('Network error')).toBeTruthy();
+  });
+});

--- a/mobile/src/features/stories/data/mappers/index.ts
+++ b/mobile/src/features/stories/data/mappers/index.ts
@@ -15,6 +15,7 @@ interface StoryMediaItemRecord {
 
 interface StoryRecord {
   id: string | number;
+  user?: unknown;
   title?: unknown;
   narrative?: unknown;
   status?: unknown;
@@ -251,6 +252,7 @@ export function mapStory(value: unknown): StoryEntity {
 
   return {
     id,
+    contributorUserId: asStringId(story.user),
     title: story.title,
     narrative,
     status,

--- a/mobile/src/features/stories/domain/entities/index.ts
+++ b/mobile/src/features/stories/domain/entities/index.ts
@@ -15,6 +15,7 @@ export interface StoryLocation {
 
 export interface StoryEntity {
   id: string;
+  contributorUserId?: string;
   title: string;
   narrative: string[];
   status: StoryStatus;

--- a/mobile/src/features/stories/presentation/screens/StoryScreen.tsx
+++ b/mobile/src/features/stories/presentation/screens/StoryScreen.tsx
@@ -21,6 +21,7 @@ interface StoryScreenProps {
   session?: Pick<Session, 'role' | 'user'>;
   onRequestLogin?: () => void;
   onGoBack?: () => void;
+  onOpenContributorProfile?: (userId: string) => void;
   getStory?: typeof storyService.getStory;
 }
 
@@ -60,6 +61,49 @@ function StoryMetaRow({ label, value }: { label: string; value: string }) {
         {value}
       </Text>
     </View>
+  );
+}
+
+function StoryMetaActionRow({
+  label,
+  value,
+  onPress,
+}: {
+  label: string;
+  value: string;
+  onPress?: () => void;
+}) {
+  const { colors, spacing, typography } = useAppTheme();
+
+  return (
+    <Pressable
+      accessibilityRole={onPress ? 'button' : undefined}
+      accessibilityLabel={onPress ? `Open profile: ${value}` : undefined}
+      disabled={!onPress}
+      onPress={onPress}
+      style={{
+        width: '48%',
+        padding: spacing.md,
+        borderRadius: 14,
+        backgroundColor: colors.surface,
+        borderWidth: 1,
+        borderColor: colors.border,
+      }}
+    >
+      <Text style={{ color: colors.muted, fontSize: typography.caption, textTransform: 'uppercase' }}>
+        {label}
+      </Text>
+      <Text
+        style={{
+          marginTop: spacing.xs,
+          color: onPress ? colors.primary : colors.text,
+          fontSize: typography.body,
+          fontWeight: '600',
+        }}
+      >
+        {value}
+      </Text>
+    </Pressable>
   );
 }
 
@@ -301,6 +345,7 @@ export function StoryScreen({
   session,
   onRequestLogin,
   onGoBack,
+  onOpenContributorProfile,
   getStory = storyService.getStory,
 }: StoryScreenProps) {
   const { colors, spacing, typography } = useAppTheme();
@@ -531,7 +576,17 @@ export function StoryScreen({
       >
         <StoryMetaRow label="Location" value={story.location.name} />
         <StoryMetaRow label="Time period" value={story.timePeriod} />
-        <StoryMetaRow label="Contributor" value={story.contributorName} />
+        <StoryMetaActionRow
+          label="Contributor"
+          value={story.contributorName}
+          onPress={
+            story.contributorUserId
+              ? () => {
+                  onOpenContributorProfile?.(story.contributorUserId!);
+                }
+              : undefined
+          }
+        />
         <StoryMetaRow label="Submitted" value={formatDate(story.submittedAt)} />
       </View>
 

--- a/mobile/src/features/stories/presentation/screens/__tests__/StoryScreen.test.tsx
+++ b/mobile/src/features/stories/presentation/screens/__tests__/StoryScreen.test.tsx
@@ -31,6 +31,7 @@ jest.mock('../../../../interactions/application/services', () => ({
 
 const baseStory: StoryEntity = {
   id: 'story-001',
+  contributorUserId: '22',
   title: 'The Day the Harbor Fell Silent',
   narrative: [
     'By dusk, the harbor had stopped sounding like work and started sounding like memory.',
@@ -116,6 +117,23 @@ describe('StoryScreen', () => {
     expect(screen.getByText(baseStory.comments[0].body)).toBeTruthy();
     expect(screen.getByText('Story location')).toBeTruthy();
     expect(screen.getByTestId('story-location-map')).toBeTruthy();
+  });
+
+  it('opens the contributor profile when the contributor name is pressed', async () => {
+    const onOpenContributorProfile = jest.fn();
+
+    render(
+      <StoryScreen
+        storyId="story-001"
+        getStory={async () => baseStory}
+        onOpenContributorProfile={onOpenContributorProfile}
+      />,
+    );
+
+    expect(await screen.findByText(baseStory.title)).toBeTruthy();
+    fireEvent.press(screen.getByLabelText(`Open profile: ${baseStory.contributorName}`));
+
+    expect(onOpenContributorProfile).toHaveBeenCalledWith('22');
   });
 
   it('shows an image fallback message when the media fails to load', async () => {


### PR DESCRIPTION
# 📝 Description
Fixes #168 

Implements the mobile profile flow by turning the profile screen into a reusable self/public profile screen, adds editing support for the authenticated user via `/users/me/`, keeps public profile viewing via `/users/:id`, adds contributor-to-profile navigation, and updates the mobile service/auth flow so profile changes are reflected immediately in the UI.

# 📊 Type of Change
- [x] Bug fix
- [x] New feature
- [x] Refactoring
- [ ] Documentation
 
# ✅ Acceptance Criteria / Checklist
- [x] Project builds successfully
- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, especially in hard-to-understand parts
- [x] I have performed a self-review of my code
- [x] I have added/updated tests
- [ ] New and existing unit tests pass locally with my changes

Notes:
- `npm run typecheck` passes in `mobile/`
- Jest test execution in this environment hit Windows/OneDrive `EPERM` cache/rename issues, so I could not fully confirm local test pass status here

# 📸 Screenshots / Recordings
<p>
  <img src="https://github.com/user-attachments/assets/436d0002-a7c6-4486-9fe7-1a793f5ae984" width="220" alt="foto1" />
  <img src="https://github.com/user-attachments/assets/0c768891-7b43-4bee-ad55-db942f8f0297" width="220" alt="foto2" />
  <img src="https://github.com/user-attachments/assets/9e332086-7ec9-40d5-96c4-5dd167bbecb0" width="220" alt="foto3" />
  <img src="https://github.com/user-attachments/assets/dae06123-b02c-434c-bfc8-15e533fa77d2" width="220" alt="foto4" />
</p>

# ⏱️ Estimated Review Time
- [ ] < 5 min
- [ ] 5-15 min
- [x] > 15 min
