### PR TITLE
fix: indicate search results clearly in map view

### DIFF
--- a/frontend/src/pages/MapPage.jsx
+++ b/frontend/src/pages/MapPage.jsx
@@ -8,9 +8,10 @@ import { useFilterState } from "@/hooks/useFilterState";
 const EMPTY_FEATURE_COLLECTION = { type: "FeatureCollection", features: [] };
 
 function MapPage() {
-  const { q, yearFrom, yearTo, location } = useFilterState();
+  const { q, yearFrom, yearTo, location, hasActiveFilters } = useFilterState();
 
   const [featureCollection, setFeatureCollection] = useState(EMPTY_FEATURE_COLLECTION);
+  const [totalCount, setTotalCount] = useState(0);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
 
@@ -19,7 +20,9 @@ function MapPage() {
     setError(null);
     try {
       const data = await getMapStories({ q, yearFrom, yearTo, location });
-      setFeatureCollection(data ?? EMPTY_FEATURE_COLLECTION);
+      const fc = data ?? EMPTY_FEATURE_COLLECTION;
+      setFeatureCollection(fc);
+      setTotalCount(fc.totalCount ?? fc.features?.length ?? 0);
     } catch (err) {
       setError(
         err?.response?.data?.detail ||
@@ -43,6 +46,16 @@ function MapPage() {
       <div className="absolute top-3 left-3 right-3 z-[1000] sm:left-4 sm:right-auto sm:w-[32rem]">
         <div className="rounded-lg border bg-background/95 p-3 shadow-md backdrop-blur-sm">
           <SearchFilter />
+          {hasActiveFilters && !loading && !error && (
+            <p className="mt-2 text-sm text-muted-foreground" aria-live="polite">
+              {featureCollection.features.length === 0
+                ? "No stories match your search."
+                : `${featureCollection.features.length} ${featureCollection.features.length === 1 ? "story" : "stories"} found.`}
+              {featureCollection.features.length > 0 && q && totalCount > 100 && (
+                <span className="block text-xs">Showing first 100 results.</span>
+              )}
+            </p>
+          )}
         </div>
       </div>
 

--- a/frontend/src/pages/MapPage.jsx
+++ b/frontend/src/pages/MapPage.jsx
@@ -2,7 +2,7 @@ import { useState, useEffect, useCallback } from "react";
 
 import MapView from "@/components/MapView/MapView";
 import SearchFilter from "@/components/SearchFilter/SearchFilter";
-import { getMapStories } from "@/services/storyService";
+import { getMapStories, MAP_SEARCH_CAP } from "@/services/storyService";
 import { useFilterState } from "@/hooks/useFilterState";
 
 const EMPTY_FEATURE_COLLECTION = { type: "FeatureCollection", features: [] };
@@ -11,7 +11,6 @@ function MapPage() {
   const { q, yearFrom, yearTo, location, hasActiveFilters } = useFilterState();
 
   const [featureCollection, setFeatureCollection] = useState(EMPTY_FEATURE_COLLECTION);
-  const [totalCount, setTotalCount] = useState(0);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
 
@@ -20,9 +19,7 @@ function MapPage() {
     setError(null);
     try {
       const data = await getMapStories({ q, yearFrom, yearTo, location });
-      const fc = data ?? EMPTY_FEATURE_COLLECTION;
-      setFeatureCollection(fc);
-      setTotalCount(fc.totalCount ?? fc.features?.length ?? 0);
+      setFeatureCollection(data ?? EMPTY_FEATURE_COLLECTION);
     } catch (err) {
       setError(
         err?.response?.data?.detail ||
@@ -51,7 +48,7 @@ function MapPage() {
               {featureCollection.features.length === 0
                 ? "No stories match your search."
                 : `${featureCollection.features.length} ${featureCollection.features.length === 1 ? "story" : "stories"} found.`}
-              {featureCollection.features.length > 0 && q && totalCount > 100 && (
+              {featureCollection.features.length > 0 && q && (featureCollection.totalCount ?? featureCollection.features.length) > MAP_SEARCH_CAP && (
                 <span className="block text-xs">Showing first 100 results.</span>
               )}
             </p>

--- a/frontend/src/pages/__tests__/MapPage.test.jsx
+++ b/frontend/src/pages/__tests__/MapPage.test.jsx
@@ -33,6 +33,7 @@ vi.mock("leaflet", () => {
 
 vi.mock("@/services/storyService", () => ({
   getMapStories: vi.fn(),
+  MAP_SEARCH_CAP: 100,
 }));
 
 vi.mock("react-router-dom", async () => {
@@ -215,7 +216,7 @@ describe("MapPage", () => {
         </MemoryRouter>,
       );
 
-      expect(screen.queryByRole("paragraph")).not.toBeInTheDocument();
+      expect(screen.queryByText(/stories? found|no stories match/i)).not.toBeInTheDocument();
     });
 
     it("does not show indicator when no filters are active", async () => {

--- a/frontend/src/pages/__tests__/MapPage.test.jsx
+++ b/frontend/src/pages/__tests__/MapPage.test.jsx
@@ -155,7 +155,7 @@ describe("MapPage", () => {
       );
 
       await waitFor(() => {
-        expect(screen.getByText(/2 stories found in this area/i)).toBeInTheDocument();
+        expect(screen.getByText(/2 stories found/i)).toBeInTheDocument();
       });
     });
 
@@ -171,7 +171,7 @@ describe("MapPage", () => {
       );
 
       await waitFor(() => {
-        expect(screen.getByText(/1 story found in this area/i)).toBeInTheDocument();
+        expect(screen.getByText(/1 story found/i)).toBeInTheDocument();
       });
     });
 
@@ -185,7 +185,7 @@ describe("MapPage", () => {
 
       await waitFor(() => {
         expect(
-          screen.getByText(/no stories found with this criteria/i),
+          screen.getByText(/no stories match your search/i),
         ).toBeInTheDocument();
       });
     });
@@ -226,7 +226,7 @@ describe("MapPage", () => {
       renderPage();
 
       await waitFor(() => {
-        expect(screen.queryByText(/found in this area/i)).not.toBeInTheDocument();
+        expect(screen.queryByText(/stories found/i)).not.toBeInTheDocument();
       });
     });
   });

--- a/frontend/src/pages/__tests__/MapPage.test.jsx
+++ b/frontend/src/pages/__tests__/MapPage.test.jsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { BrowserRouter } from "react-router-dom";
+import { BrowserRouter, MemoryRouter } from "react-router-dom";
 
 vi.mock("react-leaflet", () => ({
   MapContainer: ({ children, ...props }) => (
@@ -139,6 +139,103 @@ describe("MapPage", () => {
 
     await waitFor(() => {
       expect(screen.queryByTestId("map-marker")).not.toBeInTheDocument();
+    });
+  });
+
+  describe("search status indicator", () => {
+    function renderPageWithSearch(search = "") {
+      return render(
+        <MemoryRouter initialEntries={[`/${search}`]}>
+          <MapPage />
+        </MemoryRouter>,
+      );
+    }
+
+    it("shows story count when filters are active and results exist", async () => {
+      getMapStories.mockResolvedValue({
+        ...makeFeatureCollection([makeFeature(1), makeFeature(2)]),
+        totalCount: 2,
+      });
+      render(
+        <MemoryRouter initialEntries={["/?q=bridge"]}>
+          <MapPage />
+        </MemoryRouter>,
+      );
+
+      await waitFor(() => {
+        expect(screen.getByText(/2 stories found in this area/i)).toBeInTheDocument();
+      });
+    });
+
+    it("shows singular 'story' when exactly one result exists", async () => {
+      getMapStories.mockResolvedValue({
+        ...makeFeatureCollection([makeFeature(1)]),
+        totalCount: 1,
+      });
+      render(
+        <MemoryRouter initialEntries={["/?q=bridge"]}>
+          <MapPage />
+        </MemoryRouter>,
+      );
+
+      await waitFor(() => {
+        expect(screen.getByText(/1 story found in this area/i)).toBeInTheDocument();
+      });
+    });
+
+    it("shows empty message when filters are active but no results exist", async () => {
+      getMapStories.mockResolvedValue({ ...makeFeatureCollection([]), totalCount: 0 });
+      render(
+        <MemoryRouter initialEntries={["/?q=bridge"]}>
+          <MapPage />
+        </MemoryRouter>,
+      );
+
+      await waitFor(() => {
+        expect(
+          screen.getByText(/no stories found with this criteria/i),
+        ).toBeInTheDocument();
+      });
+    });
+
+    it("shows cap notice when totalCount exceeds 100 with q filter", async () => {
+      const features = Array.from({ length: 100 }, (_, i) => makeFeature(i + 1));
+      getMapStories.mockResolvedValue({
+        ...makeFeatureCollection(features),
+        totalCount: 150,
+      });
+      render(
+        <MemoryRouter initialEntries={["/?q=bridge"]}>
+          <MapPage />
+        </MemoryRouter>,
+      );
+
+      await waitFor(() => {
+        expect(screen.getByText(/showing first 100 results/i)).toBeInTheDocument();
+      });
+    });
+
+    it("does not show indicator while loading", () => {
+      getMapStories.mockReturnValue(new Promise(() => {}));
+      render(
+        <MemoryRouter initialEntries={["/?q=bridge"]}>
+          <MapPage />
+        </MemoryRouter>,
+      );
+
+      expect(screen.queryByRole("paragraph")).not.toBeInTheDocument();
+    });
+
+    it("does not show indicator when no filters are active", async () => {
+      getMapStories.mockResolvedValue({
+        ...makeFeatureCollection([makeFeature(1)]),
+        totalCount: 1,
+      });
+      renderPage();
+
+      await waitFor(() => {
+        expect(screen.queryByText(/found in this area/i)).not.toBeInTheDocument();
+      });
     });
   });
 });

--- a/frontend/src/pages/__tests__/MapPage.test.jsx
+++ b/frontend/src/pages/__tests__/MapPage.test.jsx
@@ -143,14 +143,6 @@ describe("MapPage", () => {
   });
 
   describe("search status indicator", () => {
-    function renderPageWithSearch(search = "") {
-      return render(
-        <MemoryRouter initialEntries={[`/${search}`]}>
-          <MapPage />
-        </MemoryRouter>,
-      );
-    }
-
     it("shows story count when filters are active and results exist", async () => {
       getMapStories.mockResolvedValue({
         ...makeFeatureCollection([makeFeature(1), makeFeature(2)]),

--- a/frontend/src/services/__tests__/storyService.test.js
+++ b/frontend/src/services/__tests__/storyService.test.js
@@ -139,7 +139,7 @@ describe("storyService", () => {
       expect(api.get).toHaveBeenCalledWith("/stories/map/", { params: {} });
     });
 
-    it("returns the GeoJSON FeatureCollection from the map endpoint as-is", async () => {
+    it("returns the GeoJSON FeatureCollection from the map endpoint with totalCount", async () => {
       const featureCollection = {
         type: "FeatureCollection",
         features: [
@@ -155,7 +155,7 @@ describe("storyService", () => {
 
       const result = await getMapStories();
 
-      expect(result).toEqual(featureCollection);
+      expect(result).toEqual({ ...featureCollection, totalCount: 1 });
     });
 
     it("passes yearFrom, yearTo and location filter params to map API", async () => {
@@ -190,6 +190,8 @@ describe("storyService", () => {
       expect(feature.geometry).toEqual({ type: "Point", coordinates: [28.9, 41.0] });
       expect(feature.properties.title).toBe("Bridge");
       expect(feature.properties.location_name).toBe("Galata");
+      // totalCount reflects the full API count, not the filtered feature count
+      expect(result.totalCount).toBe(2);
     });
 
     it("passes year and location filters to search API when q and filters are combined", async () => {

--- a/frontend/src/services/storyService.js
+++ b/frontend/src/services/storyService.js
@@ -39,6 +39,8 @@ export const EMPTY_FEATURE_COLLECTION = Object.freeze({
   features: [],
 });
 
+export const MAP_SEARCH_CAP = 100;
+
 function storyToFeature(story) {
   return {
     type: "Feature",
@@ -68,8 +70,8 @@ function storyToFeature(story) {
  */
 export async function getMapStories({ q, yearFrom, yearTo, location } = {}) {
   if (q?.trim()) {
-    // Hard cap at 100 results — pins beyond the first 100 are silently dropped.
-    const params = { q: q.trim(), page_size: 100 };
+    // Hard cap — pins beyond MAP_SEARCH_CAP are silently dropped.
+    const params = { q: q.trim(), page_size: MAP_SEARCH_CAP };
     if (yearFrom) params.year_from = yearFrom;
     if (yearTo) params.year_to = yearTo;
     if (location?.trim()) params.location = location.trim();

--- a/frontend/src/services/storyService.js
+++ b/frontend/src/services/storyService.js
@@ -74,11 +74,13 @@ export async function getMapStories({ q, yearFrom, yearTo, location } = {}) {
     if (yearTo) params.year_to = yearTo;
     if (location?.trim()) params.location = location.trim();
     const response = await api.get("/stories/search/", { params });
+    const features = response.data.results
+      .filter((s) => s.location_lat != null && s.location_lng != null)
+      .map(storyToFeature);
     return {
       type: "FeatureCollection",
-      features: response.data.results
-        .filter((s) => s.location_lat != null && s.location_lng != null)
-        .map(storyToFeature),
+      features,
+      totalCount: response.data.count,
     };
   }
 
@@ -88,7 +90,8 @@ export async function getMapStories({ q, yearFrom, yearTo, location } = {}) {
   if (location?.trim()) params.location = location.trim();
 
   const response = await api.get("/stories/map/", { params });
-  return response.data ?? EMPTY_FEATURE_COLLECTION;
+  const fc = response.data ?? EMPTY_FEATURE_COLLECTION;
+  return { ...fc, totalCount: fc.features?.length ?? 0 };
 }
 
 export async function createStory(formData) {


### PR DESCRIPTION
# 📝 Description
Fixes #405 
Adds a search result status indicator to the Map View. After a search or filter is applied, a small text badge appears inside the search panel showing how many stories were found (or a "no results" message). The indicator also notes when results are capped at 100. Matches the phrasing and styling used in the Feed View. 

### Changes Made
- src/services/storyService.js: getMapStories now returns a totalCount field alongside the FeatureCollection: the raw count from the search API (so we can detect the 100-result cap) or features.length for the map-endpoint path.

- src/pages/MapPage.jsx: Added hasActiveFilters from useFilterState, a totalCount state, and a status indicator paragraph rendered inside the search panel overlay. It shows "X stories/story found", "No stories found match your search.", and an extra "Showing first 100 results." line when q is set and totalCount > 100.

- Tests: Updated storyService.test.js to assert on the new totalCount field, and added 6 new test cases to MapPage.test.jsx covering count display, singular/plural, empty state, cap notice, loading suppression, and no-filter suppression.

# 📊 Type of Change
- [x]  Bug fix
- [ ]  New feature
- [ ]  Refactoring
- [ ]  Documentation
 
# ✅ Acceptance Criteria / Checklist
- [x] Project builds successfully
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, especially in hard-to-understand parts
- [x] I have performed a self-review of my code
- [x] I have added/updated tests
- [x] New and existing unit tests pass locally with my changes

# 📸 Screenshots / Recordings
<img width="1440" height="770" alt="Screenshot 2026-04-20 at 16 38 52" src="https://github.com/user-attachments/assets/b36a4d6a-3f2f-4ebb-8090-a2adb41a634c" />

# ⏱️ Estimated Review Time
- [x] < 5 min
- [ ] 5-15 min
- [ ] > 15 min
