### PR TITLE
Feat/account deletion

### DIFF
--- a/backend/apps/users/serializers.py
+++ b/backend/apps/users/serializers.py
@@ -224,3 +224,16 @@ class PublicUserProfileSerializer(serializers.Serializer):
         if profile and profile.is_birth_date_public and profile.birth_date:
             return profile.birth_date.year
         return None
+
+
+class DeleteAccountSerializer(serializers.Serializer):
+    password = serializers.CharField(write_only=True)
+    hard_delete = serializers.BooleanField(default=True, required=False)
+    refresh = serializers.CharField(required=False, allow_blank=True, default='')
+
+    def validate_password(self, value):
+        """Reject the request immediately if the password is wrong."""
+        user = self.context['request'].user
+        if not user.check_password(value):
+            raise serializers.ValidationError('Incorrect password.')
+        return value

--- a/backend/apps/users/serializers.py
+++ b/backend/apps/users/serializers.py
@@ -227,6 +227,8 @@ class PublicUserProfileSerializer(serializers.Serializer):
 
 
 class DeleteAccountSerializer(serializers.Serializer):
+    """Validates an account deletion request. Requires the current password as confirmation."""
+
     password = serializers.CharField(write_only=True)
     hard_delete = serializers.BooleanField(default=True, required=False)
     refresh = serializers.CharField(required=False, allow_blank=True, default='')

--- a/backend/apps/users/services.py
+++ b/backend/apps/users/services.py
@@ -167,6 +167,41 @@ def delete_profile_photo(user: User) -> None:
         profile.save(update_fields=['profile_photo'])
 
 
+def delete_account(user: User, hard_delete: bool, refresh_token: str = '') -> None:
+    """
+    Deletes or deactivates a user account based on the hard_delete flag.
+
+    Hard delete: removes profile photo file, explicitly deletes all user stories
+    (required because Story.user has on_delete=SET_NULL — without this the stories
+    would be anonymized instead of removed), then deletes the User row (cascades
+    UserProfile and EmailVerificationCode).
+
+    Soft delete: sets is_active=False to block login, then bulk-sets story.user=NULL
+    to anonymize community content without removing it.
+
+    In both cases, if a non-empty refresh_token is provided it is blacklisted.
+    TokenError is silently ignored — a stale or already-blacklisted token is harmless
+    once the account is gone or inactive.
+    """
+    from apps.stories.models import Story  # local import to avoid circular imports
+
+    if refresh_token:
+        try:
+            token = RefreshToken(refresh_token)
+            token.blacklist()
+        except TokenError:
+            pass
+
+    if hard_delete:
+        delete_profile_photo(user)
+        Story.objects.filter(user=user).delete()
+        user.delete()
+    else:
+        user.is_active = False
+        user.save(update_fields=['is_active'])
+        Story.objects.filter(user=user).update(user=None)
+
+
 def get_public_profile(user_id: int) -> User:
     """
     Return a User annotated with published_story_count for the public profile endpoint.

--- a/backend/apps/users/tests/test_serializers.py
+++ b/backend/apps/users/tests/test_serializers.py
@@ -11,6 +11,7 @@ from rest_framework.test import APIRequestFactory
 from apps.users.models import User, UserProfile
 from apps.users.serializers import (
     CurrentUserSerializer,
+    DeleteAccountSerializer,
     LoginSerializer,
     ProfilePhotoSerializer,
     PublicUserProfileSerializer,
@@ -481,3 +482,65 @@ class TestProfilePhotoSerializer:
         serializer = ProfilePhotoSerializer(data={'photo': file})
         assert not serializer.is_valid()
         assert 'photo' in serializer.errors
+
+
+# ── DeleteAccountSerializer ───────────────────────────────────────────────────
+
+@pytest.mark.django_db
+class TestDeleteAccountSerializer:
+    def setup_method(self):
+        self.user = User.objects.create_user(
+            email='del@example.com',
+            username='deluser',
+            password='Password1',
+        )
+
+    def _make_request(self):
+        from unittest.mock import Mock
+        req = Mock()
+        req.user = self.user
+        return req
+
+    def _serializer(self, data):
+        return DeleteAccountSerializer(data=data, context={'request': self._make_request()})
+
+    def test_valid_data_with_hard_delete_true_passes(self):
+        s = self._serializer({'password': 'Password1', 'hard_delete': True})
+        assert s.is_valid(), s.errors
+
+    def test_valid_data_with_hard_delete_false_passes(self):
+        s = self._serializer({'password': 'Password1', 'hard_delete': False})
+        assert s.is_valid(), s.errors
+
+    def test_hard_delete_defaults_to_true(self):
+        s = self._serializer({'password': 'Password1'})
+        assert s.is_valid(), s.errors
+        assert s.validated_data['hard_delete'] is True
+
+    def test_refresh_is_optional(self):
+        s = self._serializer({'password': 'Password1'})
+        assert s.is_valid(), s.errors
+
+    def test_refresh_with_token_passes(self):
+        s = self._serializer({'password': 'Password1', 'refresh': 'sometoken'})
+        assert s.is_valid(), s.errors
+
+    def test_password_is_write_only(self):
+        s = self._serializer({'password': 'Password1'})
+        s.is_valid()
+        assert 'password' not in s.data
+
+    def test_missing_password_fails(self):
+        s = self._serializer({})
+        assert not s.is_valid()
+        assert 'password' in s.errors
+
+    def test_wrong_password_fails(self):
+        s = self._serializer({'password': 'WrongPassword1'})
+        assert not s.is_valid()
+        assert 'password' in s.errors
+
+    def test_wrong_password_error_message_is_clear(self):
+        s = self._serializer({'password': 'WrongPassword1'})
+        s.is_valid()
+        assert s.errors['password'][0] == 'Incorrect password.'

--- a/backend/apps/users/tests/test_services.py
+++ b/backend/apps/users/tests/test_services.py
@@ -10,6 +10,7 @@ from rest_framework.exceptions import AuthenticationFailed, ValidationError
 
 from apps.users.models import EmailVerificationCode, User, UserProfile
 from apps.users.services import (
+    delete_account,
     delete_profile_photo,
     get_own_profile,
     get_public_profile,
@@ -359,6 +360,105 @@ class TestUploadProfilePhoto:
         upload_profile_photo(self.user, _make_image_file('PNG'))
         new_name = UserProfile.objects.get(user=self.user).profile_photo.name
         assert new_name != old_name
+
+
+# ── delete_account ───────────────────────────────────────────────────────────
+
+@pytest.mark.django_db
+class TestDeleteAccount:
+    def setup_method(self):
+        self.user = User.objects.create_user(
+            email='del@example.com',
+            username='deluser',
+            password='Password1',
+        )
+
+    def _make_story(self, title='Story'):
+        return Story.objects.create(
+            user=self.user,
+            title=title,
+            narrative='Narrative',
+            status=Story.STATUS_PUBLISHED,
+            location_lat=Decimal('41.0'),
+            location_lng=Decimal('29.0'),
+            location_name='Istanbul',
+            time_type=Story.TIME_EXACT,
+            year=2000,
+        )
+
+    def test_hard_delete_removes_user(self):
+        pk = self.user.pk
+        delete_account(self.user, hard_delete=True)
+        assert not User.objects.filter(pk=pk).exists()
+
+    def test_hard_delete_removes_stories(self):
+        story = self._make_story()
+        delete_account(self.user, hard_delete=True)
+        assert not Story.objects.filter(pk=story.pk).exists()
+
+    def test_hard_delete_deletes_profile_photo_file(self):
+        upload_profile_photo(self.user, _make_image_file('JPEG'))
+        photo_name = UserProfile.objects.get(user=self.user).profile_photo.name
+        delete_account(self.user, hard_delete=True)
+        assert not default_storage.exists(photo_name)
+
+    def test_hard_delete_with_no_photo_does_not_raise(self):
+        delete_account(self.user, hard_delete=True)
+
+    def test_hard_delete_with_no_stories_does_not_raise(self):
+        delete_account(self.user, hard_delete=True)
+
+    def test_soft_delete_deactivates_user(self):
+        delete_account(self.user, hard_delete=False)
+        self.user.refresh_from_db()
+        assert self.user.is_active is False
+
+    def test_soft_delete_anonymizes_stories(self):
+        story = self._make_story()
+        delete_account(self.user, hard_delete=False)
+        assert Story.objects.get(pk=story.pk).user is None
+
+    def test_soft_delete_preserves_story_data(self):
+        story = self._make_story(title='Keep Me')
+        delete_account(self.user, hard_delete=False)
+        preserved = Story.objects.get(pk=story.pk)
+        assert preserved.title == 'Keep Me'
+        assert preserved.narrative == 'Narrative'
+
+    def test_soft_delete_does_not_delete_user_row(self):
+        delete_account(self.user, hard_delete=False)
+        assert User.objects.filter(pk=self.user.pk).exists()
+
+    def test_blacklists_refresh_token_on_hard_delete(self):
+        from rest_framework_simplejwt.tokens import RefreshToken
+        from rest_framework_simplejwt.exceptions import TokenError
+        refresh = RefreshToken.for_user(self.user)
+        token_str = str(refresh)
+        delete_account(self.user, hard_delete=True, refresh_token=token_str)
+        with pytest.raises(TokenError):
+            RefreshToken(token_str).blacklist()
+
+    def test_blacklists_refresh_token_on_soft_delete(self):
+        from rest_framework_simplejwt.tokens import RefreshToken
+        from rest_framework_simplejwt.exceptions import TokenError
+        refresh = RefreshToken.for_user(self.user)
+        token_str = str(refresh)
+        delete_account(self.user, hard_delete=False, refresh_token=token_str)
+        with pytest.raises(TokenError):
+            RefreshToken(token_str).blacklist()
+
+    def test_empty_refresh_token_does_not_raise(self):
+        delete_account(self.user, hard_delete=True, refresh_token='')
+
+    def test_already_blacklisted_token_does_not_raise(self):
+        from rest_framework_simplejwt.tokens import RefreshToken
+        refresh = RefreshToken.for_user(self.user)
+        token_str = str(refresh)
+        refresh.blacklist()
+        delete_account(self.user, hard_delete=True, refresh_token=token_str)
+
+    def test_malformed_refresh_token_does_not_raise(self):
+        delete_account(self.user, hard_delete=True, refresh_token='not-a-token')
 
 
 # ── delete_profile_photo ──────────────────────────────────────────────────────

--- a/backend/apps/users/tests/test_views.py
+++ b/backend/apps/users/tests/test_views.py
@@ -1,5 +1,6 @@
 import io
 import os
+from decimal import Decimal
 
 import pytest
 from django.core.files.uploadedfile import InMemoryUploadedFile
@@ -8,6 +9,7 @@ from rest_framework import status
 from rest_framework.test import APIClient
 
 from apps.users.models import User
+from apps.stories.models import Story
 
 
 def _make_image_file(fmt='JPEG'):
@@ -637,3 +639,85 @@ class TestProfilePhotoView:
         response = client.get(f'/users/{registered_user.pk}/')
         assert response.data['profile_photo'] is not None
         assert response.data['profile_photo'].startswith('http')
+
+
+# ── DELETE /users/me/ ─────────────────────────────────────────────────────────
+
+@pytest.mark.django_db
+class TestDeleteAccountView:
+    url = '/users/me/'
+
+    def _make_story(self, user):
+        return Story.objects.create(
+            user=user,
+            title='My Story',
+            narrative='Narrative',
+            status=Story.STATUS_PUBLISHED,
+            location_lat=Decimal('41.0'),
+            location_lng=Decimal('29.0'),
+            location_name='Istanbul',
+            time_type=Story.TIME_EXACT,
+            year=2000,
+        )
+
+    def test_delete_unauthenticated_returns_401(self, client):
+        response = client.delete(self.url, {'password': 'Password1'}, format='json')
+        assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
+    def test_hard_delete_returns_204(self, auth_client):
+        response = auth_client.delete(self.url, {'password': 'Password1'}, format='json')
+        assert response.status_code == status.HTTP_204_NO_CONTENT
+
+    def test_hard_delete_removes_user_from_db(self, auth_client, registered_user):
+        auth_client.delete(self.url, {'password': 'Password1'}, format='json')
+        assert not User.objects.filter(pk=registered_user.pk).exists()
+
+    def test_hard_delete_removes_stories(self, auth_client, registered_user):
+        story = self._make_story(registered_user)
+        auth_client.delete(self.url, {'password': 'Password1'}, format='json')
+        assert not Story.objects.filter(pk=story.pk).exists()
+
+    def test_soft_delete_returns_204(self, auth_client):
+        response = auth_client.delete(
+            self.url, {'password': 'Password1', 'hard_delete': False}, format='json'
+        )
+        assert response.status_code == status.HTTP_204_NO_CONTENT
+
+    def test_soft_delete_deactivates_user(self, auth_client, registered_user):
+        auth_client.delete(
+            self.url, {'password': 'Password1', 'hard_delete': False}, format='json'
+        )
+        assert User.objects.get(pk=registered_user.pk).is_active is False
+
+    def test_soft_delete_anonymizes_stories(self, auth_client, registered_user):
+        story = self._make_story(registered_user)
+        auth_client.delete(
+            self.url, {'password': 'Password1', 'hard_delete': False}, format='json'
+        )
+        assert Story.objects.get(pk=story.pk).user is None
+
+    def test_with_refresh_token_blacklists_it(self, auth_client):
+        refresh = auth_client.refresh_token
+        auth_client.delete(
+            self.url,
+            {'password': 'Password1', 'refresh': refresh},
+            format='json',
+        )
+        response = auth_client.post('/auth/token/refresh/', {'refresh': refresh})
+        assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
+    def test_without_refresh_token_still_returns_204(self, auth_client):
+        response = auth_client.delete(self.url, {'password': 'Password1'}, format='json')
+        assert response.status_code == status.HTTP_204_NO_CONTENT
+
+    def test_wrong_password_returns_400(self, auth_client):
+        response = auth_client.delete(self.url, {'password': 'WrongPassword'}, format='json')
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+    def test_wrong_password_error_references_password_field(self, auth_client):
+        response = auth_client.delete(self.url, {'password': 'WrongPassword'}, format='json')
+        assert 'password' in response.data['errors']
+
+    def test_missing_password_returns_400(self, auth_client):
+        response = auth_client.delete(self.url, {}, format='json')
+        assert response.status_code == status.HTTP_400_BAD_REQUEST

--- a/backend/apps/users/views.py
+++ b/backend/apps/users/views.py
@@ -90,6 +90,7 @@ class CurrentUserView(APIView):
         )
 
     def delete(self, request):
+        """Hard-deletes (default) or soft-deletes the authenticated user's account."""
         serializer = DeleteAccountSerializer(data=request.data, context={'request': request})
         serializer.is_valid(raise_exception=True)
         delete_account(

--- a/backend/apps/users/views.py
+++ b/backend/apps/users/views.py
@@ -5,6 +5,7 @@ from rest_framework.views import APIView
 
 from apps.users.serializers import (
     CurrentUserSerializer,
+    DeleteAccountSerializer,
     LoginSerializer,
     LogoutSerializer,
     ProfilePhotoSerializer,
@@ -14,6 +15,7 @@ from apps.users.serializers import (
     UserResponseSerializer,
 )
 from apps.users.services import (
+    delete_account,
     delete_profile_photo,
     get_own_profile,
     get_public_profile,
@@ -86,6 +88,16 @@ class CurrentUserView(APIView):
             {'success': True, 'data': CurrentUserSerializer(user, context={'request': request}).data},
             status=status.HTTP_200_OK,
         )
+
+    def delete(self, request):
+        serializer = DeleteAccountSerializer(data=request.data, context={'request': request})
+        serializer.is_valid(raise_exception=True)
+        delete_account(
+            user=request.user,
+            hard_delete=serializer.validated_data['hard_delete'],
+            refresh_token=serializer.validated_data.get('refresh', ''),
+        )
+        return Response(status=status.HTTP_204_NO_CONTENT)
 
 
 class ProfilePhotoView(APIView):


### PR DESCRIPTION
# 📝 Description
Fixes #401

This PR adds account deletion support for authenticated users by introducing the `DELETE /users/me/` endpoint, along with serializer, service, and test coverage for both hard delete and soft delete flows.

### What changed
- Added `DeleteAccountSerializer` to validate account deletion requests
- Required current password confirmation before deletion
- Added optional `hard_delete` flag to choose between hard delete and soft delete
- Set `hard_delete=True` as the default behavior
- Added optional `refresh` token handling so an existing refresh token can be blacklisted during account deletion
- Implemented `delete_account(...)` service to centralize deletion logic
- Wired `DELETE /users/me/` in the current user view
- Added tests for serializer validation, service behavior, and endpoint behavior

### Deletion behavior
- **Hard delete (default):**
  - Deletes the user account
  - Deletes the user’s profile photo file if present
  - Explicitly deletes the user’s stories before deleting the user record
  - Blacklists the provided refresh token if one is sent

- **Soft delete (optional):**
  - Deactivates the user by setting `is_active=False`
  - Preserves the user row
  - Anonymizes stories by setting `story.user = NULL`
  - Blacklists the provided refresh token if one is sent

### Note on default deletion behavior
This PR supports both hard delete and soft delete, which gives flexibility for future moderation or account-retention needs. However, unless there is a clear product or business requirement to preserve the account record and anonymized content, using the default hard delete path is the more appropriate behavior. It keeps the implementation simpler, avoids retaining unnecessary inactive accounts by default, and better matches the expected meaning of “delete my account” for users. Soft delete remains available when preserving content or account traceability is specifically needed.

# 📊 Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Refactoring
- [ ] Documentation
 
# ✅ Acceptance Criteria / Checklist
- [x] Project builds successfully
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, especially in hard-to-understand parts
- [x] I have performed a self-review of my code
- [x] I have added/updated tests
- [x] New and existing unit tests pass locally with my changes

# ⏱️ Estimated Review Time
- [ ] < 5 min
- [x] 5-15 min
- [ ] > 15 min