### PR TITLE
Fix/ hide author_username in comments when user has private username

### DIFF
--- a/backend/apps/interactions/serializers.py
+++ b/backend/apps/interactions/serializers.py
@@ -22,6 +22,8 @@ class CommentResponseSerializer(serializers.ModelSerializer):
     def get_author_username(self, obj):
         if obj.is_anonymized or obj.author is None:
             return None
+        if not obj.author.is_username_public:
+            return None
         return obj.author.username
 
 

--- a/backend/apps/interactions/tests/test_serializers.py
+++ b/backend/apps/interactions/tests/test_serializers.py
@@ -60,6 +60,25 @@ class TestCommentResponseSerializer:
         for field in ['id', 'story_id', 'author_username', 'text', 'is_anonymized', 'created_at']:
             assert field in data
 
+    def test_response_serializer_hides_username_when_private(self, story):
+        private_user = User.objects.create_user(
+            email='private@example.com', username='privateuser', password='Password1',
+            is_username_public=False,
+        )
+        comment = Comment.objects.create(story=story, author=private_user, text='Incognito')
+        data = CommentResponseSerializer(comment).data
+        assert data['author_username'] is None
+        assert data['is_anonymized'] is False
+
+    def test_response_serializer_shows_username_when_public(self, story):
+        public_user = User.objects.create_user(
+            email='public@example.com', username='publicuser', password='Password1',
+            is_username_public=True,
+        )
+        comment = Comment.objects.create(story=story, author=public_user, text='Visible')
+        data = CommentResponseSerializer(comment).data
+        assert data['author_username'] == 'publicuser'
+
 
 # ── LikeResponseSerializer ────────────────────────────────────────────────────
 

--- a/backend/apps/interactions/tests/test_views.py
+++ b/backend/apps/interactions/tests/test_views.py
@@ -280,6 +280,27 @@ class TestStoryCommentList:
         response = client.get(self.url.format(story_id=story.pk))
         assert response.data['results'][0]['author_username'] is None
 
+    def test_private_username_author_shows_null_in_list(self, client, story):
+        private_user = User.objects.create_user(
+            email='private_view@example.com', username='privateview', password='Password1',
+            is_username_public=False,
+        )
+        Comment.objects.create(story=story, author=private_user, text='Hidden identity')
+        response = client.get(self.url.format(story_id=story.pk))
+        assert response.status_code == 200
+        assert response.data['results'][0]['author_username'] is None
+        assert response.data['results'][0]['is_anonymized'] is False
+
+    def test_public_username_author_shows_username_in_list(self, client, story):
+        public_user = User.objects.create_user(
+            email='public_view@example.com', username='publicview', password='Password1',
+            is_username_public=True,
+        )
+        Comment.objects.create(story=story, author=public_user, text='Visible identity')
+        response = client.get(self.url.format(story_id=story.pk))
+        assert response.status_code == 200
+        assert response.data['results'][0]['author_username'] == 'publicview'
+
     def test_only_returns_comments_for_requested_story(self, client, story, second_user):
         from decimal import Decimal
         other_story = Story.objects.create(


### PR DESCRIPTION
# 📝 Description
Fixes #393 

This PR updates comment serialization so that `author_username` is hidden when the comment author has a private username setting (`is_username_public=False`).

It also adds serializer and view tests to verify:
- private usernames are returned as `null`
- public usernames are still shown normally
- anonymized comment behavior remains unchanged

# 📊 Type of Change
- [x]  Bug fix
- [ ]  New feature
- [ ]  Refactoring
- [ ]  Documentation
 
# ✅ Acceptance Criteria / Checklist
- [x] Project builds successfully
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, especially in hard-to-understand parts
- [x] I have performed a self-review of my code
- [x] I have added/updated tests
- [x] New and existing unit tests pass locally with my changes



# ⏱️ Estimated Review Time
- [x] < 5 min
- [ ] 5-15 min
- [ ] > 15 min