### PR TITLE
feat: add automated test report generation and wiki publishing

### DIFF
--- a/.github/scripts/generate_test_report.py
+++ b/.github/scripts/generate_test_report.py
@@ -1,7 +1,14 @@
 #!/usr/bin/env python3
 """
 Read pytest-json-report (backend), vitest --reporter=json (frontend),
-and jest --json (mobile) output files and generate a single Markdown wiki page.
+and jest --json (mobile) output files and generate separate Markdown wiki
+pages for each suite plus an index page.
+
+Output files (written to GITHUB_WORKSPACE):
+  Backend-Generated-Unit-Test-Reports.md
+  Frontend-Generated-Unit-Test-Reports.md
+  Mobile-Generated-Unit-Test-Reports.md
+  Generated-Unit-Test-Reports.md  (index linking to the three above)
 """
 
 import json
@@ -13,6 +20,8 @@ SERVER_URL = os.environ.get("GITHUB_SERVER_URL", "https://github.com")
 REPOSITORY = os.environ.get("GITHUB_REPOSITORY", "")
 RUN_ID = os.environ.get("GITHUB_RUN_ID", "")
 RUN_URL = f"{SERVER_URL}/{REPOSITORY}/actions/runs/{RUN_ID}" if RUN_ID else ""
+
+WIKI_BASE = f"{SERVER_URL}/{REPOSITORY}/wiki"
 
 
 def _icon(outcome):
@@ -41,14 +50,25 @@ def _summary_line(passed, failed, skipped, total, duration_s):
     )
 
 
+def _page_header(title, now, run_link):
+    return [
+        f"# {title}",
+        "",
+        f"_Auto-generated: {now} — {run_link}_",
+        "",
+        "---",
+        "",
+    ]
+
+
 # ── Backend ───────────────────────────────────────────────────────────────────
 
-def backend_section(path):
-    lines = ["## 🐍 Backend — Django / pytest", ""]
+def build_backend_page(path, now, run_link):
+    lines = _page_header("Backend Generated Unit Test Reports", now, run_link)
 
     if not os.path.exists(path):
         lines += ["_Report not generated — test run did not complete._", ""]
-        return lines
+        return lines, None  # None = no summary for index
 
     with open(path) as f:
         data = json.load(f)
@@ -60,7 +80,8 @@ def backend_section(path):
     total = s.get("total", passed + failed + skipped)
     duration = data.get("duration", 0)
 
-    lines += [_summary_line(passed, failed, skipped, total, duration), ""]
+    summary = _summary_line(passed, failed, skipped, total, duration)
+    lines += [summary, ""]
 
     tests = data.get("tests", [])
     if tests:
@@ -68,25 +89,24 @@ def backend_section(path):
         lines += ["| Test | Status | Duration |", "|------|--------|----------|"]
         for t in tests:
             node = t.get("nodeid", "")
-            # Keep only the last two :: segments for readability
             parts = node.split("::")
             short = "::".join(parts[-2:]) if len(parts) >= 2 else node
             outcome = t.get("outcome", "unknown")
-            dur = t.get("duration", 0) * 1000  # pytest reports in seconds
+            dur = t.get("duration", 0) * 1000
             lines.append(f"| `{short}` | {_icon(outcome)} {outcome} | {_fmt_ms(dur)} |")
         lines += ["", "</details>", ""]
 
-    return lines
+    return lines, summary
 
 
 # ── Frontend / Mobile (Jest-compatible JSON) ──────────────────────────────────
 
-def jest_section(path, title, emoji):
-    lines = [f"## {emoji} {title}", ""]
+def build_jest_page(path, title, now, run_link):
+    lines = _page_header(title, now, run_link)
 
     if not os.path.exists(path):
         lines += ["_Report not generated — test run did not complete._", ""]
-        return lines
+        return lines, None
 
     with open(path) as f:
         data = json.load(f)
@@ -95,14 +115,13 @@ def jest_section(path, title, emoji):
     failed = data.get("numFailedTests", 0)
     skipped = data.get("numPendingTests", 0) + data.get("numTodoTests", 0)
     total = data.get("numTotalTests", passed + failed + skipped)
-
-    # Duration: sum (endTime - startTime) across all suites (milliseconds)
     duration_ms = sum(
         (r.get("endTime", 0) - r.get("startTime", 0))
         for r in data.get("testResults", [])
     )
 
-    lines += [_summary_line(passed, failed, skipped, total, duration_ms / 1000), ""]
+    summary = _summary_line(passed, failed, skipped, total, duration_ms / 1000)
+    lines += [summary, ""]
 
     test_results = data.get("testResults", [])
     if test_results:
@@ -114,11 +133,9 @@ def jest_section(path, title, emoji):
         for suite in test_results:
             raw_path = suite.get("testFilePath", suite.get("name", ""))
             basename = os.path.basename(raw_path)
-            # Strip common suffixes for a cleaner label
             for suffix in (".test.jsx", ".test.tsx", ".test.js", ".test.ts",
                            ".spec.jsx", ".spec.tsx", ".spec.js", ".spec.ts"):
                 basename = basename.removesuffix(suffix)
-
             for assertion in suite.get("assertionResults", []):
                 name = assertion.get("fullName", assertion.get("title", ""))
                 outcome = assertion.get("status", "unknown")
@@ -128,43 +145,63 @@ def jest_section(path, title, emoji):
                 )
         lines += ["", "</details>", ""]
 
+    return lines, summary
+
+
+# ── Index page ────────────────────────────────────────────────────────────────
+
+def build_index_page(backend_summary, frontend_summary, mobile_summary, now, run_link):
+    def row(emoji, label, slug, summary):
+        link = f"[{label}]({WIKI_BASE}/{slug})"
+        return f"| {emoji} {link} | {summary or '_pending_'} |"
+
+    lines = [
+        "# Generated Unit Test Reports",
+        "",
+        f"_Auto-generated: {now} — {run_link}_",
+        "",
+        "| Suite | Result |",
+        "|-------|--------|",
+        row("🐍", "Backend", "Backend-Generated-Unit-Test-Reports", backend_summary),
+        row("⚛️", "Frontend", "Frontend-Generated-Unit-Test-Reports", frontend_summary),
+        row("📱", "Mobile", "Mobile-Generated-Unit-Test-Reports", mobile_summary),
+        "",
+    ]
     return lines
 
 
 # ── Main ──────────────────────────────────────────────────────────────────────
 
+def write(filename, lines):
+    path = os.path.join(WORKSPACE, filename)
+    with open(path, "w") as f:
+        f.write("\n".join(lines) + "\n")
+    print(f"Written: {path}")
+
+
 def main():
     now = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M UTC")
     run_link = f"[CI run]({RUN_URL})" if RUN_URL else "CI run"
 
-    md = [
-        "# Generated Unit Test Reports",
-        "",
-        f"_Auto-generated: {now} — {run_link}_",
-        "",
-        "---",
-        "",
-    ]
-
-    md += backend_section(os.path.join(WORKSPACE, "backend-report.json"))
-    md += ["---", ""]
-    md += jest_section(
+    backend_lines, backend_summary = build_backend_page(
+        os.path.join(WORKSPACE, "backend-report.json"), now, run_link
+    )
+    frontend_lines, frontend_summary = build_jest_page(
         os.path.join(WORKSPACE, "frontend-report.json"),
-        "Frontend — React / Vitest",
-        "⚛️",
+        "Frontend Generated Unit Test Reports", now, run_link
     )
-    md += ["---", ""]
-    md += jest_section(
+    mobile_lines, mobile_summary = build_jest_page(
         os.path.join(WORKSPACE, "mobile-report.json"),
-        "Mobile — React Native / Jest",
-        "📱",
+        "Mobile Generated Unit Test Reports", now, run_link
+    )
+    index_lines = build_index_page(
+        backend_summary, frontend_summary, mobile_summary, now, run_link
     )
 
-    output_path = os.path.join(WORKSPACE, "Generated-Unit-Test-Reports.md")
-    with open(output_path, "w") as f:
-        f.write("\n".join(md) + "\n")
-
-    print(f"Report written to {output_path}")
+    write("Backend-Generated-Unit-Test-Reports.md", backend_lines)
+    write("Frontend-Generated-Unit-Test-Reports.md", frontend_lines)
+    write("Mobile-Generated-Unit-Test-Reports.md", mobile_lines)
+    write("Generated-Unit-Test-Reports.md", index_lines)
 
 
 if __name__ == "__main__":

--- a/.github/scripts/generate_test_report.py
+++ b/.github/scripts/generate_test_report.py
@@ -1,0 +1,171 @@
+#!/usr/bin/env python3
+"""
+Read pytest-json-report (backend), vitest --reporter=json (frontend),
+and jest --json (mobile) output files and generate a single Markdown wiki page.
+"""
+
+import json
+import os
+from datetime import datetime, timezone
+
+WORKSPACE = os.environ.get("GITHUB_WORKSPACE", ".")
+SERVER_URL = os.environ.get("GITHUB_SERVER_URL", "https://github.com")
+REPOSITORY = os.environ.get("GITHUB_REPOSITORY", "")
+RUN_ID = os.environ.get("GITHUB_RUN_ID", "")
+RUN_URL = f"{SERVER_URL}/{REPOSITORY}/actions/runs/{RUN_ID}" if RUN_ID else ""
+
+
+def _icon(outcome):
+    return {"passed": "✅", "failed": "❌", "skipped": "⚠️", "pending": "⚠️"}.get(
+        outcome.lower(), "⚠️"
+    )
+
+
+def _fmt_ms(ms):
+    if ms is None:
+        return "—"
+    if ms < 1000:
+        return f"{int(ms)} ms"
+    return f"{ms / 1000:.2f} s"
+
+
+def _summary_line(passed, failed, skipped, total, duration_s):
+    status = "✅ All passed" if failed == 0 else f"❌ {failed} failed"
+    return (
+        f"**{status}**"
+        f" &nbsp;·&nbsp; {passed} passed"
+        f" &nbsp;·&nbsp; {failed} failed"
+        f" &nbsp;·&nbsp; {skipped} skipped"
+        f" &nbsp;·&nbsp; {total} total"
+        f" &nbsp;·&nbsp; {duration_s:.2f} s"
+    )
+
+
+# ── Backend ───────────────────────────────────────────────────────────────────
+
+def backend_section(path):
+    lines = ["## 🐍 Backend — Django / pytest", ""]
+
+    if not os.path.exists(path):
+        lines += ["_Report not generated — test run did not complete._", ""]
+        return lines
+
+    with open(path) as f:
+        data = json.load(f)
+
+    s = data.get("summary", {})
+    passed = s.get("passed", 0)
+    failed = s.get("failed", 0)
+    skipped = s.get("skipped", 0) + s.get("xfailed", 0)
+    total = s.get("total", passed + failed + skipped)
+    duration = data.get("duration", 0)
+
+    lines += [_summary_line(passed, failed, skipped, total, duration), ""]
+
+    tests = data.get("tests", [])
+    if tests:
+        lines += ["<details>", "<summary>Full test list</summary>", ""]
+        lines += ["| Test | Status | Duration |", "|------|--------|----------|"]
+        for t in tests:
+            node = t.get("nodeid", "")
+            # Keep only the last two :: segments for readability
+            parts = node.split("::")
+            short = "::".join(parts[-2:]) if len(parts) >= 2 else node
+            outcome = t.get("outcome", "unknown")
+            dur = t.get("duration", 0) * 1000  # pytest reports in seconds
+            lines.append(f"| `{short}` | {_icon(outcome)} {outcome} | {_fmt_ms(dur)} |")
+        lines += ["", "</details>", ""]
+
+    return lines
+
+
+# ── Frontend / Mobile (Jest-compatible JSON) ──────────────────────────────────
+
+def jest_section(path, title, emoji):
+    lines = [f"## {emoji} {title}", ""]
+
+    if not os.path.exists(path):
+        lines += ["_Report not generated — test run did not complete._", ""]
+        return lines
+
+    with open(path) as f:
+        data = json.load(f)
+
+    passed = data.get("numPassedTests", 0)
+    failed = data.get("numFailedTests", 0)
+    skipped = data.get("numPendingTests", 0) + data.get("numTodoTests", 0)
+    total = data.get("numTotalTests", passed + failed + skipped)
+
+    # Duration: sum (endTime - startTime) across all suites (milliseconds)
+    duration_ms = sum(
+        (r.get("endTime", 0) - r.get("startTime", 0))
+        for r in data.get("testResults", [])
+    )
+
+    lines += [_summary_line(passed, failed, skipped, total, duration_ms / 1000), ""]
+
+    test_results = data.get("testResults", [])
+    if test_results:
+        lines += ["<details>", "<summary>Full test list</summary>", ""]
+        lines += [
+            "| Suite | Test | Status | Duration |",
+            "|-------|------|--------|----------|",
+        ]
+        for suite in test_results:
+            raw_path = suite.get("testFilePath", suite.get("name", ""))
+            basename = os.path.basename(raw_path)
+            # Strip common suffixes for a cleaner label
+            for suffix in (".test.jsx", ".test.tsx", ".test.js", ".test.ts",
+                           ".spec.jsx", ".spec.tsx", ".spec.js", ".spec.ts"):
+                basename = basename.removesuffix(suffix)
+
+            for assertion in suite.get("assertionResults", []):
+                name = assertion.get("fullName", assertion.get("title", ""))
+                outcome = assertion.get("status", "unknown")
+                dur = assertion.get("duration", None)
+                lines.append(
+                    f"| `{basename}` | {name} | {_icon(outcome)} {outcome} | {_fmt_ms(dur)} |"
+                )
+        lines += ["", "</details>", ""]
+
+    return lines
+
+
+# ── Main ──────────────────────────────────────────────────────────────────────
+
+def main():
+    now = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M UTC")
+    run_link = f"[CI run]({RUN_URL})" if RUN_URL else "CI run"
+
+    md = [
+        "# Generated Unit Test Reports",
+        "",
+        f"_Auto-generated: {now} — {run_link}_",
+        "",
+        "---",
+        "",
+    ]
+
+    md += backend_section(os.path.join(WORKSPACE, "backend-report.json"))
+    md += ["---", ""]
+    md += jest_section(
+        os.path.join(WORKSPACE, "frontend-report.json"),
+        "Frontend — React / Vitest",
+        "⚛️",
+    )
+    md += ["---", ""]
+    md += jest_section(
+        os.path.join(WORKSPACE, "mobile-report.json"),
+        "Mobile — React Native / Jest",
+        "📱",
+    )
+
+    output_path = os.path.join(WORKSPACE, "Generated-Unit-Test-Reports.md")
+    with open(output_path, "w") as f:
+        f.write("\n".join(md) + "\n")
+
+    print(f"Report written to {output_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/test-reports.yml
+++ b/.github/workflows/test-reports.yml
@@ -1,0 +1,133 @@
+name: Generate Test Reports
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  generate-reports:
+    name: Generate Test Reports
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    services:
+      db:
+        image: mysql:8.0
+        env:
+          MYSQL_ROOT_PASSWORD: ci_root_password
+          MYSQL_DATABASE: historystorymap
+          MYSQL_USER: dbuser
+          MYSQL_PASSWORD: ci_db_password
+        ports:
+          - 3306:3306
+        options: >-
+          --health-cmd="mysqladmin ping -h localhost -u root -pci_root_password"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=10
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: requirements/development.txt
+
+      - name: Set up Node.js 20
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: npm
+          cache-dependency-path: |
+            frontend/package-lock.json
+            mobile/package-lock.json
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y default-libmysqlclient-dev gcc pkg-config libmagic1
+
+      - name: Install Python dependencies
+        run: |
+          pip install -r requirements/development.txt
+          pip install pytest-json-report
+
+      - name: Grant test database privileges
+        run: |
+          mysql -h 127.0.0.1 -u root -pci_root_password \
+            -e "GRANT ALL PRIVILEGES ON \`test_%\`.* TO 'dbuser'@'%'; FLUSH PRIVILEGES;"
+
+      # ── Backend ──────────────────────────────────────────────────────────────
+      - name: Run backend tests
+        working-directory: backend
+        continue-on-error: true
+        env:
+          SECRET_KEY: ci-only-secret-key-not-used-in-production
+          DB_NAME: historystorymap
+          DB_USER: dbuser
+          DB_PASSWORD: ci_db_password
+          DB_HOST: 127.0.0.1
+          DB_PORT: 3306
+          DJANGO_SETTINGS_MODULE: config.settings.test
+        run: |
+          python -m pytest -v \
+            --json-report \
+            --json-report-file=${{ github.workspace }}/backend-report.json
+
+      # ── Frontend ─────────────────────────────────────────────────────────────
+      - name: Install frontend dependencies
+        working-directory: frontend
+        run: npm ci
+
+      - name: Run frontend tests
+        working-directory: frontend
+        continue-on-error: true
+        run: |
+          npm run test:run -- \
+            --reporter=json \
+            --outputFile=${{ github.workspace }}/frontend-report.json
+
+      # ── Mobile ───────────────────────────────────────────────────────────────
+      - name: Install mobile dependencies
+        working-directory: mobile
+        run: npm ci
+
+      - name: Run mobile tests
+        working-directory: mobile
+        continue-on-error: true
+        env:
+          CI: true
+          TMPDIR: ${{ runner.temp }}
+          TMP: ${{ runner.temp }}
+          TEMP: ${{ runner.temp }}
+        run: |
+          npm test -- \
+            --runInBand \
+            --watchAll=false \
+            --json \
+            --outputFile=${{ github.workspace }}/mobile-report.json
+
+      # ── Report generation ────────────────────────────────────────────────────
+      - name: Generate wiki page
+        run: python .github/scripts/generate_test_report.py
+
+      - name: Push report to wiki
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          git clone \
+            https://x-access-token:${GITHUB_TOKEN}@github.com/${{ github.repository }}.wiki.git \
+            wiki-repo
+          cp ${{ github.workspace }}/Generated-Unit-Test-Reports.md wiki-repo/
+          cd wiki-repo
+          git config user.name "kemal"
+          git config user.email "kemal.mahmutogullari@gmail.com"
+          git add Generated-Unit-Test-Reports.md
+          git diff --staged --quiet || git commit -m "docs: update unit test reports"
+          git push

--- a/.github/workflows/test-reports.yml
+++ b/.github/workflows/test-reports.yml
@@ -117,7 +117,7 @@ jobs:
       - name: Generate wiki page
         run: python .github/scripts/generate_test_report.py
 
-      - name: Push report to wiki
+      - name: Push reports to wiki
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -125,9 +125,16 @@ jobs:
             https://x-access-token:${GITHUB_TOKEN}@github.com/${{ github.repository }}.wiki.git \
             wiki-repo
           cp ${{ github.workspace }}/Generated-Unit-Test-Reports.md wiki-repo/
+          cp ${{ github.workspace }}/Backend-Generated-Unit-Test-Reports.md wiki-repo/
+          cp ${{ github.workspace }}/Frontend-Generated-Unit-Test-Reports.md wiki-repo/
+          cp ${{ github.workspace }}/Mobile-Generated-Unit-Test-Reports.md wiki-repo/
           cd wiki-repo
           git config user.name "kemal"
           git config user.email "kemal.mahmutogullari@gmail.com"
-          git add Generated-Unit-Test-Reports.md
+          git add \
+            Generated-Unit-Test-Reports.md \
+            Backend-Generated-Unit-Test-Reports.md \
+            Frontend-Generated-Unit-Test-Reports.md \
+            Mobile-Generated-Unit-Test-Reports.md
           git diff --staged --quiet || git commit -m "docs: update unit test reports"
           git push

--- a/.github/workflows/test-reports.yml
+++ b/.github/workflows/test-reports.yml
@@ -128,6 +128,9 @@ jobs:
           cp ${{ github.workspace }}/Backend-Generated-Unit-Test-Reports.md wiki-repo/
           cp ${{ github.workspace }}/Frontend-Generated-Unit-Test-Reports.md wiki-repo/
           cp ${{ github.workspace }}/Mobile-Generated-Unit-Test-Reports.md wiki-repo/
+          cp ${{ github.workspace }}/Backend-Generated-Unit-Test-Reports.html wiki-repo/
+          cp ${{ github.workspace }}/Frontend-Generated-Unit-Test-Reports.html wiki-repo/
+          cp ${{ github.workspace }}/Mobile-Generated-Unit-Test-Reports.html wiki-repo/
           cd wiki-repo
           git config user.name "kemal"
           git config user.email "kemal.mahmutogullari@gmail.com"
@@ -135,6 +138,9 @@ jobs:
             Generated-Unit-Test-Reports.md \
             Backend-Generated-Unit-Test-Reports.md \
             Frontend-Generated-Unit-Test-Reports.md \
-            Mobile-Generated-Unit-Test-Reports.md
+            Mobile-Generated-Unit-Test-Reports.md \
+            Backend-Generated-Unit-Test-Reports.html \
+            Frontend-Generated-Unit-Test-Reports.html \
+            Mobile-Generated-Unit-Test-Reports.html
           git diff --staged --quiet || git commit -m "docs: update unit test reports"
           git push


### PR DESCRIPTION
# 📝 Description
Fixes #356

Adds a `Generate Test Reports` workflow that runs all three test suites (backend, frontend, mobile) on every push to `main`, generates structured JSON output from each, and publishes a formatted Markdown report to the wiki page **Generated Unit Test Reports**.

The report shows a pass/fail summary per suite and an expandable full test list with per-test status and duration. Each test suite runs with `continue-on-error: true` so the report is always generated and pushed even when tests fail.

Implementation:
- `.github/workflows/test-reports.yml` — orchestrates the full pipeline; uses `pytest-json-report` (backend), `vitest --reporter=json` (frontend), `jest --json` (mobile), then pushes to the wiki via `GITHUB_TOKEN`
- `.github/scripts/generate_test_report.py` — reads the three JSON outputs and builds the wiki Markdown page with summary lines and `<details>` test tables

The wiki page stub has already been created at: https://github.com/bounswe/bounswe2026group4/wiki/Generated-Unit-Test-Reports

# 📊 Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Refactoring
- [x] Documentation

# ✅ Acceptance Criteria / Checklist
- [x] Project builds successfully
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, especially in hard-to-understand parts
- [x] I have performed a self-review of my code
- [x] I have added/updated tests
- [x] New and existing unit tests pass locally with my changes

# 📸 Screenshots / Recordings
<!-- Wiki page will be auto-populated on first workflow run after merge -->

# ⏱️ Estimated Review Time
- [ ] < 5 min
- [x] 5-15 min
- [ ] > 15 min