### PR TITLE
fix:profile-private-settings

### DIFF
--- a/mobile/src/app/navigation/__tests__/RootNavigator.test.tsx
+++ b/mobile/src/app/navigation/__tests__/RootNavigator.test.tsx
@@ -652,7 +652,7 @@ describe('RootNavigator auth flow', () => {
     fireEvent.press(screen.getByLabelText('Read story: Harbor Memory'));
 
     expect(await screen.findByText('Harbor Memory')).toBeTruthy();
-    fireEvent.press(screen.getByLabelText('Open profile: Traveler'));
+    fireEvent.press(screen.getByLabelText('Open profile: Traveler (You)'));
 
     await waitFor(() => {
       expect(screen.getByText('Signed in as Traveler.')).toBeTruthy();

--- a/mobile/src/core/auth/session.ts
+++ b/mobile/src/core/auth/session.ts
@@ -5,6 +5,7 @@ export interface SessionUser {
   email: string;
   username: string;
   role: AppRole;
+  isUsernamePublic?: boolean;
 }
 
 export type AuthUser = SessionUser;

--- a/mobile/src/features/auth/data/mappers/index.ts
+++ b/mobile/src/features/auth/data/mappers/index.ts
@@ -14,6 +14,8 @@ export function mapAuth(value: unknown): AuthSessionEntity {
       username?: unknown;
       email?: unknown;
       role?: unknown;
+      isUsernamePublic?: unknown;
+      is_username_public?: unknown;
     };
   };
 
@@ -39,6 +41,12 @@ export function mapAuth(value: unknown): AuthSessionEntity {
       username: payload.user.username,
       email: payload.user.email,
       role: payload.user.role,
+      isUsernamePublic:
+        typeof payload.user.isUsernamePublic === 'boolean'
+          ? payload.user.isUsernamePublic
+          : typeof payload.user.is_username_public === 'boolean'
+            ? payload.user.is_username_public
+            : undefined,
     },
   };
 }

--- a/mobile/src/features/profile/presentation/screens/ProfileScreen.tsx
+++ b/mobile/src/features/profile/presentation/screens/ProfileScreen.tsx
@@ -231,6 +231,7 @@ export function ProfileScreen({
       setProfile(updatedProfile);
       setFormState(createFormState(updatedProfile));
       await updateUser({
+        isUsernamePublic: updatedProfile.isUsernamePublic,
         username: updatedProfile.username ?? user?.username ?? '',
       });
       setSaveMessage('Profile updated successfully.');
@@ -249,7 +250,7 @@ export function ProfileScreen({
     return 'User profile';
   }, [isSelfMode]);
 
-  const resolvedName = profile?.username || (isSelfMode ? user?.username : null) || 'Private user';
+  const resolvedName = profile?.username || (isSelfMode ? user?.username : null) || 'Anonymous user';
   const joinedDate = formatJoinedDate(profile?.dateJoined);
   const isDirty = useMemo(() => {
     if (!profile) {

--- a/mobile/src/features/profile/presentation/screens/__tests__/ProfileScreen.test.tsx
+++ b/mobile/src/features/profile/presentation/screens/__tests__/ProfileScreen.test.tsx
@@ -116,6 +116,21 @@ describe('ProfileScreen', () => {
     expect(screen.getByText('Stories are intentionally out of scope for this profile version and will be added later.')).toBeTruthy();
   });
 
+  it('shows anonymous user when the public profile username is hidden', async () => {
+    render(
+      <ProfileScreen
+        mode="public"
+        userId="12"
+        getPublicProfile={async () => ({
+          ...publicProfile,
+          username: null,
+        })}
+      />,
+    );
+
+    expect(await screen.findByText('Anonymous user')).toBeTruthy();
+  });
+
   it('shows an error state when profile loading fails', async () => {
     render(
       <ProfileScreen

--- a/mobile/src/features/stories/presentation/screens/StoryScreen.tsx
+++ b/mobile/src/features/stories/presentation/screens/StoryScreen.tsx
@@ -37,17 +37,12 @@ function formatDate(dateString: string) {
   });
 }
 
-function getResolvedContributorName(story: StoryEntity, session?: Pick<Session, 'user'>) {
-  const isOwnStory =
-    session?.user?.id !== undefined &&
-    story.contributorUserId !== undefined &&
-    String(session.user.id) === story.contributorUserId;
-
-  if (isOwnStory && session?.user?.isUsernamePublic === false) {
-    return 'Anonymous';
-  }
-
+function getResolvedContributorName(story: StoryEntity) {
   return story.contributorName;
+}
+
+function getDisplayNameWithYouLabel(name: string, isCurrentUser: boolean) {
+  return isCurrentUser ? `${name} (You)` : name;
 }
 
 function StoryMetaRow({ label, value }: { label: string; value: string }) {
@@ -294,6 +289,7 @@ function CommentsSection({
       {displayedComments.map((comment) => {
         const isOwnComment = isAuthenticated && currentUsername === comment.authorName;
         const awaitingConfirm = confirmDeleteId === comment.id;
+        const authorDisplayName = getDisplayNameWithYouLabel(comment.authorName, isOwnComment);
 
         return (
         <View
@@ -307,7 +303,7 @@ function CommentsSection({
             backgroundColor: colors.surface,
           }}
         >
-          <Text style={{ color: colors.text, fontWeight: '700' }}>{comment.authorName}</Text>
+          <Text style={{ color: colors.text, fontWeight: '700' }}>{authorDisplayName}</Text>
           <Text style={{ marginTop: spacing.xs, color: colors.muted, fontSize: typography.caption }}>
             {formatDate(comment.createdAt)}
           </Text>
@@ -441,13 +437,12 @@ export function StoryScreen({
       };
     }
 
-    const isOwnPrivateStory =
+    const isOwnStory =
       session?.user?.id !== undefined &&
-      String(session.user.id) === story.contributorUserId &&
-      session.user.isUsernamePublic === false;
+      String(session.user.id) === story.contributorUserId;
 
-    if (isOwnPrivateStory) {
-      setIsContributorAnonymous(true);
+    if (isOwnStory) {
+      setIsContributorAnonymous(false);
       return () => {
         isMounted = false;
       };
@@ -468,7 +463,7 @@ export function StoryScreen({
     return () => {
       isMounted = false;
     };
-  }, [getPublicProfile, session?.user?.id, session?.user?.isUsernamePublic, state.story]);
+  }, [getPublicProfile, session?.user?.id, state.story]);
 
   const extractInteractionError = (error: unknown, fallback: string) => {
     const response = (error as { response?: { data?: unknown } })?.response?.data;
@@ -646,7 +641,8 @@ export function StoryScreen({
   const story = state.story;
   const isStoryOwner = session?.user?.id !== undefined && String(session.user.id) === story.contributorUserId;
   const canDeleteStory = session?.role === roles.admin || isStoryOwner;
-  const contributorName = isContributorAnonymous ? 'Anonymous' : getResolvedContributorName(story, session);
+  const contributorName = isContributorAnonymous ? 'Anonymous' : getResolvedContributorName(story);
+  const contributorDisplayName = getDisplayNameWithYouLabel(contributorName, isStoryOwner);
   const canOpenContributorProfile = Boolean(story.contributorUserId);
 
   const promptDeleteStory = () => {
@@ -707,7 +703,7 @@ export function StoryScreen({
         <StoryMetaRow label="Time period" value={story.timePeriod} />
         <StoryMetaActionRow
           label="Contributor"
-          value={contributorName}
+          value={contributorDisplayName}
           onPress={
             canOpenContributorProfile
               ? () => {

--- a/mobile/src/features/stories/presentation/screens/StoryScreen.tsx
+++ b/mobile/src/features/stories/presentation/screens/StoryScreen.tsx
@@ -13,6 +13,7 @@ import { Input } from '../../../../shared/ui/Input';
 import { Loader } from '../../../../shared/ui/Loader';
 import { NotFoundPage } from '../../../../shared/ui/NotFoundPage';
 import { WebMapView } from '../../../../shared/components/WebMapView';
+import { userService } from '../../../profile/application/services';
 import { createInitialStoryDetailUiState } from '../state/storiesUiState';
 import { loadStoryDetail } from '../state/storyDetailController';
 
@@ -25,6 +26,7 @@ interface StoryScreenProps {
   onOpenContributorProfile?: (userId: string) => void;
   getStory?: typeof storyService.getStory;
   deleteStory?: typeof storyService.deleteStory;
+  getPublicProfile?: typeof userService.getPublicProfile;
 }
 
 function formatDate(dateString: string) {
@@ -33,6 +35,19 @@ function formatDate(dateString: string) {
     month: 'short',
     year: 'numeric',
   });
+}
+
+function getResolvedContributorName(story: StoryEntity, session?: Pick<Session, 'user'>) {
+  const isOwnStory =
+    session?.user?.id !== undefined &&
+    story.contributorUserId !== undefined &&
+    String(session.user.id) === story.contributorUserId;
+
+  if (isOwnStory && session?.user?.isUsernamePublic === false) {
+    return 'Anonymous';
+  }
+
+  return story.contributorName;
 }
 
 function StoryMetaRow({ label, value }: { label: string; value: string }) {
@@ -344,6 +359,7 @@ export function StoryScreen({
   onOpenContributorProfile,
   getStory = storyService.getStory,
   deleteStory = storyService.deleteStory,
+  getPublicProfile = userService.getPublicProfile,
 }: StoryScreenProps) {
   const { colors, spacing, typography } = useAppTheme();
   const [state, setState] = useState(() =>
@@ -359,6 +375,7 @@ export function StoryScreen({
   const [isStoryDeleting, setIsStoryDeleting] = useState(false);
   const [confirmDeleteId, setConfirmDeleteId] = useState<string>();
   const [interactionError, setInteractionError] = useState<string>();
+  const [isContributorAnonymous, setIsContributorAnonymous] = useState(false);
   const deletedCommentIdsRef = useRef<Set<string>>(new Set());
 
   useEffect(() => {
@@ -373,6 +390,7 @@ export function StoryScreen({
     setStoryDeleteError(undefined);
     setConfirmDeleteId(undefined);
     setInteractionError(undefined);
+    setIsContributorAnonymous(false);
     deletedCommentIdsRef.current = new Set();
 
     loadStoryDetail(storyId, session?.role, getStory).then((nextState) => {
@@ -411,6 +429,46 @@ export function StoryScreen({
       isMounted = false;
     };
   }, [getStory, session?.role, storyId]);
+
+  useEffect(() => {
+    let isMounted = true;
+
+    const story = state.story;
+    if (!story?.contributorUserId) {
+      setIsContributorAnonymous(story?.contributorName === 'Anonymous');
+      return () => {
+        isMounted = false;
+      };
+    }
+
+    const isOwnPrivateStory =
+      session?.user?.id !== undefined &&
+      String(session.user.id) === story.contributorUserId &&
+      session.user.isUsernamePublic === false;
+
+    if (isOwnPrivateStory) {
+      setIsContributorAnonymous(true);
+      return () => {
+        isMounted = false;
+      };
+    }
+
+    setIsContributorAnonymous(story.contributorName === 'Anonymous');
+
+    getPublicProfile(story.contributorUserId)
+      .then((profile) => {
+        if (!isMounted) {
+          return;
+        }
+
+        setIsContributorAnonymous(!profile.username);
+      })
+      .catch(() => undefined);
+
+    return () => {
+      isMounted = false;
+    };
+  }, [getPublicProfile, session?.user?.id, session?.user?.isUsernamePublic, state.story]);
 
   const extractInteractionError = (error: unknown, fallback: string) => {
     const response = (error as { response?: { data?: unknown } })?.response?.data;
@@ -588,6 +646,8 @@ export function StoryScreen({
   const story = state.story;
   const isStoryOwner = session?.user?.id !== undefined && String(session.user.id) === story.contributorUserId;
   const canDeleteStory = session?.role === roles.admin || isStoryOwner;
+  const contributorName = isContributorAnonymous ? 'Anonymous' : getResolvedContributorName(story, session);
+  const canOpenContributorProfile = Boolean(story.contributorUserId);
 
   const promptDeleteStory = () => {
     if (!canDeleteStory || isStoryDeleting) {
@@ -647,9 +707,9 @@ export function StoryScreen({
         <StoryMetaRow label="Time period" value={story.timePeriod} />
         <StoryMetaActionRow
           label="Contributor"
-          value={story.contributorName}
+          value={contributorName}
           onPress={
-            story.contributorUserId
+            canOpenContributorProfile
               ? () => {
                   onOpenContributorProfile?.(story.contributorUserId!);
                 }

--- a/mobile/src/features/stories/presentation/screens/__tests__/StoryScreen.test.tsx
+++ b/mobile/src/features/stories/presentation/screens/__tests__/StoryScreen.test.tsx
@@ -171,7 +171,7 @@ describe('StoryScreen', () => {
     expect(onOpenContributorProfile).toHaveBeenCalledWith('22');
   });
 
-  it('shows the signed-in user as anonymous after they make their username private', async () => {
+  it('marks the signed-in user on their own story even if their username is private', async () => {
     render(
       <StoryScreen
         storyId="story-001"
@@ -188,9 +188,9 @@ describe('StoryScreen', () => {
     );
 
     expect(await screen.findByText(baseStory.title)).toBeTruthy();
-    expect(screen.getByText('Anonymous')).toBeTruthy();
-    expect(screen.queryByText(baseStory.contributorName)).toBeNull();
-    expect(screen.getByLabelText('Open profile: Anonymous')).toBeTruthy();
+    expect(screen.getByText(`${baseStory.contributorName} (You)`)).toBeTruthy();
+    expect(screen.queryByText('Anonymous')).toBeNull();
+    expect(screen.getByLabelText(`Open profile: ${baseStory.contributorName} (You)`)).toBeTruthy();
   });
 
   it('uses the contributor public profile to hide private usernames', async () => {
@@ -413,6 +413,46 @@ describe('StoryScreen', () => {
     await waitFor(() => {
       expect(screen.queryByText('Delete this comment?')).toBeNull();
     });
+  });
+
+  it('marks the signed-in user on their own comments even when private', async () => {
+    (interactionService.getComments as jest.Mock).mockResolvedValueOnce([
+      {
+        id: 'comment-own',
+        authorUsername: 'Traveler',
+        text: 'My own comment',
+        createdAt: '2026-03-21T12:00:00Z',
+      },
+    ]);
+
+    render(
+      <StoryScreen
+        storyId="story-001"
+        session={{
+          ...userSession,
+          user: {
+            ...userSession.user,
+            isUsernamePublic: false,
+          },
+        }}
+        getStory={async () => ({
+          ...baseStory,
+          comments: [
+            {
+              id: 'comment-own',
+              authorName: 'Traveler',
+              body: 'My own comment',
+              createdAt: '2026-03-21T12:00:00Z',
+            },
+          ],
+        })}
+      />,
+    );
+
+    await screen.findByText('My own comment');
+    expect(screen.getByText('Traveler (You)')).toBeTruthy();
+    expect(screen.queryByText('Anonymous')).toBeNull();
+    expect(screen.getByText('Delete comment')).toBeTruthy();
   });
 
   it('shows the delete story action only to the owner or an admin', async () => {

--- a/mobile/src/features/stories/presentation/screens/__tests__/StoryScreen.test.tsx
+++ b/mobile/src/features/stories/presentation/screens/__tests__/StoryScreen.test.tsx
@@ -140,6 +140,7 @@ describe('StoryScreen', () => {
       <StoryScreen
         storyId="story-001"
         getStory={async () => baseStory}
+        getPublicProfile={async () => ({ id: '22', username: 'Aylin Demir', totalPoints: 0 })}
         onOpenContributorProfile={onOpenContributorProfile}
       />,
     );
@@ -148,6 +149,65 @@ describe('StoryScreen', () => {
     fireEvent.press(screen.getByLabelText(`Open profile: ${baseStory.contributorName}`));
 
     expect(onOpenContributorProfile).toHaveBeenCalledWith('22');
+  });
+
+  it('keeps the profile action for anonymous contributors', async () => {
+    const onOpenContributorProfile = jest.fn();
+
+    render(
+      <StoryScreen
+        storyId="story-001"
+        getStory={async () => ({
+          ...baseStory,
+          contributorName: 'Anonymous',
+        })}
+        getPublicProfile={async () => ({ id: '22', username: null, totalPoints: 0 })}
+        onOpenContributorProfile={onOpenContributorProfile}
+      />,
+    );
+
+    expect(await screen.findByText(baseStory.title)).toBeTruthy();
+    fireEvent.press(screen.getByLabelText('Open profile: Anonymous'));
+    expect(onOpenContributorProfile).toHaveBeenCalledWith('22');
+  });
+
+  it('shows the signed-in user as anonymous after they make their username private', async () => {
+    render(
+      <StoryScreen
+        storyId="story-001"
+        session={{
+          ...ownerSession,
+          user: {
+            ...ownerSession.user,
+            isUsernamePublic: false,
+          },
+        }}
+        getStory={async () => baseStory}
+        getPublicProfile={async () => ({ id: '22', username: null, totalPoints: 0 })}
+      />,
+    );
+
+    expect(await screen.findByText(baseStory.title)).toBeTruthy();
+    expect(screen.getByText('Anonymous')).toBeTruthy();
+    expect(screen.queryByText(baseStory.contributorName)).toBeNull();
+    expect(screen.getByLabelText('Open profile: Anonymous')).toBeTruthy();
+  });
+
+  it('uses the contributor public profile to hide private usernames', async () => {
+    render(
+      <StoryScreen
+        storyId="story-001"
+        getStory={async () => baseStory}
+        getPublicProfile={async () => ({ id: '22', username: null, totalPoints: 0 })}
+      />,
+    );
+
+    expect(await screen.findByText(baseStory.title)).toBeTruthy();
+    await waitFor(() => {
+      expect(screen.getByText('Anonymous')).toBeTruthy();
+    });
+    expect(screen.queryByText(baseStory.contributorName)).toBeNull();
+    expect(screen.getByLabelText('Open profile: Anonymous')).toBeTruthy();
   });
 
   it('shows an image fallback message when the media fails to load', async () => {


### PR DESCRIPTION
# 📝 Description
Fixes #382 

This PR fixes a mobile privacy bug where users with private username visibility could still appear by name in story and profile-related UI.

Changes included in this PR:
- show `Anonymous` in the story contributor area when the contributor's public profile does not expose a username
- keep contributor profile navigation working even when the displayed name is `Anonymous`
- update the profile screen fallback label from `Private user` to `Anonymous user`
- persist `isUsernamePublic` in the mobile auth/session state so privacy changes are reflected correctly in the app

# 📊 Type of Change
- [x]  Bug fix
- [ ]  New feature
- [ ]  Refactoring
- [ ]  Documentation
 
# ✅ Acceptance Criteria / Checklist
- [x] Project builds successfully
- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, especially in hard-to-understand parts
- [x] I have performed a self-review of my code
- [x] I have added/updated tests
- [x] New and existing unit tests pass locally with my changes

# 📸 Screenshots / Recordings
<!-- If applicable !-->

# ⏱️ Estimated Review Time
- [ ] < 5 min
- [x] 5-15 min
- [ ] > 15 min
