### PR TITLE
fix: frontend search filter UX improvements

### DIFF
--- a/frontend/src/components/AppLayout/AppLayout.jsx
+++ b/frontend/src/components/AppLayout/AppLayout.jsx
@@ -14,8 +14,8 @@ import {
 import { useAuth } from "@/hooks/useAuth";
 
 const publicLinks = [
-  { to: "/map", label: "Map" },
-  { to: "/", label: "Feed" },
+  { to: "/map", label: "Map", preserveSearch: true },
+  { to: "/", label: "Feed", preserveSearch: true },
   { to: "/submit-story", label: "Submit Story", icon: Plus },
 ];
 
@@ -49,7 +49,12 @@ function AppLayout() {
     navigate("/");
   };
 
-  const links = publicLinks;
+  const isFilterPage = location.pathname === "/" || location.pathname.startsWith("/map");
+  const links = publicLinks.map((link) =>
+    link.preserveSearch && isFilterPage
+      ? { ...link, to: `${link.to}${location.search}` }
+      : link
+  );
 
   return (
     <div className="min-h-screen">

--- a/frontend/src/components/AppLayout/AppLayout.jsx
+++ b/frontend/src/components/AppLayout/AppLayout.jsx
@@ -19,8 +19,9 @@ const publicLinks = [
   { to: "/submit-story", label: "Submit Story", icon: Plus },
 ];
 
-function NavLink({ to, label, icon: Icon, pathname, onClick }) {
-  const isActive = to === "/" ? pathname === "/" : pathname.startsWith(to);
+function NavLink({ to, basePath, label, icon: Icon, pathname, onClick }) {
+  const base = basePath ?? to;
+  const isActive = base === "/" ? pathname === "/" : pathname === base || pathname.startsWith(base + "/");
 
   return (
     <Link
@@ -49,10 +50,10 @@ function AppLayout() {
     navigate("/");
   };
 
-  const isFilterPage = location.pathname === "/" || location.pathname.startsWith("/map");
+  const isFilterPage = location.pathname === "/" || location.pathname === "/map";
   const links = publicLinks.map((link) =>
-    link.preserveSearch && isFilterPage
-      ? { ...link, to: `${link.to}${location.search}` }
+    link.preserveSearch && isFilterPage && location.search
+      ? { ...link, basePath: link.to, to: `${link.to}${location.search}` }
       : link
   );
 
@@ -70,8 +71,9 @@ function AppLayout() {
           <nav className="hidden md:flex items-center space-x-6">
             {links.map((link) => (
               <NavLink
-                key={link.to}
+                key={link.label}
                 to={link.to}
+                basePath={link.basePath}
                 label={link.label}
                 icon={link.icon}
                 pathname={location.pathname}
@@ -123,8 +125,9 @@ function AppLayout() {
                 <nav className="flex flex-col space-y-4 mt-4">
                   {links.map((link) => (
                     <NavLink
-                      key={link.to}
+                      key={link.label}
                       to={link.to}
+                      basePath={link.basePath}
                       label={link.label}
                       icon={link.icon}
                       pathname={location.pathname}

--- a/frontend/src/components/AppLayout/__tests__/AppLayout.test.jsx
+++ b/frontend/src/components/AppLayout/__tests__/AppLayout.test.jsx
@@ -145,6 +145,26 @@ describe("AppLayout", () => {
     expect(mapLinks[0]).toHaveAttribute("href", "/map");
   });
 
+  it("Map link is still highlighted when filters are active on /map", () => {
+    renderWithRouter("/map?q=galata&year_from=1980");
+
+    const mapLink = screen.getByText("Map");
+    const feedLink = screen.getByText("Feed");
+
+    expect(mapLink.className).toContain("text-primary");
+    expect(feedLink.className).toContain("text-muted-foreground");
+  });
+
+  it("Feed link is still highlighted when filters are active on /", () => {
+    renderWithRouter("/?q=galata&year_from=1980");
+
+    const feedLink = screen.getByText("Feed");
+    const mapLink = screen.getByText("Map");
+
+    expect(feedLink.className).toContain("text-primary");
+    expect(mapLink.className).toContain("text-muted-foreground");
+  });
+
   it("renders mobile hamburger button", () => {
     renderWithRouter();
 

--- a/frontend/src/components/AppLayout/__tests__/AppLayout.test.jsx
+++ b/frontend/src/components/AppLayout/__tests__/AppLayout.test.jsx
@@ -115,6 +115,36 @@ describe("AppLayout", () => {
     expect(screen.getByText("Feed Content")).toBeInTheDocument();
   });
 
+  it("Map link carries current search params when on the Feed page", () => {
+    renderWithRouter("/?q=galata&year_from=1980");
+
+    const mapLinks = screen.getAllByRole("link", { name: /^map$/i });
+    expect(mapLinks[0]).toHaveAttribute("href", "/map?q=galata&year_from=1980");
+  });
+
+  it("Feed link carries current search params when on the Map page", () => {
+    renderWithRouter("/map?q=galata&year_from=1980");
+
+    const feedLinks = screen.getAllByRole("link", { name: /^feed$/i });
+    expect(feedLinks[0]).toHaveAttribute("href", "/?q=galata&year_from=1980");
+  });
+
+  it("Map and Feed links use bare paths when on a non-filter page", () => {
+    renderWithRouter("/profile?some=param");
+
+    const mapLinks = screen.getAllByRole("link", { name: /^map$/i });
+    const feedLinks = screen.getAllByRole("link", { name: /^feed$/i });
+    expect(mapLinks[0]).toHaveAttribute("href", "/map");
+    expect(feedLinks[0]).toHaveAttribute("href", "/");
+  });
+
+  it("Map and Feed links use bare paths when there are no active filters", () => {
+    renderWithRouter("/");
+
+    const mapLinks = screen.getAllByRole("link", { name: /^map$/i });
+    expect(mapLinks[0]).toHaveAttribute("href", "/map");
+  });
+
   it("renders mobile hamburger button", () => {
     renderWithRouter();
 

--- a/frontend/src/components/SearchFilter/FilterPanel.jsx
+++ b/frontend/src/components/SearchFilter/FilterPanel.jsx
@@ -8,7 +8,7 @@ import { Label } from "@/components/ui/label";
 const YEAR_MIN = 1000;
 const YEAR_MAX = 2030;
 const YEAR_SPINNER_FROM = 1980;
-const YEAR_SPINNER_TO = 2026;
+const YEAR_SPINNER_TO = new Date().getFullYear();
 
 /**
  * Collapsible filter panel for year range and location.

--- a/frontend/src/components/SearchFilter/FilterPanel.jsx
+++ b/frontend/src/components/SearchFilter/FilterPanel.jsx
@@ -5,6 +5,11 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 
+const YEAR_MIN = 1000;
+const YEAR_MAX = 2030;
+const YEAR_SPINNER_FROM = 1980;
+const YEAR_SPINNER_TO = 2026;
+
 /**
  * Collapsible filter panel for year range and location.
  * Maintains local form state; commits to URL only on "Apply".
@@ -18,12 +23,19 @@ function FilterPanel({ yearFrom = "", yearTo = "", location = "", onApply, activ
   const [localLocation, setLocalLocation] = useState(location);
   const [yearError, setYearError] = useState("");
 
+  function clampYear(value) {
+    if (value === "") return value;
+    const num = Number(value);
+    if (isNaN(num)) return value;
+    return num > YEAR_MAX ? YEAR_MAX : num;
+  }
+
   function handleApply() {
     const from = localYearFrom === "" ? "" : Number(localYearFrom);
     const to = localYearTo === "" ? "" : Number(localYearTo);
 
-    if ((from !== "" && from < 1) || (to !== "" && to < 1)) {
-      setYearError("Year must be a positive number.");
+    if ((from !== "" && (isNaN(from) || from < YEAR_MIN)) || (to !== "" && (isNaN(to) || to < YEAR_MIN))) {
+      setYearError(`Year must be ${YEAR_MIN} or later.`);
       return;
     }
     if (from !== "" && to !== "" && from > to) {
@@ -87,12 +99,26 @@ function FilterPanel({ yearFrom = "", yearTo = "", location = "", onApply, activ
                     type="number"
                     placeholder="From"
                     value={localYearFrom}
+                    onKeyDown={(e) => {
+                      if ((e.key === "ArrowUp" || e.key === "ArrowDown") && localYearFrom === "") {
+                        e.preventDefault();
+                        setLocalYearFrom(YEAR_SPINNER_FROM);
+                        setYearError("");
+                      }
+                    }}
                     onChange={(e) => {
-                      setLocalYearFrom(e.target.value);
+                      const val = e.target.value;
+                      if (val === "") { setLocalYearFrom(""); setYearError(""); return; }
+                      // When mouse-spinner is clicked on empty field the browser fires YEAR_MIN; override with default
+                      if (localYearFrom === "" && Number(val) === YEAR_MIN) {
+                        setLocalYearFrom(YEAR_SPINNER_FROM);
+                      } else {
+                        setLocalYearFrom(clampYear(val));
+                      }
                       setYearError("");
                     }}
-                    min="1"
-                    max="2999"
+                    min={YEAR_MIN}
+                    max={YEAR_MAX}
                     aria-label="From year"
                   />
                 </div>
@@ -108,12 +134,26 @@ function FilterPanel({ yearFrom = "", yearTo = "", location = "", onApply, activ
                     type="number"
                     placeholder="To"
                     value={localYearTo}
+                    onKeyDown={(e) => {
+                      if ((e.key === "ArrowUp" || e.key === "ArrowDown") && localYearTo === "") {
+                        e.preventDefault();
+                        setLocalYearTo(YEAR_SPINNER_TO);
+                        setYearError("");
+                      }
+                    }}
                     onChange={(e) => {
-                      setLocalYearTo(e.target.value);
+                      const val = e.target.value;
+                      if (val === "") { setLocalYearTo(""); setYearError(""); return; }
+                      // When mouse-spinner is clicked on empty field the browser fires YEAR_MIN; override with default
+                      if (localYearTo === "" && Number(val) === YEAR_MIN) {
+                        setLocalYearTo(YEAR_SPINNER_TO);
+                      } else {
+                        setLocalYearTo(clampYear(val));
+                      }
                       setYearError("");
                     }}
-                    min="1"
-                    max="2999"
+                    min={YEAR_MIN}
+                    max={YEAR_MAX}
                     aria-label="To year"
                   />
                 </div>

--- a/frontend/src/components/SearchFilter/__tests__/FilterPanel.test.jsx
+++ b/frontend/src/components/SearchFilter/__tests__/FilterPanel.test.jsx
@@ -63,7 +63,9 @@ describe("FilterPanel", () => {
     renderPanel({ onApply });
 
     await user.click(screen.getByRole("button", { name: /^filters$/i }));
+    await user.clear(screen.getByLabelText("From year"));
     await user.type(screen.getByLabelText("From year"), "1900");
+    await user.clear(screen.getByLabelText("To year"));
     await user.type(screen.getByLabelText("To year"), "2000");
     await user.type(screen.getByLabelText("Location filter"), "Galata");
     await user.click(screen.getByRole("button", { name: /apply/i }));
@@ -71,18 +73,6 @@ describe("FilterPanel", () => {
     expect(onApply).toHaveBeenCalledWith({ yearFrom: 1900, yearTo: 2000, location: "Galata" });
   });
 
-  it("shows validation error when year is zero or negative", async () => {
-    const user = userEvent.setup();
-    const onApply = vi.fn();
-    renderPanel({ onApply });
-
-    await user.click(screen.getByRole("button", { name: /^filters$/i }));
-    await user.type(screen.getByLabelText("From year"), "-500");
-    await user.click(screen.getByRole("button", { name: /apply/i }));
-
-    expect(screen.getByRole("alert")).toHaveTextContent(/year must be a positive number/i);
-    expect(onApply).not.toHaveBeenCalled();
-  });
 
   it("shows validation error when yearFrom > yearTo", async () => {
     const user = userEvent.setup();
@@ -90,7 +80,9 @@ describe("FilterPanel", () => {
     renderPanel({ onApply });
 
     await user.click(screen.getByRole("button", { name: /^filters$/i }));
+    await user.clear(screen.getByLabelText("From year"));
     await user.type(screen.getByLabelText("From year"), "2000");
+    await user.clear(screen.getByLabelText("To year"));
     await user.type(screen.getByLabelText("To year"), "1900");
     await user.click(screen.getByRole("button", { name: /apply/i }));
 
@@ -118,5 +110,90 @@ describe("FilterPanel", () => {
     expect(screen.getByLabelText("From year")).toHaveValue(1453);
     expect(screen.getByLabelText("To year")).toHaveValue(1923);
     expect(screen.getByLabelText("Location filter")).toHaveValue("Galata");
+  });
+
+  it("year fields are empty on first open (placeholder visible)", async () => {
+    const user = userEvent.setup();
+    renderPanel();
+
+    await user.click(screen.getByRole("button", { name: /^filters$/i }));
+
+    expect(screen.getByLabelText("From year")).toHaveValue(null);
+    expect(screen.getByLabelText("To year")).toHaveValue(null);
+  });
+
+  it("both inputs have min=1000 and max=2030", async () => {
+    const user = userEvent.setup();
+    renderPanel();
+
+    await user.click(screen.getByRole("button", { name: /^filters$/i }));
+
+    expect(screen.getByLabelText("From year")).toHaveAttribute("min", "1000");
+    expect(screen.getByLabelText("To year")).toHaveAttribute("min", "1000");
+    expect(screen.getByLabelText("From year")).toHaveAttribute("max", "2030");
+    expect(screen.getByLabelText("To year")).toHaveAttribute("max", "2030");
+  });
+
+  it("ArrowUp on empty From year sets it to 1980", async () => {
+    const user = userEvent.setup();
+    renderPanel();
+
+    await user.click(screen.getByRole("button", { name: /^filters$/i }));
+    await user.type(screen.getByLabelText("From year"), "{ArrowUp}");
+
+    expect(screen.getByLabelText("From year")).toHaveValue(1980);
+  });
+
+  it("ArrowUp on empty To year sets it to 2026", async () => {
+    const user = userEvent.setup();
+    renderPanel();
+
+    await user.click(screen.getByRole("button", { name: /^filters$/i }));
+    await user.type(screen.getByLabelText("To year"), "{ArrowUp}");
+
+    expect(screen.getByLabelText("To year")).toHaveValue(2026);
+  });
+
+  it("shows validation error when year is below 1000", async () => {
+    const user = userEvent.setup();
+    const onApply = vi.fn();
+    renderPanel({ onApply });
+
+    await user.click(screen.getByRole("button", { name: /^filters$/i }));
+    await user.type(screen.getByLabelText("From year"), "500");
+    await user.click(screen.getByRole("button", { name: /apply/i }));
+
+    expect(screen.getByRole("alert")).toHaveTextContent(/1000 or later/i);
+    expect(onApply).not.toHaveBeenCalled();
+  });
+
+  it("clamps typed year above 2030 to 2030 on From year field", async () => {
+    const user = userEvent.setup();
+    renderPanel();
+
+    await user.click(screen.getByRole("button", { name: /^filters$/i }));
+    await user.type(screen.getByLabelText("From year"), "2050");
+
+    expect(screen.getByLabelText("From year")).toHaveValue(2030);
+  });
+
+  it("clamps typed year above 2030 to 2030 on To year field", async () => {
+    const user = userEvent.setup();
+    renderPanel();
+
+    await user.click(screen.getByRole("button", { name: /^filters$/i }));
+    await user.type(screen.getByLabelText("To year"), "3000");
+
+    expect(screen.getByLabelText("To year")).toHaveValue(2030);
+  });
+
+  it("does not clamp years within valid range", async () => {
+    const user = userEvent.setup();
+    renderPanel();
+
+    await user.click(screen.getByRole("button", { name: /^filters$/i }));
+    await user.type(screen.getByLabelText("From year"), "2020");
+
+    expect(screen.getByLabelText("From year")).toHaveValue(2020);
   });
 });


### PR DESCRIPTION
# 📝 Description
Fixes #406 
Improves the year filter UX and persists search/filter state when switching between the Feed and Map pages.                                          
                                                                                                                                                       
 Year filter changes: The From and To year fields now start empty (placeholder visible). Clicking the spinner starts From at 1980 and To at 2026. Values are capped at a maximum of 2030 and a minimum of 1000; typing above the max auto-corrects to 2030.                                            
                                                                                                                                                       
  Filter persistence: Navigating between Feed and Map via the navbar now carries the active query params (search term, year range, location) across    
  pages.
### Files Changed 
- src/components/SearchFilter/FilterPanel.jsx             
- src/components/SearchFilter/__tests__/FilterPanel.test.jsx
- src/components/AppLayout/AppLayout.jsx                                                                                                             
- src/components/AppLayout/__tests__/AppLayout.test.jsx

# 📊 Type of Change
- [x]  Bug fix
- [ ]  New feature
- [ ]  Refactoring
- [ ]  Documentation
 
# ✅ Acceptance Criteria / Checklist
- [x] Project builds successfully
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, especially in hard-to-understand parts
- [x] I have performed a self-review of my code
- [x] I have added/updated tests
- [x] New and existing unit tests pass locally with my changes

# 📸 Screenshots / Recordings

# ⏱️ Estimated Review Time
- [x] < 5 min
- [ ] 5-15 min
- [ ] > 15 min
