### PR TITLE
fix(mobile): resolve map search and filter behavior issues

### DIFF
--- a/mobile/src/app/navigation/RootNavigator.tsx
+++ b/mobile/src/app/navigation/RootNavigator.tsx
@@ -541,8 +541,10 @@ export function RootNavigator() {
       <View style={{ flex: 1 }}>
         <ScrollView
           ref={pagerRef}
+          testID="main-route-pager"
           horizontal
           pagingEnabled
+          contentOffset={{ x: currentRoute === ROUTES.MAP ? 0 : width, y: 0 }}
           showsHorizontalScrollIndicator={false}
           scrollEventThrottle={16}
           onMomentumScrollEnd={(event) => {
@@ -624,7 +626,7 @@ export function RootNavigator() {
             <TopIconButton label="Login" onPress={() => handleNavigate(ROUTES.AUTH)} />
           )}
         </View>
-        {isMainRoute ? <StorySearchControls hideHeading /> : null}
+      {isMainRoute ? <StorySearchControls hideHeading scope={currentRoute === ROUTES.MAP ? 'map' : 'feed'} /> : null}
       </View>
       <View style={{ flex: 1, backgroundColor: colors.background }}>{content}</View>
       {isMainRoute ? (

--- a/mobile/src/app/navigation/__tests__/RootNavigator.test.tsx
+++ b/mobile/src/app/navigation/__tests__/RootNavigator.test.tsx
@@ -205,6 +205,14 @@ describe('RootNavigator auth flow', () => {
     expect(screen.getByLabelText('Submission')).toBeTruthy();
   });
 
+  it('opens the main pager on the feed tab by default', async () => {
+    renderNavigator();
+
+    await waitFor(() => {
+      expect(screen.getByTestId('main-route-pager').props.contentOffset.x).toBeGreaterThan(0);
+    });
+  });
+
   it('allows access to protected screens after login and returns to a public route on logout', async () => {
     renderNavigator();
 
@@ -229,7 +237,7 @@ describe('RootNavigator auth flow', () => {
     });
   });
 
-  it('keeps applied feed filters when navigating to map and back', async () => {
+  it('keeps feed and map search states independent', async () => {
     renderNavigator();
 
     await screen.findByLabelText('Search stories');
@@ -242,10 +250,23 @@ describe('RootNavigator auth flow', () => {
 
     fireEvent.press(screen.getByLabelText('Map'));
     await screen.findByLabelText('Search stories');
+    expect(screen.getByLabelText('Search stories').props.value).toBe('');
+
+    fireEvent.changeText(screen.getByLabelText('Search stories'), 'pier');
+    fireEvent.press(screen.getByLabelText('Apply search'));
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('Search stories').props.value).toBe('pier');
+    });
+
     fireEvent.press(screen.getByLabelText('Feed'));
 
     await screen.findByLabelText('Search stories');
     expect(screen.getByLabelText('Search stories').props.value).toBe('harbor');
+
+    fireEvent.press(screen.getByLabelText('Map'));
+    await screen.findByLabelText('Search stories');
+    expect(screen.getByLabelText('Search stories').props.value).toBe('pier');
   });
 
   it('opens a protected screen after login and returns with the back button', async () => {

--- a/mobile/src/core/storage/keys.ts
+++ b/mobile/src/core/storage/keys.ts
@@ -1,6 +1,8 @@
 export const storageKeys = {
   session: 'session',
   authSession: 'authSession',
-  searchFilters: 'searchFilters',
+  legacySearchFilters: 'searchFilters',
+  feedSearchFilters: 'feedSearchFilters',
+  mapSearchFilters: 'mapSearchFilters',
   draftStory: 'draftStory',
 };

--- a/mobile/src/features/feed/presentation/screens/FeedScreen.tsx
+++ b/mobile/src/features/feed/presentation/screens/FeedScreen.tsx
@@ -20,6 +20,7 @@ interface FeedScreenProps {
   onOpenStory?: (storyId: string) => void;
   getFeed?: typeof storyService.getFeed;
   showSearchControls?: boolean;
+  searchScope?: 'feed' | 'map';
 }
 
 const EMPTY_FILTERS: StoryFilters = {};
@@ -29,10 +30,12 @@ export function FeedScreen({
   onOpenStory,
   getFeed = storyService.getFeed,
   showSearchControls = true,
+  searchScope = 'feed',
 }: FeedScreenProps) {
   const { colors, spacing, typography } = useAppTheme();
-  const { filters, isHydrated, setFilters } = useSearchFilters();
+  const { filters, refreshToken, isHydrated, setFilters } = useSearchFilters(searchScope);
   const debouncedQuery = useDebounce(filters.query, 350);
+  const [useImmediateQuery, setUseImmediateQuery] = useState(false);
   const [state, setState] = useState(() => createInitialFeedUiState(initialFilters));
   const stateRef = useRef(state);
   const hasRequestedNextPage = useRef(false);
@@ -51,9 +54,21 @@ export function FeedScreen({
     setFilters(seedFilters);
   }, [filters, isHydrated, seedFilters, setFilters]);
 
+  useEffect(() => {
+    if (filters.query !== debouncedQuery) {
+      return;
+    }
+
+    setUseImmediateQuery(false);
+  }, [debouncedQuery, filters.query]);
+
+  useEffect(() => {
+    setUseImmediateQuery(true);
+  }, [refreshToken]);
+
   const activeFilters = useMemo<StoryFilters>(
-    () => toSearchParams({ ...filters, query: debouncedQuery }),
-    [debouncedQuery, filters],
+    () => toSearchParams({ ...filters, query: useImmediateQuery ? filters.query : debouncedQuery }),
+    [debouncedQuery, filters, useImmediateQuery],
   );
 
   const hasActiveFilters = Boolean(
@@ -155,7 +170,7 @@ export function FeedScreen({
         </Pressable>
       </View>
 
-      {showSearchControls ? <StorySearchControls helperText="Search by title or place." /> : null}
+      {showSearchControls ? <StorySearchControls helperText="Search by title or place." scope={searchScope} /> : null}
     </View>
   );
 

--- a/mobile/src/features/feed/presentation/screens/__tests__/FeedScreen.test.tsx
+++ b/mobile/src/features/feed/presentation/screens/__tests__/FeedScreen.test.tsx
@@ -187,6 +187,52 @@ describe('FeedScreen', () => {
     expect(screen.getByText('Filters')).toBeTruthy();
   });
 
+  it('closes the filter panel when tapping outside of it', async () => {
+    renderScreen(<FeedScreen getFeed={async () => makeFeedPage()} />);
+
+    await screen.findByText('Story 1');
+    fireEvent.press(screen.getByText('Show filters'));
+
+    expect(screen.getByText('Filters')).toBeTruthy();
+
+    fireEvent.press(screen.getByLabelText('Close filters'));
+
+    await waitFor(() => {
+      expect(screen.queryByText('Filters')).toBeNull();
+    });
+  });
+
+  it('resets only filter fields and preserves the search query', async () => {
+    const getFeed = jest.fn<Promise<FeedPageEntity>, [any]>().mockResolvedValue(makeFeedPage());
+
+    renderScreen(<FeedScreen getFeed={getFeed} />);
+
+    await screen.findByText('Story 1');
+    fireEvent.changeText(screen.getByLabelText('Search stories'), 'harbor');
+    fireEvent.press(screen.getByText('Show filters'));
+    fireEvent.changeText(screen.getByLabelText('Location filter'), 'Istanbul');
+    fireEvent.changeText(screen.getByLabelText('Start year'), '1900');
+    fireEvent.changeText(screen.getByLabelText('End year'), '1950');
+    fireEvent.press(screen.getByText('Reset filter form'));
+    fireEvent.press(screen.getByLabelText('Apply search'));
+
+    await waitFor(() => {
+      expect(getFeed).toHaveBeenLastCalledWith({
+        page: 1,
+        sort: 'recent',
+        filters: {
+          q: 'harbor',
+          location: undefined,
+          yearFrom: undefined,
+          yearTo: undefined,
+        },
+      });
+    });
+
+    expect(screen.getByLabelText('Search stories').props.value).toBe('harbor');
+    expect(screen.queryByText('Location: Istanbul')).toBeNull();
+  });
+
   it('syncs draft filters from incoming initial filters', async () => {
     const getFeed = jest.fn<Promise<FeedPageEntity>, [any]>().mockResolvedValue(makeFeedPage());
     const { rerender } = render(

--- a/mobile/src/features/map/data/repositories/__tests__/MapRepository.test.ts
+++ b/mobile/src/features/map/data/repositories/__tests__/MapRepository.test.ts
@@ -1,0 +1,57 @@
+import { MapRepositoryImpl } from '..';
+import { storyService } from '../../../../stories/application/services';
+
+jest.mock('../../../../stories/application/services', () => ({
+  storyService: {
+    getMapPins: jest.fn(),
+  },
+}));
+
+describe('MapRepositoryImpl', () => {
+  it('returns one marker per story pin without clustering', async () => {
+    const getMapPins = jest.mocked(storyService.getMapPins);
+    getMapPins.mockResolvedValue([
+      {
+        id: 'story-1',
+        title: 'Story 1',
+        placeName: 'Golden Horn',
+        timePeriod: '2021',
+        previewText: 'Preview 1',
+        latitude: 41.02,
+        longitude: 28.96,
+      },
+      {
+        id: 'story-2',
+        title: 'Story 2',
+        placeName: 'Golden Horn',
+        timePeriod: '2022',
+        previewText: 'Preview 2',
+        latitude: 41.0202,
+        longitude: 28.9601,
+      },
+    ]);
+
+    const repository = new MapRepositoryImpl();
+    const markers = await repository.getMarkerGroups({ yearFrom: 2021 });
+
+    expect(markers).toHaveLength(2);
+    expect(markers).toEqual([
+      {
+        id: 'story-1',
+        latitude: 41.02,
+        longitude: 28.96,
+        stories: [expect.objectContaining({ id: 'story-1' })],
+        count: 1,
+        isCluster: false,
+      },
+      {
+        id: 'story-2',
+        latitude: 41.0202,
+        longitude: 28.9601,
+        stories: [expect.objectContaining({ id: 'story-2' })],
+        count: 1,
+        isCluster: false,
+      },
+    ]);
+  });
+});

--- a/mobile/src/features/map/data/repositories/index.ts
+++ b/mobile/src/features/map/data/repositories/index.ts
@@ -2,42 +2,17 @@ import { storyService } from '../../../stories/application/services';
 import { StoryFilters } from '../../../stories/domain/repositories';
 import { MapMarkerGroup } from '../../domain/entities';
 
-const CLUSTER_PRECISION = 350;
-
 export class MapRepositoryImpl {
   async getMarkerGroups(filters: StoryFilters = {}): Promise<MapMarkerGroup[]> {
     const pins = await storyService.getMapPins(filters);
-    const groups = new Map<string, MapMarkerGroup>();
 
-    pins.forEach((pin) => {
-      const latBucket = Math.round(pin.latitude * CLUSTER_PRECISION);
-      const lngBucket = Math.round(pin.longitude * CLUSTER_PRECISION);
-      const key = `${latBucket}:${lngBucket}`;
-      const existing = groups.get(key);
-
-      if (existing) {
-        existing.stories.push(pin);
-        existing.count = existing.stories.length;
-        existing.isCluster = existing.count > 1;
-        existing.latitude = average(existing.stories.map((story) => story.latitude));
-        existing.longitude = average(existing.stories.map((story) => story.longitude));
-        return;
-      }
-
-      groups.set(key, {
-        id: key,
-        latitude: pin.latitude,
-        longitude: pin.longitude,
-        stories: [pin],
-        count: 1,
-        isCluster: false,
-      });
-    });
-
-    return Array.from(groups.values());
+    return pins.map((pin) => ({
+      id: pin.id,
+      latitude: pin.latitude,
+      longitude: pin.longitude,
+      stories: [pin],
+      count: 1,
+      isCluster: false,
+    }));
   }
-}
-
-function average(values: number[]) {
-  return values.reduce((sum, value) => sum + value, 0) / values.length;
 }

--- a/mobile/src/features/map/presentation/components/MapCard.tsx
+++ b/mobile/src/features/map/presentation/components/MapCard.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useMemo, useState } from 'react';
 import { ActivityIndicator, LayoutChangeEvent, Pressable, ScrollView, StyleSheet, Text, View } from 'react-native';
 import MapView, { Marker, Region } from 'react-native-maps';
 import { useAppTheme } from '../../../../core/hooks/useAppTheme';
@@ -32,6 +32,11 @@ export function MapCard({
 }: MapCardProps) {
   const { colors, spacing, typography } = useAppTheme();
   const selectedMarker = markers.find((marker) => marker.id === selectedMarkerId) ?? markers[0];
+  const [currentRegion, setCurrentRegion] = useState(region);
+  const mapContentKey = useMemo(
+    () => (markers.length ? markers.map((marker) => `${marker.id}:${marker.latitude}:${marker.longitude}`).join('|') : 'empty'),
+    [markers],
+  );
 
   return (
     <View
@@ -45,7 +50,8 @@ export function MapCard({
     >
       <View style={{ height: 420 }}>
         <MapView
-          initialRegion={region}
+          key={mapContentKey}
+          initialRegion={currentRegion}
           style={StyleSheet.absoluteFill}
           testID="story-map"
           accessibilityLabel="Interactive story map"
@@ -55,6 +61,7 @@ export function MapCard({
           scrollEnabled
           pitchEnabled
           rotateEnabled
+          onRegionChangeComplete={setCurrentRegion}
         >
           {markers.map((marker) => (
             <Marker

--- a/mobile/src/features/map/presentation/screens/MapScreen.tsx
+++ b/mobile/src/features/map/presentation/screens/MapScreen.tsx
@@ -7,7 +7,7 @@ import { MapMarkerGroup } from '../../domain/entities';
 import { mapService } from '../../application/services';
 import { createInitialMapUiState, MapUiState } from '../state/mapUiState';
 import { MapCard } from '../components/MapCard';
-import { useSearchFilters, toSearchParams } from '../../../search/presentation/context/SearchFiltersContext';
+import { SearchFilterScope, useSearchFilters, toSearchParams } from '../../../search/presentation/context/SearchFiltersContext';
 import { useDebounce } from '../../../../shared/hooks/useDebounce';
 import { StorySearchControls } from '../../../search/presentation/components/StorySearchControls';
 
@@ -18,6 +18,7 @@ interface MapScreenProps {
   onMarkerPreviewRequested?: (targetY: number) => void;
   showSearchControls?: boolean;
   onRegisterRefresh?: (handler: (() => Promise<void>) | null) => void;
+  searchScope?: SearchFilterScope;
 }
 
 const EMPTY_FILTERS: StoryFilters = {};
@@ -36,20 +37,34 @@ export function MapScreen({
   onMarkerPreviewRequested,
   showSearchControls = true,
   onRegisterRefresh,
+  searchScope = 'map',
 }: MapScreenProps) {
   const { colors, spacing, typography } = useAppTheme();
-  const { filters, isHydrated } = useSearchFilters();
+  const { filters, refreshToken, isHydrated } = useSearchFilters(searchScope);
   const debouncedQuery = useDebounce(filters.query, 350);
+  const [useImmediateQuery, setUseImmediateQuery] = useState(false);
   const [state, setState] = useState<MapUiState>(() => createInitialMapUiState(initialFilters));
   const [mapCardTop, setMapCardTop] = useState(0);
   const previewOffsetRef = useRef<number | null>(null);
 
+  useEffect(() => {
+    if (filters.query !== debouncedQuery) {
+      return;
+    }
+
+    setUseImmediateQuery(false);
+  }, [debouncedQuery, filters.query]);
+
+  useEffect(() => {
+    setUseImmediateQuery(true);
+  }, [refreshToken]);
+
   const activeFilters = useMemo<StoryFilters>(
     () => ({
       ...initialFilters,
-      ...toSearchParams({ ...filters, query: debouncedQuery }),
+      ...toSearchParams({ ...filters, query: useImmediateQuery ? filters.query : debouncedQuery }),
     }),
-    [debouncedQuery, filters, initialFilters],
+    [debouncedQuery, filters, initialFilters, useImmediateQuery],
   );
 
   const loadMarkers = React.useCallback(async () => {
@@ -130,7 +145,7 @@ export function MapScreen({
 
   return (
     <View style={{ gap: spacing.md }}>
-      {showSearchControls ? <StorySearchControls helperText="Search by title or place." /> : null}
+      {showSearchControls ? <StorySearchControls helperText="Search by title or place." scope={searchScope} /> : null}
       {activeFilterSummary.length ? <Text style={{ color: colors.muted }}>{activeFilterSummary.join('  |  ')}</Text> : null}
 
       <Text style={{ color: colors.muted, fontSize: typography.caption }}>

--- a/mobile/src/features/map/presentation/screens/__tests__/MapScreen.test.tsx
+++ b/mobile/src/features/map/presentation/screens/__tests__/MapScreen.test.tsx
@@ -159,6 +159,66 @@ describe('MapScreen', () => {
     });
   });
 
+  it('refetches all markers when a chip filter is removed', async () => {
+    const getMarkerGroups = jest.fn<Promise<MapMarkerGroup[]>, [any]>().mockResolvedValue(markerGroups);
+
+    renderScreen(<MapScreen getMarkerGroups={getMarkerGroups} />);
+
+    await screen.findByText('The Day the Harbor Fell Silent');
+    fireEvent.press(screen.getByText('Show filters'));
+    fireEvent.changeText(screen.getByLabelText('Location filter'), 'Golden Horn');
+
+    await waitFor(() => {
+      expect(getMarkerGroups).toHaveBeenLastCalledWith({
+        q: undefined,
+        location: 'Golden Horn',
+        yearFrom: undefined,
+        yearTo: undefined,
+      });
+    });
+
+    fireEvent.press(screen.getByLabelText('Remove Location: Golden Horn'));
+
+    await waitFor(() => {
+      expect(getMarkerGroups).toHaveBeenLastCalledWith({
+        q: undefined,
+        location: undefined,
+        yearFrom: undefined,
+        yearTo: undefined,
+      });
+    });
+  });
+
+  it('refetches all markers when clear all filters is pressed', async () => {
+    const getMarkerGroups = jest.fn<Promise<MapMarkerGroup[]>, [any]>().mockResolvedValue(markerGroups);
+
+    renderScreen(<MapScreen getMarkerGroups={getMarkerGroups} />);
+
+    await screen.findByText('The Day the Harbor Fell Silent');
+    fireEvent.press(screen.getByText('Show filters'));
+    fireEvent.changeText(screen.getByLabelText('Location filter'), 'Golden Horn');
+
+    await waitFor(() => {
+      expect(getMarkerGroups).toHaveBeenLastCalledWith({
+        q: undefined,
+        location: 'Golden Horn',
+        yearFrom: undefined,
+        yearTo: undefined,
+      });
+    });
+
+    fireEvent.press(screen.getByText('Clear all filters'));
+
+    await waitFor(() => {
+      expect(getMarkerGroups).toHaveBeenLastCalledWith({
+        q: undefined,
+        location: undefined,
+        yearFrom: undefined,
+        yearTo: undefined,
+      });
+    });
+  });
+
   it('keeps the map visible and shows an error overlay when loading fails', async () => {
     renderScreen(<MapScreen getMarkerGroups={async () => Promise.reject(new Error('API unavailable'))} />);
 

--- a/mobile/src/features/search/presentation/components/StorySearchControls.tsx
+++ b/mobile/src/features/search/presentation/components/StorySearchControls.tsx
@@ -1,10 +1,10 @@
 import React, { useMemo, useState } from 'react';
-import { Pressable, Text, View } from 'react-native';
+import { Modal, Pressable, Text, View } from 'react-native';
 import { useAppTheme } from '../../../../core/hooks/useAppTheme';
 import { FilterPanel } from '../../../../shared/components/FilterPanel';
 import { FilterChipItem, FilterChips } from '../../../../shared/components/FilterChips';
 import { SearchInput } from '../../../../shared/components/SearchInput';
-import { useSearchFilters } from '../context/SearchFiltersContext';
+import { SearchFilterScope, useSearchFilters } from '../context/SearchFiltersContext';
 
 function buildChips(
   filters: ReturnType<typeof useSearchFilters>['filters'],
@@ -33,11 +33,12 @@ function buildChips(
 interface StorySearchControlsProps {
   helperText?: string;
   hideHeading?: boolean;
+  scope: SearchFilterScope;
 }
 
-export function StorySearchControls({ helperText, hideHeading = false }: StorySearchControlsProps) {
+export function StorySearchControls({ helperText, hideHeading = false, scope }: StorySearchControlsProps) {
   const { colors, spacing, typography } = useAppTheme();
-  const { filters, updateFilters, removeFilter, clearFilters } = useSearchFilters();
+  const { filters, updateFilters, removeFilter, clearFilters, applyFilters } = useSearchFilters(scope);
   const [showFilters, setShowFilters] = useState(false);
 
   const chips = useMemo(() => buildChips(filters), [filters]);
@@ -56,7 +57,7 @@ export function StorySearchControls({ helperText, hideHeading = false }: StorySe
       <SearchInput
         value={filters.query}
         onChangeText={(query) => updateFilters({ query })}
-        onSearch={() => updateFilters({ query: filters.query })}
+        onSearch={() => applyFilters()}
       />
 
       <View style={{ flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center' }}>
@@ -72,17 +73,41 @@ export function StorySearchControls({ helperText, hideHeading = false }: StorySe
         ) : null}
       </View>
 
-      {showFilters ? (
-        <FilterPanel
-          location={filters.location}
-          timeFrom={filters.timeFrom}
-          timeTo={filters.timeTo}
-          onLocationChange={(location) => updateFilters({ location })}
-          onTimeFromChange={(timeFrom) => updateFilters({ timeFrom })}
-          onTimeToChange={(timeTo) => updateFilters({ timeTo })}
-          onClearAll={clearFilters}
-        />
-      ) : null}
+      <Modal
+        transparent
+        animationType="fade"
+        visible={showFilters}
+        onRequestClose={() => setShowFilters(false)}
+      >
+        <Pressable
+          accessibilityRole="button"
+          accessibilityLabel="Close filters"
+          onPress={() => setShowFilters(false)}
+          style={{
+            flex: 1,
+            justifyContent: 'flex-start',
+            backgroundColor: 'rgba(17, 24, 39, 0.35)',
+            paddingHorizontal: spacing.lg,
+            paddingTop: spacing.xl * 2,
+          }}
+        >
+          <Pressable onPress={(event) => event.stopPropagation()} style={{ width: '100%' }}>
+            <FilterPanel
+              location={filters.location}
+              timeFrom={filters.timeFrom}
+              timeTo={filters.timeTo}
+              onLocationChange={(location) => updateFilters({ location }, { refresh: true })}
+              onTimeFromChange={(timeFrom) => updateFilters({ timeFrom }, { refresh: true })}
+              onTimeToChange={(timeTo) => updateFilters({ timeTo }, { refresh: true })}
+              onClearAll={clearFilters}
+              onApply={() => {
+                applyFilters();
+                setShowFilters(false);
+              }}
+            />
+          </Pressable>
+        </Pressable>
+      </Modal>
 
       <FilterChips
         chips={chips}

--- a/mobile/src/features/search/presentation/context/SearchFiltersContext.tsx
+++ b/mobile/src/features/search/presentation/context/SearchFiltersContext.tsx
@@ -3,6 +3,8 @@ import { storageKeys } from '../../../../core/storage/keys';
 import { storage } from '../../../../core/storage/storage';
 import { StoryFilters } from '../../../stories/domain/repositories';
 
+export type SearchFilterScope = 'feed' | 'map';
+
 export interface SearchFiltersState {
   query: string;
   location: string;
@@ -11,12 +13,14 @@ export interface SearchFiltersState {
 }
 
 interface SearchFiltersContextValue {
-  filters: SearchFiltersState;
+  filtersByScope: Record<SearchFilterScope, SearchFiltersState>;
+  refreshTokensByScope: Record<SearchFilterScope, number>;
   isHydrated: boolean;
-  setFilters: (nextFilters: SearchFiltersState) => void;
-  updateFilters: (patch: Partial<SearchFiltersState>) => void;
-  removeFilter: (key: keyof SearchFiltersState) => void;
-  clearFilters: () => void;
+  setFilters: (scope: SearchFilterScope, nextFilters: SearchFiltersState) => void;
+  updateFilters: (scope: SearchFilterScope, patch: Partial<SearchFiltersState>, options?: { refresh?: boolean }) => void;
+  removeFilter: (scope: SearchFilterScope, key: keyof SearchFiltersState) => void;
+  clearFilters: (scope: SearchFilterScope) => void;
+  applyFilters: (scope: SearchFilterScope) => void;
 }
 
 const initialFilters: SearchFiltersState = {
@@ -26,26 +30,45 @@ const initialFilters: SearchFiltersState = {
   timeTo: '',
 };
 
+const initialFiltersByScope: Record<SearchFilterScope, SearchFiltersState> = {
+  feed: initialFilters,
+  map: initialFilters,
+};
+
+const storageKeyByScope: Record<SearchFilterScope, string> = {
+  feed: storageKeys.feedSearchFilters,
+  map: storageKeys.mapSearchFilters,
+};
+
 const SearchFiltersContext = createContext<SearchFiltersContextValue | undefined>(undefined);
 
 export function SearchFiltersProvider({ children }: PropsWithChildren) {
-  const [filters, setFiltersState] = useState<SearchFiltersState>(initialFilters);
+  const [filtersByScope, setFiltersState] = useState<Record<SearchFilterScope, SearchFiltersState>>(initialFiltersByScope);
+  const [refreshTokensByScope, setRefreshTokensByScope] = useState<Record<SearchFilterScope, number>>({
+    feed: 0,
+    map: 0,
+  });
   const [isHydrated, setIsHydrated] = useState(false);
 
   useEffect(() => {
     let isMounted = true;
 
-    storage
-      .get<Partial<SearchFiltersState>>(storageKeys.searchFilters)
-      .then((storedFilters) => {
-        if (isMounted && storedFilters) {
-          setFiltersState({
-            query: storedFilters.query ?? '',
-            location: storedFilters.location ?? '',
-            timeFrom: storedFilters.timeFrom ?? '',
-            timeTo: storedFilters.timeTo ?? '',
-          });
+    Promise.all([
+      storage.get<Partial<SearchFiltersState>>(storageKeys.feedSearchFilters),
+      storage.get<Partial<SearchFiltersState>>(storageKeys.mapSearchFilters),
+      storage.get<Partial<SearchFiltersState>>(storageKeys.legacySearchFilters),
+    ])
+      .then(([storedFeedFilters, storedMapFilters, legacyFilters]) => {
+        if (!isMounted) {
+          return;
         }
+
+        const fallbackFilters = normalizeStoredFilters(legacyFilters);
+
+        setFiltersState({
+          feed: normalizeStoredFilters(storedFeedFilters ?? fallbackFilters),
+          map: normalizeStoredFilters(storedMapFilters),
+        });
       })
       .finally(() => {
         if (isMounted) {
@@ -58,40 +81,88 @@ export function SearchFiltersProvider({ children }: PropsWithChildren) {
     };
   }, []);
 
-  const setFilters = (nextFilters: SearchFiltersState) => {
-    setFiltersState(nextFilters);
-    void storage.set(storageKeys.searchFilters, nextFilters);
+  const setFilters = (scope: SearchFilterScope, nextFilters: SearchFiltersState) => {
+    setFiltersState((current) => ({
+      ...current,
+      [scope]: nextFilters,
+    }));
+    void storage.set(storageKeyByScope[scope], nextFilters);
+  };
+
+  const updateScopedFilters = (
+    scope: SearchFilterScope,
+    updater: (currentFilters: SearchFiltersState) => SearchFiltersState,
+    options?: { refresh?: boolean },
+  ) => {
+    setFiltersState((current) => {
+      const nextFilters = updater(current[scope]);
+      void storage.set(storageKeyByScope[scope], nextFilters);
+
+      return {
+        ...current,
+        [scope]: nextFilters,
+      };
+    });
+
+    if (options?.refresh) {
+      setRefreshTokensByScope((current) => ({
+        ...current,
+        [scope]: current[scope] + 1,
+      }));
+    }
   };
 
   const value = useMemo<SearchFiltersContextValue>(
     () => ({
-      filters,
+      filtersByScope,
+      refreshTokensByScope,
       isHydrated,
-      setFilters,
-      updateFilters: (patch) => {
-        setFilters({ ...filters, ...patch });
+      setFilters: (scope, nextFilters) => {
+        setFilters(scope, nextFilters);
       },
-      removeFilter: (key) => {
-        setFilters({ ...filters, [key]: '' });
+      updateFilters: (scope, patch, options) => {
+        updateScopedFilters(scope, (currentFilters) => ({ ...currentFilters, ...patch }), options);
       },
-      clearFilters: () => {
-        setFilters(initialFilters);
+      removeFilter: (scope, key) => {
+        updateScopedFilters(scope, (currentFilters) => ({ ...currentFilters, [key]: '' }), { refresh: true });
+      },
+      clearFilters: (scope) => {
+        updateScopedFilters(scope, (currentFilters) => ({
+          ...initialFilters,
+          query: currentFilters.query,
+        }), { refresh: true });
+      },
+      applyFilters: (scope) => {
+        setRefreshTokensByScope((current) => ({
+          ...current,
+          [scope]: current[scope] + 1,
+        }));
       },
     }),
-    [filters, isHydrated],
+    [filtersByScope, isHydrated, refreshTokensByScope],
   );
 
   return <SearchFiltersContext.Provider value={value}>{children}</SearchFiltersContext.Provider>;
 }
 
-export function useSearchFilters() {
+export function useSearchFilters(scope: SearchFilterScope) {
   const context = useContext(SearchFiltersContext);
 
   if (!context) {
     throw new Error('useSearchFilters must be used within a SearchFiltersProvider.');
   }
 
-  return context;
+  return {
+    filters: context.filtersByScope[scope],
+    refreshToken: context.refreshTokensByScope[scope],
+    isHydrated: context.isHydrated,
+    setFilters: (nextFilters: SearchFiltersState) => context.setFilters(scope, nextFilters),
+    updateFilters: (patch: Partial<SearchFiltersState>, options?: { refresh?: boolean }) =>
+      context.updateFilters(scope, patch, options),
+    removeFilter: (key: keyof SearchFiltersState) => context.removeFilter(scope, key),
+    clearFilters: () => context.clearFilters(scope),
+    applyFilters: () => context.applyFilters(scope),
+  };
 }
 
 export function toSearchParams(filters: SearchFiltersState): StoryFilters {
@@ -109,5 +180,14 @@ export function toSearchParams(filters: SearchFiltersState): StoryFilters {
     location: filters.location.trim() || undefined,
     yearFrom,
     yearTo,
+  };
+}
+
+function normalizeStoredFilters(filters?: Partial<SearchFiltersState> | null): SearchFiltersState {
+  return {
+    query: filters?.query ?? '',
+    location: filters?.location ?? '',
+    timeFrom: filters?.timeFrom ?? '',
+    timeTo: filters?.timeTo ?? '',
   };
 }

--- a/mobile/src/shared/components/FilterPanel.tsx
+++ b/mobile/src/shared/components/FilterPanel.tsx
@@ -27,6 +27,7 @@ interface FilterPanelProps {
   onTimeFromChange: (value: string) => void;
   onTimeToChange: (value: string) => void;
   onClearAll: () => void;
+  onApply?: () => void;
 }
 
 export function FilterPanel({
@@ -37,6 +38,7 @@ export function FilterPanel({
   onTimeFromChange,
   onTimeToChange,
   onClearAll,
+  onApply,
 }: FilterPanelProps) {
   const { colors, spacing, typography } = useAppTheme();
   const parsedTimeFrom = timeFrom ? Number(timeFrom) : undefined;
@@ -55,10 +57,6 @@ export function FilterPanel({
       return;
     }
 
-    if (normalized && timeTo && Number(normalized) > Number(timeTo)) {
-      return;
-    }
-
     onTimeFromChange(normalized);
   };
 
@@ -66,10 +64,6 @@ export function FilterPanel({
     const normalized = normalizeYearInput(value);
 
     if (normalized === null) {
-      return;
-    }
-
-    if (normalized && timeFrom && Number(normalized) < Number(timeFrom)) {
       return;
     }
 
@@ -135,9 +129,26 @@ export function FilterPanel({
         </Text>
       ) : null}
 
-      <Pressable accessibilityRole="button" onPress={onClearAll}>
-        <Text style={{ color: colors.text, fontWeight: '700' }}>Reset filter form</Text>
-      </Pressable>
+      <View style={{ flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center' }}>
+        <Pressable accessibilityRole="button" onPress={onClearAll}>
+          <Text style={{ color: colors.text, fontWeight: '700' }}>Reset filter form</Text>
+        </Pressable>
+        {onApply ? (
+          <Pressable
+            accessibilityRole="button"
+            accessibilityLabel="Apply filters"
+            onPress={onApply}
+            style={{
+              paddingHorizontal: spacing.md,
+              paddingVertical: spacing.sm,
+              borderRadius: 999,
+              backgroundColor: colors.primary,
+            }}
+          >
+            <Text style={{ color: '#FFFFFF', fontWeight: '700' }}>Apply</Text>
+          </Pressable>
+        ) : null}
+      </View>
     </View>
   );
 }

--- a/mobile/src/shared/components/SearchInput.tsx
+++ b/mobile/src/shared/components/SearchInput.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Pressable, Text, View } from 'react-native';
+import { Keyboard, Pressable, Text, View } from 'react-native';
 import { useAppTheme } from '../../core/hooks/useAppTheme';
 import { Input } from '../ui/Input';
 
@@ -17,6 +17,10 @@ export function SearchInput({
   placeholder = 'Search by story title or place',
 }: SearchInputProps) {
   const { colors, spacing } = useAppTheme();
+  const handleSearch = () => {
+    Keyboard.dismiss();
+    onSearch?.();
+  };
 
   return (
     <View style={{ flexDirection: 'row', gap: spacing.sm, alignItems: 'center' }}>
@@ -28,7 +32,7 @@ export function SearchInput({
             placeholder={placeholder}
             accessibilityLabel="Search stories"
             returnKeyType="search"
-            onSubmitEditing={onSearch}
+            onSubmitEditing={handleSearch}
             style={{ paddingRight: value ? 44 : spacing.md }}
           />
           {value ? (
@@ -57,7 +61,7 @@ export function SearchInput({
       <Pressable
         accessibilityRole="button"
         accessibilityLabel="Apply search"
-        onPress={onSearch}
+        onPress={handleSearch}
         style={({ pressed }) => ({
           minWidth: 72,
           paddingHorizontal: spacing.md,

--- a/mobile/src/shared/components/__tests__/FilterPanel.test.tsx
+++ b/mobile/src/shared/components/__tests__/FilterPanel.test.tsx
@@ -60,7 +60,7 @@ describe('FilterPanel', () => {
     expect(onTimeToChange).not.toHaveBeenCalledWith('10000');
   });
 
-  it('allows a start year without an end year and blocks an earlier end year', () => {
+  it('allows entering an end year even before the start year and shows the range warning', () => {
     const onTimeFromChange = jest.fn();
     const onTimeToChange = jest.fn();
 
@@ -95,8 +95,22 @@ describe('FilterPanel', () => {
     fireEvent.changeText(screen.getByLabelText('End year'), '1800');
     fireEvent.changeText(screen.getByLabelText('End year'), '1950');
 
-    expect(onTimeToChange).not.toHaveBeenCalledWith('1800');
+    expect(onTimeToChange).toHaveBeenCalledWith('1800');
     expect(onTimeToChange).toHaveBeenCalledWith('1950');
+
+    rerender(
+      <FilterPanel
+        location=""
+        timeFrom="1900"
+        timeTo="1800"
+        onLocationChange={jest.fn()}
+        onTimeFromChange={onTimeFromChange}
+        onTimeToChange={onTimeToChange}
+        onClearAll={jest.fn()}
+      />,
+    );
+
+    expect(screen.getByText('Start year cannot be later than end year.')).toBeTruthy();
   });
 
   it('resets the filter form', () => {


### PR DESCRIPTION
# 📝 Description
Fixes #328 
Improves the mobile search and filter experience by fixing multiple usability and consistency issues.

This PR:
- fixes the filter panel behavior so it can be dismissed by tapping outside (instead of only via the filter button)
- resolves the issue where the `to year` field in the year range filter was not accepting input
- separates search and filter states for **Map** and **Feed**, preventing shared state conflicts between the two views
- ensures that search results and filters are applied independently for each view
- fixes the reset filter behavior so that it no longer clears the active search query

# 📊 Type of Change
- [x]  Bug fix
- [ ]  New feature
- [ ]  Refactoring
- [ ]  Documentation
 
# ✅ Acceptance Criteria / Checklist
- [x] Project builds successfully
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, especially in hard-to-understand parts
- [x] I have performed a self-review of my code
- [x] I have added/updated tests
- [x] New and existing unit tests pass locally with my changes

# ⏱️ Estimated Review Time
- [ ] < 5 min
- [x] 5-15 min
- [ ] > 15 min
