### PR TITLE
Fix/search filter params

### DIFF
--- a/backend/apps/stories/serializers.py
+++ b/backend/apps/stories/serializers.py
@@ -298,7 +298,31 @@ class StoryMapSerializer(serializers.ModelSerializer):
 
 
 class SearchQuerySerializer(serializers.Serializer):
-    """Validates the q query parameter for the story search endpoint."""
+    """
+    Validates query parameters for the story search endpoint.
+
+    q is required. The filter params (sort_by, year_from, year_to, location) are
+    optional and mirror those accepted by FeedQuerySerializer so search results
+    can be narrowed with the same filters as the feed.
+    """
+
+    SORT_RECENT = 'recent'
+    SORT_POPULAR = 'popular'
+    SORT_CHOICES = [SORT_RECENT, SORT_POPULAR]
 
     # strip_whitespace=True (default) means a whitespace-only value becomes '' and fails min_length
     q = serializers.CharField(required=True, min_length=1)
+    sort_by = serializers.ChoiceField(choices=SORT_CHOICES, default=SORT_RECENT, required=False)
+    year_from = serializers.IntegerField(required=False)
+    year_to = serializers.IntegerField(required=False)
+    # Substring match against location_name — partial values like "galata" are valid
+    location = serializers.CharField(required=False, allow_blank=False)
+
+    def validate(self, data):
+        year_from = data.get('year_from')
+        year_to = data.get('year_to')
+        if year_from is not None and year_to is not None and year_from > year_to:
+            raise serializers.ValidationError(
+                {'year_to': 'year_to must be greater than or equal to year_from.'}
+            )
+        return data

--- a/backend/apps/stories/services.py
+++ b/backend/apps/stories/services.py
@@ -66,19 +66,42 @@ def get_story_feed(sort_by='recent', year_from=None, year_to=None, location=None
     return qs
 
 
-def get_story_search(q: str):
+def get_story_search(q: str, sort_by='recent', year_from=None, year_to=None, location=None):
     """Return published stories whose title or location_name contains q (case-insensitive).
+
+    Accepts the same optional filter params as get_story_feed so search results
+    can be narrowed by year range and location in addition to the text query.
 
     Returns an empty queryset if q is blank or whitespace-only — callers should
     validate q before calling, but the service is safe to call directly.
     """
     if not q or not q.strip():
         return Story.objects.none()
-    return (
+
+    qs = (
         Story.objects
         .filter(status=Story.STATUS_PUBLISHED)
-        .filter(
-            Q(title__icontains=q) | Q(location_name__icontains=q)
-        )
-        .order_by('-submitted_at')
+        .filter(Q(title__icontains=q) | Q(location_name__icontains=q))
     )
+
+    if year_from is not None:
+        qs = qs.filter(
+            Q(year__gte=year_from) |
+            Q(year_end__gte=year_from)  # catches year_range stories that end within or after the window
+        )
+
+    if year_to is not None:
+        qs = qs.filter(
+            Q(year__lte=year_to) |
+            Q(year_start__lte=year_to)  # catches year_range stories that start within or before the window
+        )
+
+    if location:
+        qs = qs.filter(location_name__icontains=location)
+
+    if sort_by == 'recent':
+        qs = qs.order_by('-submitted_at')
+
+    # TODO: add sort_by='popular' ordered by like_count once interactions app is implemented
+
+    return qs

--- a/backend/apps/stories/tests/test_serializers.py
+++ b/backend/apps/stories/tests/test_serializers.py
@@ -266,6 +266,42 @@ class TestSearchQuerySerializer:
         s = SearchQuerySerializer(data={'q': 'a'})
         assert s.is_valid(), s.errors
 
+    def test_valid_with_all_filter_params(self):
+        s = SearchQuerySerializer(data={
+            'q': 'tower',
+            'sort_by': 'recent',
+            'year_from': 1900,
+            'year_to': 2000,
+            'location': 'istanbul',
+        })
+        assert s.is_valid(), s.errors
+        assert s.validated_data['year_from'] == 1900
+        assert s.validated_data['year_to'] == 2000
+        assert s.validated_data['location'] == 'istanbul'
+
+    def test_year_from_greater_than_year_to_fails(self):
+        s = SearchQuerySerializer(data={'q': 'bridge', 'year_from': 2000, 'year_to': 1900})
+        assert not s.is_valid()
+        assert 'year_to' in str(s.errors)
+
+    def test_invalid_sort_by_fails(self):
+        s = SearchQuerySerializer(data={'q': 'bridge', 'sort_by': 'invalid'})
+        assert not s.is_valid()
+        assert 'sort_by' in s.errors
+
+    def test_defaults_sort_by_to_recent_when_omitted(self):
+        s = SearchQuerySerializer(data={'q': 'bridge'})
+        assert s.is_valid(), s.errors
+        assert s.validated_data['sort_by'] == 'recent'
+
+    def test_filter_params_are_optional(self):
+        # Only q provided — all other filter params should be absent from validated_data
+        s = SearchQuerySerializer(data={'q': 'galata'})
+        assert s.is_valid(), s.errors
+        assert 'year_from' not in s.validated_data
+        assert 'year_to' not in s.validated_data
+        assert 'location' not in s.validated_data
+
 
 # ── StoryMapSerializer ────────────────────────────────────────────────────────
 

--- a/backend/apps/stories/tests/test_services.py
+++ b/backend/apps/stories/tests/test_services.py
@@ -253,6 +253,45 @@ class TestGetStorySearch:
         make_story(title='Istanbul Today')
         assert get_story_search('Istanbul').count() == 2
 
+    def test_get_story_search_filters_by_year_from(self):
+        make_story(title='Old Istanbul', year=1800)
+        make_story(title='New Istanbul', year=1950)
+        assert get_story_search('Istanbul', year_from=1900).count() == 1
+        assert get_story_search('Istanbul', year_from=1900).first().title == 'New Istanbul'
+
+    def test_get_story_search_filters_by_year_to(self):
+        make_story(title='Old Istanbul', year=1800)
+        make_story(title='New Istanbul', year=1950)
+        assert get_story_search('Istanbul', year_to=1900).count() == 1
+        assert get_story_search('Istanbul', year_to=1900).first().title == 'Old Istanbul'
+
+    def test_get_story_search_filters_by_year_from_and_year_to(self):
+        make_story(title='Istanbul 1700', year=1700)
+        make_story(title='Istanbul 1850', year=1850)
+        make_story(title='Istanbul 2000', year=2000)
+        qs = get_story_search('Istanbul', year_from=1800, year_to=1900)
+        assert qs.count() == 1
+        assert qs.first().title == 'Istanbul 1850'
+
+    def test_get_story_search_filters_by_location(self):
+        make_story(title='Bridge Story', location_name='Galata Bridge')
+        make_story(title='Tower Story', location_name='Galata Tower')
+        make_story(title='Ankara Story', location_name='Ankara Castle')
+        qs = get_story_search('Story', location='Galata')
+        assert qs.count() == 2
+
+    def test_get_story_search_excludes_non_matching_location(self):
+        make_story(title='Istanbul Story', location_name='Galata Bridge')
+        assert get_story_search('Istanbul', location='Ankara').count() == 0
+
+    def test_get_story_search_combined_text_year_and_location(self):
+        make_story(title='Tower in Galata', year=1900, location_name='Galata')
+        make_story(title='Tower in Ankara', year=1900, location_name='Ankara')
+        make_story(title='Tower too late', year=2000, location_name='Galata')
+        qs = get_story_search('Tower', year_from=1800, year_to=1950, location='Galata')
+        assert qs.count() == 1
+        assert qs.first().title == 'Tower in Galata'
+
 
 # ── delete_story ──────────────────────────────────────────────────────────────
 

--- a/backend/apps/stories/tests/test_views.py
+++ b/backend/apps/stories/tests/test_views.py
@@ -345,6 +345,43 @@ class TestStorySearchView:
         response = client.get(SEARCH_URL + '?q=Gone')
         assert response.data['count'] == 0
 
+    def test_search_filters_by_year_from(self, client):
+        make_story(title='Old Istanbul', year=1800)
+        make_story(title='New Istanbul', year=1950)
+        response = client.get(SEARCH_URL + '?q=Istanbul&year_from=1900')
+        assert response.data['count'] == 1
+        assert response.data['results'][0]['title'] == 'New Istanbul'
+
+    def test_search_filters_by_year_to(self, client):
+        make_story(title='Old Istanbul', year=1800)
+        make_story(title='New Istanbul', year=1950)
+        response = client.get(SEARCH_URL + '?q=Istanbul&year_to=1900')
+        assert response.data['count'] == 1
+        assert response.data['results'][0]['title'] == 'Old Istanbul'
+
+    def test_search_filters_by_location(self, client):
+        make_story(title='Galata Story', location_name='Galata Bridge')
+        make_story(title='Ankara Story', location_name='Ankara Castle')
+        response = client.get(SEARCH_URL + '?q=Story&location=Galata')
+        assert response.data['count'] == 1
+        assert response.data['results'][0]['title'] == 'Galata Story'
+
+    def test_search_with_combined_filters(self, client):
+        make_story(title='Tower Galata', year=1900, location_name='Galata')
+        make_story(title='Tower Ankara', year=1900, location_name='Ankara')
+        make_story(title='Tower Late', year=2000, location_name='Galata')
+        response = client.get(SEARCH_URL + '?q=Tower&year_from=1800&year_to=1950&location=Galata')
+        assert response.data['count'] == 1
+        assert response.data['results'][0]['title'] == 'Tower Galata'
+
+    def test_search_returns_400_for_invalid_year_range(self, client):
+        response = client.get(SEARCH_URL + '?q=Istanbul&year_from=2000&year_to=1900')
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+    def test_search_returns_400_for_invalid_sort_by(self, client):
+        response = client.get(SEARCH_URL + '?q=Istanbul&sort_by=invalid')
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+
 
 # ── GET /stories/map/ ─────────────────────────────────────────────────────────
 

--- a/backend/apps/stories/views.py
+++ b/backend/apps/stories/views.py
@@ -115,9 +115,15 @@ class StorySearchView(APIView):
     def get(self, request):
         query_serializer = SearchQuerySerializer(data=request.query_params)
         query_serializer.is_valid(raise_exception=True)
-        q = query_serializer.validated_data['q']
+        params = query_serializer.validated_data
 
-        qs = get_story_search(q)
+        qs = get_story_search(
+            q=params['q'],
+            sort_by=params.get('sort_by', 'recent'),
+            year_from=params.get('year_from'),
+            year_to=params.get('year_to'),
+            location=params.get('location'),
+        )
         if request.user.is_authenticated:
             qs = annotate_user_interactions(qs, request.user)
 


### PR DESCRIPTION
# 📝 Description
Fixes #359

This PR fixes the backend bug where the story search endpoint could not accept the same filter parameters as the feed endpoint, which prevented search and filtering from being used together.

With this change, the search endpoint now supports the required `q` parameter together with optional feed-style filters such as `sort_by`, `year_from`, `year_to`, and `location`.

The PR includes:
- extending `SearchQuerySerializer` to validate these additional filter parameters
- adding validation for invalid year ranges
- updating the search service to apply the filters
- updating the view to pass validated parameters correctly
- adding and updating serializer, service, and view tests for valid, invalid, and combined filter cases

# 📊 Type of Change
- [x]  Bug fix
- [ ]  New feature
- [ ]  Refactoring
- [ ]  Documentation
 
# ✅ Acceptance Criteria / Checklist
- [x] Project builds successfully
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, especially in hard-to-understand parts
- [x] I have performed a self-review of my code
- [x] I have added/updated tests
- [x] New and existing unit tests pass locally with my changes

# 📸 Screenshots / Recordings
<!-- If applicable !-->

# ⏱️ Estimated Review Time
- [ ] < 5 min
- [x] 5-15 min
- [ ] > 15 min