### PR TITLE
refactor: make map endpoint RFC 7946-compliant

### DIFF
--- a/backend/apps/stories/serializers.py
+++ b/backend/apps/stories/serializers.py
@@ -272,13 +272,16 @@ class FeedQuerySerializer(serializers.Serializer):
         return data
 
 
-class StoryMapGeoJSONSerializer(serializers.ModelSerializer):
+class StoryMapGeoJSONSerializer(serializers.BaseSerializer):
     """
     Serializes a Story as a GeoJSON Feature (RFC 7946).
 
     Coordinates follow the RFC 7946 §3.1.1 mandate: [longitude, latitude].
     Decimal fields are cast to float so the JSON encoder emits numeric values,
     not quoted decimal strings.
+
+    BaseSerializer is used intentionally — we own the full output shape via
+    to_representation, so ModelSerializer's field introspection is pure overhead.
     """
 
     def to_representation(self, instance):
@@ -299,10 +302,6 @@ class StoryMapGeoJSONSerializer(serializers.ModelSerializer):
                 "year_end": instance.year_end,
             },
         }
-
-    class Meta:
-        model = Story
-        fields = []
 
 
 class SearchQuerySerializer(serializers.Serializer):

--- a/backend/apps/stories/serializers.py
+++ b/backend/apps/stories/serializers.py
@@ -272,29 +272,37 @@ class FeedQuerySerializer(serializers.Serializer):
         return data
 
 
-class StoryMapSerializer(serializers.ModelSerializer):
+class StoryMapGeoJSONSerializer(serializers.ModelSerializer):
     """
-    Read-only serializer returning only the fields needed to render a map pin.
+    Serializes a Story as a GeoJSON Feature (RFC 7946).
 
-    Intentionally minimal — the map view only needs coordinates, place name,
-    title, and time info to position a pin and show a preview tooltip.
-    Full story content is loaded separately when a pin is clicked.
+    Coordinates follow the RFC 7946 §3.1.1 mandate: [longitude, latitude].
+    Decimal fields are cast to float so the JSON encoder emits numeric values,
+    not quoted decimal strings.
     """
+
+    def to_representation(self, instance):
+        return {
+            "type": "Feature",
+            "id": instance.id,
+            "geometry": {
+                "type": "Point",
+                # RFC 7946 §3.1.1: coordinate order is [longitude, latitude]
+                "coordinates": [float(instance.location_lng), float(instance.location_lat)],
+            },
+            "properties": {
+                "title": instance.title,
+                "location_name": instance.location_name,
+                "time_type": instance.time_type,
+                "year": instance.year,
+                "year_start": instance.year_start,
+                "year_end": instance.year_end,
+            },
+        }
 
     class Meta:
         model = Story
-        fields = [
-            'id',
-            'title',
-            'location_name',
-            'location_lat',
-            'location_lng',
-            'time_type',
-            'year',
-            'year_start',
-            'year_end',
-        ]
-        read_only_fields = fields
+        fields = []
 
 
 class SearchQuerySerializer(serializers.Serializer):

--- a/backend/apps/stories/tests/test_serializers.py
+++ b/backend/apps/stories/tests/test_serializers.py
@@ -5,7 +5,7 @@ import pytest
 from apps.stories.models import Story
 from apps.interactions.models import Like, SavedStory
 from apps.media.models import MediaItem, MediaType
-from apps.stories.serializers import SearchQuerySerializer, StoryDetailSerializer, StoryFeedSerializer, StoryMapSerializer, StorySerializer
+from apps.stories.serializers import SearchQuerySerializer, StoryDetailSerializer, StoryFeedSerializer, StoryMapGeoJSONSerializer, StorySerializer
 from apps.users.models import User
 
 
@@ -303,63 +303,6 @@ class TestSearchQuerySerializer:
         assert 'location' not in s.validated_data
 
 
-# ── StoryMapSerializer ────────────────────────────────────────────────────────
-
-@pytest.mark.django_db
-class TestStoryMapSerializer:
-    MAP_FIELDS = {
-        'id', 'title', 'location_name', 'location_lat', 'location_lng',
-        'time_type', 'year', 'year_start', 'year_end',
-    }
-    EXCLUDED_FIELDS = {
-        'narrative', 'contributor_name', 'preview_text', 'status',
-        'like_count', 'save_count', 'submitted_at', 'updated_at',
-        'region', 'contributor_visible', 'user',
-    }
-
-    def _make_story(self, **kwargs):
-        user = make_user()
-        return make_story(user=user, **kwargs)
-
-    def test_contains_exactly_required_map_fields(self):
-        story = self._make_story()
-        data = StoryMapSerializer(story).data
-        assert set(data.keys()) == self.MAP_FIELDS
-
-    def test_excludes_heavy_fields(self):
-        story = self._make_story()
-        data = StoryMapSerializer(story).data
-        for field in self.EXCLUDED_FIELDS:
-            assert field not in data
-
-    def test_coordinates_are_present_and_correct(self):
-        story = self._make_story(
-            location_lat='41.015137', location_lng='28.979530',
-            location_name='Galata Bridge',
-        )
-        data = StoryMapSerializer(story).data
-        assert str(data['location_lat']) == '41.015137'
-        assert str(data['location_lng']) == '28.979530'
-        assert data['location_name'] == 'Galata Bridge'
-
-    def test_exact_year_story_has_year_set(self):
-        story = self._make_story(time_type=Story.TIME_EXACT, year=1923)
-        data = StoryMapSerializer(story).data
-        assert data['time_type'] == Story.TIME_EXACT
-        assert data['year'] == 1923
-        assert data['year_start'] is None
-        assert data['year_end'] is None
-
-    def test_year_range_story_has_year_start_and_end(self):
-        story = self._make_story(
-            time_type=Story.TIME_RANGE, year=None, year_start=1900, year_end=1950,
-        )
-        data = StoryMapSerializer(story).data
-        assert data['time_type'] == Story.TIME_RANGE
-        assert data['year'] is None
-        assert data['year_start'] == 1900
-        assert data['year_end'] == 1950
-
 
 # ── StoryDetailSerializer ─────────────────────────────────────────────────────
 
@@ -549,3 +492,72 @@ class TestStoryFeedSerializerUserInteractionFields:
         data = StoryFeedSerializer(story).data
         assert data['user_has_liked'] is False
         assert data['user_has_saved'] is True
+
+
+# ── StoryMapGeoJSONSerializer ─────────────────────────────────────────────
+
+@pytest.mark.django_db
+class TestStoryMapGeoJSONSerializer:
+    def _make_story(self, **kwargs):
+        user = make_user()
+        return make_story(user=user, **kwargs)
+
+    def test_feature_has_required_geojson_keys(self):
+        story = self._make_story()
+        data = StoryMapGeoJSONSerializer(story).data
+        assert data['type'] == 'Feature'
+        assert data['id'] == story.id
+        assert 'geometry' in data
+        assert 'properties' in data
+
+    def test_geometry_is_point_with_coordinates(self):
+        story = self._make_story(location_lat='41.015137', location_lng='28.979530')
+        data = StoryMapGeoJSONSerializer(story).data
+        assert data['geometry']['type'] == 'Point'
+        assert len(data['geometry']['coordinates']) == 2
+
+    def test_coordinates_are_lng_lat_order(self):
+        # RFC 7946 §3.1.1 mandates [longitude, latitude] ordering
+        story = self._make_story(location_lat='41.015137', location_lng='28.979530')
+        data = StoryMapGeoJSONSerializer(story).data
+        coords = data['geometry']['coordinates']
+        assert coords[0] == pytest.approx(28.979530)
+        assert coords[1] == pytest.approx(41.015137)
+
+    def test_coordinates_are_float_not_decimal_strings(self):
+        story = self._make_story(location_lat='41.015137', location_lng='28.979530')
+        data = StoryMapGeoJSONSerializer(story).data
+        coords = data['geometry']['coordinates']
+        assert isinstance(coords[0], float)
+        assert isinstance(coords[1], float)
+
+    def test_properties_contains_required_fields(self):
+        story = self._make_story(title='Bridge', location_name='Galata', time_type=Story.TIME_EXACT, year=1950)
+        data = StoryMapGeoJSONSerializer(story).data
+        props = data['properties']
+        assert props['title'] == 'Bridge'
+        assert props['location_name'] == 'Galata'
+        assert props['time_type'] == Story.TIME_EXACT
+        assert props['year'] == 1950
+        assert props['year_start'] is None
+        assert props['year_end'] is None
+
+    def test_properties_contains_year_range_fields(self):
+        story = self._make_story(
+            time_type=Story.TIME_RANGE,
+            year=None,
+            year_start=1950,
+            year_end=1970,
+        )
+        data = StoryMapGeoJSONSerializer(story).data
+        props = data['properties']
+        assert props['year_start'] == 1950
+        assert props['year_end'] == 1970
+
+    def test_many_true_returns_list_of_features(self):
+        make_story(user=make_user(email='u1@example.com', username='u1'))
+        make_story(user=make_user(email='u2@example.com', username='u2'))
+        qs = Story.objects.all()
+        data = StoryMapGeoJSONSerializer(qs, many=True).data
+        assert len(data) == 2
+        assert all(f['type'] == 'Feature' for f in data)

--- a/backend/apps/stories/tests/test_views.py
+++ b/backend/apps/stories/tests/test_views.py
@@ -387,73 +387,89 @@ class TestStorySearchView:
 
 @pytest.mark.django_db
 class TestStoryMapView:
-    MAP_FIELDS = {
-        'id', 'title', 'location_name', 'location_lat', 'location_lng',
-        'time_type', 'year', 'year_start', 'year_end',
-    }
-
     def test_returns_200_without_authentication(self, client):
         response = client.get(MAP_URL)
         assert response.status_code == status.HTTP_200_OK
 
-    def test_response_is_paginated(self, client):
-        make_story(status=Story.STATUS_PUBLISHED)
+    def test_response_is_feature_collection(self, client):
         response = client.get(MAP_URL)
-        for key in ['count', 'next', 'previous', 'results']:
-            assert key in response.data
+        assert response.data['type'] == 'FeatureCollection'
+        assert 'features' in response.data
+        assert isinstance(response.data['features'], list)
 
-    def test_result_contains_exactly_map_fields(self, client):
+    def test_response_is_not_paginated(self, client):
+        response = client.get(MAP_URL)
+        assert 'count' not in response.data
+        assert 'next' not in response.data
+        assert 'previous' not in response.data
+        assert 'results' not in response.data
+
+    def test_each_story_is_a_geojson_feature(self, client):
         make_story(status=Story.STATUS_PUBLISHED)
         response = client.get(MAP_URL)
-        assert response.data['count'] == 1
-        result = response.data['results'][0]
-        assert set(result.keys()) == self.MAP_FIELDS
+        feature = response.data['features'][0]
+        assert feature['type'] == 'Feature'
+        assert 'id' in feature
+        assert feature['geometry']['type'] == 'Point'
+        assert 'properties' in feature
+
+    def test_coordinates_are_lng_lat_order(self, client):
+        # RFC 7946 §3.1.1: coordinates are [longitude, latitude]
+        make_story(location_lat='41.015137', location_lng='28.979530')
+        response = client.get(MAP_URL)
+        coords = response.data['features'][0]['geometry']['coordinates']
+        assert coords[0] == pytest.approx(28.979530)
+        assert coords[1] == pytest.approx(41.015137)
 
     def test_only_published_stories_appear(self, client):
         make_story(title='Published', status=Story.STATUS_PUBLISHED)
         make_story(title='Draft', status=Story.STATUS_DRAFT)
         make_story(title='Removed', status=Story.STATUS_REMOVED)
         response = client.get(MAP_URL)
-        assert response.data['count'] == 1
-        assert response.data['results'][0]['title'] == 'Published'
+        assert len(response.data['features']) == 1
+        assert response.data['features'][0]['properties']['title'] == 'Published'
 
-    def test_empty_result_when_no_published_stories(self, client):
+    def test_empty_feature_collection_when_no_published_stories(self, client):
         make_story(status=Story.STATUS_DRAFT)
         response = client.get(MAP_URL)
-        assert response.data['count'] == 0
-        assert response.data['results'] == []
+        assert response.data['features'] == []
+
+    def test_returns_all_stories_without_pagination(self, client):
+        for i in range(15):
+            make_story(title=f'Story {i}')
+        response = client.get(MAP_URL)
+        assert len(response.data['features']) == 15
 
     def test_year_from_filter_excludes_older_stories(self, client):
         make_story(title='Old', time_type=Story.TIME_EXACT, year=1800)
         make_story(title='New', time_type=Story.TIME_EXACT, year=2000)
         response = client.get(MAP_URL + '?year_from=1900')
-        assert response.data['count'] == 1
-        assert response.data['results'][0]['title'] == 'New'
+        assert len(response.data['features']) == 1
+        assert response.data['features'][0]['properties']['title'] == 'New'
 
     def test_year_to_filter_excludes_newer_stories(self, client):
         make_story(title='Old', time_type=Story.TIME_EXACT, year=1800)
         make_story(title='New', time_type=Story.TIME_EXACT, year=2000)
         response = client.get(MAP_URL + '?year_to=1900')
-        assert response.data['count'] == 1
-        assert response.data['results'][0]['title'] == 'Old'
+        assert len(response.data['features']) == 1
+        assert response.data['features'][0]['properties']['title'] == 'Old'
 
     def test_location_filter_is_case_insensitive(self, client):
         make_story(title='Istanbul Story', location_name='Galata Bridge')
         make_story(title='Ankara Story', location_name='Atakule Tower')
         response = client.get(MAP_URL + '?location=galata')
-        assert response.data['count'] == 1
-        assert response.data['results'][0]['title'] == 'Istanbul Story'
+        assert len(response.data['features']) == 1
+        assert response.data['features'][0]['properties']['location_name'] == 'Galata Bridge'
 
     def test_invalid_year_range_returns_400(self, client):
         response = client.get(MAP_URL + '?year_from=2000&year_to=1900')
         assert response.status_code == status.HTTP_400_BAD_REQUEST
 
-    def test_narrative_not_exposed_in_results(self, client):
+    def test_narrative_not_exposed_in_properties(self, client):
         make_story(narrative='Secret text that should not appear.')
         response = client.get(MAP_URL)
-        if response.data['count']:
-            result = response.data['results'][0]
-            assert 'narrative' not in result
+        if response.data['features']:
+            assert 'narrative' not in response.data['features'][0]['properties']
 
 
 # ── StoryDetailView — media_items ─────────────────────────────────────────────

--- a/backend/apps/stories/views.py
+++ b/backend/apps/stories/views.py
@@ -1,11 +1,12 @@
 from django.db.models import Exists, OuterRef
 from rest_framework import generics
 from rest_framework.permissions import AllowAny, IsAuthenticated
+from rest_framework.response import Response
 from rest_framework.views import APIView
 
 from apps.interactions.models import Like, SavedStory
 from apps.stories.models import Story
-from apps.stories.serializers import FeedQuerySerializer, SearchQuerySerializer, StoryDetailSerializer, StoryFeedSerializer, StoryMapSerializer, StorySerializer
+from apps.stories.serializers import FeedQuerySerializer, SearchQuerySerializer, StoryDetailSerializer, StoryFeedSerializer, StoryMapGeoJSONSerializer, StorySerializer
 from apps.stories.services import delete_story, get_story_feed, get_story_search
 from common.pagination import StoryPagination
 from common.permissions import IsOwnerOrAdmin
@@ -68,16 +69,16 @@ class StoryMapView(APIView):
     """
     GET /stories/map/
 
-    Returns a paginated list of published stories with only the fields needed
-    to render map pins: coordinates, place name, title, and time info.
-    Guests and authenticated users both have read access.
+    Returns all published stories as a GeoJSON FeatureCollection (RFC 7946).
+    No pagination — map clients need the full set of pins in a single response.
+    Each story is a Feature with a Point geometry and basic metadata in properties.
+
+    Coordinates follow RFC 7946 §3.1.1: [longitude, latitude].
 
     Query params:
       year_from  — include stories from this year onwards
       year_to    — include stories up to and including this year
       location   — case-insensitive substring match against location_name
-      page       — page number (default 1)
-      page_size  — results per page (default 10, max 100)
     """
 
     permission_classes = [AllowAny]
@@ -93,10 +94,11 @@ class StoryMapView(APIView):
             location=params.get('location'),
         )
 
-        paginator = StoryPagination()
-        page = paginator.paginate_queryset(qs, request)
-        serializer = StoryMapSerializer(page, many=True)
-        return paginator.get_paginated_response(serializer.data)
+        serializer = StoryMapGeoJSONSerializer(qs, many=True)
+        return Response({
+            "type": "FeatureCollection",
+            "features": serializer.data,
+        })
 
 
 class StorySearchView(APIView):


### PR DESCRIPTION
# 📝 Description
Fixes #379 

This PR refactors the map endpoint to return an RFC 7946-compliant GeoJSON response instead of the previous custom paginated structure.

### What changed
- Replaced the old `StoryMapSerializer` with `StoryMapGeoJSONSerializer`
- Updated `GET /stories/map/` to return a GeoJSON `FeatureCollection`
- Ensured each story is serialized as a GeoJSON `Feature`
- Moved coordinates into `geometry.coordinates` using RFC 7946 ordering: `[longitude, latitude]`
- Moved map-related metadata into `properties`
- Removed pagination from the map endpoint so map clients can receive the full pin set in one response
- Updated serializer and view tests to match the new GeoJSON response contract
- Added tests verifying:
  - `FeatureCollection` response shape
  - `Feature` structure
  - `[lng, lat]` coordinate ordering
  - numeric coordinate serialization
  - filtering behavior with the new response format
  - no unintended field exposure in map properties

### Important note for frontend
Frontend map implementations should also be updated to follow this new response format as soon as possible. The endpoint no longer returns the old paginated structure with flat story fields, so any frontend code still expecting fields like `results`, `location_lat`, or `location_lng` at the top level will misread the backend response and likely fail in the map flow. To stay compatible with the backend, the frontend should now read map data from the GeoJSON structure (`features`, `geometry`, and `properties`) and align its parsing/rendering logic with this standard.

# 📊 Type of Change
- [ ] Bug fix
- [ ] New feature
- [x] Refactoring
- [ ] Documentation
 
# ✅ Acceptance Criteria / Checklist
- [x] Project builds successfully
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, especially in hard-to-understand parts
- [x] I have performed a self-review of my code
- [x] I have added/updated tests
- [x] New and existing unit tests pass locally with my changes


# ⏱️ Estimated Review Time
- [ ] < 5 min
- [x] 5-15 min
- [ ] > 15 min