### PR TITLE
feat: extend media upload endpoint to support audio and video

### DIFF
--- a/backend/apps/media/serializers.py
+++ b/backend/apps/media/serializers.py
@@ -1,10 +1,22 @@
 import magic
 from rest_framework import serializers
 
-from apps.media.models import MediaItem
+from apps.media.models import MediaItem, MediaType
 
 ALLOWED_MIME_TYPES = {'image/jpeg', 'image/png'}
 MAX_FILE_SIZE = 2 * 1024 * 1024  # 2 MB
+
+ALLOWED_AUDIO_MIME_TYPES = {'audio/mpeg', 'audio/wav', 'audio/x-wav', 'audio/ogg'}
+ALLOWED_VIDEO_MIME_TYPES = {'video/mp4', 'video/webm'}
+ALLOWED_MEDIA_MIME_TYPES = ALLOWED_AUDIO_MIME_TYPES | ALLOWED_VIDEO_MIME_TYPES
+
+MIME_TO_MEDIA_TYPE = {
+    **{mime: MediaType.AUDIO for mime in ALLOWED_AUDIO_MIME_TYPES},
+    **{mime: MediaType.VIDEO for mime in ALLOWED_VIDEO_MIME_TYPES},
+}
+
+MAX_AUDIO_FILE_SIZE = 50 * 1024 * 1024   # 50 MB
+MAX_VIDEO_FILE_SIZE = 200 * 1024 * 1024  # 200 MB
 
 
 class ImageUploadSerializer(serializers.Serializer):
@@ -39,6 +51,47 @@ class ImageUploadSerializer(serializers.Serializer):
         return value
 
 
+class MediaFileUploadSerializer(serializers.Serializer):
+    """
+    Validates a POST /stories/<id>/media/ request (audio and video).
+
+    Uses python-magic to detect the real MIME type from file bytes, independent
+    of the spoofable HTTP Content-Type header. On success, validated_data includes
+    both 'file' and 'media_type' so the view can pass both to the service.
+    """
+
+    file = serializers.FileField()
+
+    def validate_file(self, value):
+        value.seek(0)
+        self._detected_mime = magic.from_buffer(value.read(1024), mime=True)
+        value.seek(0)
+
+        if self._detected_mime not in ALLOWED_MEDIA_MIME_TYPES:
+            raise serializers.ValidationError(
+                'Unsupported file type. '
+                'Accepted audio formats: mp3, wav, ogg. '
+                'Accepted video formats: mp4, webm.'
+            )
+
+        max_size = (
+            MAX_AUDIO_FILE_SIZE
+            if self._detected_mime in ALLOWED_AUDIO_MIME_TYPES
+            else MAX_VIDEO_FILE_SIZE
+        )
+        if value.size > max_size:
+            limit_mb = max_size // (1024 * 1024)
+            raise serializers.ValidationError(
+                f'File size must not exceed {limit_mb} MB.'
+            )
+
+        return value
+
+    def validate(self, attrs):
+        attrs['media_type'] = MIME_TO_MEDIA_TYPE[self._detected_mime]
+        return attrs
+
+
 class MediaItemResponseSerializer(serializers.ModelSerializer):
     """Read-only representation of a MediaItem returned after a successful upload."""
 
@@ -47,7 +100,7 @@ class MediaItemResponseSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = MediaItem
-        fields = ['id', 'url', 'file_size', 'original_filename', 'uploaded_at']
+        fields = ['id', 'media_type', 'url', 'file_size', 'original_filename', 'uploaded_at']
 
     def get_url(self, obj):
         request = self.context.get('request')

--- a/backend/apps/media/serializers.py
+++ b/backend/apps/media/serializers.py
@@ -15,8 +15,8 @@ MIME_TO_MEDIA_TYPE = {
     **{mime: MediaType.VIDEO for mime in ALLOWED_VIDEO_MIME_TYPES},
 }
 
-MAX_AUDIO_FILE_SIZE = 50 * 1024 * 1024   # 50 MB
-MAX_VIDEO_FILE_SIZE = 200 * 1024 * 1024  # 200 MB
+MAX_AUDIO_FILE_SIZE = 10 * 1024 * 1024   # 10 MB
+MAX_VIDEO_FILE_SIZE = 50 * 1024 * 1024   # 50 MB
 
 
 class ImageUploadSerializer(serializers.Serializer):
@@ -64,10 +64,10 @@ class MediaFileUploadSerializer(serializers.Serializer):
 
     def validate_file(self, value):
         value.seek(0)
-        self._detected_mime = magic.from_buffer(value.read(1024), mime=True)
+        detected_mime = magic.from_buffer(value.read(1024), mime=True)
         value.seek(0)
 
-        if self._detected_mime not in ALLOWED_MEDIA_MIME_TYPES:
+        if detected_mime not in ALLOWED_MEDIA_MIME_TYPES:
             raise serializers.ValidationError(
                 'Unsupported file type. '
                 'Accepted audio formats: mp3, wav, ogg. '
@@ -76,7 +76,7 @@ class MediaFileUploadSerializer(serializers.Serializer):
 
         max_size = (
             MAX_AUDIO_FILE_SIZE
-            if self._detected_mime in ALLOWED_AUDIO_MIME_TYPES
+            if detected_mime in ALLOWED_AUDIO_MIME_TYPES
             else MAX_VIDEO_FILE_SIZE
         )
         if value.size > max_size:
@@ -85,10 +85,11 @@ class MediaFileUploadSerializer(serializers.Serializer):
                 f'File size must not exceed {limit_mb} MB.'
             )
 
+        value._detected_mime = detected_mime
         return value
 
     def validate(self, attrs):
-        attrs['media_type'] = MIME_TO_MEDIA_TYPE[self._detected_mime]
+        attrs['media_type'] = MIME_TO_MEDIA_TYPE[attrs['file']._detected_mime]
         return attrs
 
 

--- a/backend/apps/media/services.py
+++ b/backend/apps/media/services.py
@@ -17,3 +17,21 @@ def upload_story_image(story, file):
         file_size=file.size,
         original_filename=file.name,
     )
+
+
+def upload_story_media(story, file, media_type):
+    """
+    Save an audio or video file as a MediaItem attached to a story.
+
+    The caller is responsible for validating the file type and size before
+    calling this function (via MediaFileUploadSerializer).
+
+    Returns the saved MediaItem instance.
+    """
+    return MediaItem.objects.create(
+        story=story,
+        file=file,
+        media_type=media_type,
+        file_size=file.size,
+        original_filename=file.name,
+    )

--- a/backend/apps/media/tests/test_serializers.py
+++ b/backend/apps/media/tests/test_serializers.py
@@ -5,6 +5,45 @@ import pytest
 from django.core.files.uploadedfile import InMemoryUploadedFile
 from PIL import Image
 
+# Minimal magic-byte headers for each supported audio/video format.
+# python-magic identifies the MIME type from these header bytes alone —
+# no real audio/video payload is needed.
+_MEDIA_MAGIC_BYTES = {
+    'mp3':  b'\xff\xfb\x90\x00' + b'\x00' * 60,
+    'wav':  (b'RIFF\x00\x00\x00\x00WAVEfmt '
+             b'\x10\x00\x00\x00\x01\x00\x01\x00'
+             b'\x44\xac\x00\x00\x88\x58\x01\x00'
+             b'\x02\x00\x10\x00data\x00\x00\x00\x00'),
+    'ogg':  (b'OggS\x00\x02\x00\x00\x00\x00\x00\x00\x00\x00'
+             b'\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
+             b'\x01\x1e\x01vorbis\x00\x00\x00\x00\x02'
+             b'\x44\xac\x00\x00\x00\x00\x00\x00\x00\xee\x02\x00'
+             b'\x00\xee\x02\x00\xb8\x01\x01'),
+    'mp4':  b'\x00\x00\x00\x18ftypisom\x00\x00\x02\x00isomiso2',
+    'webm': (b'\x1a\x45\xdf\xa3\x01\x00\x00\x00\x00\x00\x00\x1f'
+             b'\x42\x86\x81\x01\x42\xf7\x81\x01\x42\xf2\x81\x04'
+             b'\x42\xf3\x81\x08\x42\x82\x84webm\x42\x87\x81\x04'),
+}
+_MEDIA_CONTENT_TYPES = {
+    'mp3': 'audio/mpeg', 'wav': 'audio/x-wav', 'ogg': 'audio/ogg',
+    'mp4': 'video/mp4', 'webm': 'video/webm',
+}
+
+
+def make_media_file(ext='mp3', name=None, size_override=None):
+    """Build an InMemoryUploadedFile with correct magic bytes for the given format."""
+    content = _MEDIA_MAGIC_BYTES[ext]
+    buf = io.BytesIO(content)
+    reported_size = size_override if size_override is not None else len(content)
+    return InMemoryUploadedFile(
+        file=buf,
+        field_name='file',
+        name=name or f'media.{ext}',
+        content_type=_MEDIA_CONTENT_TYPES[ext],
+        size=reported_size,
+        charset=None,
+    )
+
 
 def make_image_file(fmt='JPEG', name='photo.jpg', content_type='image/jpeg', size_override=None):
     """
@@ -85,6 +124,70 @@ class TestImageUploadSerializer:
         assert 'JPEG' in error_text or 'PNG' in error_text
 
 
+# ── MediaFileUploadSerializer ─────────────────────────────────────────────────
+
+class TestMediaFileUploadSerializer:
+    """Pure-Python validation tests — no database access needed."""
+
+    def _serialize(self, file_obj):
+        from apps.media.serializers import MediaFileUploadSerializer
+        s = MediaFileUploadSerializer(data={'file': file_obj})
+        s.is_valid()
+        return s
+
+    def test_valid_mp3_passes(self):
+        s = self._serialize(make_media_file('mp3'))
+        assert s.is_valid(), s.errors
+
+    def test_valid_wav_passes(self):
+        s = self._serialize(make_media_file('wav'))
+        assert s.is_valid(), s.errors
+
+    def test_valid_mp4_passes(self):
+        s = self._serialize(make_media_file('mp4'))
+        assert s.is_valid(), s.errors
+
+    def test_valid_webm_passes(self):
+        s = self._serialize(make_media_file('webm'))
+        assert s.is_valid(), s.errors
+
+    def test_image_rejected(self):
+        # JPEG magic bytes are not in the allowed audio/video MIME set
+        s = self._serialize(make_image_file())
+        assert not s.is_valid()
+        assert 'file' in s.errors
+
+    def test_mp3_media_type_is_audio(self):
+        from apps.media.models import MediaType
+        s = self._serialize(make_media_file('mp3'))
+        assert s.is_valid(), s.errors
+        assert s.validated_data['media_type'] == MediaType.AUDIO
+
+    def test_mp4_media_type_is_video(self):
+        from apps.media.models import MediaType
+        s = self._serialize(make_media_file('mp4'))
+        assert s.is_valid(), s.errors
+        assert s.validated_data['media_type'] == MediaType.VIDEO
+
+    def test_oversized_audio_rejected(self):
+        oversized = make_media_file('mp3', size_override=50 * 1024 * 1024 + 1)
+        s = self._serialize(oversized)
+        assert not s.is_valid()
+        assert 'file' in s.errors
+
+    def test_oversized_video_rejected(self):
+        oversized = make_media_file('mp4', size_override=200 * 1024 * 1024 + 1)
+        s = self._serialize(oversized)
+        assert not s.is_valid()
+        assert 'file' in s.errors
+
+    def test_error_message_mentions_accepted_formats(self):
+        s = self._serialize(make_image_file())
+        assert not s.is_valid()
+        error_text = str(s.errors)
+        assert 'mp3' in error_text or 'mp4' in error_text
+
+
 # ── MediaItemResponseSerializer ───────────────────────────────────────────────
 
 @pytest.mark.django_db
@@ -115,7 +218,7 @@ class TestMediaItemResponseSerializer:
     def test_contains_expected_fields(self):
         from apps.media.serializers import MediaItemResponseSerializer
         data = MediaItemResponseSerializer(self._make_item()).data
-        for field in ['id', 'url', 'file_size', 'original_filename', 'uploaded_at']:
+        for field in ['id', 'media_type', 'url', 'file_size', 'original_filename', 'uploaded_at']:
             assert field in data
 
     def test_url_is_built_from_request_context(self):

--- a/backend/apps/media/tests/test_serializers.py
+++ b/backend/apps/media/tests/test_serializers.py
@@ -170,13 +170,13 @@ class TestMediaFileUploadSerializer:
         assert s.validated_data['media_type'] == MediaType.VIDEO
 
     def test_oversized_audio_rejected(self):
-        oversized = make_media_file('mp3', size_override=50 * 1024 * 1024 + 1)
+        oversized = make_media_file('mp3', size_override=10 * 1024 * 1024 + 1)
         s = self._serialize(oversized)
         assert not s.is_valid()
         assert 'file' in s.errors
 
     def test_oversized_video_rejected(self):
-        oversized = make_media_file('mp4', size_override=200 * 1024 * 1024 + 1)
+        oversized = make_media_file('mp4', size_override=50 * 1024 * 1024 + 1)
         s = self._serialize(oversized)
         assert not s.is_valid()
         assert 'file' in s.errors

--- a/backend/apps/media/tests/test_services.py
+++ b/backend/apps/media/tests/test_services.py
@@ -24,6 +24,18 @@ def _make_fake_file(name='photo.jpg', size=1024):
     return SimpleUploadedFile(name=name, content=content, content_type='image/jpeg')
 
 
+def _make_fake_audio_file(name='audio.mp3', size=1024):
+    """Minimal MP3-magic-byte file wrapped in SimpleUploadedFile."""
+    content = b'\xff\xfb\x90\x00' + b'\x00' * (size - 4)
+    return SimpleUploadedFile(name=name, content=content, content_type='audio/mpeg')
+
+
+def _make_fake_video_file(name='video.mp4', size=1024):
+    """Minimal MP4-magic-byte file wrapped in SimpleUploadedFile."""
+    content = b'\x00\x00\x00\x18ftypisom' + b'\x00' * (size - 12)
+    return SimpleUploadedFile(name=name, content=content, content_type='video/mp4')
+
+
 @pytest.mark.django_db
 class TestUploadStoryImage:
     def setup_method(self):
@@ -63,4 +75,50 @@ class TestUploadStoryImage:
     def test_returns_media_item_instance(self):
         from apps.media.services import upload_story_image
         result = upload_story_image(self.story, _make_fake_file())
+        assert isinstance(result, MediaItem)
+
+
+@pytest.mark.django_db
+class TestUploadStoryMedia:
+    def setup_method(self):
+        self.user = User.objects.create_user(
+            email='svc2@example.com', username='svc2user', password='Password1'
+        )
+        self.story = _make_story(self.user)
+
+    def test_creates_media_item(self):
+        from apps.media.services import upload_story_media
+        item = upload_story_media(self.story, _make_fake_audio_file(), MediaType.AUDIO)
+        assert MediaItem.objects.filter(pk=item.pk).exists()
+
+    def test_audio_media_type_stored(self):
+        from apps.media.services import upload_story_media
+        item = upload_story_media(self.story, _make_fake_audio_file(), MediaType.AUDIO)
+        assert item.media_type == MediaType.AUDIO
+
+    def test_video_media_type_stored(self):
+        from apps.media.services import upload_story_media
+        item = upload_story_media(self.story, _make_fake_video_file(), MediaType.VIDEO)
+        assert item.media_type == MediaType.VIDEO
+
+    def test_story_is_set(self):
+        from apps.media.services import upload_story_media
+        item = upload_story_media(self.story, _make_fake_audio_file(), MediaType.AUDIO)
+        assert item.story_id == self.story.pk
+
+    def test_file_size_is_stored(self):
+        from apps.media.services import upload_story_media
+        file = _make_fake_audio_file(size=4096)
+        item = upload_story_media(self.story, file, MediaType.AUDIO)
+        assert item.file_size == 4096
+
+    def test_original_filename_is_stored(self):
+        from apps.media.services import upload_story_media
+        file = _make_fake_audio_file(name='podcast.mp3')
+        item = upload_story_media(self.story, file, MediaType.AUDIO)
+        assert item.original_filename == 'podcast.mp3'
+
+    def test_returns_media_item_instance(self):
+        from apps.media.services import upload_story_media
+        result = upload_story_media(self.story, _make_fake_audio_file(), MediaType.AUDIO)
         assert isinstance(result, MediaItem)

--- a/backend/apps/media/tests/test_views.py
+++ b/backend/apps/media/tests/test_views.py
@@ -1,4 +1,4 @@
-"""Integration tests for the image upload endpoint."""
+"""Integration tests for the image and media upload endpoints."""
 import io
 
 import pytest
@@ -7,6 +7,25 @@ from rest_framework.test import APIClient
 
 from apps.media.models import MediaItem, MediaType
 from apps.stories.models import Story
+
+# Minimal magic-byte content for each audio/video format (mirrors test_serializers.py).
+_MEDIA_MAGIC_BYTES = {
+    'mp3':  b'\xff\xfb\x90\x00' + b'\x00' * 60,
+    'mp4':  b'\x00\x00\x00\x18ftypisom\x00\x00\x02\x00isomiso2',
+    'webm': (b'\x1a\x45\xdf\xa3\x01\x00\x00\x00\x00\x00\x00\x1f'
+             b'\x42\x86\x81\x01\x42\xf7\x81\x01\x42\xf2\x81\x04'
+             b'\x42\xf3\x81\x08\x42\x82\x84webm\x42\x87\x81\x04'),
+}
+_MEDIA_CONTENT_TYPES = {'mp3': 'audio/mpeg', 'mp4': 'video/mp4', 'webm': 'video/webm'}
+
+
+def make_media_file(ext='mp3'):
+    """Create an in-memory audio/video file suitable for multipart upload."""
+    buf = io.BytesIO(_MEDIA_MAGIC_BYTES[ext])
+    buf.seek(0)
+    buf.name = f'media.{ext}'
+    buf.content_type = _MEDIA_CONTENT_TYPES[ext]
+    return buf
 
 
 def make_image_file(name='photo.jpg', fmt='JPEG', content_type='image/jpeg', size_bytes=None):
@@ -168,3 +187,109 @@ class TestStoryImageUpload:
             format='multipart',
         )
         assert response.status_code == 201
+
+
+# ── POST /stories/<story_id>/media/ ─────────────────────────────────────────
+
+@pytest.mark.django_db
+class TestStoryMediaUpload:
+    url = '/stories/{story_id}/media/'
+
+    def test_upload_audio_success(self, auth_client, story):
+        response = auth_client.post(
+            self.url.format(story_id=story.pk),
+            {'file': make_media_file('mp3')},
+            format='multipart',
+        )
+        assert response.status_code == 201
+        assert 'media' in response.data
+        assert MediaItem.objects.filter(story=story, media_type=MediaType.AUDIO).exists()
+
+    def test_upload_video_success(self, auth_client, story):
+        response = auth_client.post(
+            self.url.format(story_id=story.pk),
+            {'file': make_media_file('mp4')},
+            format='multipart',
+        )
+        assert response.status_code == 201
+        assert MediaItem.objects.filter(story=story, media_type=MediaType.VIDEO).exists()
+
+    def test_response_contains_expected_fields(self, auth_client, story):
+        response = auth_client.post(
+            self.url.format(story_id=story.pk),
+            {'file': make_media_file('mp3')},
+            format='multipart',
+        )
+        assert response.status_code == 201
+        media_data = response.data['media']
+        for field in ['id', 'media_type', 'url', 'file_size', 'original_filename', 'uploaded_at']:
+            assert field in media_data
+
+    def test_audio_media_type_in_response(self, auth_client, story):
+        response = auth_client.post(
+            self.url.format(story_id=story.pk),
+            {'file': make_media_file('mp3')},
+            format='multipart',
+        )
+        assert response.data['media']['media_type'] == 'audio'
+
+    def test_video_media_type_in_response(self, auth_client, story):
+        response = auth_client.post(
+            self.url.format(story_id=story.pk),
+            {'file': make_media_file('mp4')},
+            format='multipart',
+        )
+        assert response.data['media']['media_type'] == 'video'
+
+    def test_unauthenticated_returns_401(self, client, story):
+        response = client.post(
+            self.url.format(story_id=story.pk),
+            {'file': make_media_file('mp3')},
+            format='multipart',
+        )
+        assert response.status_code == 401
+
+    def test_non_owner_returns_403(self, client, second_user, story):
+        client.force_authenticate(user=second_user)
+        response = client.post(
+            self.url.format(story_id=story.pk),
+            {'file': make_media_file('mp3')},
+            format='multipart',
+        )
+        assert response.status_code == 403
+
+    def test_story_not_found_returns_404(self, auth_client):
+        response = auth_client.post(
+            self.url.format(story_id=99999),
+            {'file': make_media_file('mp3')},
+            format='multipart',
+        )
+        assert response.status_code == 404
+
+    def test_removed_story_returns_404(self, auth_client, story):
+        story.status = Story.STATUS_REMOVED
+        story.save()
+        response = auth_client.post(
+            self.url.format(story_id=story.pk),
+            {'file': make_media_file('mp3')},
+            format='multipart',
+        )
+        assert response.status_code == 404
+
+    def test_unsupported_type_returns_400(self, auth_client, story):
+        response = auth_client.post(
+            self.url.format(story_id=story.pk),
+            {'file': make_image_file()},
+            format='multipart',
+        )
+        assert response.status_code == 400
+
+    def test_upload_stores_correct_metadata(self, auth_client, story):
+        auth_client.post(
+            self.url.format(story_id=story.pk),
+            {'file': make_media_file('mp3')},
+            format='multipart',
+        )
+        item = MediaItem.objects.get(story=story, media_type=MediaType.AUDIO)
+        assert item.original_filename == 'media.mp3'
+        assert item.file_size > 0

--- a/backend/apps/media/urls.py
+++ b/backend/apps/media/urls.py
@@ -1,9 +1,10 @@
 from django.urls import path
 
-from apps.media.views import StoryImageUploadView
+from apps.media.views import StoryImageUploadView, StoryMediaUploadView
 
 app_name = 'media'
 
 urlpatterns = [
     path('stories/<int:story_id>/images/', StoryImageUploadView.as_view(), name='story-image-upload'),
+    path('stories/<int:story_id>/media/', StoryMediaUploadView.as_view(), name='story-media-upload'),
 ]

--- a/backend/apps/media/views.py
+++ b/backend/apps/media/views.py
@@ -3,8 +3,8 @@ from rest_framework import status
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
-from apps.media.serializers import ImageUploadSerializer, MediaItemResponseSerializer
-from apps.media.services import upload_story_image
+from apps.media.serializers import ImageUploadSerializer, MediaFileUploadSerializer, MediaItemResponseSerializer
+from apps.media.services import upload_story_image, upload_story_media
 from apps.stories.models import Story
 from common.permissions import IsOwnerOrAdmin
 
@@ -32,6 +32,36 @@ class StoryImageUploadView(APIView):
             {
                 'message': 'Image uploaded successfully.',
                 'image': MediaItemResponseSerializer(media_item, context={'request': request}).data,
+            },
+            status=status.HTTP_201_CREATED,
+        )
+
+
+class StoryMediaUploadView(APIView):
+    """POST /stories/<story_id>/media/ — upload audio or video to a story (owner only)."""
+
+    permission_classes = [IsOwnerOrAdmin]
+
+    def post(self, request, story_id):
+        story = get_object_or_404(
+            Story.objects.exclude(status=Story.STATUS_REMOVED),
+            pk=story_id,
+        )
+        self.check_object_permissions(request, story)
+
+        serializer = MediaFileUploadSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+
+        media_item = upload_story_media(
+            story,
+            serializer.validated_data['file'],
+            serializer.validated_data['media_type'],
+        )
+
+        return Response(
+            {
+                'message': 'Media uploaded successfully.',
+                'media': MediaItemResponseSerializer(media_item, context={'request': request}).data,
             },
             status=status.HTTP_201_CREATED,
         )


### PR DESCRIPTION
# 📝 Description
Fixes #225

Extends the story media upload infrastructure to support audio (mp3, wav, ogg) and video (mp4, webm) files via a new `POST /stories/<id>/media/` endpoint. The existing `POST /stories/<id>/images/` endpoint is unchanged.

**Changes:**
- `serializers.py` — new `MediaFileUploadSerializer`: accepts any `FileField`, uses `python-magic` to detect MIME from raw bytes (spoofing-resistant), maps MIME → `MediaType.AUDIO/VIDEO`, enforces per-type size limits (50 MB audio / 200 MB video). Also adds `media_type` to `MediaItemResponseSerializer`.
- `services.py` — new `upload_story_media(story, file, media_type)` that mirrors `upload_story_image` but accepts the media type as a parameter.
- `views.py` + `urls.py` — new `StoryMediaUploadView` at `POST /stories/<id>/media/`, identical auth/ownership flow as the image endpoint (`IsOwnerOrAdmin`, removed stories → 404).
- Tests — serializer unit tests (all 5 formats, size limits, image rejection, `media_type` in `validated_data`), service unit tests (audio + video), view integration tests (success for audio + video, 401/403/404, unsupported type → 400, metadata stored correctly).

# 📊 Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Refactoring
- [ ] Documentation

# ✅ Acceptance Criteria / Checklist
- [x] Project builds successfully
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, especially in hard-to-understand parts
- [x] I have performed a self-review of my code
- [x] I have added/updated tests
- [x] New and existing unit tests pass locally with my changes

# 📸 Screenshots / Recordings
<!-- If applicable -->

# ⏱️ Estimated Review Time
- [ ] < 5 min
- [x] 5-15 min
- [ ] > 15 min