### PR TITLE
fix:improve-search-and-filte

### DIFF
--- a/mobile/src/app/navigation/RootNavigator.tsx
+++ b/mobile/src/app/navigation/RootNavigator.tsx
@@ -581,6 +581,7 @@ export function RootNavigator() {
                   onMarkerPreviewRequested={(targetY) => scrollTo(targetY)}
                   showSearchControls={false}
                   onRegisterRefresh={registerRefreshHandler}
+                  searchScope="main"
                 />
               )}
             </ScreenShell>
@@ -593,7 +594,7 @@ export function RootNavigator() {
               fillContent
               hideHeader
             >
-              <FeedScreen onOpenStory={handleOpenStoryDetail} showSearchControls={false} />
+              <FeedScreen onOpenStory={handleOpenStoryDetail} showSearchControls={false} searchScope="main" />
             </ScreenShell>
           </View>
         </ScrollView>
@@ -632,7 +633,7 @@ export function RootNavigator() {
             <TopIconButton label="Login" onPress={() => handleNavigate(ROUTES.AUTH)} />
           )}
         </View>
-      {isMainRoute ? <StorySearchControls hideHeading scope={currentRoute === ROUTES.MAP ? 'map' : 'feed'} /> : null}
+      {isMainRoute ? <StorySearchControls hideHeading scope="main" /> : null}
       </View>
       <View style={{ flex: 1, backgroundColor: colors.background }}>{content}</View>
       {isMainRoute ? (

--- a/mobile/src/app/navigation/__tests__/RootNavigator.test.tsx
+++ b/mobile/src/app/navigation/__tests__/RootNavigator.test.tsx
@@ -439,12 +439,17 @@ describe('RootNavigator auth flow', () => {
     });
   });
 
-  it('keeps feed and map search states independent', async () => {
+  it('persists search and filter state between feed and map views', async () => {
     renderNavigator();
 
     await screen.findByLabelText('Search stories');
     fireEvent.changeText(screen.getByLabelText('Search stories'), 'harbor');
     fireEvent.press(screen.getByLabelText('Apply search'));
+    fireEvent.press(screen.getByText('Show filters'));
+    fireEvent.changeText(screen.getByLabelText('Location filter'), 'Golden Horn');
+    fireEvent.changeText(screen.getByLabelText('Start year'), '1990');
+    fireEvent.changeText(screen.getByLabelText('End year'), '2000');
+    fireEvent.press(screen.getByLabelText('Apply filters'));
 
     await waitFor(() => {
       expect(screen.getByLabelText('Search stories').props.value).toBe('harbor');
@@ -452,23 +457,17 @@ describe('RootNavigator auth flow', () => {
 
     fireEvent.press(screen.getByLabelText('Map'));
     await screen.findByLabelText('Search stories');
-    expect(screen.getByLabelText('Search stories').props.value).toBe('');
-
-    fireEvent.changeText(screen.getByLabelText('Search stories'), 'pier');
-    fireEvent.press(screen.getByLabelText('Apply search'));
-
-    await waitFor(() => {
-      expect(screen.getByLabelText('Search stories').props.value).toBe('pier');
-    });
+    expect(screen.getByLabelText('Search stories').props.value).toBe('harbor');
+    fireEvent.press(screen.getByText('Show filters'));
+    expect(screen.getByLabelText('Location filter').props.value).toBe('Golden Horn');
+    expect(screen.getByLabelText('Start year').props.value).toBe('1990');
+    expect(screen.getByLabelText('End year').props.value).toBe('2000');
+    fireEvent.press(screen.getByLabelText('Close filters'));
 
     fireEvent.press(screen.getByLabelText('Feed'));
 
     await screen.findByLabelText('Search stories');
     expect(screen.getByLabelText('Search stories').props.value).toBe('harbor');
-
-    fireEvent.press(screen.getByLabelText('Map'));
-    await screen.findByLabelText('Search stories');
-    expect(screen.getByLabelText('Search stories').props.value).toBe('pier');
   });
 
   it('opens a protected screen after login and returns with the back button', async () => {

--- a/mobile/src/core/storage/keys.ts
+++ b/mobile/src/core/storage/keys.ts
@@ -4,5 +4,6 @@ export const storageKeys = {
   legacySearchFilters: 'searchFilters',
   feedSearchFilters: 'feedSearchFilters',
   mapSearchFilters: 'mapSearchFilters',
+  mainSearchFilters: 'mainSearchFilters',
   draftStory: 'draftStory',
 };

--- a/mobile/src/features/feed/presentation/screens/FeedScreen.tsx
+++ b/mobile/src/features/feed/presentation/screens/FeedScreen.tsx
@@ -7,6 +7,7 @@ import { storyService } from '../../../stories/application/services';
 import { StoryFilters } from '../../../stories/domain/repositories';
 import { StorySearchControls } from '../../../search/presentation/components/StorySearchControls';
 import {
+  SearchFilterScope,
   SearchFiltersState,
   toSearchParams,
   useSearchFilters,
@@ -20,7 +21,7 @@ interface FeedScreenProps {
   onOpenStory?: (storyId: string) => void;
   getFeed?: typeof storyService.getFeed;
   showSearchControls?: boolean;
-  searchScope?: 'feed' | 'map';
+  searchScope?: SearchFilterScope;
 }
 
 const EMPTY_FILTERS: StoryFilters = {};

--- a/mobile/src/features/feed/presentation/screens/__tests__/FeedScreen.test.tsx
+++ b/mobile/src/features/feed/presentation/screens/__tests__/FeedScreen.test.tsx
@@ -169,7 +169,7 @@ describe('FeedScreen', () => {
     fireEvent.changeText(screen.getByLabelText('Location filter'), 'Istanbul');
     fireEvent.changeText(screen.getByLabelText('Start year'), '1900');
     fireEvent.changeText(screen.getByLabelText('End year'), '1950');
-    fireEvent.press(screen.getByLabelText('Apply search'));
+    fireEvent.press(screen.getByLabelText('Apply filters'));
 
     await waitFor(() => {
       expect(getFeed).toHaveBeenLastCalledWith({
@@ -184,7 +184,9 @@ describe('FeedScreen', () => {
       });
     });
 
-    expect(screen.getByText('Filters')).toBeTruthy();
+    expect(screen.getByLabelText('Remove Location: Istanbul')).toBeTruthy();
+    expect(screen.getByLabelText('Remove From: 1900')).toBeTruthy();
+    expect(screen.getByLabelText('Remove To: 1950')).toBeTruthy();
   });
 
   it('closes the filter panel when tapping outside of it', async () => {
@@ -214,7 +216,7 @@ describe('FeedScreen', () => {
     fireEvent.changeText(screen.getByLabelText('Start year'), '1900');
     fireEvent.changeText(screen.getByLabelText('End year'), '1950');
     fireEvent.press(screen.getByText('Reset filter form'));
-    fireEvent.press(screen.getByLabelText('Apply search'));
+    fireEvent.press(screen.getByLabelText('Apply filters'));
 
     await waitFor(() => {
       expect(getFeed).toHaveBeenLastCalledWith({

--- a/mobile/src/features/feed/presentation/screens/__tests__/FeedScreen.test.tsx
+++ b/mobile/src/features/feed/presentation/screens/__tests__/FeedScreen.test.tsx
@@ -189,6 +189,29 @@ describe('FeedScreen', () => {
     expect(screen.getByLabelText('Remove To: 1950')).toBeTruthy();
   });
 
+  it('applies the default year filters when submitted unchanged', async () => {
+    const getFeed = jest.fn<Promise<FeedPageEntity>, [any]>().mockResolvedValue(makeFeedPage());
+
+    renderScreen(<FeedScreen getFeed={getFeed} />);
+
+    await screen.findByText('Story 1');
+    fireEvent.press(screen.getByText('Show filters'));
+    fireEvent.press(screen.getByLabelText('Apply filters'));
+
+    await waitFor(() => {
+      expect(getFeed).toHaveBeenLastCalledWith({
+        page: 1,
+        sort: 'recent',
+        filters: {
+          q: undefined,
+          location: undefined,
+          yearFrom: 1980,
+          yearTo: 2026,
+        },
+      });
+    });
+  });
+
   it('closes the filter panel when tapping outside of it', async () => {
     renderScreen(<FeedScreen getFeed={async () => makeFeedPage()} />);
 
@@ -225,8 +248,8 @@ describe('FeedScreen', () => {
         filters: {
           q: 'harbor',
           location: undefined,
-          yearFrom: undefined,
-          yearTo: undefined,
+          yearFrom: 1980,
+          yearTo: 2026,
         },
       });
     });

--- a/mobile/src/features/map/presentation/screens/MapScreen.tsx
+++ b/mobile/src/features/map/presentation/screens/MapScreen.tsx
@@ -26,12 +26,12 @@ const EMPTY_FILTERS: StoryFilters = {};
 const ISTANBUL_REGION: Region = {
   latitude: 41.0082,
   longitude: 28.9784,
-  latitudeDelta: 0.12,
-  longitudeDelta: 0.12,
+  latitudeDelta: 0.32,
+  longitudeDelta: 0.48,
 };
 
-const MIN_FIT_DELTA = 0.03;
-const FIT_PADDING_FACTOR = 1.8;
+const MIN_FIT_DELTA = 0.06;
+const FIT_PADDING_FACTOR = 2.6;
 type StatusIndicatorMode = 'hidden' | 'filters' | 'area';
 
 export function MapScreen({

--- a/mobile/src/features/map/presentation/screens/MapScreen.tsx
+++ b/mobile/src/features/map/presentation/screens/MapScreen.tsx
@@ -30,8 +30,8 @@ const ISTANBUL_REGION: Region = {
   longitudeDelta: 0.12,
 };
 
-const MIN_FIT_DELTA = 0.02;
-const FIT_PADDING_FACTOR = 1.4;
+const MIN_FIT_DELTA = 0.03;
+const FIT_PADDING_FACTOR = 1.8;
 type StatusIndicatorMode = 'hidden' | 'filters' | 'area';
 
 export function MapScreen({
@@ -208,12 +208,6 @@ export function MapScreen({
     <View style={{ gap: spacing.md }}>
       {showSearchControls ? <StorySearchControls helperText="Search by title or place." scope={searchScope} /> : null}
       {activeFilterSummary.length ? <Text style={{ color: colors.muted }}>{activeFilterSummary.join('  |  ')}</Text> : null}
-
-      {hasActiveFilters ? (
-        <Text style={{ color: colors.muted, fontSize: typography.caption }}>
-          {state.markers.reduce((sum, marker) => sum + marker.count, 0)} stories currently match the active filters.
-        </Text>
-      ) : null}
 
       <View
         testID="map-card-container"

--- a/mobile/src/features/map/presentation/screens/__tests__/MapScreen.test.tsx
+++ b/mobile/src/features/map/presentation/screens/__tests__/MapScreen.test.tsx
@@ -221,7 +221,7 @@ describe('MapScreen', () => {
 
     await waitFor(() => {
       expect(screen.getByTestId('map-region-props').props.accessibilityLabel).toContain('region:41.0192:28.96735:');
-      expect(screen.getByTestId('map-region-props').props.accessibilityLabel).toContain(':0.02');
+      expect(screen.getByTestId('map-region-props').props.accessibilityLabel).toContain(':0.03');
     });
   });
 
@@ -231,6 +231,7 @@ describe('MapScreen', () => {
     await screen.findByText('No stories match the current filters.');
     fireEvent.press(screen.getByText('Show filters'));
     fireEvent.changeText(screen.getByLabelText('Location filter'), 'Beykoz');
+    fireEvent.press(screen.getByLabelText('Apply filters'));
 
     expect(await screen.findByText('No stories found in Beykoz')).toBeTruthy();
   });
@@ -276,6 +277,7 @@ describe('MapScreen', () => {
     await screen.findByText('The Day the Harbor Fell Silent');
     fireEvent.press(screen.getByText('Show filters'));
     fireEvent.changeText(screen.getByLabelText('Location filter'), 'Golden Horn');
+    fireEvent.press(screen.getByLabelText('Apply filters'));
 
     await waitFor(() => {
       expect(getMarkerGroups).toHaveBeenLastCalledWith({
@@ -306,6 +308,7 @@ describe('MapScreen', () => {
     await screen.findByText('The Day the Harbor Fell Silent');
     fireEvent.press(screen.getByText('Show filters'));
     fireEvent.changeText(screen.getByLabelText('Location filter'), 'Golden Horn');
+    fireEvent.press(screen.getByLabelText('Apply filters'));
 
     await waitFor(() => {
       expect(getMarkerGroups).toHaveBeenLastCalledWith({

--- a/mobile/src/features/map/presentation/screens/__tests__/MapScreen.test.tsx
+++ b/mobile/src/features/map/presentation/screens/__tests__/MapScreen.test.tsx
@@ -128,6 +128,7 @@ describe('MapScreen', () => {
 
     expect(screen.getByLabelText('Loading map pins')).toBeTruthy();
     expect(await screen.findByTestId('story-map')).toBeTruthy();
+    expect(screen.getByTestId('map-region-props').props.accessibilityLabel).toContain('region:41.0082:28.9784:0.32:0.48');
     await waitFor(() => {
       expect(screen.getAllByTestId('story-marker')).toHaveLength(2);
     });
@@ -221,7 +222,7 @@ describe('MapScreen', () => {
 
     await waitFor(() => {
       expect(screen.getByTestId('map-region-props').props.accessibilityLabel).toContain('region:41.0192:28.96735:');
-      expect(screen.getByTestId('map-region-props').props.accessibilityLabel).toContain(':0.03');
+      expect(screen.getByTestId('map-region-props').props.accessibilityLabel).toContain(':0.06');
     });
   });
 
@@ -234,6 +235,25 @@ describe('MapScreen', () => {
     fireEvent.press(screen.getByLabelText('Apply filters'));
 
     expect(await screen.findByText('No stories found in Beykoz')).toBeTruthy();
+  });
+
+  it('applies the default year filters when submitted unchanged', async () => {
+    const getMarkerGroups = jest.fn<Promise<MapMarkerGroup[]>, [any]>().mockResolvedValue(markerGroups);
+
+    renderScreen(<MapScreen getMarkerGroups={getMarkerGroups} />);
+
+    await screen.findByText('The Day the Harbor Fell Silent');
+    fireEvent.press(screen.getByText('Show filters'));
+    fireEvent.press(screen.getByLabelText('Apply filters'));
+
+    await waitFor(() => {
+      expect(getMarkerGroups).toHaveBeenLastCalledWith({
+        q: undefined,
+        location: undefined,
+        yearFrom: 1980,
+        yearTo: 2026,
+      });
+    });
   });
 
   it('hides the badge when the active search is cleared', async () => {
@@ -283,8 +303,8 @@ describe('MapScreen', () => {
       expect(getMarkerGroups).toHaveBeenLastCalledWith({
         q: undefined,
         location: 'Golden Horn',
-        yearFrom: undefined,
-        yearTo: undefined,
+        yearFrom: 1980,
+        yearTo: 2026,
       });
     });
 
@@ -294,8 +314,8 @@ describe('MapScreen', () => {
       expect(getMarkerGroups).toHaveBeenLastCalledWith({
         q: undefined,
         location: undefined,
-        yearFrom: undefined,
-        yearTo: undefined,
+        yearFrom: 1980,
+        yearTo: 2026,
       });
     });
   });
@@ -314,8 +334,8 @@ describe('MapScreen', () => {
       expect(getMarkerGroups).toHaveBeenLastCalledWith({
         q: undefined,
         location: 'Golden Horn',
-        yearFrom: undefined,
-        yearTo: undefined,
+        yearFrom: 1980,
+        yearTo: 2026,
       });
     });
 

--- a/mobile/src/features/search/presentation/components/StorySearchControls.tsx
+++ b/mobile/src/features/search/presentation/components/StorySearchControls.tsx
@@ -118,8 +118,8 @@ export function StorySearchControls({ helperText, hideHeading = false, scope }: 
               onApply={() => {
                 updateFilters({
                   location: draftLocation,
-                  timeFrom: draftTimeFrom === DEFAULT_FROM_YEAR ? '' : draftTimeFrom,
-                  timeTo: draftTimeTo === DEFAULT_TO_YEAR ? '' : draftTimeTo,
+                  timeFrom: draftTimeFrom,
+                  timeTo: draftTimeTo,
                 }, { refresh: true });
                 applyFilters();
                 setShowFilters(false);

--- a/mobile/src/features/search/presentation/components/StorySearchControls.tsx
+++ b/mobile/src/features/search/presentation/components/StorySearchControls.tsx
@@ -1,7 +1,7 @@
 import React, { useMemo, useState } from 'react';
 import { Modal, Pressable, Text, View } from 'react-native';
 import { useAppTheme } from '../../../../core/hooks/useAppTheme';
-import { FilterPanel } from '../../../../shared/components/FilterPanel';
+import { DEFAULT_FROM_YEAR, DEFAULT_TO_YEAR, FilterPanel } from '../../../../shared/components/FilterPanel';
 import { FilterChipItem, FilterChips } from '../../../../shared/components/FilterChips';
 import { SearchInput } from '../../../../shared/components/SearchInput';
 import { SearchFilterScope, useSearchFilters } from '../context/SearchFiltersContext';
@@ -40,8 +40,18 @@ export function StorySearchControls({ helperText, hideHeading = false, scope }: 
   const { colors, spacing, typography } = useAppTheme();
   const { filters, updateFilters, removeFilter, clearFilters, applyFilters } = useSearchFilters(scope);
   const [showFilters, setShowFilters] = useState(false);
+  const [draftLocation, setDraftLocation] = useState('');
+  const [draftTimeFrom, setDraftTimeFrom] = useState(DEFAULT_FROM_YEAR);
+  const [draftTimeTo, setDraftTimeTo] = useState(DEFAULT_TO_YEAR);
 
   const chips = useMemo(() => buildChips(filters), [filters]);
+
+  const openFilters = () => {
+    setDraftLocation(filters.location);
+    setDraftTimeFrom(filters.timeFrom || DEFAULT_FROM_YEAR);
+    setDraftTimeTo(filters.timeTo || DEFAULT_TO_YEAR);
+    setShowFilters(true);
+  };
 
   return (
     <View style={{ gap: spacing.md }}>
@@ -61,7 +71,7 @@ export function StorySearchControls({ helperText, hideHeading = false, scope }: 
       />
 
       <View style={{ flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center' }}>
-        <Pressable accessibilityRole="button" onPress={() => setShowFilters((current) => !current)}>
+        <Pressable accessibilityRole="button" onPress={() => (showFilters ? setShowFilters(false) : openFilters())}>
           <Text style={{ color: colors.text, fontWeight: '700' }}>
             {showFilters ? 'Hide filters' : 'Show filters'}
           </Text>
@@ -93,14 +103,24 @@ export function StorySearchControls({ helperText, hideHeading = false, scope }: 
         >
           <Pressable onPress={(event) => event.stopPropagation()} style={{ width: '100%' }}>
             <FilterPanel
-              location={filters.location}
-              timeFrom={filters.timeFrom}
-              timeTo={filters.timeTo}
-              onLocationChange={(location) => updateFilters({ location }, { refresh: true })}
-              onTimeFromChange={(timeFrom) => updateFilters({ timeFrom }, { refresh: true })}
-              onTimeToChange={(timeTo) => updateFilters({ timeTo }, { refresh: true })}
-              onClearAll={clearFilters}
+              location={draftLocation}
+              timeFrom={draftTimeFrom}
+              timeTo={draftTimeTo}
+              onLocationChange={setDraftLocation}
+              onTimeFromChange={setDraftTimeFrom}
+              onTimeToChange={setDraftTimeTo}
+              onClearAll={() => {
+                setDraftLocation('');
+                setDraftTimeFrom(DEFAULT_FROM_YEAR);
+                setDraftTimeTo(DEFAULT_TO_YEAR);
+                clearFilters();
+              }}
               onApply={() => {
+                updateFilters({
+                  location: draftLocation,
+                  timeFrom: draftTimeFrom === DEFAULT_FROM_YEAR ? '' : draftTimeFrom,
+                  timeTo: draftTimeTo === DEFAULT_TO_YEAR ? '' : draftTimeTo,
+                }, { refresh: true });
                 applyFilters();
                 setShowFilters(false);
               }}

--- a/mobile/src/features/search/presentation/context/SearchFiltersContext.tsx
+++ b/mobile/src/features/search/presentation/context/SearchFiltersContext.tsx
@@ -3,7 +3,7 @@ import { storageKeys } from '../../../../core/storage/keys';
 import { storage } from '../../../../core/storage/storage';
 import { StoryFilters } from '../../../stories/domain/repositories';
 
-export type SearchFilterScope = 'feed' | 'map';
+export type SearchFilterScope = 'feed' | 'map' | 'main';
 
 export interface SearchFiltersState {
   query: string;
@@ -33,11 +33,13 @@ const initialFilters: SearchFiltersState = {
 const initialFiltersByScope: Record<SearchFilterScope, SearchFiltersState> = {
   feed: initialFilters,
   map: initialFilters,
+  main: initialFilters,
 };
 
 const storageKeyByScope: Record<SearchFilterScope, string> = {
   feed: storageKeys.feedSearchFilters,
   map: storageKeys.mapSearchFilters,
+  main: storageKeys.mainSearchFilters,
 };
 
 const SearchFiltersContext = createContext<SearchFiltersContextValue | undefined>(undefined);
@@ -47,6 +49,7 @@ export function SearchFiltersProvider({ children }: PropsWithChildren) {
   const [refreshTokensByScope, setRefreshTokensByScope] = useState<Record<SearchFilterScope, number>>({
     feed: 0,
     map: 0,
+    main: 0,
   });
   const [isHydrated, setIsHydrated] = useState(false);
 
@@ -56,18 +59,21 @@ export function SearchFiltersProvider({ children }: PropsWithChildren) {
     Promise.all([
       storage.get<Partial<SearchFiltersState>>(storageKeys.feedSearchFilters),
       storage.get<Partial<SearchFiltersState>>(storageKeys.mapSearchFilters),
+      storage.get<Partial<SearchFiltersState>>(storageKeys.mainSearchFilters),
       storage.get<Partial<SearchFiltersState>>(storageKeys.legacySearchFilters),
     ])
-      .then(([storedFeedFilters, storedMapFilters, legacyFilters]) => {
+      .then(([storedFeedFilters, storedMapFilters, storedMainFilters, legacyFilters]) => {
         if (!isMounted) {
           return;
         }
 
         const fallbackFilters = normalizeStoredFilters(legacyFilters);
+        const mainFilters = normalizeStoredFilters(storedMainFilters ?? storedFeedFilters ?? storedMapFilters ?? fallbackFilters);
 
         setFiltersState({
           feed: normalizeStoredFilters(storedFeedFilters ?? fallbackFilters),
           map: normalizeStoredFilters(storedMapFilters),
+          main: mainFilters,
         });
       })
       .finally(() => {

--- a/mobile/src/shared/components/FilterPanel.tsx
+++ b/mobile/src/shared/components/FilterPanel.tsx
@@ -3,6 +3,11 @@ import { Pressable, Text, View } from 'react-native';
 import { useAppTheme } from '../../core/hooks/useAppTheme';
 import { Input } from '../ui/Input';
 
+export const DEFAULT_FROM_YEAR = '1980';
+export const DEFAULT_TO_YEAR = '2026';
+export const MIN_YEAR = 1000;
+export const MAX_YEAR = 2030;
+
 function normalizeYearInput(value: string) {
   if (value === '') {
     return value;
@@ -17,6 +22,20 @@ function normalizeYearInput(value: string) {
   }
 
   return value;
+}
+
+function clampYearValue(value: string) {
+  if (!value.trim()) {
+    return value;
+  }
+
+  const parsed = Number(value);
+
+  if (!Number.isFinite(parsed)) {
+    return value;
+  }
+
+  return String(Math.min(MAX_YEAR, Math.max(MIN_YEAR, parsed)));
 }
 
 interface FilterPanelProps {
@@ -70,6 +89,17 @@ export function FilterPanel({
     onTimeToChange(normalized);
   };
 
+  const stepYear = (
+    currentValue: string,
+    nextValue: (value: string) => void,
+    delta: number,
+    fallbackValue: string,
+  ) => {
+    const baseValue = currentValue.trim() ? Number(currentValue) : Number(fallbackValue);
+    const clamped = Math.min(MAX_YEAR, Math.max(MIN_YEAR, baseValue + delta));
+    nextValue(String(clamped));
+  };
+
   return (
     <View
       style={{
@@ -106,9 +136,40 @@ export function FilterPanel({
           <Input
             value={timeFrom}
             onChangeText={handleTimeFromChange}
-            placeholder="1900"
+            onBlur={() => onTimeFromChange(clampYearValue(timeFrom))}
+            placeholder={DEFAULT_FROM_YEAR}
             keyboardType="number-pad"
             accessibilityLabel="Start year"
+            trailingElement={
+              <View style={{ flexDirection: 'row', alignItems: 'center', paddingRight: spacing.xs }}>
+                <Pressable
+                  accessibilityRole="button"
+                  accessibilityLabel="Decrease start year"
+                  onPress={() => stepYear(timeFrom, onTimeFromChange, -1, DEFAULT_FROM_YEAR)}
+                  style={({ pressed }) => ({
+                    paddingHorizontal: spacing.sm,
+                    paddingVertical: spacing.sm,
+                    opacity: pressed ? 0.75 : 1,
+                  })}
+                >
+                  <Text style={{ color: colors.text, fontWeight: '700' }}>-</Text>
+                </Pressable>
+                <Pressable
+                  accessibilityRole="button"
+                  accessibilityLabel="Increase start year"
+                  disabled={Number(clampYearValue(timeFrom || DEFAULT_FROM_YEAR)) >= MAX_YEAR}
+                  onPress={() => stepYear(timeFrom, onTimeFromChange, 1, DEFAULT_FROM_YEAR)}
+                  style={({ pressed }) => ({
+                    paddingHorizontal: spacing.sm,
+                    paddingVertical: spacing.sm,
+                    opacity:
+                      Number(clampYearValue(timeFrom || DEFAULT_FROM_YEAR)) >= MAX_YEAR ? 0.4 : pressed ? 0.75 : 1,
+                  })}
+                >
+                  <Text style={{ color: colors.text, fontWeight: '700' }}>+</Text>
+                </Pressable>
+              </View>
+            }
           />
         </View>
         <View style={{ flex: 1, gap: spacing.sm }}>
@@ -116,9 +177,40 @@ export function FilterPanel({
           <Input
             value={timeTo}
             onChangeText={handleTimeToChange}
-            placeholder="2024"
+            onBlur={() => onTimeToChange(clampYearValue(timeTo))}
+            placeholder={DEFAULT_TO_YEAR}
             keyboardType="number-pad"
             accessibilityLabel="End year"
+            trailingElement={
+              <View style={{ flexDirection: 'row', alignItems: 'center', paddingRight: spacing.xs }}>
+                <Pressable
+                  accessibilityRole="button"
+                  accessibilityLabel="Decrease end year"
+                  onPress={() => stepYear(timeTo, onTimeToChange, -1, DEFAULT_TO_YEAR)}
+                  style={({ pressed }) => ({
+                    paddingHorizontal: spacing.sm,
+                    paddingVertical: spacing.sm,
+                    opacity: pressed ? 0.75 : 1,
+                  })}
+                >
+                  <Text style={{ color: colors.text, fontWeight: '700' }}>-</Text>
+                </Pressable>
+                <Pressable
+                  accessibilityRole="button"
+                  accessibilityLabel="Increase end year"
+                  disabled={Number(clampYearValue(timeTo || DEFAULT_TO_YEAR)) >= MAX_YEAR}
+                  onPress={() => stepYear(timeTo, onTimeToChange, 1, DEFAULT_TO_YEAR)}
+                  style={({ pressed }) => ({
+                    paddingHorizontal: spacing.sm,
+                    paddingVertical: spacing.sm,
+                    opacity:
+                      Number(clampYearValue(timeTo || DEFAULT_TO_YEAR)) >= MAX_YEAR ? 0.4 : pressed ? 0.75 : 1,
+                  })}
+                >
+                  <Text style={{ color: colors.text, fontWeight: '700' }}>+</Text>
+                </Pressable>
+              </View>
+            }
           />
         </View>
       </View>

--- a/mobile/src/shared/components/WebMapView.tsx
+++ b/mobile/src/shared/components/WebMapView.tsx
@@ -69,6 +69,22 @@ const mapHtml = ({
       .marker.selected {
         background: #0a0a0a;
       }
+
+      .marker-label {
+        position: absolute;
+        top: 50%;
+        left: 50%;
+        transform: translate(-50%, -50%);
+        min-width: 14px;
+        max-width: 18px;
+        color: #ffffff;
+        font-size: 10px;
+        font-weight: 700;
+        line-height: 1;
+        text-align: center;
+        text-shadow: 0 1px 2px rgba(0, 0, 0, 0.35);
+        pointer-events: none;
+      }
     </style>
   </head>
   <body>
@@ -122,6 +138,14 @@ const mapHtml = ({
       markers.forEach((marker) => {
         const element = document.createElement('div');
         element.className = marker.selected ? 'marker selected' : 'marker';
+
+        if (marker.label) {
+          const label = document.createElement('span');
+          label.className = 'marker-label';
+          label.textContent = marker.label;
+          element.appendChild(label);
+        }
+
         element.addEventListener('click', () => {
           window.ReactNativeWebView?.postMessage(
             JSON.stringify({ type: 'markerPress', markerId: marker.id })

--- a/mobile/src/shared/components/__tests__/FilterPanel.test.tsx
+++ b/mobile/src/shared/components/__tests__/FilterPanel.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { fireEvent, render, screen } from '@testing-library/react-native';
-import { FilterPanel } from '../FilterPanel';
+import { DEFAULT_FROM_YEAR, DEFAULT_TO_YEAR, FilterPanel, MAX_YEAR } from '../FilterPanel';
 
 describe('FilterPanel', () => {
   it('forwards location and valid year filter updates', () => {
@@ -27,6 +27,23 @@ describe('FilterPanel', () => {
     expect(onLocationChange).toHaveBeenCalledWith('Fatih');
     expect(onTimeFromChange).toHaveBeenCalledWith('1900');
     expect(onTimeToChange).toHaveBeenCalledWith('1950');
+  });
+
+  it('shows the expected default year values when initialized', () => {
+    render(
+      <FilterPanel
+        location=""
+        timeFrom={DEFAULT_FROM_YEAR}
+        timeTo={DEFAULT_TO_YEAR}
+        onLocationChange={jest.fn()}
+        onTimeFromChange={jest.fn()}
+        onTimeToChange={jest.fn()}
+        onClearAll={jest.fn()}
+      />,
+    );
+
+    expect(screen.getByLabelText('Start year').props.value).toBe(DEFAULT_FROM_YEAR);
+    expect(screen.getByLabelText('End year').props.value).toBe(DEFAULT_TO_YEAR);
   });
 
   it('accepts only positive four-digit-or-shorter numeric years', () => {
@@ -58,6 +75,69 @@ describe('FilterPanel', () => {
     expect(onTimeFromChange).not.toHaveBeenCalledWith('fvbnj');
     expect(onTimeFromChange).not.toHaveBeenCalledWith('99999');
     expect(onTimeToChange).not.toHaveBeenCalledWith('10000');
+  });
+
+  it('clamps manual year entries to the supported bounds on blur', () => {
+    const onTimeFromChange = jest.fn();
+    const onTimeToChange = jest.fn();
+
+    render(
+      <FilterPanel
+        location=""
+        timeFrom="2050"
+        timeTo="0999"
+        onLocationChange={jest.fn()}
+        onTimeFromChange={onTimeFromChange}
+        onTimeToChange={onTimeToChange}
+        onClearAll={jest.fn()}
+      />,
+    );
+
+    fireEvent(screen.getByLabelText('Start year'), 'blur');
+    fireEvent(screen.getByLabelText('End year'), 'blur');
+
+    expect(onTimeFromChange).toHaveBeenCalledWith(String(MAX_YEAR));
+    expect(onTimeToChange).toHaveBeenCalledWith('1000');
+  });
+
+  it('disables increment once the maximum year is reached', () => {
+    render(
+      <FilterPanel
+        location=""
+        timeFrom={String(MAX_YEAR)}
+        timeTo={String(MAX_YEAR)}
+        onLocationChange={jest.fn()}
+        onTimeFromChange={jest.fn()}
+        onTimeToChange={jest.fn()}
+        onClearAll={jest.fn()}
+      />,
+    );
+
+    expect(screen.getByLabelText('Increase start year').props.accessibilityState.disabled).toBe(true);
+    expect(screen.getByLabelText('Increase end year').props.accessibilityState.disabled).toBe(true);
+  });
+
+  it('increments and decrements year values with the step buttons', () => {
+    const onTimeFromChange = jest.fn();
+    const onTimeToChange = jest.fn();
+
+    render(
+      <FilterPanel
+        location=""
+        timeFrom="1980"
+        timeTo="2026"
+        onLocationChange={jest.fn()}
+        onTimeFromChange={onTimeFromChange}
+        onTimeToChange={onTimeToChange}
+        onClearAll={jest.fn()}
+      />,
+    );
+
+    fireEvent.press(screen.getByLabelText('Increase start year'));
+    fireEvent.press(screen.getByLabelText('Decrease end year'));
+
+    expect(onTimeFromChange).toHaveBeenCalledWith('1981');
+    expect(onTimeToChange).toHaveBeenCalledWith('2025');
   });
 
   it('allows entering an end year even before the start year and shows the range warning', () => {

--- a/mobile/src/shared/ui/Input/Input.tsx
+++ b/mobile/src/shared/ui/Input/Input.tsx
@@ -29,6 +29,7 @@ interface InputProps {
   blurOnSubmit?: TextInputProps['blurOnSubmit'];
   submitBehavior?: TextInputProps['submitBehavior'];
   onSubmitEditing?: TextInputProps['onSubmitEditing'];
+  onBlur?: TextInputProps['onBlur'];
   trailingActionLabel?: string;
   trailingActionAccessibilityLabel?: string;
   onTrailingActionPress?: () => void;
@@ -39,6 +40,7 @@ export const Input = forwardRef<TextInput, InputProps>(function Input({
   value,
   onChangeText,
   onSubmitEditing,
+  onBlur,
   placeholder,
   secureTextEntry,
   autoCapitalize = 'none',
@@ -81,6 +83,7 @@ export const Input = forwardRef<TextInput, InputProps>(function Input({
         placeholderTextColor={colors.muted}
         onChangeText={onChangeText}
         onSubmitEditing={onSubmitEditing}
+        onBlur={onBlur}
         secureTextEntry={secureTextEntry}
         autoCapitalize={autoCapitalize}
         keyboardType={keyboardType}


### PR DESCRIPTION
# 📝 Description
Fixes #416 

Improves the mobile search and filter experience by making year filters more practical and preserving active search/filter state between Map and Feed views.

This update includes:
- default year values of `1980` and `2026` in the filter UI
- year bounds enforcement between `1000` and `2030`
- clamping invalid manual year input to the nearest valid bound
- stepper controls for year inputs with disabled increment at the upper bound
- shared search/filter state persistence between Map and Feed views
- updated mobile tests for filter behavior and cross-view state persistence

# 📊 Type of Change
- [x] Bug fix
- [x] New feature
- [ ] Refactoring
- [ ] Documentation
 
# ✅ Acceptance Criteria / Checklist
- [ ] Project builds successfully
- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, especially in hard-to-understand parts
- [x] I have performed a self-review of my code
- [x] I have added/updated tests
- [x] New and existing unit tests pass locally with my changes

# 📸 Screenshots / Recordings
<!-- If applicable !-->

# ⏱️ Estimated Review Time
- [ ] < 5 min
- [x] 5-15 min
- [ ] > 15 min
