### PR TITLE
fix: resolve conflict between navigation bar and map view on mobile view

### DIFF
--- a/frontend/src/pages/MapPage.jsx
+++ b/frontend/src/pages/MapPage.jsx
@@ -34,7 +34,7 @@ function MapPage() {
   }, [fetchPins]);
 
   return (
-    <div className="relative" style={{ height: "calc(100vh - 3.5rem)" }}>
+    <div className="relative isolate" style={{ height: "calc(100vh - 3.5rem)" }}>
       <MapView stories={stories} loading={loading} />
 
       {/* Search & filter overlay */}


### PR DESCRIPTION
# 📝 Description
Fixes #338 

The navigation bar was being visually obscured by the Leaflet map on mobile viewports, and the hamburger menu button was unresponsive due to a stacking context conflict with the Sheet (mobile nav drawer).                                                                                       
                                                                                                                                                      
  Root cause: Leaflet's internal elements (controls, panes) use z-index values up to 1000 within the map container, but without an isolated stacking context they competed directly with the sticky header. An initial attempted fix raised the header to z-[1001], which resolved the visual overlap but broke the hamburger button, the Sheet (Radix portal) renders its overlay/content at z-50, and with the header above it, Radix's dialog accessibility mechanism blocked pointer events on elements outside the open sheet, including the trigger button.                                  

  Fix: Added isolation: isolate to the MapPage container, which creates a new CSS stacking context that traps Leaflet's z-index values inside it. The header is restored to z-40, which sits above the isolated map container (z-index: auto) while remaining below the Sheet overlay (z-50) when the drawer is open.

# 📊 Type of Change
- [x]  Bug fix
- [ ]  New feature
- [ ]  Refactoring
- [ ]  Documentation
 
# ✅ Acceptance Criteria / Checklist
- [x] Project builds successfully
- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, especially in hard-to-understand parts
- [x] I have performed a self-review of my code
- [ ] I have added/updated tests
- [x] New and existing unit tests pass locally with my changes

# 📸 Screenshots / Recordings
<img width="585" height="730" alt="Screenshot 2026-04-07 at 14 16 46" src="https://github.com/user-attachments/assets/856190dc-67c4-45a5-a99e-73bb1e66a097" />

# ⏱️ Estimated Review Time
- [x] < 5 min
- [ ] 5-15 min
- [ ] > 15 min
