### PR TITLE
feat:profile-deletion-mobile

### DIFF
--- a/mobile/src/core/api/client.ts
+++ b/mobile/src/core/api/client.ts
@@ -4,7 +4,7 @@ import { ApiRequestConfig, ApiResponse, interceptors } from './interceptors';
 
 type HttpMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE';
 type ApiTransport = <T>(method: HttpMethod, config: ApiRequestConfig) => Promise<ApiResponse<T>>;
-type RequestConfigInput = Omit<ApiRequestConfig, 'url' | 'data'> & { token?: string };
+type RequestConfigInput = Omit<ApiRequestConfig, 'url'> & { token?: string };
 const REQUEST_TIMEOUT_MS = 15000;
 
 function buildUrl(path: string) {

--- a/mobile/src/features/auth/context/AuthContext.tsx
+++ b/mobile/src/features/auth/context/AuthContext.tsx
@@ -221,13 +221,19 @@ export function AuthProvider({ children }: PropsWithChildren) {
   const logout = useCallback(async () => {
     const activeSession = sessionRef.current;
 
-    await authService.logout(activeSession);
-    sessionRef.current = null;
-    setState({
-      isLoading: false,
-      session: null,
-    });
-    navigationRef.redirectToPublic?.();
+    try {
+      await authService.logout(activeSession);
+    } catch {
+      await authService.clear();
+    } finally {
+      sessionRef.current = null;
+      refreshSessionPromiseRef.current = null;
+      setState({
+        isLoading: false,
+        session: null,
+      });
+      navigationRef.redirectToPublic?.();
+    }
   }, []);
 
   const updateUser = useCallback(async (userPatch: Partial<AuthUser>) => {

--- a/mobile/src/features/auth/context/__tests__/AuthContext.test.tsx
+++ b/mobile/src/features/auth/context/__tests__/AuthContext.test.tsx
@@ -73,6 +73,7 @@ function installAuthTransport(options?: {
   unauthorizedOnProfile?: boolean;
   unauthorizedOnceOnProfile?: boolean;
   refreshFails?: boolean;
+  logoutFails?: boolean;
   rotatedRefreshToken?: string;
   onProfileRequest?: (config: ApiRequestConfig) => void;
 }) {
@@ -88,6 +89,10 @@ function installAuthTransport(options?: {
     }
 
     if (method === 'POST' && config.url === '/auth/logout/') {
+      if (options?.logoutFails) {
+        throw new Error('Logout failed');
+      }
+
       return {
         status: 204,
         data: null as never,
@@ -197,6 +202,29 @@ describe('AuthProvider', () => {
 
     const storedSession = await storage.get<{ accessToken: string }>(storageKeys.authSession);
     expect(storedSession?.accessToken).toBe(loginResponse.access);
+
+    fireEvent.press(screen.getByText('logout'));
+
+    await waitFor(() => {
+      expect(screen.getByText('guest')).toBeTruthy();
+    });
+    expect(await storage.get(storageKeys.authSession)).toBeNull();
+  });
+
+  it('clears auth state even when the logout request fails', async () => {
+    installAuthTransport({ logoutFails: true });
+
+    render(
+      <AuthProvider>
+        <AuthHarness />
+      </AuthProvider>,
+    );
+
+    fireEvent.press(await screen.findByText('login'));
+
+    await waitFor(() => {
+      expect(screen.getByText('authenticated')).toBeTruthy();
+    });
 
     fireEvent.press(screen.getByText('logout'));
 

--- a/mobile/src/features/profile/application/services/__tests__/userService.test.ts
+++ b/mobile/src/features/profile/application/services/__tests__/userService.test.ts
@@ -168,4 +168,25 @@ describe('userService', () => {
       publishedStoryCount: 4,
     });
   });
+
+  it('deletes the authenticated account via DELETE /users/me/', async () => {
+    setApiTransport(async (method: any, config: any) => {
+      if (method === 'DELETE' && config.url === '/users/me/') {
+        expect(config.data).toMatchObject({
+          password: 'Password1',
+          hard_delete: true,
+        });
+
+        return {
+          status: 204,
+          data: null as never,
+          config,
+        };
+      }
+
+      throw new Error(`Unexpected request: ${method} ${config.url}`);
+    });
+
+    await expect(userService.deleteAccount('Password1', true)).resolves.toBeUndefined();
+  });
 });

--- a/mobile/src/features/profile/application/services/index.ts
+++ b/mobile/src/features/profile/application/services/index.ts
@@ -13,4 +13,7 @@ export const userService = {
   async updateCurrentProfile(input: UpdateProfileInput): Promise<ProfileEntity> {
     return repository.updateCurrentProfile(input);
   },
+  async deleteAccount(password: string, deleteStories: boolean): Promise<void> {
+    return repository.deleteAccount(password, deleteStories);
+  },
 };

--- a/mobile/src/features/profile/data/repositories/index.ts
+++ b/mobile/src/features/profile/data/repositories/index.ts
@@ -128,4 +128,8 @@ export class ProfileRepositoryImpl implements ProfileRepository {
       return mappedProfile;
     }
   }
+
+  async deleteAccount(password: string, deleteStories: boolean): Promise<void> {
+    await profileRemoteSource.deleteAccount(password, deleteStories);
+  }
 }

--- a/mobile/src/features/profile/data/sources/index.ts
+++ b/mobile/src/features/profile/data/sources/index.ts
@@ -53,6 +53,15 @@ export const profileRemoteSource = {
 
     return unwrapCurrentUser(response);
   },
+
+  async deleteAccount(password: string, deleteStories: boolean) {
+    await apiClient.delete<void>('/users/me/', {
+      data: {
+        password,
+        hard_delete: deleteStories,
+      },
+    });
+  },
 };
 
 export const profileLocalSource = {};

--- a/mobile/src/features/profile/domain/repositories/index.ts
+++ b/mobile/src/features/profile/domain/repositories/index.ts
@@ -4,4 +4,5 @@ export interface ProfileRepository {
   getCurrentProfile(): Promise<ProfileEntity>;
   getPublicProfile(userId: string): Promise<ProfileEntity>;
   updateCurrentProfile(input: UpdateProfileInput): Promise<ProfileEntity>;
+  deleteAccount(password: string, deleteStories: boolean): Promise<void>;
 }

--- a/mobile/src/features/profile/presentation/screens/ProfileScreen.tsx
+++ b/mobile/src/features/profile/presentation/screens/ProfileScreen.tsx
@@ -1,7 +1,8 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
-import { Pressable, ScrollView, Text, View } from 'react-native';
+import { Modal, Pressable, ScrollView, Text, View } from 'react-native';
 import { useAppTheme } from '../../../../core/hooks/useAppTheme';
 import { Button, ErrorState, Input, Loader, Skeleton } from '../../../../shared';
+import { useToast } from '../../../../shared/hooks/useToast';
 import { useAuth } from '../../../auth';
 import { userService } from '../../application/services';
 import { ProfileEntity, UpdateProfileInput } from '../../domain/entities';
@@ -14,6 +15,7 @@ interface ProfileScreenProps {
   getCurrentProfile?: typeof userService.getCurrentProfile;
   getPublicProfile?: typeof userService.getPublicProfile;
   updateCurrentProfile?: typeof userService.updateCurrentProfile;
+  deleteAccount?: typeof userService.deleteAccount;
 }
 
 interface ProfileFormState {
@@ -168,17 +170,23 @@ export function ProfileScreen({
   getCurrentProfile = userService.getCurrentProfile,
   getPublicProfile = userService.getPublicProfile,
   updateCurrentProfile = userService.updateCurrentProfile,
+  deleteAccount = userService.deleteAccount,
 }: ProfileScreenProps) {
   const { user, updateUser, logout } = useAuth();
+  const { toast } = useToast();
   const { colors, spacing, typography } = useAppTheme();
   const isSelfMode = mode === 'self';
   const [profile, setProfile] = useState<ProfileEntity | null>(null);
   const [formState, setFormState] = useState<ProfileFormState>(createFormState());
   const [isLoading, setIsLoading] = useState(true);
   const [isSaving, setIsSaving] = useState(false);
+  const [isDeleting, setIsDeleting] = useState(false);
   const [isEditing, setIsEditing] = useState(false);
+  const [isDeleteModalVisible, setIsDeleteModalVisible] = useState(false);
+  const [deletePassword, setDeletePassword] = useState('');
   const [error, setError] = useState<string>();
   const [saveMessage, setSaveMessage] = useState<string>();
+  const [deleteError, setDeleteError] = useState<string>();
 
   const loadProfile = useCallback(async () => {
     setIsLoading(true);
@@ -242,6 +250,41 @@ export function ProfileScreen({
     }
   }, [formState, updateCurrentProfile, updateUser, user?.username]);
 
+  const handleCloseDeleteModal = useCallback(() => {
+    if (isDeleting) {
+      return;
+    }
+
+    setIsDeleteModalVisible(false);
+    setDeletePassword('');
+    setDeleteError(undefined);
+  }, [isDeleting]);
+
+  const handleDeleteAccount = useCallback(async () => {
+    if (!deletePassword.trim()) {
+      setDeleteError('Please re-enter your password to confirm account deletion.');
+      return;
+    }
+
+    setIsDeleting(true);
+    setDeleteError(undefined);
+
+    try {
+      await deleteAccount(deletePassword, true);
+      handleCloseDeleteModal();
+      toast.success('Your account has been deleted.');
+      await logout();
+    } catch (deleteRequestError) {
+      setDeleteError(
+        deleteRequestError instanceof Error
+          ? deleteRequestError.message
+          : 'Unable to delete your account.',
+      );
+    } finally {
+      setIsDeleting(false);
+    }
+  }, [deleteAccount, deletePassword, handleCloseDeleteModal, logout, toast]);
+
   const title = useMemo(() => {
     if (isSelfMode) {
       return 'Your profile';
@@ -282,73 +325,14 @@ export function ProfileScreen({
   }
 
   return (
-    <ScrollView
-      contentContainerStyle={{
-        paddingBottom: spacing.xl,
-        gap: spacing.lg,
-      }}
-      showsVerticalScrollIndicator={false}
-    >
-      <View
-        style={{
-          padding: spacing.lg,
-          borderRadius: 20,
-          borderWidth: 1,
-          borderColor: colors.border,
-          backgroundColor: colors.surface,
-          gap: spacing.md,
+    <>
+      <ScrollView
+        contentContainerStyle={{
+          paddingBottom: spacing.xl,
+          gap: spacing.lg,
         }}
+        showsVerticalScrollIndicator={false}
       >
-        <View
-          style={{
-            width: 56,
-            height: 56,
-            borderRadius: 28,
-            alignItems: 'center',
-            justifyContent: 'center',
-            backgroundColor: colors.infoSurface,
-          }}
-        >
-          <Text style={{ color: colors.primary, fontSize: typography.title, fontWeight: '800' }}>
-            {resolvedName.slice(0, 1).toUpperCase()}
-          </Text>
-        </View>
-
-        <View>
-          <Text style={{ color: colors.muted, fontSize: typography.caption, textTransform: 'uppercase' }}>{title}</Text>
-          <Text style={{ marginTop: spacing.xs, color: colors.text, fontSize: typography.title, fontWeight: '800' }}>
-            {resolvedName}
-          </Text>
-          {isSelfMode && profile.email ? (
-            <Text style={{ marginTop: spacing.xs, color: colors.muted }}>{profile.email}</Text>
-          ) : null}
-        </View>
-
-        <View style={{ flexDirection: 'row', flexWrap: 'wrap', gap: spacing.md }}>
-          {joinedDate ? <StatChip label="Joined" value={joinedDate} /> : null}
-          {isSelfMode ? <StatChip label="Points" value={String(profile.totalPoints)} /> : null}
-          <StatChip label="Stories" value={String(profile.publishedStoryCount ?? 0)} />
-          {profile.location ? <StatChip label="Location" value={profile.location} /> : null}
-          {profile.birthYear ? <StatChip label="Birth year" value={String(profile.birthYear)} /> : null}
-        </View>
-
-        {profile.bio ? (
-          <View
-            style={{
-              padding: spacing.md,
-              borderRadius: 16,
-              borderWidth: 1,
-              borderColor: colors.border,
-              backgroundColor: colors.background,
-            }}
-          >
-            <Text style={{ color: colors.muted, fontSize: typography.caption, textTransform: 'uppercase' }}>Bio</Text>
-            <Text style={{ marginTop: spacing.sm, color: colors.text }}>{profile.bio}</Text>
-          </View>
-        ) : null}
-      </View>
-
-      {isSelfMode ? (
         <View
           style={{
             padding: spacing.lg,
@@ -361,145 +345,346 @@ export function ProfileScreen({
         >
           <View
             style={{
-              flexDirection: 'row',
+              width: 56,
+              height: 56,
+              borderRadius: 28,
               alignItems: 'center',
-              justifyContent: 'space-between',
+              justifyContent: 'center',
+              backgroundColor: colors.infoSurface,
+            }}
+          >
+            <Text style={{ color: colors.primary, fontSize: typography.title, fontWeight: '800' }}>
+              {resolvedName.slice(0, 1).toUpperCase()}
+            </Text>
+          </View>
+
+          <View>
+            <Text style={{ color: colors.muted, fontSize: typography.caption, textTransform: 'uppercase' }}>{title}</Text>
+            <Text style={{ marginTop: spacing.xs, color: colors.text, fontSize: typography.title, fontWeight: '800' }}>
+              {resolvedName}
+            </Text>
+            {isSelfMode && profile.email ? (
+              <Text style={{ marginTop: spacing.xs, color: colors.muted }}>{profile.email}</Text>
+            ) : null}
+          </View>
+
+          <View style={{ flexDirection: 'row', flexWrap: 'wrap', gap: spacing.md }}>
+            {joinedDate ? <StatChip label="Joined" value={joinedDate} /> : null}
+            {isSelfMode ? <StatChip label="Points" value={String(profile.totalPoints)} /> : null}
+            <StatChip label="Stories" value={String(profile.publishedStoryCount ?? 0)} />
+            {profile.location ? <StatChip label="Location" value={profile.location} /> : null}
+            {profile.birthYear ? <StatChip label="Birth year" value={String(profile.birthYear)} /> : null}
+          </View>
+
+          {profile.bio ? (
+            <View
+              style={{
+                padding: spacing.md,
+                borderRadius: 16,
+                borderWidth: 1,
+                borderColor: colors.border,
+                backgroundColor: colors.background,
+              }}
+            >
+              <Text style={{ color: colors.muted, fontSize: typography.caption, textTransform: 'uppercase' }}>Bio</Text>
+              <Text style={{ marginTop: spacing.sm, color: colors.text }}>{profile.bio}</Text>
+            </View>
+          ) : null}
+        </View>
+
+        {isSelfMode ? (
+          <View
+            style={{
+              padding: spacing.lg,
+              borderRadius: 20,
+              borderWidth: 1,
+              borderColor: colors.border,
+              backgroundColor: colors.surface,
               gap: spacing.md,
             }}
           >
-            <Text style={{ color: colors.text, fontSize: typography.subtitle, fontWeight: '800' }}>
-              Edit profile
-            </Text>
-            <Button
-              onPress={() => {
-                setSaveMessage(undefined);
-                setError(undefined);
-                setIsEditing((current) => {
-                  const nextValue = !current;
-
-                  if (!nextValue) {
-                    setFormState(createFormState(profile));
-                  }
-
-                  return nextValue;
-                });
+            <View
+              style={{
+                flexDirection: 'row',
+                alignItems: 'center',
+                justifyContent: 'space-between',
+                gap: spacing.md,
               }}
-              variant="outline"
             >
-              <Text style={{ color: colors.text, fontWeight: '700' }}>
-                {isEditing ? 'Cancel' : 'Edit profile'}
+              <Text style={{ color: colors.text, fontSize: typography.subtitle, fontWeight: '800' }}>
+                Edit profile
               </Text>
-            </Button>
-          </View>
+              <Button
+                onPress={() => {
+                  setSaveMessage(undefined);
+                  setError(undefined);
+                  setIsEditing((current) => {
+                    const nextValue = !current;
 
-          {saveMessage ? <Text style={{ color: colors.success }}>{saveMessage}</Text> : null}
+                    if (!nextValue) {
+                      setFormState(createFormState(profile));
+                    }
 
-          {isEditing ? (
-            <>
-              <Input
-                accessibilityLabel="Username"
-                value={formState.username}
-                onChangeText={(value) => {
-                  setSaveMessage(undefined);
-                  setFormState((current) => ({ ...current, username: value }));
+                    return nextValue;
+                  });
                 }}
-                placeholder="Username"
-              />
-              <Input
-                accessibilityLabel="Location"
-                value={formState.location}
-                onChangeText={(value) => {
-                  setSaveMessage(undefined);
-                  setFormState((current) => ({ ...current, location: value }));
-                }}
-                placeholder="Location"
-              />
-              <Input
-                accessibilityLabel="Birth date"
-                value={formState.birthDate}
-                onChangeText={(value) => {
-                  setSaveMessage(undefined);
-                  setFormState((current) => ({ ...current, birthDate: value }));
-                }}
-                placeholder="YYYY-MM-DD"
-              />
-              <Input
-                accessibilityLabel="Bio"
-                value={formState.bio}
-                onChangeText={(value) => {
-                  setSaveMessage(undefined);
-                  setFormState((current) => ({ ...current, bio: value }));
-                }}
-                placeholder="Tell people about yourself"
-                style={{ minHeight: 110, textAlignVertical: 'top' as const }}
-              />
+                variant="outline"
+              >
+                <Text style={{ color: colors.text, fontWeight: '700' }}>
+                  {isEditing ? 'Cancel' : 'Edit profile'}
+                </Text>
+              </Button>
+            </View>
 
-              <ToggleRow
-                label="Show username on your public profile"
-                value={formState.isUsernamePublic}
-                onToggle={() => {
-                  setSaveMessage(undefined);
-                  setFormState((current) => ({ ...current, isUsernamePublic: !current.isUsernamePublic }));
-                }}
-              />
-              <ToggleRow
-                label="Show location publicly"
-                value={formState.isLocationPublic}
-                onToggle={() => {
-                  setSaveMessage(undefined);
-                  setFormState((current) => ({ ...current, isLocationPublic: !current.isLocationPublic }));
-                }}
-              />
-              <ToggleRow
-                label="Show birth date publicly"
-                value={formState.isBirthDatePublic}
-                onToggle={() => {
-                  setSaveMessage(undefined);
-                  setFormState((current) => ({ ...current, isBirthDatePublic: !current.isBirthDatePublic }));
-                }}
-              />
-              <ToggleRow
-                label="Show profile photo publicly"
-                value={formState.isPhotoPublic}
-                onToggle={() => {
-                  setSaveMessage(undefined);
-                  setFormState((current) => ({ ...current, isPhotoPublic: !current.isPhotoPublic }));
-                }}
-              />
+            {saveMessage ? <Text style={{ color: colors.success }}>{saveMessage}</Text> : null}
 
-              {error ? <Text style={{ color: colors.danger }}>{error}</Text> : null}
+            {isEditing ? (
+              <>
+                <Input
+                  accessibilityLabel="Username"
+                  value={formState.username}
+                  onChangeText={(value) => {
+                    setSaveMessage(undefined);
+                    setFormState((current) => ({ ...current, username: value }));
+                  }}
+                  placeholder="Username"
+                />
+                <Input
+                  accessibilityLabel="Location"
+                  value={formState.location}
+                  onChangeText={(value) => {
+                    setSaveMessage(undefined);
+                    setFormState((current) => ({ ...current, location: value }));
+                  }}
+                  placeholder="Location"
+                />
+                <Input
+                  accessibilityLabel="Birth date"
+                  value={formState.birthDate}
+                  onChangeText={(value) => {
+                    setSaveMessage(undefined);
+                    setFormState((current) => ({ ...current, birthDate: value }));
+                  }}
+                  placeholder="YYYY-MM-DD"
+                />
+                <Input
+                  accessibilityLabel="Bio"
+                  value={formState.bio}
+                  onChangeText={(value) => {
+                    setSaveMessage(undefined);
+                    setFormState((current) => ({ ...current, bio: value }));
+                  }}
+                  placeholder="Tell people about yourself"
+                  style={{ minHeight: 110, textAlignVertical: 'top' as const }}
+                />
 
-              {isDirty || isSaving ? (
-                <Button onPress={() => void handleSave()} disabled={isSaving}>
-                  {isSaving ? 'Saving...' : 'Save changes'}
+                <ToggleRow
+                  label="Show username on your public profile"
+                  value={formState.isUsernamePublic}
+                  onToggle={() => {
+                    setSaveMessage(undefined);
+                    setFormState((current) => ({ ...current, isUsernamePublic: !current.isUsernamePublic }));
+                  }}
+                />
+                <ToggleRow
+                  label="Show location publicly"
+                  value={formState.isLocationPublic}
+                  onToggle={() => {
+                    setSaveMessage(undefined);
+                    setFormState((current) => ({ ...current, isLocationPublic: !current.isLocationPublic }));
+                  }}
+                />
+                <ToggleRow
+                  label="Show birth date publicly"
+                  value={formState.isBirthDatePublic}
+                  onToggle={() => {
+                    setSaveMessage(undefined);
+                    setFormState((current) => ({ ...current, isBirthDatePublic: !current.isBirthDatePublic }));
+                  }}
+                />
+                <ToggleRow
+                  label="Show profile photo publicly"
+                  value={formState.isPhotoPublic}
+                  onToggle={() => {
+                    setSaveMessage(undefined);
+                    setFormState((current) => ({ ...current, isPhotoPublic: !current.isPhotoPublic }));
+                  }}
+                />
+
+                {error ? <Text style={{ color: colors.danger }}>{error}</Text> : null}
+
+                {isDirty || isSaving ? (
+                  <Button onPress={() => void handleSave()} disabled={isSaving}>
+                    {isSaving ? 'Saving...' : 'Save changes'}
+                  </Button>
+                ) : null}
+              </>
+            ) : (
+              <>
+                <Button variant="outline" onPress={() => void logout()}>
+                  Sign out
                 </Button>
-              ) : null}
-            </>
-          ) : (
-            <Button variant="outline" onPress={() => void logout()}>
-              Sign out
-            </Button>
-          )}
-        </View>
-      ) : (
+
+                <View
+                  style={{
+                    marginTop: spacing.sm,
+                    paddingTop: spacing.md,
+                    borderTopWidth: 1,
+                    borderTopColor: colors.border,
+                    gap: spacing.sm,
+                  }}
+                >
+                  <Text style={{ color: colors.muted, fontSize: typography.caption, textTransform: 'uppercase' }}>
+                    Danger zone
+                  </Text>
+                  <Text style={{ color: colors.muted }}>
+                    Account deletion is permanent. You will need your password to continue.
+                  </Text>
+                  <Pressable
+                    accessibilityRole="button"
+                    accessibilityLabel="Delete Account"
+                    onPress={() => {
+                      setDeletePassword('');
+                      setDeleteError(undefined);
+                      setIsDeleteModalVisible(true);
+                    }}
+                    style={({ pressed }) => ({
+                      alignSelf: 'flex-start',
+                      paddingHorizontal: spacing.sm,
+                      paddingVertical: spacing.sm,
+                      borderRadius: 10,
+                      opacity: pressed ? 0.8 : 1,
+                    })}
+                  >
+                    <Text style={{ color: colors.danger, fontWeight: '700' }}>Delete Account</Text>
+                  </Pressable>
+                </View>
+              </>
+            )}
+          </View>
+        ) : (
+          <View
+            style={{
+              padding: spacing.lg,
+              borderRadius: 20,
+              borderWidth: 1,
+              borderColor: colors.border,
+              backgroundColor: colors.surface,
+              gap: spacing.sm,
+            }}
+          >
+            <Text style={{ color: colors.text, fontSize: typography.subtitle, fontWeight: '800' }}>
+              Stories
+            </Text>
+            <Text style={{ color: colors.muted }}>
+              Stories are intentionally out of scope for this profile version and will be added later.
+            </Text>
+          </View>
+        )}
+      </ScrollView>
+
+      <Modal
+        animationType="slide"
+        transparent
+        visible={isDeleteModalVisible}
+        onRequestClose={handleCloseDeleteModal}
+      >
         <View
           style={{
-            padding: spacing.lg,
-            borderRadius: 20,
-            borderWidth: 1,
-            borderColor: colors.border,
-            backgroundColor: colors.surface,
-            gap: spacing.sm,
+            flex: 1,
+            backgroundColor: 'rgba(10, 10, 10, 0.4)',
+            justifyContent: 'flex-end',
           }}
         >
-          <Text style={{ color: colors.text, fontSize: typography.subtitle, fontWeight: '800' }}>
-            Stories
-          </Text>
-          <Text style={{ color: colors.muted }}>
-            Stories are intentionally out of scope for this profile version and will be added later.
-          </Text>
+          <Pressable style={{ flex: 1 }} onPress={handleCloseDeleteModal} disabled={isDeleting} />
+          <View
+            style={{
+              paddingHorizontal: spacing.lg,
+              paddingTop: spacing.lg,
+              paddingBottom: spacing.xl,
+              borderTopLeftRadius: 24,
+              borderTopRightRadius: 24,
+              backgroundColor: colors.background,
+              gap: spacing.md,
+            }}
+          >
+            <View
+              style={{
+                alignSelf: 'center',
+                width: 48,
+                height: 5,
+                borderRadius: 999,
+                backgroundColor: colors.border,
+              }}
+            />
+
+            <Text style={{ color: colors.danger, fontSize: typography.caption, fontWeight: '800', textTransform: 'uppercase' }}>
+              Delete account
+            </Text>
+            <Text style={{ color: colors.text, fontSize: typography.title, fontWeight: '800' }}>
+              This action cannot be undone
+            </Text>
+
+            <View
+              style={{
+                padding: spacing.md,
+                borderRadius: 16,
+                borderWidth: 1,
+                borderColor: colors.danger,
+                backgroundColor: colors.dangerSurface,
+                gap: spacing.sm,
+              }}
+            >
+              <Text style={{ color: colors.text }}>
+                Your account will be permanently deleted.
+              </Text>
+              <Text style={{ color: colors.text }}>
+                Your stories and related likes will be permanently deleted.
+              </Text>
+            </View>
+
+            <Input
+              accessibilityLabel="Account deletion password"
+              value={deletePassword}
+              onChangeText={(value) => {
+                setDeleteError(undefined);
+                setDeletePassword(value);
+              }}
+              placeholder="Re-enter your password"
+              secureTextEntry
+              autoCapitalize="none"
+              editable={!isDeleting}
+            />
+
+            {deleteError ? <Text style={{ color: colors.danger }}>{deleteError}</Text> : null}
+
+            <Pressable
+              accessibilityRole="button"
+              accessibilityLabel="Delete My Account"
+              disabled={isDeleting}
+              onPress={() => void handleDeleteAccount()}
+              style={({ pressed }) => ({
+                minHeight: 48,
+                paddingHorizontal: spacing.md,
+                paddingVertical: spacing.md - 2,
+                borderRadius: 14,
+                alignItems: 'center',
+                justifyContent: 'center',
+                backgroundColor: colors.danger,
+                opacity: isDeleting ? 0.7 : pressed ? 0.88 : 1,
+              })}
+            >
+              <Text style={{ color: colors.background, fontWeight: '800' }}>
+                {isDeleting ? 'Deleting account...' : 'Delete My Account'}
+              </Text>
+            </Pressable>
+
+            <Button variant="outline" onPress={handleCloseDeleteModal} disabled={isDeleting}>
+              Cancel
+            </Button>
+          </View>
         </View>
-      )}
-    </ScrollView>
+      </Modal>
+    </>
   );
 }

--- a/mobile/src/features/profile/presentation/screens/__tests__/ProfileScreen.test.tsx
+++ b/mobile/src/features/profile/presentation/screens/__tests__/ProfileScreen.test.tsx
@@ -1,6 +1,10 @@
 import React from 'react';
-import { fireEvent, render, screen } from '@testing-library/react-native';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react-native';
 import { ProfileScreen } from '../ProfileScreen';
+
+const mockLogout = jest.fn(async () => undefined);
+const mockUpdateUser = jest.fn(async () => undefined);
+const mockToastSuccess = jest.fn();
 
 jest.mock('../../../../auth', () => ({
   useAuth: () => ({
@@ -10,7 +14,20 @@ jest.mock('../../../../auth', () => ({
       username: 'Traveler',
       role: 'user',
     },
-    updateUser: jest.fn(async () => undefined),
+    updateUser: mockUpdateUser,
+    logout: mockLogout,
+  }),
+}));
+
+jest.mock('../../../../../shared/hooks/useToast', () => ({
+  useToast: () => ({
+    toast: {
+      success: mockToastSuccess,
+      error: jest.fn(),
+      info: jest.fn(),
+      show: jest.fn(),
+    },
+    dismiss: jest.fn(),
   }),
 }));
 
@@ -42,6 +59,12 @@ const publicProfile = {
 };
 
 describe('ProfileScreen', () => {
+  beforeEach(() => {
+    mockLogout.mockClear();
+    mockUpdateUser.mockClear();
+    mockToastSuccess.mockClear();
+  });
+
   it('renders a loading state while profile data is being fetched', () => {
     render(
       <ProfileScreen
@@ -52,7 +75,7 @@ describe('ProfileScreen', () => {
     expect(screen.getByLabelText('Loading profile')).toBeTruthy();
   });
 
-  it('renders self profile data with edit controls', async () => {
+  it('renders self profile data with edit controls and delete action', async () => {
     render(
       <ProfileScreen
         mode="self"
@@ -63,6 +86,7 @@ describe('ProfileScreen', () => {
     expect(await screen.findByText('Traveler')).toBeTruthy();
     expect(screen.getByText('traveler@example.com')).toBeTruthy();
     expect(screen.getAllByText('Edit profile')).toHaveLength(2);
+    expect(screen.getByLabelText('Delete Account')).toBeTruthy();
 
     fireEvent.press(screen.getAllByText('Edit profile').at(-1)!);
 
@@ -98,6 +122,62 @@ describe('ProfileScreen', () => {
       }),
     );
     expect(await screen.findByText('Profile updated successfully.')).toBeTruthy();
+  });
+
+  it('opens the delete confirmation flow with direct hard delete messaging', async () => {
+    render(
+      <ProfileScreen
+        mode="self"
+        getCurrentProfile={async () => selfProfile}
+      />,
+    );
+
+    fireEvent.press(await screen.findByLabelText('Delete Account'));
+
+    expect(await screen.findByText('This action cannot be undone')).toBeTruthy();
+    expect(screen.getByText('Your account will be permanently deleted.')).toBeTruthy();
+    expect(screen.getByText('Your stories and related likes will be permanently deleted.')).toBeTruthy();
+    expect(screen.queryByLabelText('Also delete all my stories')).toBeNull();
+  });
+
+  it('requires password before deleting the account', async () => {
+    const deleteAccount = jest.fn(async () => undefined);
+
+    render(
+      <ProfileScreen
+        mode="self"
+        getCurrentProfile={async () => selfProfile}
+        deleteAccount={deleteAccount}
+      />,
+    );
+
+    fireEvent.press(await screen.findByLabelText('Delete Account'));
+    fireEvent.press(screen.getByLabelText('Delete My Account'));
+
+    expect(await screen.findByText('Please re-enter your password to confirm account deletion.')).toBeTruthy();
+    expect(deleteAccount).not.toHaveBeenCalled();
+  });
+
+  it('deletes the account, shows success toast, and logs out', async () => {
+    const deleteAccount = jest.fn(async () => undefined);
+
+    render(
+      <ProfileScreen
+        mode="self"
+        getCurrentProfile={async () => selfProfile}
+        deleteAccount={deleteAccount}
+      />,
+    );
+
+    fireEvent.press(await screen.findByLabelText('Delete Account'));
+    fireEvent.changeText(screen.getByLabelText('Account deletion password'), 'Password1');
+    fireEvent.press(screen.getByLabelText('Delete My Account'));
+
+    await waitFor(() => {
+      expect(deleteAccount).toHaveBeenCalledWith('Password1', true);
+    });
+    expect(mockToastSuccess).toHaveBeenCalledWith('Your account has been deleted.');
+    expect(mockLogout).toHaveBeenCalled();
   });
 
   it('renders a public profile in read-only mode', async () => {

--- a/mobile/src/features/stories/data/mappers/__tests__/storyMappers.test.ts
+++ b/mobile/src/features/stories/data/mappers/__tests__/storyMappers.test.ts
@@ -37,13 +37,32 @@ describe('story mappers', () => {
         longitude: 28.9784,
       },
       timePeriod: '1453',
-      contributorName: 'Anonymous',
+      contributorName: 'Deleted user',
       submittedAt: '2026-03-18T10:00:00Z',
       mediaUrl: 'https://example.com/photo.jpg',
       likeCount: 7,
       likedByViewer: true,
       comments: [],
     });
+  });
+
+  it('keeps anonymous fallback when a contributor exists but their public name is hidden', () => {
+    const result = mapStory({
+      id: 52,
+      user: 7,
+      title: 'Hidden Author Story',
+      narrative: 'Only one paragraph.',
+      status: 'published',
+      location_name: 'Beyoglu',
+      location_lat: '41.0369',
+      location_lng: '28.9850',
+      time_type: 'exact_year',
+      year: 1923,
+      contributor_name: null,
+      submitted_at: '2026-03-18T10:00:00Z',
+    });
+
+    expect(result.contributorName).toBe('Anonymous');
   });
 
   it('maps backend comments into the mobile comment shape', () => {
@@ -57,7 +76,7 @@ describe('story mappers', () => {
       }),
     ).toEqual({
       id: '9',
-      authorName: 'Anonymous',
+      authorName: 'Deleted account',
       body: 'Great story!',
       createdAt: '2026-03-20T12:00:00Z',
     });

--- a/mobile/src/features/stories/data/mappers/index.ts
+++ b/mobile/src/features/stories/data/mappers/index.ts
@@ -230,7 +230,17 @@ function getPrimaryMediaUrl(value: StoryRecord) {
 }
 
 function getContributorName(value: StoryRecord) {
-  return asString(value.contributorName) || asString(value.contributor_name) || 'Anonymous';
+  const resolvedName = asString(value.contributorName) || asString(value.contributor_name);
+
+  if (resolvedName) {
+    return resolvedName;
+  }
+
+  if (!asStringId(value.user)) {
+    return 'Deleted user';
+  }
+
+  return 'Anonymous';
 }
 
 export function mapStory(value: unknown): StoryEntity {
@@ -343,7 +353,7 @@ export function mapStoryComment(value: unknown): StoryCommentPreview {
   const authorName =
     asString(comment.authorName) ||
     asString(comment.author_username) ||
-    (comment.is_anonymized === true ? 'Anonymous' : '') ||
+    (comment.is_anonymized === true || comment.isAnonymized === true ? 'Deleted account' : '') ||
     'Anonymous';
 
   if (!id || !body || !createdAt) {

--- a/mobile/src/features/stories/presentation/screens/StoryScreen.tsx
+++ b/mobile/src/features/stories/presentation/screens/StoryScreen.tsx
@@ -197,7 +197,7 @@ function sortCommentsNewestFirst<T extends { createdAt: string }>(comments: T[])
 function mapStoryCommentPreview(comment: StoryCommentEntity) {
   return {
     id: comment.id,
-    authorName: comment.authorUsername || 'Anonymous',
+    authorName: comment.authorUsername || (comment.isAnonymized ? 'Deleted account' : 'Anonymous'),
     body: comment.text,
     createdAt: comment.createdAt,
   };
@@ -371,7 +371,7 @@ export function StoryScreen({
   const [isStoryDeleting, setIsStoryDeleting] = useState(false);
   const [confirmDeleteId, setConfirmDeleteId] = useState<string>();
   const [interactionError, setInteractionError] = useState<string>();
-  const [isContributorAnonymous, setIsContributorAnonymous] = useState(false);
+  const [contributorVisibilityOverride, setContributorVisibilityOverride] = useState<string | null>(null);
   const deletedCommentIdsRef = useRef<Set<string>>(new Set());
 
   useEffect(() => {
@@ -386,7 +386,7 @@ export function StoryScreen({
     setStoryDeleteError(undefined);
     setConfirmDeleteId(undefined);
     setInteractionError(undefined);
-    setIsContributorAnonymous(false);
+    setContributorVisibilityOverride(null);
     deletedCommentIdsRef.current = new Set();
 
     loadStoryDetail(storyId, session?.role, getStory).then((nextState) => {
@@ -431,7 +431,7 @@ export function StoryScreen({
 
     const story = state.story;
     if (!story?.contributorUserId) {
-      setIsContributorAnonymous(story?.contributorName === 'Anonymous');
+      setContributorVisibilityOverride(story?.contributorName === 'Deleted user' ? 'Deleted user' : null);
       return () => {
         isMounted = false;
       };
@@ -442,13 +442,13 @@ export function StoryScreen({
       String(session.user.id) === story.contributorUserId;
 
     if (isOwnStory) {
-      setIsContributorAnonymous(false);
+      setContributorVisibilityOverride(null);
       return () => {
         isMounted = false;
       };
     }
 
-    setIsContributorAnonymous(story.contributorName === 'Anonymous');
+    setContributorVisibilityOverride(story.contributorName === 'Deleted user' ? 'Deleted user' : null);
 
     getPublicProfile(story.contributorUserId)
       .then((profile) => {
@@ -456,7 +456,7 @@ export function StoryScreen({
           return;
         }
 
-        setIsContributorAnonymous(!profile.username);
+        setContributorVisibilityOverride(!profile.username ? 'Anonymous' : null);
       })
       .catch(() => undefined);
 
@@ -641,7 +641,7 @@ export function StoryScreen({
   const story = state.story;
   const isStoryOwner = session?.user?.id !== undefined && String(session.user.id) === story.contributorUserId;
   const canDeleteStory = session?.role === roles.admin || isStoryOwner;
-  const contributorName = isContributorAnonymous ? 'Anonymous' : getResolvedContributorName(story);
+  const contributorName = contributorVisibilityOverride ?? getResolvedContributorName(story);
   const contributorDisplayName = getDisplayNameWithYouLabel(contributorName, isStoryOwner);
   const canOpenContributorProfile = Boolean(story.contributorUserId);
 

--- a/mobile/src/features/stories/presentation/screens/__tests__/StoryScreen.test.tsx
+++ b/mobile/src/features/stories/presentation/screens/__tests__/StoryScreen.test.tsx
@@ -171,6 +171,50 @@ describe('StoryScreen', () => {
     expect(onOpenContributorProfile).toHaveBeenCalledWith('22');
   });
 
+  it('shows deleted user when the story belongs to a deleted account', async () => {
+    render(
+      <StoryScreen
+        storyId="story-001"
+        getStory={async () => ({
+          ...baseStory,
+          contributorUserId: undefined,
+          contributorName: 'Deleted user',
+        })}
+      />,
+    );
+
+    expect(await screen.findByText(baseStory.title)).toBeTruthy();
+    expect(screen.getByText('Deleted user')).toBeTruthy();
+    expect(screen.queryByLabelText('Open profile: Deleted user')).toBeNull();
+  });
+
+  it('shows deleted account for anonymized comments from deleted users', async () => {
+    (interactionService.getComments as jest.Mock).mockResolvedValueOnce([
+      {
+        id: 'comment-deleted',
+        authorUsername: null,
+        text: 'I used to work there too.',
+        createdAt: '2026-03-20T12:00:00Z',
+        isAnonymized: true,
+        is_anonymized: true,
+      },
+    ]);
+
+    render(
+      <StoryScreen
+        storyId="story-001"
+        getStory={async () => ({
+          ...baseStory,
+          comments: [],
+        })}
+      />,
+    );
+
+    await screen.findByText(baseStory.title);
+    expect(await screen.findByText('Deleted account')).toBeTruthy();
+    expect(screen.getByText('I used to work there too.')).toBeTruthy();
+  });
+
   it('marks the signed-in user on their own story even if their username is private', async () => {
     render(
       <StoryScreen


### PR DESCRIPTION
# 📝 Description
Fixes #194 

Implements the mobile account deletion flow and related deleted-user rendering updates.

Included in this PR:
- Added `Delete Account` action to the mobile profile screen
- Added a mobile-friendly destructive confirmation bottom sheet
- Added password re-entry validation before deletion
- Wired mobile deletion submission through `userService.deleteAccount(password, deleteStories)`
- Cleared auth state and logged the user out after successful deletion
- Added success toast and loading state for deletion
- Updated deleted story contributors to render as `Deleted user`
- Updated deleted comment authors to render as `Deleted account`
- Added/updated unit tests for deletion flow and deleted-user rendering

# 📊 Type of Change
- [x]  Bug fix
- [x]  New feature
- [ ]  Refactoring
- [ ]  Documentation
 
# ✅ Acceptance Criteria / Checklist
- [x] Project builds successfully
- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, especially in hard-to-understand parts
- [x] I have performed a self-review of my code
- [x] I have added/updated tests
- [x] New and existing unit tests pass locally with my changes

# 📸 Screenshots / Recordings
<!-- If applicable !-->

# ⏱️ Estimated Review Time
- [ ] < 5 min
- [x] 5-15 min
- [ ] > 15 min
