### PR TITLE
fix:search-result-status

### DIFF
--- a/mobile/src/features/map/presentation/components/MapCard.tsx
+++ b/mobile/src/features/map/presentation/components/MapCard.tsx
@@ -12,9 +12,12 @@ interface MapCardProps {
   selectedMarkerId?: string;
   isLoading?: boolean;
   error?: string;
+  statusBadgeText?: string;
+  fitToMarkers?: boolean;
   onSelectMarker: (markerId: string) => void;
   onOpenStory: (storyId: string) => void;
   onMarkerPress?: () => void;
+  onRegionChangeComplete?: (region: Region) => void;
   onPreviewLayout?: (event: LayoutChangeEvent) => void;
 }
 
@@ -25,9 +28,12 @@ export function MapCard({
   selectedMarkerId,
   isLoading = false,
   error,
+  statusBadgeText,
+  fitToMarkers = false,
   onSelectMarker,
   onOpenStory,
   onMarkerPress,
+  onRegionChangeComplete,
   onPreviewLayout,
 }: MapCardProps) {
   const { colors, spacing, typography } = useAppTheme();
@@ -39,6 +45,11 @@ export function MapCard({
   );
 
   useEffect(() => {
+    if (fitToMarkers) {
+      setCurrentRegion(region);
+      return;
+    }
+
     if (!selectedMarker) {
       setCurrentRegion(region);
       return;
@@ -50,7 +61,7 @@ export function MapCard({
       latitudeDelta: current.latitudeDelta,
       longitudeDelta: current.longitudeDelta,
     }));
-  }, [region, selectedMarker]);
+  }, [fitToMarkers, region, selectedMarker]);
 
   return (
     <View
@@ -77,7 +88,45 @@ export function MapCard({
             onSelectMarker(markerId);
             onMarkerPress?.();
           }}
+          onRegionChangeComplete={onRegionChangeComplete}
         />
+
+        {statusBadgeText ? (
+          <View
+            testID="map-search-status-badge"
+            pointerEvents="none"
+            style={{
+              position: 'absolute',
+              top: spacing.md,
+              left: spacing.md,
+              right: spacing.md,
+              alignItems: 'center',
+            }}
+          >
+            <View
+              style={{
+                maxWidth: '100%',
+                paddingHorizontal: spacing.sm + 4,
+                paddingVertical: spacing.xs + 2,
+                borderRadius: 999,
+                borderWidth: 1,
+                borderColor: colors.border,
+                backgroundColor: colors.infoSurface,
+              }}
+            >
+              <Text
+                style={{
+                  color: colors.muted,
+                  fontSize: typography.caption,
+                  fontWeight: '700',
+                  textAlign: 'center',
+                }}
+              >
+                {statusBadgeText}
+              </Text>
+            </View>
+          </View>
+        ) : null}
 
         {isLoading ? (
           <View

--- a/mobile/src/features/map/presentation/screens/MapScreen.tsx
+++ b/mobile/src/features/map/presentation/screens/MapScreen.tsx
@@ -30,6 +30,10 @@ const ISTANBUL_REGION: Region = {
   longitudeDelta: 0.12,
 };
 
+const MIN_FIT_DELTA = 0.02;
+const FIT_PADDING_FACTOR = 1.4;
+type StatusIndicatorMode = 'hidden' | 'filters' | 'area';
+
 export function MapScreen({
   initialFilters = EMPTY_FILTERS,
   onOpenStory,
@@ -45,6 +49,9 @@ export function MapScreen({
   const [useImmediateQuery, setUseImmediateQuery] = useState(false);
   const [state, setState] = useState<MapUiState>(() => createInitialMapUiState(initialFilters));
   const [mapCardTop, setMapCardTop] = useState(0);
+  const [visibleRegion, setVisibleRegion] = useState<Region | undefined>();
+  const [hasInteractedWithArea, setHasInteractedWithArea] = useState(false);
+  const [statusIndicatorMode, setStatusIndicatorMode] = useState<StatusIndicatorMode>('hidden');
   const previewOffsetRef = useRef<number | null>(null);
 
   useEffect(() => {
@@ -65,6 +72,10 @@ export function MapScreen({
       ...toSearchParams({ ...filters, query: useImmediateQuery ? filters.query : debouncedQuery }),
     }),
     [debouncedQuery, filters, initialFilters, useImmediateQuery],
+  );
+
+  const hasActiveFilters = Boolean(
+    activeFilters.q || activeFilters.location || activeFilters.yearFrom || activeFilters.yearTo,
   );
 
   const loadMarkers = React.useCallback(async () => {
@@ -113,6 +124,18 @@ export function MapScreen({
     };
   }, [isHydrated, loadMarkers, onRegisterRefresh]);
 
+  useEffect(() => {
+    setHasInteractedWithArea(false);
+    setVisibleRegion(undefined);
+
+    if (!hasActiveFilters) {
+      setStatusIndicatorMode('hidden');
+      return;
+    }
+
+    setStatusIndicatorMode('filters');
+  }, [activeFilters, hasActiveFilters]);
+
   const activeFilterSummary = useMemo(() => {
     const parts = [];
 
@@ -128,6 +151,44 @@ export function MapScreen({
 
     return parts;
   }, [state.filters]);
+
+  const totalStoryCount = useMemo(
+    () => state.markers.reduce((sum, marker) => sum + marker.count, 0),
+    [state.markers],
+  );
+
+  const mapRegion = useMemo(
+    () => (hasActiveFilters ? getRegionForMarkers(state.markers, ISTANBUL_REGION) : ISTANBUL_REGION),
+    [hasActiveFilters, state.markers],
+  );
+
+  const statusStoryCount = useMemo(() => {
+    if (statusIndicatorMode !== 'area' || !hasInteractedWithArea || !visibleRegion) {
+      return totalStoryCount;
+    }
+
+    return countStoriesInRegion(state.markers, visibleRegion);
+  }, [hasInteractedWithArea, state.markers, statusIndicatorMode, totalStoryCount, visibleRegion]);
+
+  const statusBadgeText = useMemo(() => {
+    if (state.isLoading || state.error || statusIndicatorMode === 'hidden') {
+      return undefined;
+    }
+
+    if (statusStoryCount > 0) {
+      return `${formatStoryCount(statusStoryCount)} found in this area`;
+    }
+
+    if (statusIndicatorMode === 'area') {
+      return 'No stories found in this area';
+    }
+
+    if (activeFilters.location?.trim()) {
+      return `No stories found in ${activeFilters.location.trim()}`;
+    }
+
+    return 'No stories found with this criteria';
+  }, [activeFilters.location, state.error, state.isLoading, statusIndicatorMode, statusStoryCount]);
 
   function handlePreviewLayout(event: LayoutChangeEvent) {
     previewOffsetRef.current = event.nativeEvent.layout.y;
@@ -148,9 +209,11 @@ export function MapScreen({
       {showSearchControls ? <StorySearchControls helperText="Search by title or place." scope={searchScope} /> : null}
       {activeFilterSummary.length ? <Text style={{ color: colors.muted }}>{activeFilterSummary.join('  |  ')}</Text> : null}
 
-      <Text style={{ color: colors.muted, fontSize: typography.caption }}>
-        {state.markers.reduce((sum, marker) => sum + marker.count, 0)} stories currently match the active filters.
-      </Text>
+      {hasActiveFilters ? (
+        <Text style={{ color: colors.muted, fontSize: typography.caption }}>
+          {state.markers.reduce((sum, marker) => sum + marker.count, 0)} stories currently match the active filters.
+        </Text>
+      ) : null}
 
       <View
         testID="map-card-container"
@@ -158,14 +221,21 @@ export function MapScreen({
         onLayout={(event) => setMapCardTop(event.nativeEvent.layout.y)}
       >
         <MapCard
-          region={ISTANBUL_REGION}
+          region={mapRegion}
           markers={state.markers}
           selectedMarkerId={state.selectedMarkerId}
           isLoading={state.isLoading}
           error={state.error}
+          statusBadgeText={statusBadgeText}
+          fitToMarkers={hasActiveFilters}
           onSelectMarker={(markerId) => setState((current) => ({ ...current, selectedMarkerId: markerId }))}
           onOpenStory={(storyId) => onOpenStory?.(storyId)}
           onMarkerPress={handleMarkerPreviewRequest}
+          onRegionChangeComplete={(region) => {
+            setVisibleRegion(region);
+            setHasInteractedWithArea(true);
+            setStatusIndicatorMode('area');
+          }}
           onPreviewLayout={handlePreviewLayout}
         />
       </View>
@@ -230,4 +300,45 @@ function getMarkerScore(marker: MapMarkerGroup, searchTerm?: string, locationTer
 
     return Math.max(bestScore, score);
   }, 0);
+}
+
+function countStoriesInRegion(markers: MapMarkerGroup[], region: Region) {
+  const latitudeMin = region.latitude - region.latitudeDelta / 2;
+  const latitudeMax = region.latitude + region.latitudeDelta / 2;
+  const longitudeMin = region.longitude - region.longitudeDelta / 2;
+  const longitudeMax = region.longitude + region.longitudeDelta / 2;
+
+  return markers.reduce((sum, marker) => {
+    const isMarkerVisible =
+      marker.latitude >= latitudeMin &&
+      marker.latitude <= latitudeMax &&
+      marker.longitude >= longitudeMin &&
+      marker.longitude <= longitudeMax;
+
+    return sum + (isMarkerVisible ? marker.count : 0);
+  }, 0);
+}
+
+function formatStoryCount(count: number) {
+  return `${count} ${count === 1 ? 'story' : 'stories'}`;
+}
+
+function getRegionForMarkers(markers: MapMarkerGroup[], fallbackRegion: Region): Region {
+  if (!markers.length) {
+    return fallbackRegion;
+  }
+
+  const latitudes = markers.map((marker) => marker.latitude);
+  const longitudes = markers.map((marker) => marker.longitude);
+  const minLatitude = Math.min(...latitudes);
+  const maxLatitude = Math.max(...latitudes);
+  const minLongitude = Math.min(...longitudes);
+  const maxLongitude = Math.max(...longitudes);
+
+  return {
+    latitude: (minLatitude + maxLatitude) / 2,
+    longitude: (minLongitude + maxLongitude) / 2,
+    latitudeDelta: Math.max((maxLatitude - minLatitude) * FIT_PADDING_FACTOR, MIN_FIT_DELTA),
+    longitudeDelta: Math.max((maxLongitude - minLongitude) * FIT_PADDING_FACTOR, MIN_FIT_DELTA),
+  };
 }

--- a/mobile/src/features/map/presentation/screens/__tests__/MapScreen.test.tsx
+++ b/mobile/src/features/map/presentation/screens/__tests__/MapScreen.test.tsx
@@ -11,13 +11,53 @@ jest.mock('../../../../../shared/components/WebMapView', () => {
 
   return {
     WebMapView: ({
+      region,
       markers = [],
       onMarkerPress,
+      onRegionChangeComplete,
     }: {
+      region?: {
+        latitude: number;
+        longitude: number;
+        latitudeDelta: number;
+        longitudeDelta: number;
+      };
       markers?: Array<{ id: string }>;
       onMarkerPress?: (markerId: string) => void;
+      onRegionChangeComplete?: (region: {
+        latitude: number;
+        longitude: number;
+        latitudeDelta: number;
+        longitudeDelta: number;
+      }) => void;
     }) => (
       <View testID="story-map" accessibilityLabel="Interactive story map">
+        <View
+          testID="map-region-props"
+          accessibilityLabel={`region:${region?.latitude}:${region?.longitude}:${region?.latitudeDelta}:${region?.longitudeDelta}`}
+        />
+        <Pressable
+          testID="map-region-change"
+          onPress={() =>
+            onRegionChangeComplete?.({
+              latitude: 41.0284,
+              longitude: 28.9647,
+              latitudeDelta: 0.005,
+              longitudeDelta: 0.005,
+            })
+          }
+        />
+        <Pressable
+          testID="map-region-empty"
+          onPress={() =>
+            onRegionChangeComplete?.({
+              latitude: 40.5,
+              longitude: 29.8,
+              latitudeDelta: 0.02,
+              longitudeDelta: 0.02,
+            })
+          }
+        />
         {markers.map((marker) => (
           <Pressable key={marker.id} onPress={() => onMarkerPress?.(marker.id)} testID="story-marker" />
         ))}
@@ -155,6 +195,77 @@ describe('MapScreen', () => {
         yearTo: undefined,
       });
     });
+  });
+
+  it('shows a floating status badge after a search returns results', async () => {
+    renderScreen(
+      <MapScreen
+        getMarkerGroups={async (filters) =>
+          filters?.q === 'harbor' ? [markerGroups[0]] : markerGroups
+        }
+      />,
+    );
+
+    await screen.findByText('The Day the Harbor Fell Silent');
+    fireEvent.changeText(screen.getByLabelText('Search stories'), 'harbor');
+
+    expect(await screen.findByText('1 story found in this area')).toBeTruthy();
+    expect(screen.getByTestId('map-search-status-badge')).toBeTruthy();
+  });
+
+  it('fits the map to all matched stories after a search', async () => {
+    renderScreen(<MapScreen getMarkerGroups={async () => markerGroups} />);
+
+    await screen.findByText('The Day the Harbor Fell Silent');
+    fireEvent.changeText(screen.getByLabelText('Search stories'), 'market');
+
+    await waitFor(() => {
+      expect(screen.getByTestId('map-region-props').props.accessibilityLabel).toContain('region:41.0192:28.96735:');
+      expect(screen.getByTestId('map-region-props').props.accessibilityLabel).toContain(':0.02');
+    });
+  });
+
+  it('shows a no-results badge for a location search', async () => {
+    renderScreen(<MapScreen getMarkerGroups={async () => []} />);
+
+    await screen.findByText('No stories match the current filters.');
+    fireEvent.press(screen.getByText('Show filters'));
+    fireEvent.changeText(screen.getByLabelText('Location filter'), 'Beykoz');
+
+    expect(await screen.findByText('No stories found in Beykoz')).toBeTruthy();
+  });
+
+  it('hides the badge when the active search is cleared', async () => {
+    renderScreen(
+      <MapScreen
+        getMarkerGroups={async (filters) =>
+          filters?.q === 'harbor' ? [markerGroups[0]] : markerGroups
+        }
+      />,
+    );
+
+    await screen.findByText('The Day the Harbor Fell Silent');
+    fireEvent.changeText(screen.getByLabelText('Search stories'), 'harbor');
+    expect(await screen.findByText('1 story found in this area')).toBeTruthy();
+
+    fireEvent.changeText(screen.getByLabelText('Search stories'), '');
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('map-search-status-badge')).toBeNull();
+    });
+  });
+
+  it('updates the badge when the visible map area changes', async () => {
+    renderScreen(<MapScreen getMarkerGroups={async () => markerGroups} />);
+
+    await screen.findByText('The Day the Harbor Fell Silent');
+    fireEvent.press(screen.getByTestId('map-region-empty'));
+
+    expect(await screen.findByText('No stories found in this area')).toBeTruthy();
+
+    fireEvent.press(screen.getByTestId('map-region-change'));
+
+    expect(await screen.findByText('1 story found in this area')).toBeTruthy();
   });
 
   it('refetches all markers when a chip filter is removed', async () => {

--- a/mobile/src/features/stories/data/repositories/__tests__/StoryRepository.test.ts
+++ b/mobile/src/features/stories/data/repositories/__tests__/StoryRepository.test.ts
@@ -64,4 +64,41 @@ describe('StoryRepositoryImpl', () => {
 
     expect(deleteStorySpy).toHaveBeenCalledWith('42');
   });
+
+  it('falls back to the story feed when the map endpoint returns no pins', async () => {
+    jest.spyOn(storiesRemoteSource, 'getMapStoriesFromApi').mockResolvedValue([]);
+    jest.spyOn(storiesRemoteSource, 'getStoriesFromApi').mockResolvedValue([
+      {
+        id: 7,
+        title: 'Bosphorus Memory',
+        preview_text: 'A waterfront story.',
+        location_name: 'Istanbul',
+        location_lat: '41.0082',
+        location_lng: '28.9784',
+        time_period: '1980s',
+      },
+      {
+        id: 8,
+        title: 'Missing Coordinates',
+        preview_text: 'This one should not become a pin.',
+        location_name: 'Unknown',
+        time_period: '1990s',
+      },
+    ]);
+
+    const repository = new StoryRepositoryImpl();
+    const result = await repository.getMapPins();
+
+    expect(result).toEqual([
+      {
+        id: '7',
+        title: 'Bosphorus Memory',
+        previewText: 'A waterfront story.',
+        placeName: 'Istanbul',
+        timePeriod: '1980s',
+        latitude: 41.0082,
+        longitude: 28.9784,
+      },
+    ]);
+  });
 });

--- a/mobile/src/features/stories/data/repositories/index.ts
+++ b/mobile/src/features/stories/data/repositories/index.ts
@@ -49,8 +49,7 @@ export class StoryRepositoryImpl implements StoryRepository {
 
   async getMapPins(filters: StoryFilters = {}): Promise<StoryMapPin[]> {
     try {
-      const response = await storiesRemoteSource.getMapStoriesFromApi(filters);
-      const remotePins = response.map(mapStoryMapPin);
+      const remotePins = await this.getRemoteMapPins(filters);
 
       if (env.environment === 'development') {
         return mergeById(remotePins, storiesLocalSource.getStories(filters).map(mapStoryMapPin));
@@ -61,6 +60,24 @@ export class StoryRepositoryImpl implements StoryRepository {
       const response = await storiesRemoteSource.getStories(filters);
       return response.map(mapStoryMapPin);
     }
+  }
+
+  private async getRemoteMapPins(filters: StoryFilters) {
+    const mapStories = await storiesRemoteSource.getMapStoriesFromApi(filters);
+
+    if (mapStories.length > 0) {
+      return mapStories.map(mapStoryMapPin);
+    }
+
+    const stories = await storiesRemoteSource.getStoriesFromApi(filters);
+
+    return stories.flatMap((story) => {
+      try {
+        return [mapStoryMapPin(story)];
+      } catch {
+        return [];
+      }
+    });
   }
 }
 

--- a/mobile/src/shared/components/WebMapView.tsx
+++ b/mobile/src/shared/components/WebMapView.tsx
@@ -23,6 +23,7 @@ interface WebMapViewProps {
   interactive?: boolean;
   onMarkerPress?: (markerId: string) => void;
   onMapPress?: (coords: { latitude: number; longitude: number }) => void;
+  onRegionChangeComplete?: (region: RegionLike) => void;
 }
 
 const mapHtml = ({
@@ -77,6 +78,7 @@ const mapHtml = ({
       const region = ${JSON.stringify(region)};
       const markers = ${JSON.stringify(markers)};
       const interactive = ${interactive ? 'true' : 'false'};
+      let hasCompletedInitialMove = false;
 
       const zoom = Math.max(
         2,
@@ -100,6 +102,22 @@ const mapHtml = ({
         pitchWithRotate: false,
         keyboard: false,
       });
+
+      const postCurrentRegion = () => {
+        const bounds = map.getBounds();
+        const northEast = bounds.getNorthEast();
+        const southWest = bounds.getSouthWest();
+
+        window.ReactNativeWebView?.postMessage(
+          JSON.stringify({
+            type: 'regionChange',
+            latitude: map.getCenter().lat,
+            longitude: map.getCenter().lng,
+            latitudeDelta: Math.max(Math.abs(northEast.lat - southWest.lat), 0.0001),
+            longitudeDelta: Math.max(Math.abs(northEast.lng - southWest.lng), 0.0001),
+          })
+        );
+      };
 
       markers.forEach((marker) => {
         const element = document.createElement('div');
@@ -132,6 +150,19 @@ const mapHtml = ({
           })
         );
       });
+
+      map.on('moveend', () => {
+        if (!interactive) {
+          return;
+        }
+
+        if (!hasCompletedInitialMove) {
+          hasCompletedInitialMove = true;
+          return;
+        }
+
+        postCurrentRegion();
+      });
     </script>
   </body>
 </html>`;
@@ -142,6 +173,7 @@ export function WebMapView({
   interactive = true,
   onMarkerPress,
   onMapPress,
+  onRegionChangeComplete,
 }: WebMapViewProps) {
   const source = useMemo(
     () => ({
@@ -178,6 +210,21 @@ export function WebMapView({
               onMapPress?.({
                 latitude: payload.latitude,
                 longitude: payload.longitude,
+              });
+            }
+
+            if (
+              payload.type === 'regionChange' &&
+              typeof payload.latitude === 'number' &&
+              typeof payload.longitude === 'number' &&
+              typeof payload.latitudeDelta === 'number' &&
+              typeof payload.longitudeDelta === 'number'
+            ) {
+              onRegionChangeComplete?.({
+                latitude: payload.latitude,
+                longitude: payload.longitude,
+                latitudeDelta: payload.latitudeDelta,
+                longitudeDelta: payload.longitudeDelta,
               });
             }
           } catch {


### PR DESCRIPTION
# 📝 Description
Fixes #415 

Adds a search/status indicator to the Mobile Map View so users get immediate feedback after searching, updating filters, or changing the visible map area. The map now shows result messages such as `X stories found in this area`, `No stories found with this criteria`, or `No stories found in [Location Name]`.

This update also improves the map search UX by:
- auto-fitting the map to all matched stories when search/filter criteria are active
- hiding the status summary when no search or filter is active
- ensuring default map loading still shows all available stories in the Istanbul view when possible
- updating mobile tests accordingly

# 📊 Type of Change
- [x] Bug fix
- [x] New feature
- [ ] Refactoring
- [ ] Documentation
 
# ✅ Acceptance Criteria / Checklist
- [ ] Project builds successfully
- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, especially in hard-to-understand parts
- [x] I have performed a self-review of my code
- [x] I have added/updated tests
- [x] New and existing unit tests pass locally with my changes

# 📸 Screenshots / Recordings
<!-- If applicable !-->

# ⏱️ Estimated Review Time
- [ ] < 5 min
- [x] 5-15 min
- [ ] > 15 min
