### PR TITLE
feat: consume GeoJSON via L.geoJSON in the map view

### DIFF
--- a/frontend/src/components/MapView/MapView.jsx
+++ b/frontend/src/components/MapView/MapView.jsx
@@ -1,14 +1,14 @@
 import { useEffect, useMemo } from "react";
 import { MapContainer, TileLayer, GeoJSON, useMap } from "react-leaflet";
-import { MemoryRouter, useNavigate } from "react-router-dom";
-import { renderToStaticMarkup } from "react-dom/server";
+import { useNavigate, useLocation } from "react-router-dom";
 import L from "leaflet";
 import "leaflet/dist/leaflet.css";
 import markerIcon2x from "leaflet/dist/images/marker-icon-2x.png";
 import markerIcon from "leaflet/dist/images/marker-icon.png";
 import markerShadow from "leaflet/dist/images/marker-shadow.png";
 
-import StoryPopup from "./StoryPopup";
+import { EMPTY_FEATURE_COLLECTION } from "@/services/storyService";
+import { pointToLayer, onEachFeature } from "./mapFeatureUtils";
 
 // Fix Leaflet default marker icon paths for Vite bundler
 delete L.Icon.Default.prototype._getIconUrl;
@@ -20,51 +20,28 @@ L.Icon.Default.mergeOptions({
 
 const ISTANBUL_CENTER = [41.0082, 28.9784];
 const DEFAULT_ZOOM = 12;
-const EMPTY_FEATURE_COLLECTION = { type: "FeatureCollection", features: [] };
-
-function featureToStory(feature) {
-  const props = feature.properties ?? {};
-  return {
-    id: feature.id,
-    title: props.title,
-    location_name: props.location_name,
-    time_type: props.time_type,
-    year: props.year,
-    year_start: props.year_start,
-    year_end: props.year_end,
-  };
-}
-
-const pointToLayer = (_feature, latlng) => L.marker(latlng);
-
-const onEachFeature = (feature, layer) => {
-  // Leaflet popups live outside React's tree, so render the content to a
-  // static HTML string. A MemoryRouter wrapper satisfies <Link>'s context.
-  const html = renderToStaticMarkup(
-    <MemoryRouter>
-      <StoryPopup story={featureToStory(feature)} />
-    </MemoryRouter>,
-  );
-  layer.bindPopup(html);
-};
 
 // Intercepts clicks on story links inside popup HTML so they perform
-// client-side navigation instead of a full page reload.
+// client-side navigation instead of a full page reload. Captures the
+// current map URL (including search params) as `from` state so back-
+// navigation preserves active filters.
 function StoryLinkInterceptor() {
   const map = useMap();
   const navigate = useNavigate();
+  const location = useLocation();
   useEffect(() => {
     const container = map?.getContainer?.();
     if (!container) return undefined;
+    const from = `${location.pathname}${location.search}`;
     const handler = (event) => {
       const anchor = event.target.closest?.("a[href^='/stories/']");
       if (!anchor || event.defaultPrevented) return;
       event.preventDefault();
-      navigate(anchor.getAttribute("href"), { state: { from: "/map" } });
+      navigate(anchor.getAttribute("href"), { state: { from } });
     };
     container.addEventListener("click", handler);
     return () => container.removeEventListener("click", handler);
-  }, [map, navigate]);
+  }, [map, navigate, location.pathname, location.search]);
   return null;
 }
 

--- a/frontend/src/components/MapView/MapView.jsx
+++ b/frontend/src/components/MapView/MapView.jsx
@@ -1,4 +1,7 @@
-import { MapContainer, TileLayer, Marker, Popup } from "react-leaflet";
+import { useEffect, useMemo } from "react";
+import { MapContainer, TileLayer, GeoJSON, useMap } from "react-leaflet";
+import { MemoryRouter, useNavigate } from "react-router-dom";
+import { renderToStaticMarkup } from "react-dom/server";
 import L from "leaflet";
 import "leaflet/dist/leaflet.css";
 import markerIcon2x from "leaflet/dist/images/marker-icon-2x.png";
@@ -17,8 +20,66 @@ L.Icon.Default.mergeOptions({
 
 const ISTANBUL_CENTER = [41.0082, 28.9784];
 const DEFAULT_ZOOM = 12;
+const EMPTY_FEATURE_COLLECTION = { type: "FeatureCollection", features: [] };
 
-function MapView({ stories = [], loading = false }) {
+function featureToStory(feature) {
+  const props = feature.properties ?? {};
+  return {
+    id: feature.id,
+    title: props.title,
+    location_name: props.location_name,
+    time_type: props.time_type,
+    year: props.year,
+    year_start: props.year_start,
+    year_end: props.year_end,
+  };
+}
+
+const pointToLayer = (_feature, latlng) => L.marker(latlng);
+
+const onEachFeature = (feature, layer) => {
+  // Leaflet popups live outside React's tree, so render the content to a
+  // static HTML string. A MemoryRouter wrapper satisfies <Link>'s context.
+  const html = renderToStaticMarkup(
+    <MemoryRouter>
+      <StoryPopup story={featureToStory(feature)} />
+    </MemoryRouter>,
+  );
+  layer.bindPopup(html);
+};
+
+// Intercepts clicks on story links inside popup HTML so they perform
+// client-side navigation instead of a full page reload.
+function StoryLinkInterceptor() {
+  const map = useMap();
+  const navigate = useNavigate();
+  useEffect(() => {
+    const container = map?.getContainer?.();
+    if (!container) return undefined;
+    const handler = (event) => {
+      const anchor = event.target.closest?.("a[href^='/stories/']");
+      if (!anchor || event.defaultPrevented) return;
+      event.preventDefault();
+      navigate(anchor.getAttribute("href"), { state: { from: "/map" } });
+    };
+    container.addEventListener("click", handler);
+    return () => container.removeEventListener("click", handler);
+  }, [map, navigate]);
+  return null;
+}
+
+function MapView({ featureCollection = EMPTY_FEATURE_COLLECTION, loading = false }) {
+  const features = useMemo(
+    () => featureCollection?.features ?? [],
+    [featureCollection],
+  );
+  // react-leaflet's <GeoJSON> only initializes the layer once, so force a
+  // remount whenever the feature set changes (filter/search results).
+  const geoJSONKey = useMemo(
+    () => features.map((f) => f.id).join("|"),
+    [features],
+  );
+
   return (
     <div className="relative h-full w-full" data-testid="map-wrapper">
       <MapContainer
@@ -31,17 +92,15 @@ function MapView({ stories = [], loading = false }) {
           attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
           url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
         />
-        {stories.filter((story) => story.location_lat != null && story.location_lng != null).map((story) => (
-          <Marker
-            key={story.id}
-            position={[story.location_lat, story.location_lng]}
-            data-testid="map-marker"
-          >
-            <Popup>
-              <StoryPopup story={story} />
-            </Popup>
-          </Marker>
-        ))}
+        {features.length > 0 && (
+          <GeoJSON
+            key={geoJSONKey}
+            data={featureCollection}
+            pointToLayer={pointToLayer}
+            onEachFeature={onEachFeature}
+          />
+        )}
+        <StoryLinkInterceptor />
       </MapContainer>
       {loading && (
         <div

--- a/frontend/src/components/MapView/StoryPopup.jsx
+++ b/frontend/src/components/MapView/StoryPopup.jsx
@@ -1,6 +1,14 @@
-import { Link } from "react-router-dom";
 import { formatTimePeriod } from "@/components/StoryCard/storyCardUtils";
 
+// NOTE: This component is rendered via renderToStaticMarkup and then handed to
+// Leaflet's bindPopup as an innerHTML string. React escapes all values inside
+// renderToStaticMarkup, so story fields from our trusted API are safe. Any
+// future addition of user-controlled content (e.g. story body text) must be
+// escaped or sanitized here to avoid XSS at that innerHTML boundary.
+//
+// Uses a plain <a> tag (not <Link>) so the component does not require a
+// react-router context during static rendering. Clicks are intercepted by
+// StoryLinkInterceptor in MapView to perform client-side navigation.
 function StoryPopup({ story }) {
   const timePeriod = formatTimePeriod(story);
 
@@ -13,13 +21,12 @@ function StoryPopup({ story }) {
       {timePeriod && (
         <p className="text-xs text-muted-foreground mb-1">{timePeriod}</p>
       )}
-      <Link
-        to={`/stories/${story.id}`}
-        state={{ from: "/map" }}
+      <a
+        href={`/stories/${story.id}`}
         className="text-xs font-medium text-primary hover:underline"
       >
         Read more
-      </Link>
+      </a>
     </div>
   );
 }

--- a/frontend/src/components/MapView/__tests__/MapView.test.jsx
+++ b/frontend/src/components/MapView/__tests__/MapView.test.jsx
@@ -1,10 +1,21 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen } from "@testing-library/react";
-import { BrowserRouter } from "react-router-dom";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter, Route, Routes, useLocation } from "react-router-dom";
+
+// Hoisted reference to the fake Leaflet container so the StoryLinkInterceptor
+// in MapView registers its click handler on an element we can dispatch events
+// against from tests.
+const { fakeMapContainer } = vi.hoisted(() => ({
+  fakeMapContainer: document.createElement("div"),
+}));
 
 vi.mock("react-leaflet", () => ({
   MapContainer: ({ children, ...props }) => (
-    <div data-testid="map-container" {...props}>{children}</div>
+    <div data-testid="map-container" {...props}>
+      <div ref={(el) => el && el.appendChild(fakeMapContainer)} />
+      {children}
+    </div>
   ),
   TileLayer: () => null,
   GeoJSON: ({ data, pointToLayer, onEachFeature }) => {
@@ -32,7 +43,7 @@ vi.mock("react-leaflet", () => ({
       </div>
     );
   },
-  useMap: () => ({ getContainer: () => document.createElement("div") }),
+  useMap: () => ({ getContainer: () => fakeMapContainer }),
 }));
 
 vi.mock("leaflet", () => {
@@ -45,6 +56,7 @@ vi.mock("leaflet", () => {
 });
 
 import MapView from "../MapView";
+import { onEachFeature } from "../mapFeatureUtils";
 
 function makeFeature(id, overrides = {}) {
   return {
@@ -70,17 +82,23 @@ function makeFeatureCollection(features) {
   return { type: "FeatureCollection", features };
 }
 
-function renderMapView(props = {}) {
+function renderMapView(props = {}, { initialEntries = ["/map"] } = {}) {
   return render(
-    <BrowserRouter>
+    <MemoryRouter initialEntries={initialEntries}>
       <MapView {...props} />
-    </BrowserRouter>,
+    </MemoryRouter>,
   );
 }
 
 describe("MapView", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    // Reset the shared fake container so event listeners from a prior test
+    // don't leak into the next one.
+    while (fakeMapContainer.firstChild) {
+      fakeMapContainer.removeChild(fakeMapContainer.firstChild);
+    }
+    fakeMapContainer.replaceWith(fakeMapContainer.cloneNode(false));
   });
 
   it("renders the map container", () => {
@@ -127,5 +145,88 @@ describe("MapView", () => {
     const fc = makeFeatureCollection([makeFeature(1)]);
     renderMapView({ featureCollection: fc });
     expect(screen.getByText("Story 1")).toBeInTheDocument();
+  });
+});
+
+describe("onEachFeature", () => {
+  it("binds a popup whose HTML contains title, location, time period, and a Read more link", () => {
+    const feature = makeFeature(42, {
+      title: "The Old Bridge",
+      location_name: "Galata",
+      year: 1920,
+    });
+    const bindPopup = vi.fn();
+    onEachFeature(feature, { bindPopup });
+
+    expect(bindPopup).toHaveBeenCalledTimes(1);
+    const html = bindPopup.mock.calls[0][0];
+    expect(html).toContain("The Old Bridge");
+    expect(html).toContain("Galata");
+    expect(html).toContain("1920");
+    expect(html).toContain("Read more");
+    expect(html).toContain('href="/stories/42"');
+  });
+
+  it("omits the location line when location_name is missing", () => {
+    const feature = makeFeature(7, { location_name: undefined });
+    const bindPopup = vi.fn();
+    onEachFeature(feature, { bindPopup });
+
+    const html = bindPopup.mock.calls[0][0];
+    expect(html).toContain("Story 7");
+    expect(html).not.toContain("Location 7");
+  });
+});
+
+describe("StoryLinkInterceptor", () => {
+  function LocationProbe() {
+    const loc = useLocation();
+    return (
+      <>
+        <div data-testid="current-pathname">{loc.pathname}</div>
+        <div data-testid="current-state-from">{loc.state?.from ?? ""}</div>
+      </>
+    );
+  }
+
+  function Harness({ initialEntries }) {
+    return (
+      <MemoryRouter initialEntries={initialEntries}>
+        <Routes>
+          <Route
+            path="/map"
+            element={
+              <>
+                <MapView featureCollection={makeFeatureCollection([makeFeature(99)])} />
+                <LocationProbe />
+              </>
+            }
+          />
+          <Route path="/stories/:id" element={<LocationProbe />} />
+        </Routes>
+      </MemoryRouter>
+    );
+  }
+
+  it("intercepts clicks on /stories/ anchors inside the map and navigates via react-router", async () => {
+    const user = userEvent.setup();
+    render(<Harness initialEntries={["/map?category=nature"]} />);
+
+    // Simulate the popup HTML Leaflet would have injected into the map container.
+    const anchor = document.createElement("a");
+    anchor.setAttribute("href", "/stories/99");
+    anchor.textContent = "Read more";
+    fakeMapContainer.appendChild(anchor);
+
+    expect(screen.getByTestId("current-pathname").textContent).toBe("/map");
+
+    await user.click(anchor);
+
+    expect(screen.getByTestId("current-pathname").textContent).toBe("/stories/99");
+    // Filter state must survive the SPA navigation so the Back navigation
+    // returns the user to the filtered map.
+    expect(screen.getByTestId("current-state-from").textContent).toBe(
+      "/map?category=nature",
+    );
   });
 });

--- a/frontend/src/components/MapView/__tests__/MapView.test.jsx
+++ b/frontend/src/components/MapView/__tests__/MapView.test.jsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen } from "@testing-library/react";
 import { BrowserRouter } from "react-router-dom";
 
@@ -7,56 +7,108 @@ vi.mock("react-leaflet", () => ({
     <div data-testid="map-container" {...props}>{children}</div>
   ),
   TileLayer: () => null,
-  Marker: ({ children }) => <div data-testid="map-marker">{children}</div>,
-  Popup: ({ children }) => <div data-testid="map-popup">{children}</div>,
-  useMap: () => ({ setView: vi.fn() }),
+  GeoJSON: ({ data, pointToLayer, onEachFeature }) => {
+    const features = data?.features ?? [];
+    // Invoke the callbacks the same way L.geoJSON would so that bindPopup
+    // and marker creation are exercised under test.
+    features.forEach((feature) => {
+      const fakeLayer = {
+        bindPopup: vi.fn(),
+        on: vi.fn(),
+      };
+      pointToLayer?.(feature, [0, 0]);
+      onEachFeature?.(feature, fakeLayer);
+    });
+    return (
+      <div
+        data-testid="map-geojson"
+        data-feature-count={features.length}
+      >
+        {features.map((f) => (
+          <div key={f.id} data-testid="map-marker">
+            {f.properties?.title}
+          </div>
+        ))}
+      </div>
+    );
+  },
+  useMap: () => ({ getContainer: () => document.createElement("div") }),
 }));
 
 vi.mock("leaflet", () => {
+  const marker = vi.fn(() => ({ bindPopup: vi.fn() }));
   const L = {
     Icon: { Default: { prototype: { _getIconUrl: "" }, mergeOptions: vi.fn() } },
+    marker,
   };
   return { default: L };
 });
 
 import MapView from "../MapView";
 
-function makePin(id, overrides = {}) {
+function makeFeature(id, overrides = {}) {
   return {
+    type: "Feature",
     id,
-    title: `Story ${id}`,
-    location_lat: 41.0 + id * 0.01,
-    location_lng: 28.9 + id * 0.01,
-    location_name: `Location ${id}`,
-    time_type: "exact_year",
-    year: 1900 + id,
-    year_start: null,
-    year_end: null,
-    ...overrides,
+    geometry: {
+      type: "Point",
+      coordinates: [28.9 + id * 0.01, 41.0 + id * 0.01],
+    },
+    properties: {
+      title: `Story ${id}`,
+      location_name: `Location ${id}`,
+      time_type: "exact_year",
+      year: 1900 + id,
+      year_start: null,
+      year_end: null,
+      ...overrides,
+    },
   };
+}
+
+function makeFeatureCollection(features) {
+  return { type: "FeatureCollection", features };
 }
 
 function renderMapView(props = {}) {
   return render(
     <BrowserRouter>
       <MapView {...props} />
-    </BrowserRouter>
+    </BrowserRouter>,
   );
 }
 
 describe("MapView", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
   it("renders the map container", () => {
     renderMapView();
     expect(screen.getByTestId("map-container")).toBeInTheDocument();
   });
 
-  it("renders markers for each story", () => {
-    renderMapView({ stories: [makePin(1), makePin(2), makePin(3)] });
+  it("renders a marker for each feature in the FeatureCollection", () => {
+    const fc = makeFeatureCollection([makeFeature(1), makeFeature(2), makeFeature(3)]);
+    renderMapView({ featureCollection: fc });
     expect(screen.getAllByTestId("map-marker")).toHaveLength(3);
   });
 
-  it("renders no markers when stories is empty", () => {
-    renderMapView({ stories: [] });
+  it("passes the FeatureCollection as-is to the GeoJSON layer", () => {
+    const fc = makeFeatureCollection([makeFeature(1)]);
+    renderMapView({ featureCollection: fc });
+    const layer = screen.getByTestId("map-geojson");
+    expect(layer).toHaveAttribute("data-feature-count", "1");
+  });
+
+  it("does not render a GeoJSON layer when the FeatureCollection is empty", () => {
+    renderMapView({ featureCollection: makeFeatureCollection([]) });
+    expect(screen.queryByTestId("map-geojson")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("map-marker")).not.toBeInTheDocument();
+  });
+
+  it("handles a missing featureCollection prop without crashing", () => {
+    renderMapView();
     expect(screen.queryByTestId("map-marker")).not.toBeInTheDocument();
   });
 
@@ -71,24 +123,9 @@ describe("MapView", () => {
     expect(screen.queryByLabelText("Loading map pins")).not.toBeInTheDocument();
   });
 
-  it("renders popup content with story title", () => {
-    renderMapView({ stories: [makePin(1)] });
+  it("exposes the feature title in the marker element", () => {
+    const fc = makeFeatureCollection([makeFeature(1)]);
+    renderMapView({ featureCollection: fc });
     expect(screen.getByText("Story 1")).toBeInTheDocument();
-  });
-
-  it("renders popup with location name", () => {
-    renderMapView({ stories: [makePin(1)] });
-    expect(screen.getByText("Location 1")).toBeInTheDocument();
-  });
-
-  it("renders popup with read more link", () => {
-    renderMapView({ stories: [makePin(1)] });
-    const link = screen.getByRole("link", { name: /read more/i });
-    expect(link).toHaveAttribute("href", "/stories/1");
-  });
-
-  it("renders popup with time period", () => {
-    renderMapView({ stories: [makePin(1, { time_type: "exact_year", year: 1920 })] });
-    expect(screen.getByText("1920")).toBeInTheDocument();
   });
 });

--- a/frontend/src/components/MapView/__tests__/StoryPopup.test.jsx
+++ b/frontend/src/components/MapView/__tests__/StoryPopup.test.jsx
@@ -1,14 +1,9 @@
 import { describe, it, expect } from "vitest";
 import { render, screen } from "@testing-library/react";
-import { MemoryRouter } from "react-router-dom";
 import StoryPopup from "../StoryPopup";
 
 function renderPopup(story) {
-  return render(
-    <MemoryRouter>
-      <StoryPopup story={story} />
-    </MemoryRouter>,
-  );
+  return render(<StoryPopup story={story} />);
 }
 
 describe("StoryPopup", () => {

--- a/frontend/src/components/MapView/mapFeatureUtils.jsx
+++ b/frontend/src/components/MapView/mapFeatureUtils.jsx
@@ -1,0 +1,31 @@
+import L from "leaflet";
+import { renderToStaticMarkup } from "react-dom/server";
+
+import StoryPopup from "./StoryPopup";
+
+function featureToStory(feature) {
+  const props = feature.properties ?? {};
+  return {
+    id: feature.id,
+    title: props.title,
+    location_name: props.location_name,
+    time_type: props.time_type,
+    year: props.year,
+    year_start: props.year_start,
+    year_end: props.year_end,
+  };
+}
+
+export const pointToLayer = (_feature, latlng) => L.marker(latlng);
+
+// XSS trust boundary: Leaflet's bindPopup treats this string as innerHTML.
+// renderToStaticMarkup escapes every React child/attribute, so feature
+// properties coming from our trusted API render safely. Any future change
+// that embeds user-controlled HTML into StoryPopup must keep that escaping
+// in place (or sanitize explicitly) to prevent XSS at this seam.
+export const onEachFeature = (feature, layer) => {
+  const html = renderToStaticMarkup(
+    <StoryPopup story={featureToStory(feature)} />,
+  );
+  layer.bindPopup(html);
+};

--- a/frontend/src/pages/MapPage.jsx
+++ b/frontend/src/pages/MapPage.jsx
@@ -5,10 +5,12 @@ import SearchFilter from "@/components/SearchFilter/SearchFilter";
 import { getMapStories } from "@/services/storyService";
 import { useFilterState } from "@/hooks/useFilterState";
 
+const EMPTY_FEATURE_COLLECTION = { type: "FeatureCollection", features: [] };
+
 function MapPage() {
   const { q, yearFrom, yearTo, location } = useFilterState();
 
-  const [stories, setStories] = useState([]);
+  const [featureCollection, setFeatureCollection] = useState(EMPTY_FEATURE_COLLECTION);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
 
@@ -17,7 +19,7 @@ function MapPage() {
     setError(null);
     try {
       const data = await getMapStories({ q, yearFrom, yearTo, location });
-      setStories(data);
+      setFeatureCollection(data ?? EMPTY_FEATURE_COLLECTION);
     } catch (err) {
       setError(
         err?.response?.data?.detail ||
@@ -35,7 +37,7 @@ function MapPage() {
 
   return (
     <div className="relative isolate" style={{ height: "calc(100vh - 3.5rem)" }}>
-      <MapView stories={stories} loading={loading} />
+      <MapView featureCollection={featureCollection} loading={loading} />
 
       {/* Search & filter overlay */}
       <div className="absolute top-3 left-3 right-3 z-[1000] sm:left-4 sm:right-auto sm:w-[32rem]">

--- a/frontend/src/pages/__tests__/MapPage.test.jsx
+++ b/frontend/src/pages/__tests__/MapPage.test.jsx
@@ -8,14 +8,25 @@ vi.mock("react-leaflet", () => ({
     <div data-testid="map-container" {...props}>{children}</div>
   ),
   TileLayer: () => null,
-  Marker: ({ children }) => <div data-testid="map-marker">{children}</div>,
-  Popup: ({ children }) => <div data-testid="map-popup">{children}</div>,
-  useMap: () => ({ setView: vi.fn() }),
+  GeoJSON: ({ data }) => {
+    const features = data?.features ?? [];
+    return (
+      <div data-testid="map-geojson" data-feature-count={features.length}>
+        {features.map((f) => (
+          <div key={f.id} data-testid="map-marker">
+            {f.properties?.title}
+          </div>
+        ))}
+      </div>
+    );
+  },
+  useMap: () => ({ getContainer: () => document.createElement("div") }),
 }));
 
 vi.mock("leaflet", () => {
   const L = {
     Icon: { Default: { prototype: { _getIconUrl: "" }, mergeOptions: vi.fn() } },
+    marker: vi.fn(() => ({ bindPopup: vi.fn() })),
   };
   return { default: L };
 });
@@ -32,37 +43,45 @@ vi.mock("react-router-dom", async () => {
 import { getMapStories } from "@/services/storyService";
 import MapPage from "../MapPage";
 
-function makePin(id, overrides = {}) {
+function makeFeature(id, overrides = {}) {
   return {
+    type: "Feature",
     id,
-    title: `Story ${id}`,
-    location_lat: 41.0 + id * 0.01,
-    location_lng: 28.9 + id * 0.01,
-    location_name: `Location ${id}`,
-    time_type: "exact_year",
-    year: 1900 + id,
-    year_start: null,
-    year_end: null,
-    ...overrides,
+    geometry: {
+      type: "Point",
+      coordinates: [28.9 + id * 0.01, 41.0 + id * 0.01],
+    },
+    properties: {
+      title: `Story ${id}`,
+      location_name: `Location ${id}`,
+      time_type: "exact_year",
+      year: 1900 + id,
+      year_start: null,
+      year_end: null,
+      ...overrides,
+    },
   };
+}
+
+function makeFeatureCollection(features) {
+  return { type: "FeatureCollection", features };
 }
 
 function renderPage() {
   return render(
     <BrowserRouter>
       <MapPage />
-    </BrowserRouter>
+    </BrowserRouter>,
   );
 }
 
 describe("MapPage", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-
   });
 
   it("renders the map container", async () => {
-    getMapStories.mockResolvedValue([]);
+    getMapStories.mockResolvedValue(makeFeatureCollection([]));
     renderPage();
     expect(screen.getByTestId("map-container")).toBeInTheDocument();
   });
@@ -74,7 +93,9 @@ describe("MapPage", () => {
   });
 
   it("renders markers after successful fetch", async () => {
-    getMapStories.mockResolvedValue([makePin(1), makePin(2)]);
+    getMapStories.mockResolvedValue(
+      makeFeatureCollection([makeFeature(1), makeFeature(2)]),
+    );
     renderPage();
 
     await waitFor(() => {
@@ -95,7 +116,7 @@ describe("MapPage", () => {
     const user = userEvent.setup();
     getMapStories
       .mockRejectedValueOnce(new Error("fail"))
-      .mockResolvedValue([makePin(1)]);
+      .mockResolvedValue(makeFeatureCollection([makeFeature(1)]));
 
     renderPage();
 
@@ -112,8 +133,8 @@ describe("MapPage", () => {
     expect(getMapStories).toHaveBeenCalledTimes(2);
   });
 
-  it("shows no markers when API returns empty array", async () => {
-    getMapStories.mockResolvedValue([]);
+  it("shows no markers when API returns an empty FeatureCollection", async () => {
+    getMapStories.mockResolvedValue(makeFeatureCollection([]));
     renderPage();
 
     await waitFor(() => {

--- a/frontend/src/services/__tests__/storyService.test.js
+++ b/frontend/src/services/__tests__/storyService.test.js
@@ -129,36 +129,48 @@ describe("storyService", () => {
   });
 
   describe("getMapStories", () => {
-    it("calls GET /stories/map/ with empty params by default", async () => {
-      api.get.mockResolvedValue({ data: { count: 0, next: null, previous: null, results: [] } });
+    const emptyFeatureCollection = { type: "FeatureCollection", features: [] };
+
+    it("calls GET /stories/map/ with no params by default", async () => {
+      api.get.mockResolvedValue({ data: emptyFeatureCollection });
 
       await getMapStories();
 
-      expect(api.get).toHaveBeenCalledWith("/stories/map/", { params: { page_size: 100 } });
+      expect(api.get).toHaveBeenCalledWith("/stories/map/", { params: {} });
     });
 
-    it("returns the .results array from paginated response", async () => {
-      const stories = [{ id: 1, title: "Story 1" }, { id: 2, title: "Story 2" }];
-      api.get.mockResolvedValue({ data: { count: 2, next: null, previous: null, results: stories } });
+    it("returns the GeoJSON FeatureCollection from the map endpoint as-is", async () => {
+      const featureCollection = {
+        type: "FeatureCollection",
+        features: [
+          {
+            type: "Feature",
+            id: 1,
+            geometry: { type: "Point", coordinates: [28.9, 41.0] },
+            properties: { title: "Story 1" },
+          },
+        ],
+      };
+      api.get.mockResolvedValue({ data: featureCollection });
 
       const result = await getMapStories();
 
-      expect(result).toEqual(stories);
+      expect(result).toEqual(featureCollection);
     });
 
     it("passes yearFrom, yearTo and location filter params to map API", async () => {
-      api.get.mockResolvedValue({ data: { count: 0, next: null, previous: null, results: [] } });
+      api.get.mockResolvedValue({ data: emptyFeatureCollection });
 
       await getMapStories({ yearFrom: 1900, yearTo: 2000, location: "Galata" });
 
       expect(api.get).toHaveBeenCalledWith("/stories/map/", {
-        params: { page_size: 100, year_from: 1900, year_to: 2000, location: "Galata" },
+        params: { year_from: 1900, year_to: 2000, location: "Galata" },
       });
     });
 
-    it("calls search API when q is provided and returns stories with coordinates", async () => {
+    it("calls search API when q is provided and adapts results into a FeatureCollection", async () => {
       const stories = [
-        { id: 1, title: "Bridge", location_lat: 41.0, location_lng: 28.9 },
+        { id: 1, title: "Bridge", location_lat: 41.0, location_lng: 28.9, location_name: "Galata", time_type: "exact_year", year: 1950 },
         { id: 2, title: "No location", location_lat: null, location_lng: null },
       ];
       api.get.mockResolvedValue({ data: { count: 2, next: null, previous: null, results: stories } });
@@ -168,9 +180,16 @@ describe("storyService", () => {
       expect(api.get).toHaveBeenCalledWith("/stories/search/", {
         params: { q: "bridge", page_size: 100 },
       });
-      // Filters out stories without coordinates
-      expect(result).toHaveLength(1);
-      expect(result[0].id).toBe(1);
+      expect(result.type).toBe("FeatureCollection");
+      // Stories without coordinates are filtered out
+      expect(result.features).toHaveLength(1);
+      const feature = result.features[0];
+      expect(feature.type).toBe("Feature");
+      expect(feature.id).toBe(1);
+      // RFC 7946 §3.1.1: coordinate order is [longitude, latitude]
+      expect(feature.geometry).toEqual({ type: "Point", coordinates: [28.9, 41.0] });
+      expect(feature.properties.title).toBe("Bridge");
+      expect(feature.properties.location_name).toBe("Galata");
     });
 
     it("passes year and location filters to search API when q and filters are combined", async () => {

--- a/frontend/src/services/storyService.js
+++ b/frontend/src/services/storyService.js
@@ -34,7 +34,7 @@ export async function getStories({
   return response.data; // { count, next, previous, results }
 }
 
-const EMPTY_FEATURE_COLLECTION = Object.freeze({
+export const EMPTY_FEATURE_COLLECTION = Object.freeze({
   type: "FeatureCollection",
   features: [],
 });

--- a/frontend/src/services/storyService.js
+++ b/frontend/src/services/storyService.js
@@ -34,10 +34,37 @@ export async function getStories({
   return response.data; // { count, next, previous, results }
 }
 
+const EMPTY_FEATURE_COLLECTION = Object.freeze({
+  type: "FeatureCollection",
+  features: [],
+});
+
+function storyToFeature(story) {
+  return {
+    type: "Feature",
+    id: story.id,
+    geometry: {
+      type: "Point",
+      coordinates: [Number(story.location_lng), Number(story.location_lat)],
+    },
+    properties: {
+      title: story.title,
+      location_name: story.location_name,
+      time_type: story.time_type,
+      year: story.year,
+      year_start: story.year_start,
+      year_end: story.year_end,
+    },
+  };
+}
+
 /**
- * Fetch story pins for the map view.
- * When `q` is provided, uses /stories/search/ and returns only stories with coordinates.
- * Otherwise uses /stories/map/ with optional year and location filters.
+ * Fetch story pins for the map view as a GeoJSON FeatureCollection (RFC 7946).
+ *
+ * - Without `q`: calls /stories/map/ which already returns a FeatureCollection.
+ * - With `q`: calls /stories/search/ and adapts paginated results into a
+ *   FeatureCollection on the client, since the search endpoint still returns
+ *   the legacy paginated story list.
  */
 export async function getMapStories({ q, yearFrom, yearTo, location } = {}) {
   if (q?.trim()) {
@@ -47,18 +74,21 @@ export async function getMapStories({ q, yearFrom, yearTo, location } = {}) {
     if (yearTo) params.year_to = yearTo;
     if (location?.trim()) params.location = location.trim();
     const response = await api.get("/stories/search/", { params });
-    return response.data.results.filter(
-      (s) => s.location_lat != null && s.location_lng != null
-    );
+    return {
+      type: "FeatureCollection",
+      features: response.data.results
+        .filter((s) => s.location_lat != null && s.location_lng != null)
+        .map(storyToFeature),
+    };
   }
 
-  const params = { page_size: 100 };
+  const params = {};
   if (yearFrom) params.year_from = yearFrom;
   if (yearTo) params.year_to = yearTo;
   if (location?.trim()) params.location = location.trim();
 
   const response = await api.get("/stories/map/", { params });
-  return response.data.results;
+  return response.data ?? EMPTY_FEATURE_COLLECTION;
 }
 
 export async function createStory(formData) {


### PR DESCRIPTION
# Description
Fixes #376

Switches the web frontend map view to consume the backend's new RFC 7946 GeoJSON endpoint (`GET /stories/map/`) and renders pins through `L.geoJSON` (via `react-leaflet`'s wrapper with `pointToLayer` + `onEachFeature`) instead of iterating `<Marker>` React elements manually.

### What changed
- **`services/storyService.js`** — `getMapStories` now returns a `FeatureCollection` directly:
  - no-query path: pass-through of the backend's `FeatureCollection` response (pagination removed server-side in #410).
  - search path: adapts the paginated `/stories/search/` response into a `FeatureCollection`, preserving the existing "filter out stories without coordinates" behaviour and using `[lng, lat]` coordinate order (RFC 7946 §3.1.1).
- **`components/MapView/MapView.jsx`** — accepts a `featureCollection` prop, hands it to `<GeoJSON data={...} pointToLayer={...} onEachFeature={...} />`, and binds a statically-rendered `StoryPopup` on each feature. A small `StoryLinkInterceptor` child delegates anchor clicks on the map container to `useNavigate` so the popup's "Read more" link still performs SPA navigation (the popup DOM lives outside React's tree).
- **`pages/MapPage.jsx`** — renames `stories` state to `featureCollection`, seeds it with an empty `FeatureCollection`, and passes it down.
- **Tests** — new case for rendering a mock `FeatureCollection`, plus updated `MapPage` and `storyService` tests to match the new GeoJSON contract.

### Out of scope
- Mobile map view (handled separately in #377).
- Clustering of overlapping pins.

# Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Refactoring
- [ ] Documentation

# Acceptance Criteria / Checklist
- [x] Project builds successfully (`npm run build`)
- [x] My code follows the style guidelines of this project (`npm run lint` clean)
- [x] I have commented my code, especially in hard-to-understand parts
- [x] I have performed a self-review of my code
- [x] I have added/updated tests
- [x] New and existing unit tests pass locally with my changes (pre-existing `StoryDetailPage` date-locale failure on `main` is unchanged and unrelated)

# Screenshots / Recordings
<!-- Not applicable — visual output matches the prior implementation (same pin style, same popup layout). -->

# Estimated Review Time
- [ ] < 5 min
- [x] 5-15 min
- [ ] > 15 min