### PR TITLE
Add mobile story delete flow

### DIFF
--- a/mobile/jest.setup.ts
+++ b/mobile/jest.setup.ts
@@ -33,4 +33,4 @@ jest.mock('react-native-webview', () => {
     WebView: MockWebView,
     default: MockWebView,
   };
-});
+}, { virtual: true });

--- a/mobile/src/app/navigation/RootNavigator.tsx
+++ b/mobile/src/app/navigation/RootNavigator.tsx
@@ -535,6 +535,10 @@ export function RootNavigator() {
         session={user ? { role: user.role, user } : undefined}
         onRequestLogin={() => showAuthRequiredMessage('Please sign in to like stories and join the discussion.')}
         onGoBack={handleBack}
+        onStoryDeleted={() => {
+          toast.success('Story deleted.');
+          navigateToSnapshot({ route: ROUTES.FEED }, { resetStack: true, preserveCurrent: false });
+        }}
         onOpenContributorProfile={handleOpenUserProfile}
       />
     );

--- a/mobile/src/features/stories/application/services/__tests__/storyService.test.ts
+++ b/mobile/src/features/stories/application/services/__tests__/storyService.test.ts
@@ -23,6 +23,16 @@ describe('storyService', () => {
     getMapPinsSpy.mockRestore();
   });
 
+  it('delegates deleteStory to the repository', async () => {
+    const deleteStorySpy = jest.spyOn(StoryRepositoryImpl.prototype, 'deleteStory').mockResolvedValue(undefined);
+
+    await storyService.deleteStory('42');
+
+    expect(deleteStorySpy).toHaveBeenCalledWith('42');
+
+    deleteStorySpy.mockRestore();
+  });
+
   it('delegates getFeed to the feed service', async () => {
     const getFeedSpy = jest.spyOn(feedService, 'getFeed').mockResolvedValue({
       items: [],

--- a/mobile/src/features/stories/application/services/index.ts
+++ b/mobile/src/features/stories/application/services/index.ts
@@ -10,6 +10,9 @@ export const storyService = {
   async getStory(id: string): Promise<StoryEntity | null> {
     return repository.getStory(id);
   },
+  async deleteStory(id: string): Promise<void> {
+    return repository.deleteStory(id);
+  },
   async getStories(filters?: StoryFilters): Promise<StorySummaryEntity[]> {
     return repository.getStories(filters);
   },

--- a/mobile/src/features/stories/data/repositories/__tests__/StoryRepository.test.ts
+++ b/mobile/src/features/stories/data/repositories/__tests__/StoryRepository.test.ts
@@ -55,4 +55,13 @@ describe('StoryRepositoryImpl', () => {
 
     await expect(repository.getStory('404')).resolves.toBeNull();
   });
+
+  it('deletes a story through the remote source', async () => {
+    const deleteStorySpy = jest.spyOn(storiesRemoteSource, 'deleteStory').mockResolvedValue(undefined);
+
+    const repository = new StoryRepositoryImpl();
+    await repository.deleteStory('42');
+
+    expect(deleteStorySpy).toHaveBeenCalledWith('42');
+  });
 });

--- a/mobile/src/features/stories/data/repositories/index.ts
+++ b/mobile/src/features/stories/data/repositories/index.ts
@@ -27,6 +27,10 @@ export class StoryRepositoryImpl implements StoryRepository {
     }
   }
 
+  async deleteStory(id: string): Promise<void> {
+    await storiesRemoteSource.deleteStory(id);
+  }
+
   async getStories(filters: StoryFilters = {}): Promise<StorySummaryEntity[]> {
     try {
       const response = await storiesRemoteSource.getStoriesFromApi(filters);

--- a/mobile/src/features/stories/data/sources/index.ts
+++ b/mobile/src/features/stories/data/sources/index.ts
@@ -24,6 +24,10 @@ export const storiesRemoteSource = {
     return (await apiClient.get<{ results?: unknown[] }>(`/stories/${id}/comments/`))?.results ?? [];
   },
 
+  async deleteStory(id: string) {
+    await apiClient.delete(`/stories/${id}/`);
+  },
+
   async getStories(filters: StoryFilters = {}) {
     return storiesLocalSource.getStories(filters);
   },

--- a/mobile/src/features/stories/domain/repositories/index.ts
+++ b/mobile/src/features/stories/domain/repositories/index.ts
@@ -9,6 +9,7 @@ export interface StoryFilters {
 
 export interface StoryRepository {
   getStory(id: string): Promise<StoryEntity | null>;
+  deleteStory(id: string): Promise<void>;
   getStories(filters?: StoryFilters): Promise<StorySummaryEntity[]>;
   getMapPins(filters?: StoryFilters): Promise<StoryMapPin[]>;
 }

--- a/mobile/src/features/stories/presentation/screens/StoryScreen.tsx
+++ b/mobile/src/features/stories/presentation/screens/StoryScreen.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useMemo, useRef, useState } from 'react';
-import { Image, Pressable, ScrollView, Text, View } from 'react-native';
+import { Alert, Image, Pressable, ScrollView, Text, View } from 'react-native';
 import { roles } from '../../../../core/auth/roles';
 import { Session } from '../../../../core/auth/session';
 import { useAppTheme } from '../../../../core/hooks/useAppTheme';
@@ -21,8 +21,10 @@ interface StoryScreenProps {
   session?: Pick<Session, 'role' | 'user'>;
   onRequestLogin?: () => void;
   onGoBack?: () => void;
+  onStoryDeleted?: () => void;
   onOpenContributorProfile?: (userId: string) => void;
   getStory?: typeof storyService.getStory;
+  deleteStory?: typeof storyService.deleteStory;
 }
 
 function formatDate(dateString: string) {
@@ -338,8 +340,10 @@ export function StoryScreen({
   session,
   onRequestLogin,
   onGoBack,
+  onStoryDeleted,
   onOpenContributorProfile,
   getStory = storyService.getStory,
+  deleteStory = storyService.deleteStory,
 }: StoryScreenProps) {
   const { colors, spacing, typography } = useAppTheme();
   const [state, setState] = useState(() =>
@@ -350,7 +354,9 @@ export function StoryScreen({
   const [commentText, setCommentText] = useState('');
   const [commentError, setCommentError] = useState<string>();
   const [deleteError, setDeleteError] = useState<string>();
+  const [storyDeleteError, setStoryDeleteError] = useState<string>();
   const [isCommentSubmitting, setIsCommentSubmitting] = useState(false);
+  const [isStoryDeleting, setIsStoryDeleting] = useState(false);
   const [confirmDeleteId, setConfirmDeleteId] = useState<string>();
   const [interactionError, setInteractionError] = useState<string>();
   const deletedCommentIdsRef = useRef<Set<string>>(new Set());
@@ -364,6 +370,7 @@ export function StoryScreen({
     setCommentText('');
     setCommentError(undefined);
     setDeleteError(undefined);
+    setStoryDeleteError(undefined);
     setConfirmDeleteId(undefined);
     setInteractionError(undefined);
     deletedCommentIdsRef.current = new Set();
@@ -535,6 +542,24 @@ export function StoryScreen({
     }
   };
 
+  const handleDeleteStory = async () => {
+    if (!state.story || isStoryDeleting) {
+      return;
+    }
+
+    setStoryDeleteError(undefined);
+    setIsStoryDeleting(true);
+
+    try {
+      await deleteStory(state.story.id);
+      onStoryDeleted?.();
+    } catch (error) {
+      setStoryDeleteError(extractInteractionError(error, 'Failed to delete story. Please try again.'));
+    } finally {
+      setIsStoryDeleting(false);
+    }
+  };
+
   if (state.isLoading) {
     return <Loader fullScreen message="Loading story..." />;
   }
@@ -561,6 +586,28 @@ export function StoryScreen({
   }
 
   const story = state.story;
+  const isStoryOwner = session?.user?.id !== undefined && String(session.user.id) === story.contributorUserId;
+  const canDeleteStory = session?.role === roles.admin || isStoryOwner;
+
+  const promptDeleteStory = () => {
+    if (!canDeleteStory || isStoryDeleting) {
+      return;
+    }
+
+    Alert.alert('Delete story?', 'This action permanently removes the story and cannot be undone.', [
+      {
+        text: 'Cancel',
+        style: 'cancel',
+      },
+      {
+        text: 'Delete',
+        style: 'destructive',
+        onPress: () => {
+          void handleDeleteStory();
+        },
+      },
+    ]);
+  };
 
   return (
     <ScrollView
@@ -572,6 +619,20 @@ export function StoryScreen({
       <Text style={{ color: colors.text, fontSize: typography.title, fontWeight: '800' }}>
         {story.title}
       </Text>
+      {canDeleteStory ? (
+        <View style={{ marginTop: spacing.md, alignItems: 'flex-start' }}>
+          <Button
+            onPress={promptDeleteStory}
+            disabled={isStoryDeleting}
+            style={{ backgroundColor: colors.danger }}
+          >
+            {isStoryDeleting ? 'Deleting story...' : 'Delete story'}
+          </Button>
+        </View>
+      ) : null}
+      {storyDeleteError ? (
+        <Text style={{ marginTop: spacing.sm, color: colors.danger }}>{storyDeleteError}</Text>
+      ) : null}
 
       <View
         style={{

--- a/mobile/src/features/stories/presentation/screens/__tests__/StoryScreen.test.tsx
+++ b/mobile/src/features/stories/presentation/screens/__tests__/StoryScreen.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { fireEvent, render, screen, waitFor } from '@testing-library/react-native';
+import { Alert } from 'react-native';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react-native';
 import { StoryScreen } from '../StoryScreen';
 import { Session } from '../../../../../core/auth/session';
 import { StoryEntity } from '../../../domain/entities';
@@ -88,6 +89,24 @@ describe('StoryScreen', () => {
       email: 'guest@example.com',
       username: 'Guest',
       role: 'guest',
+    },
+  };
+
+  const ownerSession: Session = {
+    ...userSession,
+    user: {
+      ...userSession.user,
+      id: 22,
+      username: 'Aylin Demir',
+    },
+  };
+
+  const adminSession: Session = {
+    ...userSession,
+    role: 'admin',
+    user: {
+      ...userSession.user,
+      role: 'admin',
     },
   };
   it('renders loading state while fetching the story', () => {
@@ -334,6 +353,108 @@ describe('StoryScreen', () => {
     await waitFor(() => {
       expect(screen.queryByText('Delete this comment?')).toBeNull();
     });
+  });
+
+  it('shows the delete story action only to the owner or an admin', async () => {
+    const { rerender } = render(
+      <StoryScreen
+        storyId="story-001"
+        session={userSession}
+        getStory={async () => baseStory}
+      />,
+    );
+
+    await screen.findByText(baseStory.title);
+    expect(screen.queryByText('Delete story')).toBeNull();
+
+    rerender(
+      <StoryScreen
+        storyId="story-001"
+        session={ownerSession}
+        getStory={async () => baseStory}
+      />,
+    );
+
+    expect(await screen.findByText('Delete story')).toBeTruthy();
+
+    rerender(
+      <StoryScreen
+        storyId="story-001"
+        session={adminSession}
+        getStory={async () => baseStory}
+      />,
+    );
+
+    expect(await screen.findByText('Delete story')).toBeTruthy();
+  });
+
+  it('confirms and deletes the story for authorized users', async () => {
+    const deleteStory = jest.fn(async () => undefined);
+    const onStoryDeleted = jest.fn();
+    const alertSpy = jest.spyOn(Alert, 'alert').mockImplementation(() => undefined);
+
+    render(
+      <StoryScreen
+        storyId="story-001"
+        session={ownerSession}
+        getStory={async () => baseStory}
+        deleteStory={deleteStory}
+        onStoryDeleted={onStoryDeleted}
+      />,
+    );
+
+    fireEvent.press(await screen.findByText('Delete story'));
+
+    expect(alertSpy).toHaveBeenCalledWith(
+      'Delete story?',
+      'This action permanently removes the story and cannot be undone.',
+      expect.arrayContaining([
+        expect.objectContaining({ text: 'Cancel', style: 'cancel' }),
+        expect.objectContaining({ text: 'Delete', style: 'destructive', onPress: expect.any(Function) }),
+      ]),
+    );
+
+    const buttons = alertSpy.mock.calls[0]?.[2];
+    const deleteButton = buttons?.find((button) => button.text === 'Delete');
+
+    await act(async () => {
+      deleteButton?.onPress?.();
+    });
+
+    await waitFor(() => {
+      expect(deleteStory).toHaveBeenCalledWith('story-001');
+      expect(onStoryDeleted).toHaveBeenCalledTimes(1);
+    });
+
+    alertSpy.mockRestore();
+  });
+
+  it('shows a meaningful error when story deletion fails', async () => {
+    const alertSpy = jest.spyOn(Alert, 'alert').mockImplementation(() => undefined);
+
+    render(
+      <StoryScreen
+        storyId="story-001"
+        session={ownerSession}
+        getStory={async () => baseStory}
+        deleteStory={jest.fn(async () => {
+          throw new Error('Deletion failed on server');
+        })}
+      />,
+    );
+
+    fireEvent.press(await screen.findByText('Delete story'));
+
+    const buttons = alertSpy.mock.calls[0]?.[2];
+    const deleteButton = buttons?.find((button) => button.text === 'Delete');
+
+    await act(async () => {
+      deleteButton?.onPress?.();
+    });
+
+    expect(await screen.findByText('Deletion failed on server')).toBeTruthy();
+
+    alertSpy.mockRestore();
   });
 
   it('prompts unauthenticated users when they try to comment', async () => {


### PR DESCRIPTION
# 📝 Description
Fixes #323 
## Summary

Adds story deletion support to the mobile app for authorized users.

This PR completes the mobile side of the delete story flow by:
- showing a delete action only to story owners and admins
- asking for confirmation before deletion
- sending a `DELETE` request to the story detail endpoint
- handling success and failure states in the UI
- redirecting the user back to the feed after successful deletion

## Changes

- added `deleteStory` support to the mobile stories data/repository/service layers
- added a delete button to the story detail screen
- restricted delete visibility to the story owner or an admin
- added a mobile-friendly confirmation flow using a native alert
- added error handling for failed delete requests
- navigates back to feed and shows a success toast after deletion
- added tests for visibility, confirmation, success, and failure cases

## Testing

Passed:

```bash
npm test -- --runInBand src/features/stories/presentation/screens/__tests__/StoryScreen.test.tsx src/features/stories/application/services/__tests__/storyService.test.ts src/features/stories/data/repositories/__tests__/StoryRepository.test.ts


# 📊 Type of Change
- [ ]  Bug fix
- [ ]  New feature
- [ ]  Refactoring
- [ ]  Documentation
 
# ✅ Acceptance Criteria / Checklist
- [ ] Project builds successfully
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, especially in hard-to-understand parts
- [ ] I have performed a self-review of my code
- [ ] I have added/updated tests
- [ ] New and existing unit tests pass locally with my changes

# ⏱️ Estimated Review Time
- [ ] < 5 min
- [ ] 5-15 min
- [ ] > 15 min
