### PR TITLE
fix: convert sync-pr-fields to on-demand workflow_dispatch

### DIFF
--- a/.github/workflows/sync-pr-fields.yml
+++ b/.github/workflows/sync-pr-fields.yml
@@ -1,9 +1,13 @@
 name: Sync PR fields from linked issue
 
-# Fires whenever a PR is opened or its body is edited (e.g. to add the Fixes link).
+# Run on demand from the Actions tab. Supply the PR number as input.
 on:
-  pull_request:
-    types: [opened, edited]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: 'PR number to sync fields for'
+        required: true
+        type: string
 
 permissions:
   pull-requests: write   # needed to add labels and set milestone on the PR
@@ -19,12 +23,13 @@ jobs:
       - name: Sync labels and milestone from linked issue
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PR_BODY: ${{ github.event.pull_request.body }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_NUMBER: ${{ inputs.pr_number }}
           REPO: ${{ github.repository }}
         run: |
+          # Fetch the PR body via the API; passed through env (not inline-interpolated).
+          PR_BODY=$(gh pr view "$PR_NUMBER" --repo "$REPO" --json body --jq '.body' 2>/dev/null || true)
+
           # Extract the first "Fixes/Closes/Resolves #NNN" reference from the PR body.
-          # PR_BODY is passed via env (safe pattern — not inline-interpolated).
           ISSUE=$(printf '%s\n' "$PR_BODY" \
             | grep -oiE '(fixes|closes|resolves)[[:space:]]+#[0-9]+' \
             | grep -oE '[0-9]+' \
@@ -65,7 +70,7 @@ jobs:
       - name: Sync project membership and fields from linked issue
         env:
           GH_TOKEN: ${{ secrets.PROJECT_TOKEN }}
-          PR_NODE_ID: ${{ github.event.pull_request.node_id }}
+          PR_NUMBER: ${{ inputs.pr_number }}
           REPO: ${{ github.repository }}
         run: |
           if [ -z "$GH_TOKEN" ]; then
@@ -76,6 +81,13 @@ jobs:
           ISSUE="$LINKED_ISSUE"
           if [ -z "$ISSUE" ]; then
             echo "No linked issue — skipping project sync."
+            exit 0
+          fi
+
+          # Fetch the PR's GraphQL node ID via the API.
+          PR_NODE_ID=$(gh pr view "$PR_NUMBER" --repo "$REPO" --json id --jq '.id' 2>/dev/null || true)
+          if [ -z "$PR_NODE_ID" ]; then
+            echo "Could not resolve PR node ID — skipping project sync."
             exit 0
           fi
 


### PR DESCRIPTION
# 📝 Description
Fixes #422

The `sync-pr-fields` workflow was triggered on `pull_request: [opened, edited]`. The `edited` event fires on every PR body change — wording tweaks, formatting, anything — causing redundant label/milestone/project API calls even when the `Fixes #NNN` link was not changed.

This PR converts the trigger to `workflow_dispatch` with a `pr_number` input, so sync only runs when explicitly requested from the Actions tab.

**What changed:**
- Replaced `on: pull_request: [opened, edited]` with `on: workflow_dispatch` and a required `pr_number` input
- Both steps now fetch PR body / node ID via `gh pr view` (previously read from `github.event.pull_request.*`, which is unavailable under `workflow_dispatch`)
- All untrusted data still passed through `env:` variables, not inline-interpolated

# 📊 Type of Change
- [x] Bug fix

# ✅ Acceptance Criteria / Checklist
- [x] Project builds successfully
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, especially in hard-to-understand parts
- [x] I have performed a self-review of my code
- [x] I have added/updated tests
- [x] New and existing unit tests pass locally with my changes

# ⏱️ Estimated Review Time
- [x] < 5 min
- [ ] 5-15 min
- [ ] > 15 min