### PR TITLE
feat:profile-edit-page-mobile

### DIFF
--- a/mobile/jest.setup.ts
+++ b/mobile/jest.setup.ts
@@ -15,6 +15,9 @@ jest.mock('react-native-maps', () => {
 
 jest.mock('expo-image-picker', () => ({
   __esModule: true,
+  MediaTypeOptions: {
+    Images: 'images',
+  },
   requestMediaLibraryPermissionsAsync: jest.fn(async () => ({ granted: true })),
   requestCameraPermissionsAsync: jest.fn(async () => ({ granted: true })),
   launchImageLibraryAsync: jest.fn(async () => ({ canceled: true, assets: [] })),

--- a/mobile/src/core/api/client.ts
+++ b/mobile/src/core/api/client.ts
@@ -4,7 +4,7 @@ import { ApiRequestConfig, ApiResponse, interceptors } from './interceptors';
 
 type HttpMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE';
 type ApiTransport = <T>(method: HttpMethod, config: ApiRequestConfig) => Promise<ApiResponse<T>>;
-type RequestConfigInput = Omit<ApiRequestConfig, 'url' | 'data'> & { token?: string };
+type RequestConfigInput = Omit<ApiRequestConfig, 'url'> & { token?: string };
 const REQUEST_TIMEOUT_MS = 15000;
 
 function buildUrl(path: string) {
@@ -208,8 +208,20 @@ export const apiClient = {
     tokenOrConfig?: string | RequestConfigInput,
   ) =>
     request<T>('PATCH', url, { ...normalizeConfig(tokenOrConfig), data }),
-  delete: async <T>(url: string, tokenOrConfig?: string | RequestConfigInput) =>
-    request<T>('DELETE', url, normalizeConfig(tokenOrConfig)),
+  delete: async <T>(
+    url: string,
+    tokenOrConfigOrData?: string | RequestConfigInput,
+    configOverride?: RequestConfigInput,
+  ) => {
+    if (configOverride) {
+      return request<T>('DELETE', url, {
+        ...normalizeConfig(configOverride),
+        data: tokenOrConfigOrData,
+      });
+    }
+
+    return request<T>('DELETE', url, normalizeConfig(tokenOrConfigOrData));
+  },
 };
 
 function normalizeConfig(tokenOrConfig?: string | RequestConfigInput): Omit<ApiRequestConfig, 'url'> {

--- a/mobile/src/features/profile/application/services/__tests__/userService.test.ts
+++ b/mobile/src/features/profile/application/services/__tests__/userService.test.ts
@@ -168,4 +168,151 @@ describe('userService', () => {
       publishedStoryCount: 4,
     });
   });
+
+  it('uploads a profile photo via POST /users/me/photo/', async () => {
+    setApiTransport(async (method: any, config: any) => {
+      if (method === 'POST' && config.url === '/users/me/photo/') {
+        expect(config.data).toBeInstanceOf(FormData);
+
+        return {
+          status: 200,
+          data: {
+            success: true,
+            photo_url: 'https://cdn.example.com/profile.jpg',
+          } as never,
+          config,
+        };
+      }
+
+      if (method === 'GET' && config.url === '/users/me/') {
+        return {
+          status: 200,
+          data: {
+            success: true,
+            data: {
+              id: 7,
+              username: 'Traveler',
+              email: 'traveler@example.com',
+              total_points: 5,
+              is_username_public: true,
+              is_email_verified: true,
+              profile: {
+                bio: 'Collecting neighborhood memories.',
+                location: 'Istanbul',
+                profile_photo: 'https://cdn.example.com/profile.jpg',
+                is_location_public: true,
+                is_birth_date_public: false,
+                is_photo_public: true,
+              },
+            },
+          } as never,
+          config,
+        };
+      }
+
+      if (method === 'GET' && config.url === '/users/7/') {
+        return {
+          status: 200,
+          data: {
+            id: 7,
+            username: 'Traveler',
+            total_points: 5,
+            published_story_count: 3,
+          } as never,
+          config,
+        };
+      }
+
+      throw new Error(`Unexpected request: ${method} ${config.url}`);
+    });
+
+    await expect(
+      userService.uploadProfilePhoto({
+        uri: 'file:///profile.jpg',
+        fileName: 'profile.jpg',
+        mimeType: 'image/jpeg',
+      }),
+    ).resolves.toMatchObject({
+      profilePhoto: 'https://cdn.example.com/profile.jpg',
+    });
+  });
+
+  it('removes a profile photo via DELETE /users/me/photo/', async () => {
+    setApiTransport(async (method: any, config: any) => {
+      if (method === 'DELETE' && config.url === '/users/me/photo/') {
+        return {
+          status: 204,
+          data: null as never,
+          config,
+        };
+      }
+
+      if (method === 'GET' && config.url === '/users/me/') {
+        return {
+          status: 200,
+          data: {
+            success: true,
+            data: {
+              id: 7,
+              username: 'Traveler',
+              email: 'traveler@example.com',
+              total_points: 5,
+              is_username_public: true,
+              is_email_verified: true,
+              profile: {
+                bio: 'Collecting neighborhood memories.',
+                location: 'Istanbul',
+                profile_photo: null,
+                is_location_public: true,
+                is_birth_date_public: false,
+                is_photo_public: false,
+              },
+            },
+          } as never,
+          config,
+        };
+      }
+
+      if (method === 'GET' && config.url === '/users/7/') {
+        return {
+          status: 200,
+          data: {
+            id: 7,
+            username: 'Traveler',
+            total_points: 5,
+            published_story_count: 3,
+          } as never,
+          config,
+        };
+      }
+
+      throw new Error(`Unexpected request: ${method} ${config.url}`);
+    });
+
+    await expect(userService.removeProfilePhoto()).resolves.toMatchObject({
+      profilePhoto: null,
+      isPhotoPublic: false,
+    });
+  });
+
+  it('deletes the authenticated account via DELETE /users/me/', async () => {
+    setApiTransport(async (method: any, config: any) => {
+      if (method === 'DELETE' && config.url === '/users/me/') {
+        expect(config.data).toMatchObject({
+          password: 'top-secret',
+          hard_delete: true,
+        });
+
+        return {
+          status: 204,
+          data: null as never,
+          config,
+        };
+      }
+
+      throw new Error(`Unexpected request: ${method} ${config.url}`);
+    });
+
+    await expect(userService.deleteAccount('top-secret', true)).resolves.toBeUndefined();
+  });
 });

--- a/mobile/src/features/profile/application/services/index.ts
+++ b/mobile/src/features/profile/application/services/index.ts
@@ -1,5 +1,5 @@
 import { ProfileRepositoryImpl } from '../../data/repositories';
-import { ProfileEntity, UpdateProfileInput } from '../../domain/entities';
+import { ProfileEntity, ProfilePhotoUploadInput, UpdateProfileInput } from '../../domain/entities';
 
 const repository = new ProfileRepositoryImpl();
 
@@ -12,5 +12,17 @@ export const userService = {
   },
   async updateCurrentProfile(input: UpdateProfileInput): Promise<ProfileEntity> {
     return repository.updateCurrentProfile(input);
+  },
+  async updateProfile(input: UpdateProfileInput): Promise<ProfileEntity> {
+    return repository.updateCurrentProfile(input);
+  },
+  async uploadProfilePhoto(input: ProfilePhotoUploadInput): Promise<ProfileEntity> {
+    return repository.uploadProfilePhoto(input);
+  },
+  async removeProfilePhoto(): Promise<ProfileEntity> {
+    return repository.removeProfilePhoto();
+  },
+  async deleteAccount(password: string, deleteStories = true): Promise<void> {
+    return repository.deleteAccount(password, deleteStories);
   },
 };

--- a/mobile/src/features/profile/data/repositories/index.ts
+++ b/mobile/src/features/profile/data/repositories/index.ts
@@ -1,4 +1,4 @@
-import { ProfileEntity, UpdateProfileInput } from '../../domain/entities';
+import { ProfileEntity, ProfilePhotoUploadInput, UpdateProfileInput } from '../../domain/entities';
 import { ProfileRepository } from '../../domain/repositories';
 import { profileRemoteSource } from '../sources';
 
@@ -127,5 +127,19 @@ export class ProfileRepositoryImpl implements ProfileRepository {
     } catch {
       return mappedProfile;
     }
+  }
+
+  async uploadProfilePhoto(input: ProfilePhotoUploadInput): Promise<ProfileEntity> {
+    await profileRemoteSource.uploadProfilePhoto(input);
+    return this.getCurrentProfile();
+  }
+
+  async removeProfilePhoto(): Promise<ProfileEntity> {
+    await profileRemoteSource.removeProfilePhoto();
+    return this.getCurrentProfile();
+  }
+
+  async deleteAccount(password: string, deleteStories = true): Promise<void> {
+    await profileRemoteSource.deleteAccount(password, deleteStories);
   }
 }

--- a/mobile/src/features/profile/data/sources/index.ts
+++ b/mobile/src/features/profile/data/sources/index.ts
@@ -1,5 +1,5 @@
 import { apiClient } from '../../../../core/api/client';
-import { UpdateProfileInput } from '../../domain/entities';
+import { ProfilePhotoUploadInput, UpdateProfileInput } from '../../domain/entities';
 
 interface CurrentUserProfilePayload {
   success?: boolean;
@@ -52,6 +52,37 @@ export const profileRemoteSource = {
     );
 
     return unwrapCurrentUser(response);
+  },
+
+  async uploadProfilePhoto(input: ProfilePhotoUploadInput) {
+    const formData = new FormData();
+
+    formData.append('photo', {
+      uri: input.uri,
+      name: input.fileName,
+      type: input.mimeType,
+    } as unknown as Blob);
+
+    const response = await apiClient.post<Record<string, unknown>>('/users/me/photo/', formData);
+
+    if (!response || typeof response !== 'object') {
+      throw new Error('Profile photo upload did not return a response.');
+    }
+
+    return response;
+  },
+
+  async removeProfilePhoto() {
+    await apiClient.delete<void>('/users/me/photo/');
+  },
+
+  async deleteAccount(password: string, hardDelete = true) {
+    await apiClient.delete<void>('/users/me/', {
+      data: {
+        password,
+        hard_delete: hardDelete,
+      },
+    });
   },
 };
 

--- a/mobile/src/features/profile/domain/entities/index.ts
+++ b/mobile/src/features/profile/domain/entities/index.ts
@@ -17,6 +17,12 @@ export interface ProfileEntity {
   isPhotoPublic?: boolean;
 }
 
+export interface ProfilePhotoUploadInput {
+  uri: string;
+  fileName: string;
+  mimeType: 'image/jpeg' | 'image/png';
+}
+
 export interface UpdateProfileInput {
   username: string;
   isUsernamePublic: boolean;

--- a/mobile/src/features/profile/domain/repositories/index.ts
+++ b/mobile/src/features/profile/domain/repositories/index.ts
@@ -1,7 +1,10 @@
-import { ProfileEntity, UpdateProfileInput } from '../entities';
+import { ProfileEntity, ProfilePhotoUploadInput, UpdateProfileInput } from '../entities';
 
 export interface ProfileRepository {
   getCurrentProfile(): Promise<ProfileEntity>;
   getPublicProfile(userId: string): Promise<ProfileEntity>;
   updateCurrentProfile(input: UpdateProfileInput): Promise<ProfileEntity>;
+  uploadProfilePhoto(input: ProfilePhotoUploadInput): Promise<ProfileEntity>;
+  removeProfilePhoto(): Promise<ProfileEntity>;
+  deleteAccount(password: string, deleteStories?: boolean): Promise<void>;
 }

--- a/mobile/src/features/profile/presentation/screens/ProfileScreen.tsx
+++ b/mobile/src/features/profile/presentation/screens/ProfileScreen.tsx
@@ -1,19 +1,44 @@
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
-import { Pressable, ScrollView, Text, View } from 'react-native';
+import * as ImagePicker from 'expo-image-picker';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { Image, Modal, Pressable, ScrollView, Text, View } from 'react-native';
+import { navigationRef } from '../../../../app/navigation/navigationRef';
+import { limits } from '../../../../core/constants/limits';
 import { useAppTheme } from '../../../../core/hooks/useAppTheme';
 import { Button, ErrorState, Input, Loader, Skeleton } from '../../../../shared';
+import { useToast } from '../../../../shared/hooks/useToast';
+import { authService } from '../../../auth/application/services';
 import { useAuth } from '../../../auth';
 import { userService } from '../../application/services';
-import { ProfileEntity, UpdateProfileInput } from '../../domain/entities';
+import { ProfileEntity, ProfilePhotoUploadInput, UpdateProfileInput } from '../../domain/entities';
 
 type ProfileMode = 'self' | 'public';
+
+const BIO_MAX_LENGTH = 280;
+const MIN_BIRTH_YEAR = 1900;
+const MONTH_OPTIONS = [
+  'January',
+  'February',
+  'March',
+  'April',
+  'May',
+  'June',
+  'July',
+  'August',
+  'September',
+  'October',
+  'November',
+  'December',
+] as const;
 
 interface ProfileScreenProps {
   mode?: ProfileMode;
   userId?: string;
   getCurrentProfile?: typeof userService.getCurrentProfile;
   getPublicProfile?: typeof userService.getPublicProfile;
-  updateCurrentProfile?: typeof userService.updateCurrentProfile;
+  updateCurrentProfile?: typeof userService.updateProfile;
+  uploadProfilePhoto?: typeof userService.uploadProfilePhoto;
+  removeProfilePhoto?: typeof userService.removeProfilePhoto;
+  deleteAccount?: typeof userService.deleteAccount;
 }
 
 interface ProfileFormState {
@@ -22,9 +47,21 @@ interface ProfileFormState {
   location: string;
   birthDate: string;
   isUsernamePublic: boolean;
+  isBioPublic: boolean;
   isLocationPublic: boolean;
   isBirthDatePublic: boolean;
   isPhotoPublic: boolean;
+}
+
+interface FormErrors {
+  birthDate?: string;
+  bio?: string;
+  photo?: string;
+}
+
+interface PendingPhotoState extends ProfilePhotoUploadInput {
+  fileSize: number;
+  previewUri: string;
 }
 
 function formatJoinedDate(value?: string) {
@@ -44,6 +81,114 @@ function formatJoinedDate(value?: string) {
   });
 }
 
+function formatBirthDateLabel(value: string) {
+  const parsedDate = parseBirthDate(value);
+
+  if (!parsedDate) {
+    return 'Choose birth date';
+  }
+
+  return parsedDate.toLocaleDateString('en-US', {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+  });
+}
+
+function formatDateInput(date: Date) {
+  const year = date.getFullYear();
+  const month = `${date.getMonth() + 1}`.padStart(2, '0');
+  const day = `${date.getDate()}`.padStart(2, '0');
+
+  return `${year}-${month}-${day}`;
+}
+
+function parseBirthDate(value: string) {
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(value)) {
+    return null;
+  }
+
+  const [year, month, day] = value.split('-').map((part) => Number(part));
+  const parsedDate = new Date(Date.UTC(year, month - 1, day, 12));
+
+  if (Number.isNaN(parsedDate.getTime())) {
+    return null;
+  }
+
+  if (
+    parsedDate.getUTCFullYear() !== year ||
+    parsedDate.getUTCMonth() !== month - 1 ||
+    parsedDate.getUTCDate() !== day
+  ) {
+    return null;
+  }
+
+  return parsedDate;
+}
+
+function daysInMonth(year: number, monthIndex: number) {
+  return new Date(year, monthIndex + 1, 0).getDate();
+}
+
+function clampDayInput(value: string, maxDay: number) {
+  const digitsOnly = value.replace(/[^0-9]/g, '').slice(0, 2);
+
+  if (!digitsOnly) {
+    return '';
+  }
+
+  const parsedDay = Number.parseInt(digitsOnly, 10);
+
+  if (!Number.isFinite(parsedDay)) {
+    return '';
+  }
+
+  return String(Math.min(Math.max(parsedDay, 1), maxDay));
+}
+
+function clampBirthDateParts(
+  yearValue: string,
+  monthIndex: number,
+  dayValue: string,
+) {
+  const today = new Date();
+  const todayYear = today.getFullYear();
+  const todayMonthIndex = today.getMonth();
+  const todayDay = today.getDate();
+
+  const parsedYear = Number.parseInt(yearValue.replace(/[^0-9]/g, '').slice(0, 4), 10);
+  const safeYear = Number.isFinite(parsedYear) ? Math.max(parsedYear, MIN_BIRTH_YEAR) : todayYear;
+  const maxDayForMonth = daysInMonth(safeYear, monthIndex);
+  const parsedDay = Number.parseInt(dayValue.replace(/[^0-9]/g, '').slice(0, 2), 10);
+  const safeDay = Number.isFinite(parsedDay) ? Math.min(Math.max(parsedDay, 1), maxDayForMonth) : 1;
+
+  const candidate = new Date(safeYear, monthIndex, safeDay);
+
+  if (candidate.getTime() <= today.getTime()) {
+    return {
+      year: String(safeYear),
+      monthIndex,
+      day: String(safeDay),
+    };
+  }
+
+  return {
+    year: String(todayYear),
+    monthIndex: todayMonthIndex,
+    day: String(todayDay),
+  };
+}
+
+function getDraftMaxBirthDay(yearValue: string, monthIndex: number) {
+  const parsedYear = Number.parseInt(yearValue.replace(/[^0-9]/g, '').slice(0, 4), 10);
+
+  if (!Number.isFinite(parsedYear)) {
+    return 31;
+  }
+
+  return daysInMonth(Math.max(parsedYear, MIN_BIRTH_YEAR), monthIndex);
+}
+
 function createFormState(profile?: ProfileEntity | null): ProfileFormState {
   return {
     username: profile?.username ?? '',
@@ -51,6 +196,7 @@ function createFormState(profile?: ProfileEntity | null): ProfileFormState {
     location: profile?.location ?? '',
     birthDate: profile?.birthDate ?? '',
     isUsernamePublic: profile?.isUsernamePublic ?? true,
+    isBioPublic: true,
     isLocationPublic: profile?.isLocationPublic ?? true,
     isBirthDatePublic: profile?.isBirthDatePublic ?? true,
     isPhotoPublic: profile?.isPhotoPublic ?? true,
@@ -64,10 +210,69 @@ function areFormStatesEqual(left: ProfileFormState, right: ProfileFormState) {
     left.location === right.location &&
     left.birthDate === right.birthDate &&
     left.isUsernamePublic === right.isUsernamePublic &&
+    left.isBioPublic === right.isBioPublic &&
     left.isLocationPublic === right.isLocationPublic &&
     left.isBirthDatePublic === right.isBirthDatePublic &&
     left.isPhotoPublic === right.isPhotoPublic
   );
+}
+
+function validateBirthDate(value: string) {
+  if (!value) {
+    return undefined;
+  }
+
+  const parsedDate = parseBirthDate(value);
+
+  if (!parsedDate) {
+    return 'Choose a valid birth date.';
+  }
+
+  if (parsedDate.getFullYear() < MIN_BIRTH_YEAR) {
+    return `Birth date must be after ${MIN_BIRTH_YEAR}.`;
+  }
+
+  const now = new Date();
+
+  if (parsedDate.getTime() > now.getTime()) {
+    return 'Birth date cannot be in the future.';
+  }
+
+  return undefined;
+}
+
+function resolveMimeType(fileName?: string | null, mimeType?: string | null) {
+  if (mimeType === 'image/jpeg' || mimeType === 'image/png') {
+    return mimeType;
+  }
+
+  const lowerFileName = fileName?.toLowerCase() ?? '';
+
+  if (lowerFileName.endsWith('.jpg') || lowerFileName.endsWith('.jpeg')) {
+    return 'image/jpeg';
+  }
+
+  if (lowerFileName.endsWith('.png')) {
+    return 'image/png';
+  }
+
+  return null;
+}
+
+function validatePendingPhoto(photo: PendingPhotoState | null) {
+  if (!photo) {
+    return undefined;
+  }
+
+  if (photo.fileSize > limits.maxProfilePhotoMb * 1024 * 1024) {
+    return `Photo must be ${limits.maxProfilePhotoMb} MB or smaller.`;
+  }
+
+  if (photo.mimeType !== 'image/jpeg' && photo.mimeType !== 'image/png') {
+    return 'Profile photo must be a JPG or PNG image.';
+  }
+
+  return undefined;
 }
 
 function LoadingState() {
@@ -162,28 +367,77 @@ function StatChip({ label, value }: { label: string; value: string }) {
   );
 }
 
+function FieldCard({
+  title,
+  children,
+  footer,
+}: {
+  title: string;
+  children: React.ReactNode;
+  footer?: React.ReactNode;
+}) {
+  const { colors, spacing, typography } = useAppTheme();
+
+  return (
+    <View
+      style={{
+        padding: spacing.md,
+        borderRadius: 16,
+        borderWidth: 1,
+        borderColor: colors.border,
+        backgroundColor: colors.background,
+        gap: spacing.sm,
+      }}
+    >
+      <Text style={{ color: colors.muted, fontSize: typography.caption, textTransform: 'uppercase' }}>{title}</Text>
+      {children}
+      {footer}
+    </View>
+  );
+}
+
 export function ProfileScreen({
   mode = 'self',
   userId,
   getCurrentProfile = userService.getCurrentProfile,
   getPublicProfile = userService.getPublicProfile,
-  updateCurrentProfile = userService.updateCurrentProfile,
+  updateCurrentProfile = userService.updateProfile,
+  uploadProfilePhoto = userService.uploadProfilePhoto,
+  removeProfilePhoto = userService.removeProfilePhoto,
+  deleteAccount = userService.deleteAccount,
 }: ProfileScreenProps) {
   const { user, updateUser, logout } = useAuth();
+  const { toast } = useToast();
   const { colors, spacing, typography } = useAppTheme();
   const isSelfMode = mode === 'self';
   const [profile, setProfile] = useState<ProfileEntity | null>(null);
   const [formState, setFormState] = useState<ProfileFormState>(createFormState());
+  const [pendingPhoto, setPendingPhoto] = useState<PendingPhotoState | null>(null);
+  const [isPhotoRemoved, setIsPhotoRemoved] = useState(false);
   const [isLoading, setIsLoading] = useState(true);
   const [isSaving, setIsSaving] = useState(false);
   const [isEditing, setIsEditing] = useState(false);
+  const [isBirthDateModalVisible, setIsBirthDateModalVisible] = useState(false);
+  const [isDeleteModalVisible, setIsDeleteModalVisible] = useState(false);
+  const [isMonthPickerVisible, setIsMonthPickerVisible] = useState(false);
+  const [birthMonthDraft, setBirthMonthDraft] = useState<number>(0);
+  const [birthDayDraft, setBirthDayDraft] = useState('1');
+  const [birthYearDraft, setBirthYearDraft] = useState('1995');
+  const [deletePassword, setDeletePassword] = useState('');
+  const deletePasswordRef = useRef('');
+  const [deleteError, setDeleteError] = useState<string>();
+  const [isDeleting, setIsDeleting] = useState(false);
   const [error, setError] = useState<string>();
-  const [saveMessage, setSaveMessage] = useState<string>();
+  const [formErrors, setFormErrors] = useState<FormErrors>({});
+
+  const resetPhotoDraft = useCallback(() => {
+    setPendingPhoto(null);
+    setIsPhotoRemoved(false);
+  }, []);
 
   const loadProfile = useCallback(async () => {
     setIsLoading(true);
     setError(undefined);
-    setSaveMessage(undefined);
 
     try {
       const nextProfile = isSelfMode
@@ -192,13 +446,14 @@ export function ProfileScreen({
 
       setProfile(nextProfile);
       setFormState(createFormState(nextProfile));
+      resetPhotoDraft();
       setIsEditing(false);
     } catch (loadError) {
       setError(loadError instanceof Error ? loadError.message : 'Unable to load this profile.');
     } finally {
       setIsLoading(false);
     }
-  }, [getCurrentProfile, getPublicProfile, isSelfMode, userId]);
+  }, [getCurrentProfile, getPublicProfile, isSelfMode, resetPhotoDraft, userId]);
 
   useEffect(() => {
     if (!isSelfMode && !userId) {
@@ -210,7 +465,97 @@ export function ProfileScreen({
     void loadProfile();
   }, [isSelfMode, loadProfile, userId]);
 
+  const validateForm = useCallback(() => {
+    const nextErrors: FormErrors = {};
+    const birthDateError = validateBirthDate(formState.birthDate);
+
+    if (birthDateError) {
+      nextErrors.birthDate = birthDateError;
+    }
+
+    if (formState.bio.length > BIO_MAX_LENGTH) {
+      nextErrors.bio = `Bio must be ${BIO_MAX_LENGTH} characters or fewer.`;
+    }
+
+    const photoError = validatePendingPhoto(pendingPhoto);
+
+    if (photoError) {
+      nextErrors.photo = photoError;
+    }
+
+    setFormErrors(nextErrors);
+    return Object.keys(nextErrors).length === 0;
+  }, [formState.bio.length, formState.birthDate, pendingPhoto]);
+
+  const handleSelectPhoto = useCallback(async () => {
+    setFormErrors((current) => ({ ...current, photo: undefined }));
+
+    const permission = await ImagePicker.requestMediaLibraryPermissionsAsync();
+
+    if (!permission.granted) {
+      setError('Allow photo library access to choose a profile picture.');
+      return;
+    }
+
+    const result = await ImagePicker.launchImageLibraryAsync({
+      mediaTypes: ImagePicker.MediaTypeOptions.Images,
+      quality: 1,
+      allowsMultipleSelection: false,
+    });
+
+    if (result.canceled || !result.assets[0]) {
+      return;
+    }
+
+    const asset = result.assets[0];
+    const fileName = asset.fileName ?? `profile-photo-${Date.now()}.jpg`;
+    const mimeType = resolveMimeType(fileName, asset.mimeType ?? null);
+    const nextPhotoError =
+      !mimeType
+        ? 'Profile photo must be a JPG or PNG image.'
+        : asset.fileSize && asset.fileSize > limits.maxProfilePhotoMb * 1024 * 1024
+          ? `Photo must be ${limits.maxProfilePhotoMb} MB or smaller.`
+          : undefined;
+
+    if (!mimeType || nextPhotoError) {
+      setFormErrors((current) => ({ ...current, photo: nextPhotoError ?? 'Unsupported image format.' }));
+      return;
+    }
+
+    setPendingPhoto({
+      uri: asset.uri,
+      previewUri: asset.uri,
+      fileName,
+      fileSize: asset.fileSize ?? 0,
+      mimeType,
+    });
+    setIsPhotoRemoved(false);
+  }, []);
+
+  const handleRemovePhoto = useCallback(() => {
+    setFormErrors((current) => ({ ...current, photo: undefined }));
+    setPendingPhoto(null);
+    setIsPhotoRemoved(Boolean(profile?.profilePhoto));
+  }, [profile?.profilePhoto]);
+
+  const handleOpenBirthDateModal = useCallback(() => {
+    const existingDate = parseBirthDate(formState.birthDate);
+    setBirthMonthDraft(existingDate?.getUTCMonth() ?? 0);
+    setBirthDayDraft(String(existingDate?.getUTCDate() ?? 1));
+    setBirthYearDraft(String(existingDate?.getUTCFullYear() ?? 1995));
+    setIsMonthPickerVisible(false);
+    setIsBirthDateModalVisible(true);
+  }, [formState.birthDate]);
+
+  const normalizedBirthYear = Number.parseInt(birthYearDraft.replace(/[^0-9]/g, '').slice(0, 4), 10);
+  const maxBirthDay = getDraftMaxBirthDay(birthYearDraft, birthMonthDraft);
+  const normalizedBirthDay = Number.parseInt(birthDayDraft.replace(/[^0-9]/g, '').slice(0, 2), 10);
+
   const handleSave = useCallback(async () => {
+    if (!validateForm()) {
+      return;
+    }
+
     const payload: UpdateProfileInput = {
       username: formState.username,
       bio: formState.bio,
@@ -224,23 +569,75 @@ export function ProfileScreen({
 
     setIsSaving(true);
     setError(undefined);
-    setSaveMessage(undefined);
 
     try {
-      const updatedProfile = await updateCurrentProfile(payload);
+      let updatedProfile = await updateCurrentProfile(payload);
+
+      if (pendingPhoto) {
+        updatedProfile = await uploadProfilePhoto(pendingPhoto);
+      } else if (isPhotoRemoved && profile?.profilePhoto) {
+        updatedProfile = await removeProfilePhoto();
+      }
+
       setProfile(updatedProfile);
-      setFormState(createFormState(updatedProfile));
+      setFormState({
+        ...createFormState(updatedProfile),
+        isBioPublic: formState.isBioPublic,
+      });
+      resetPhotoDraft();
+      setIsEditing(false);
       await updateUser({
         isUsernamePublic: updatedProfile.isUsernamePublic,
         username: updatedProfile.username ?? user?.username ?? '',
       });
-      setSaveMessage('Profile updated successfully.');
+      toast.success('Profile updated successfully.');
     } catch (saveError) {
       setError(saveError instanceof Error ? saveError.message : 'Unable to save your profile.');
     } finally {
       setIsSaving(false);
     }
-  }, [formState, updateCurrentProfile, updateUser, user?.username]);
+  }, [
+    formState,
+    isPhotoRemoved,
+    pendingPhoto,
+    profile?.profilePhoto,
+    removeProfilePhoto,
+    resetPhotoDraft,
+    toast,
+    updateCurrentProfile,
+    updateUser,
+    uploadProfilePhoto,
+      user?.username,
+    validateForm,
+  ]);
+
+  const handleDeleteAccount = useCallback(async () => {
+    const trimmedPassword = deletePasswordRef.current.trim();
+
+    if (!trimmedPassword) {
+      setDeleteError('Re-enter your password to continue.');
+      return;
+    }
+
+    setDeleteError(undefined);
+    setIsDeleting(true);
+
+    try {
+      await deleteAccount(trimmedPassword, true);
+      await authService.clear();
+      navigationRef.redirectToPublic?.();
+      toast.success('Your account has been deleted.');
+      setIsDeleteModalVisible(false);
+      setDeletePassword('');
+      deletePasswordRef.current = '';
+    } catch (deleteAccountError) {
+      setDeleteError(
+        deleteAccountError instanceof Error ? deleteAccountError.message : 'Unable to delete your account.',
+      );
+    } finally {
+      setIsDeleting(false);
+    }
+  }, [deleteAccount, toast]);
 
   const title = useMemo(() => {
     if (isSelfMode) {
@@ -257,8 +654,13 @@ export function ProfileScreen({
       return false;
     }
 
-    return !areFormStatesEqual(formState, createFormState(profile));
-  }, [formState, profile]);
+    return (
+      !areFormStatesEqual(formState, createFormState(profile)) ||
+      Boolean(pendingPhoto) ||
+      isPhotoRemoved
+    );
+  }, [formState, isPhotoRemoved, pendingPhoto, profile]);
+  const profilePhotoUri = pendingPhoto?.previewUri ?? (isPhotoRemoved ? null : profile?.profilePhoto ?? null);
 
   if (isLoading) {
     return <LoadingState />;
@@ -282,73 +684,14 @@ export function ProfileScreen({
   }
 
   return (
-    <ScrollView
-      contentContainerStyle={{
-        paddingBottom: spacing.xl,
-        gap: spacing.lg,
-      }}
-      showsVerticalScrollIndicator={false}
-    >
-      <View
-        style={{
-          padding: spacing.lg,
-          borderRadius: 20,
-          borderWidth: 1,
-          borderColor: colors.border,
-          backgroundColor: colors.surface,
-          gap: spacing.md,
+    <>
+      <ScrollView
+        contentContainerStyle={{
+          paddingBottom: spacing.xl,
+          gap: spacing.lg,
         }}
+        showsVerticalScrollIndicator={false}
       >
-        <View
-          style={{
-            width: 56,
-            height: 56,
-            borderRadius: 28,
-            alignItems: 'center',
-            justifyContent: 'center',
-            backgroundColor: colors.infoSurface,
-          }}
-        >
-          <Text style={{ color: colors.primary, fontSize: typography.title, fontWeight: '800' }}>
-            {resolvedName.slice(0, 1).toUpperCase()}
-          </Text>
-        </View>
-
-        <View>
-          <Text style={{ color: colors.muted, fontSize: typography.caption, textTransform: 'uppercase' }}>{title}</Text>
-          <Text style={{ marginTop: spacing.xs, color: colors.text, fontSize: typography.title, fontWeight: '800' }}>
-            {resolvedName}
-          </Text>
-          {isSelfMode && profile.email ? (
-            <Text style={{ marginTop: spacing.xs, color: colors.muted }}>{profile.email}</Text>
-          ) : null}
-        </View>
-
-        <View style={{ flexDirection: 'row', flexWrap: 'wrap', gap: spacing.md }}>
-          {joinedDate ? <StatChip label="Joined" value={joinedDate} /> : null}
-          {isSelfMode ? <StatChip label="Points" value={String(profile.totalPoints)} /> : null}
-          <StatChip label="Stories" value={String(profile.publishedStoryCount ?? 0)} />
-          {profile.location ? <StatChip label="Location" value={profile.location} /> : null}
-          {profile.birthYear ? <StatChip label="Birth year" value={String(profile.birthYear)} /> : null}
-        </View>
-
-        {profile.bio ? (
-          <View
-            style={{
-              padding: spacing.md,
-              borderRadius: 16,
-              borderWidth: 1,
-              borderColor: colors.border,
-              backgroundColor: colors.background,
-            }}
-          >
-            <Text style={{ color: colors.muted, fontSize: typography.caption, textTransform: 'uppercase' }}>Bio</Text>
-            <Text style={{ marginTop: spacing.sm, color: colors.text }}>{profile.bio}</Text>
-          </View>
-        ) : null}
-      </View>
-
-      {isSelfMode ? (
         <View
           style={{
             padding: spacing.lg,
@@ -359,147 +702,610 @@ export function ProfileScreen({
             gap: spacing.md,
           }}
         >
+          {profilePhotoUri ? (
+            <Image
+              source={{ uri: profilePhotoUri }}
+              accessibilityLabel="Profile photo preview"
+              style={{
+                width: 72,
+                height: 72,
+                borderRadius: 36,
+                backgroundColor: colors.infoSurface,
+              }}
+            />
+          ) : (
+            <View
+              style={{
+                width: 72,
+                height: 72,
+                borderRadius: 36,
+                alignItems: 'center',
+                justifyContent: 'center',
+                backgroundColor: colors.infoSurface,
+              }}
+            >
+              <Text style={{ color: colors.primary, fontSize: typography.title, fontWeight: '800' }}>
+                {resolvedName.slice(0, 1).toUpperCase()}
+              </Text>
+            </View>
+          )}
+
+          <View>
+            <Text style={{ color: colors.muted, fontSize: typography.caption, textTransform: 'uppercase' }}>{title}</Text>
+            <Text style={{ marginTop: spacing.xs, color: colors.text, fontSize: typography.title, fontWeight: '800' }}>
+              {resolvedName}
+            </Text>
+            {isSelfMode && profile.email ? (
+              <Text style={{ marginTop: spacing.xs, color: colors.muted }}>{profile.email}</Text>
+            ) : null}
+          </View>
+
+          <View style={{ flexDirection: 'row', flexWrap: 'wrap', gap: spacing.md }}>
+            {joinedDate ? <StatChip label="Joined" value={joinedDate} /> : null}
+            {isSelfMode ? <StatChip label="Points" value={String(profile.totalPoints)} /> : null}
+            <StatChip label="Stories" value={String(profile.publishedStoryCount ?? 0)} />
+            {profile.location ? <StatChip label="Location" value={profile.location} /> : null}
+            {profile.birthYear ? <StatChip label="Birth year" value={String(profile.birthYear)} /> : null}
+          </View>
+
+          {profile.bio ? (
+            <FieldCard title="Bio">
+              <Text style={{ color: colors.text }}>{profile.bio}</Text>
+            </FieldCard>
+          ) : null}
+        </View>
+
+        {isSelfMode ? (
           <View
             style={{
-              flexDirection: 'row',
-              alignItems: 'center',
-              justifyContent: 'space-between',
+              padding: spacing.lg,
+              borderRadius: 20,
+              borderWidth: 1,
+              borderColor: colors.border,
+              backgroundColor: colors.surface,
+              gap: spacing.md,
+            }}
+          >
+            <View
+              style={{
+                flexDirection: 'row',
+                alignItems: 'center',
+                justifyContent: 'space-between',
+                gap: spacing.md,
+              }}
+            >
+              <Text style={{ color: colors.text, fontSize: typography.subtitle, fontWeight: '800' }}>
+                Edit profile
+              </Text>
+              <Button
+                onPress={() => {
+                  setError(undefined);
+                  setFormErrors({});
+                  setIsEditing((current) => {
+                    const nextValue = !current;
+
+                    if (!nextValue) {
+                      setFormState(createFormState(profile));
+                      resetPhotoDraft();
+                    }
+
+                    return nextValue;
+                  });
+                }}
+                variant="outline"
+              >
+                {isEditing ? 'Cancel' : 'Edit Profile'}
+              </Button>
+            </View>
+
+            {isEditing ? (
+              <>
+                <FieldCard
+                  title="Profile photo"
+                  footer={
+                    <ToggleRow
+                      label="Show profile photo publicly"
+                      value={formState.isPhotoPublic}
+                      onToggle={() => {
+                        setFormState((current) => ({ ...current, isPhotoPublic: !current.isPhotoPublic }));
+                      }}
+                    />
+                  }
+                >
+                  <View style={{ flexDirection: 'row', alignItems: 'center', gap: spacing.md }}>
+                    {profilePhotoUri ? (
+                      <Image
+                        source={{ uri: profilePhotoUri }}
+                        accessibilityLabel="Selected profile photo"
+                        style={{
+                          width: 64,
+                          height: 64,
+                          borderRadius: 32,
+                          backgroundColor: colors.infoSurface,
+                        }}
+                      />
+                    ) : (
+                      <View
+                        style={{
+                          width: 64,
+                          height: 64,
+                          borderRadius: 32,
+                          alignItems: 'center',
+                          justifyContent: 'center',
+                          backgroundColor: colors.infoSurface,
+                        }}
+                      >
+                        <Text style={{ color: colors.primary, fontSize: typography.subtitle, fontWeight: '800' }}>
+                          {resolvedName.slice(0, 1).toUpperCase()}
+                        </Text>
+                      </View>
+                    )}
+                    <View style={{ flex: 1, gap: spacing.sm }}>
+                      <Button variant="outline" onPress={() => void handleSelectPhoto()}>
+                        Choose Photo
+                      </Button>
+                      {profilePhotoUri ? (
+                        <Button variant="outline" onPress={handleRemovePhoto}>
+                          Remove Photo
+                        </Button>
+                      ) : null}
+                    </View>
+                  </View>
+                  {formErrors.photo ? <Text style={{ color: colors.danger }}>{formErrors.photo}</Text> : null}
+                  <Text style={{ color: colors.muted, fontSize: typography.caption }}>
+                    Accepts JPG, JPEG, and PNG files up to {limits.maxProfilePhotoMb} MB.
+                  </Text>
+                </FieldCard>
+
+                <FieldCard title="Username">
+                  <Input
+                    accessibilityLabel="Username"
+                    value={formState.username}
+                    onChangeText={(value) => {
+                      setFormState((current) => ({ ...current, username: value }));
+                    }}
+                    placeholder="Username"
+                  />
+                  <ToggleRow
+                    label="Show username on your public profile"
+                    value={formState.isUsernamePublic}
+                    onToggle={() => {
+                      setFormState((current) => ({ ...current, isUsernamePublic: !current.isUsernamePublic }));
+                    }}
+                  />
+                </FieldCard>
+
+                <FieldCard title="Location">
+                  <Input
+                    accessibilityLabel="Location"
+                    value={formState.location}
+                    onChangeText={(value) => {
+                      setFormState((current) => ({ ...current, location: value }));
+                    }}
+                    placeholder="Location"
+                  />
+                  <ToggleRow
+                    label="Show location publicly"
+                    value={formState.isLocationPublic}
+                    onToggle={() => {
+                      setFormState((current) => ({ ...current, isLocationPublic: !current.isLocationPublic }));
+                    }}
+                  />
+                </FieldCard>
+
+                <FieldCard title="Birth date">
+                  <Pressable
+                    accessibilityRole="button"
+                    accessibilityLabel="Open birth date picker"
+                    onPress={handleOpenBirthDateModal}
+                    style={{
+                      paddingHorizontal: spacing.md,
+                      paddingVertical: spacing.md,
+                      borderRadius: 14,
+                      borderWidth: 1,
+                      borderColor: colors.border,
+                      backgroundColor: colors.surface,
+                    }}
+                  >
+                    <Text style={{ color: colors.text }}>{formatBirthDateLabel(formState.birthDate)}</Text>
+                  </Pressable>
+                  {formErrors.birthDate ? <Text style={{ color: colors.danger }}>{formErrors.birthDate}</Text> : null}
+                  <ToggleRow
+                    label="Show birth date publicly"
+                    value={formState.isBirthDatePublic}
+                    onToggle={() => {
+                      setFormState((current) => ({ ...current, isBirthDatePublic: !current.isBirthDatePublic }));
+                    }}
+                  />
+                </FieldCard>
+
+                <FieldCard title="Bio">
+                  <Input
+                    accessibilityLabel="Bio"
+                    value={formState.bio}
+                    onChangeText={(value) => {
+                      setFormErrors((current) => ({ ...current, bio: undefined }));
+                      setFormState((current) => ({ ...current, bio: value }));
+                    }}
+                    placeholder="Tell people about yourself"
+                    multiline
+                    numberOfLines={5}
+                    style={{ minHeight: 120 }}
+                    inputStyle={{ minHeight: 108 }}
+                  />
+                  <Text style={{ color: colors.muted, textAlign: 'right' }}>
+                    {formState.bio.length}/{BIO_MAX_LENGTH}
+                  </Text>
+                  {formErrors.bio ? <Text style={{ color: colors.danger }}>{formErrors.bio}</Text> : null}
+                  <ToggleRow
+                    label="Show bio publicly"
+                    value={formState.isBioPublic}
+                    onToggle={() => {
+                      setFormState((current) => ({ ...current, isBioPublic: !current.isBioPublic }));
+                    }}
+                  />
+                  <Text style={{ color: colors.muted, fontSize: typography.caption }}>
+                    Bio privacy UI is ready, but it will start working after backend support is added.
+                  </Text>
+                </FieldCard>
+
+                {error ? <Text style={{ color: colors.danger }}>{error}</Text> : null}
+
+                <Button onPress={() => void handleSave()} disabled={isSaving || !isDirty}>
+                  {isSaving ? 'Saving...' : 'Save Changes'}
+                </Button>
+              </>
+            ) : (
+              <>
+                <Button variant="outline" onPress={() => void logout()}>
+                  Sign out
+                </Button>
+                <Pressable
+                  accessibilityRole="button"
+                  accessibilityLabel="Delete Account"
+                  onPress={() => {
+                    setDeleteError(undefined);
+                    setDeletePassword('');
+                    deletePasswordRef.current = '';
+                    setIsDeleteModalVisible(true);
+                  }}
+                  style={({ pressed }) => ({
+                    alignSelf: 'flex-start',
+                    paddingVertical: spacing.sm,
+                    opacity: pressed ? 0.75 : 1,
+                  })}
+                >
+                  <Text style={{ color: colors.danger, fontWeight: '700' }}>Delete Account</Text>
+                </Pressable>
+              </>
+            )}
+          </View>
+        ) : (
+          <View
+            style={{
+              padding: spacing.lg,
+              borderRadius: 20,
+              borderWidth: 1,
+              borderColor: colors.border,
+              backgroundColor: colors.surface,
+              gap: spacing.sm,
+            }}
+          >
+            <Text style={{ color: colors.text, fontSize: typography.subtitle, fontWeight: '800' }}>
+              Stories
+            </Text>
+            <Text style={{ color: colors.muted }}>
+              Stories are intentionally out of scope for this profile version and will be added later.
+            </Text>
+          </View>
+        )}
+      </ScrollView>
+
+      <Modal
+        animationType="slide"
+        transparent
+        visible={isDeleteModalVisible}
+        onRequestClose={() => {
+          if (!isDeleting) {
+            setIsDeleteModalVisible(false);
+          }
+        }}
+      >
+        <View
+          style={{
+            flex: 1,
+            backgroundColor: 'rgba(10, 10, 10, 0.35)',
+            justifyContent: 'flex-end',
+          }}
+        >
+          <Pressable
+            style={{ flex: 1 }}
+            onPress={() => {
+              if (!isDeleting) {
+                setIsDeleteModalVisible(false);
+              }
+            }}
+          />
+          <View
+            style={{
+              paddingHorizontal: spacing.lg,
+              paddingTop: spacing.lg,
+              paddingBottom: spacing.xl,
+              borderTopLeftRadius: 24,
+              borderTopRightRadius: 24,
+              backgroundColor: colors.background,
+              gap: spacing.md,
+            }}
+          >
+            <Text style={{ color: colors.danger, fontSize: typography.caption, fontWeight: '800', textTransform: 'uppercase' }}>
+              Delete account
+            </Text>
+            <Text style={{ color: colors.text, fontSize: typography.title, fontWeight: '800' }}>
+              This action cannot be undone
+            </Text>
+            <View
+              style={{
+                padding: spacing.md,
+                borderRadius: 18,
+                borderWidth: 1,
+                borderColor: colors.danger,
+                backgroundColor: colors.dangerSurface,
+                gap: spacing.sm,
+              }}
+            >
+              <Text style={{ color: colors.text }}>Your account will be permanently deleted.</Text>
+              <Text style={{ color: colors.text }}>
+                Your stories, comments, and likes will also be permanently deleted.
+              </Text>
+            </View>
+            <Input
+              accessibilityLabel="Re-enter your password"
+              value={deletePassword}
+              onChangeText={(value) => {
+                deletePasswordRef.current = value;
+                setDeletePassword(value);
+                if (deleteError) {
+                  setDeleteError(undefined);
+                }
+              }}
+              placeholder="Re-enter your password"
+              secureTextEntry
+            />
+            {deleteError ? <Text style={{ color: colors.danger }}>{deleteError}</Text> : null}
+            <Pressable
+              accessibilityRole="button"
+              accessibilityLabel="Confirm account deletion"
+              disabled={isDeleting}
+              onPress={() => void handleDeleteAccount()}
+              style={({ pressed }) => ({
+                width: '100%',
+                paddingHorizontal: spacing.md,
+                paddingVertical: spacing.md - 2,
+                borderRadius: 12,
+                alignItems: 'center',
+                justifyContent: 'center',
+                backgroundColor: colors.danger,
+                opacity: isDeleting ? 0.7 : pressed ? 0.85 : 1,
+              })}
+            >
+              <Text style={{ color: colors.background, fontWeight: '700' }}>
+                {isDeleting ? 'Deleting Account...' : 'Delete My Account'}
+              </Text>
+            </Pressable>
+            <Button
+              variant="outline"
+              onPress={() => {
+                setIsDeleteModalVisible(false);
+              }}
+              disabled={isDeleting}
+              fullWidth
+            >
+              Cancel
+            </Button>
+          </View>
+        </View>
+      </Modal>
+
+      <Modal
+        animationType="slide"
+        transparent
+        visible={isBirthDateModalVisible}
+        onRequestClose={() => setIsBirthDateModalVisible(false)}
+      >
+        <View
+          style={{
+            flex: 1,
+            backgroundColor: 'rgba(10, 10, 10, 0.35)',
+            justifyContent: 'flex-end',
+          }}
+        >
+          <Pressable style={{ flex: 1 }} onPress={() => setIsBirthDateModalVisible(false)} />
+          <View
+            style={{
+              paddingHorizontal: spacing.lg,
+              paddingTop: spacing.lg,
+              paddingBottom: spacing.xl,
+              borderTopLeftRadius: 24,
+              borderTopRightRadius: 24,
+              backgroundColor: colors.background,
               gap: spacing.md,
             }}
           >
             <Text style={{ color: colors.text, fontSize: typography.subtitle, fontWeight: '800' }}>
-              Edit profile
+              Select birth date
             </Text>
-            <Button
-              onPress={() => {
-                setSaveMessage(undefined);
-                setError(undefined);
-                setIsEditing((current) => {
-                  const nextValue = !current;
+            <Text style={{ color: colors.muted }}>
+              {birthYearDraft && birthDayDraft
+                ? `${MONTH_OPTIONS[birthMonthDraft]} ${birthDayDraft}, ${birthYearDraft}`
+                : 'Choose month, then enter day and year.'}
+            </Text>
 
-                  if (!nextValue) {
-                    setFormState(createFormState(profile));
-                  }
+            <View style={{ gap: spacing.sm }}>
+              <View style={{ gap: spacing.sm }}>
+                <Text style={{ color: colors.text, fontWeight: '700' }}>Month</Text>
+                <Pressable
+                  accessibilityRole="button"
+                  accessibilityLabel="Open month picker"
+                  onPress={() => setIsMonthPickerVisible((current) => !current)}
+                  style={{
+                    paddingHorizontal: spacing.md,
+                    paddingVertical: spacing.md,
+                    borderRadius: 14,
+                    borderWidth: 1,
+                    borderColor: colors.border,
+                    backgroundColor: colors.surface,
+                  }}
+                >
+                  <Text style={{ color: colors.text, fontWeight: '700' }}>{MONTH_OPTIONS[birthMonthDraft]}</Text>
+                </Pressable>
+                {isMonthPickerVisible ? (
+                  <View
+                    style={{
+                      borderRadius: 16,
+                      borderWidth: 1,
+                      borderColor: colors.border,
+                      backgroundColor: colors.surface,
+                      padding: spacing.sm,
+                      gap: spacing.xs,
+                    }}
+                  >
+                    {MONTH_OPTIONS.map((month, index) => {
+                      const active = index === birthMonthDraft;
 
-                  return nextValue;
-                });
-              }}
-              variant="outline"
-            >
-              <Text style={{ color: colors.text, fontWeight: '700' }}>
-                {isEditing ? 'Cancel' : 'Edit profile'}
+                      return (
+                        <Pressable
+                          key={month}
+                          accessibilityRole="button"
+                          accessibilityLabel={`Select ${month}`}
+                          onPress={() => {
+                            setBirthMonthDraft(index);
+                            setBirthDayDraft((current) =>
+                              clampDayInput(current, getDraftMaxBirthDay(birthYearDraft, index)),
+                            );
+                            setIsMonthPickerVisible(false);
+                          }}
+                          style={{
+                            paddingHorizontal: spacing.md,
+                            paddingVertical: spacing.sm,
+                            borderRadius: 12,
+                            backgroundColor: active ? colors.infoSurface : colors.background,
+                          }}
+                        >
+                          <Text style={{ color: active ? colors.primary : colors.text, fontWeight: active ? '700' : '500' }}>
+                            {month}
+                          </Text>
+                        </Pressable>
+                      );
+                    })}
+                  </View>
+                ) : null}
+              </View>
+
+              <View style={{ flexDirection: 'row', gap: spacing.sm }}>
+                <View style={{ flex: 1, gap: spacing.sm }}>
+                  <Text style={{ color: colors.text, fontWeight: '700' }}>Day</Text>
+                  <View
+                    style={{
+                      flexDirection: 'row',
+                      alignItems: 'center',
+                      justifyContent: 'space-between',
+                      gap: spacing.sm,
+                    }}
+                  >
+                    <Button
+                      variant="outline"
+                      onPress={() => {
+                        const nextDay = Number.isFinite(normalizedBirthDay)
+                          ? Math.max(normalizedBirthDay - 1, 1)
+                          : 1;
+                        setBirthDayDraft(String(nextDay));
+                      }}
+                    >
+                      -
+                    </Button>
+                    <View style={{ flex: 1 }}>
+                      <Input
+                        accessibilityLabel="Birth day"
+                        value={birthDayDraft}
+                        onChangeText={(value) => {
+                          setBirthDayDraft(clampDayInput(value, maxBirthDay));
+                        }}
+                        placeholder="DD"
+                        keyboardType="numeric"
+                      />
+                    </View>
+                    <Button
+                      variant="outline"
+                      onPress={() => {
+                        const nextDay = Number.isFinite(normalizedBirthDay)
+                          ? Math.min(normalizedBirthDay + 1, maxBirthDay)
+                          : 1;
+                        setBirthDayDraft(String(nextDay));
+                      }}
+                    >
+                      +
+                    </Button>
+                  </View>
+                  <Text style={{ color: colors.muted, fontSize: typography.caption }}>
+                    Day range: 1-{maxBirthDay}
+                  </Text>
+                </View>
+                <View style={{ flex: 1, gap: spacing.sm }}>
+                  <Text style={{ color: colors.text, fontWeight: '700' }}>Year</Text>
+                  <Input
+                    accessibilityLabel="Birth year"
+                    value={birthYearDraft}
+                    onChangeText={(value) => {
+                      const normalizedYearValue = value.replace(/[^0-9]/g, '').slice(0, 4);
+                      setBirthYearDraft(normalizedYearValue);
+                      setBirthDayDraft((current) =>
+                        clampDayInput(current, getDraftMaxBirthDay(normalizedYearValue, birthMonthDraft)),
+                      );
+                    }}
+                    placeholder="YYYY"
+                    keyboardType="numeric"
+                  />
+                </View>
+              </View>
+              <Text style={{ color: colors.muted, fontSize: typography.caption }}>
+                Enter the calendar day and full year. We will validate the date when you save it.
               </Text>
-            </Button>
+            </View>
+
+            <View style={{ flexDirection: 'row', gap: spacing.sm }}>
+              <Button
+                  onPress={() => {
+                    const clampedDate = clampBirthDateParts(birthYearDraft, birthMonthDraft, birthDayDraft);
+                    const normalizedDay = clampedDate.day;
+                    const normalizedYear = clampedDate.year;
+                    const nextBirthDate =
+                      normalizedDay && normalizedYear
+                      ? `${normalizedYear.padStart(4, '0')}-${`${clampedDate.monthIndex + 1}`.padStart(2, '0')}-${normalizedDay.padStart(2, '0')}`
+                      : '';
+                  setFormErrors((current) => ({ ...current, birthDate: undefined }));
+                  setFormState((current) => ({ ...current, birthDate: nextBirthDate }));
+                  setBirthMonthDraft(clampedDate.monthIndex);
+                  setBirthDayDraft(clampedDate.day);
+                  setBirthYearDraft(clampedDate.year);
+                  setIsBirthDateModalVisible(false);
+                }}
+              >
+                Use Date
+              </Button>
+              <Button
+                variant="outline"
+                onPress={() => {
+                  setFormErrors((current) => ({ ...current, birthDate: undefined }));
+                  setFormState((current) => ({ ...current, birthDate: '' }));
+                  setIsBirthDateModalVisible(false);
+                }}
+              >
+                Clear
+              </Button>
+            </View>
           </View>
-
-          {saveMessage ? <Text style={{ color: colors.success }}>{saveMessage}</Text> : null}
-
-          {isEditing ? (
-            <>
-              <Input
-                accessibilityLabel="Username"
-                value={formState.username}
-                onChangeText={(value) => {
-                  setSaveMessage(undefined);
-                  setFormState((current) => ({ ...current, username: value }));
-                }}
-                placeholder="Username"
-              />
-              <Input
-                accessibilityLabel="Location"
-                value={formState.location}
-                onChangeText={(value) => {
-                  setSaveMessage(undefined);
-                  setFormState((current) => ({ ...current, location: value }));
-                }}
-                placeholder="Location"
-              />
-              <Input
-                accessibilityLabel="Birth date"
-                value={formState.birthDate}
-                onChangeText={(value) => {
-                  setSaveMessage(undefined);
-                  setFormState((current) => ({ ...current, birthDate: value }));
-                }}
-                placeholder="YYYY-MM-DD"
-              />
-              <Input
-                accessibilityLabel="Bio"
-                value={formState.bio}
-                onChangeText={(value) => {
-                  setSaveMessage(undefined);
-                  setFormState((current) => ({ ...current, bio: value }));
-                }}
-                placeholder="Tell people about yourself"
-                style={{ minHeight: 110, textAlignVertical: 'top' as const }}
-              />
-
-              <ToggleRow
-                label="Show username on your public profile"
-                value={formState.isUsernamePublic}
-                onToggle={() => {
-                  setSaveMessage(undefined);
-                  setFormState((current) => ({ ...current, isUsernamePublic: !current.isUsernamePublic }));
-                }}
-              />
-              <ToggleRow
-                label="Show location publicly"
-                value={formState.isLocationPublic}
-                onToggle={() => {
-                  setSaveMessage(undefined);
-                  setFormState((current) => ({ ...current, isLocationPublic: !current.isLocationPublic }));
-                }}
-              />
-              <ToggleRow
-                label="Show birth date publicly"
-                value={formState.isBirthDatePublic}
-                onToggle={() => {
-                  setSaveMessage(undefined);
-                  setFormState((current) => ({ ...current, isBirthDatePublic: !current.isBirthDatePublic }));
-                }}
-              />
-              <ToggleRow
-                label="Show profile photo publicly"
-                value={formState.isPhotoPublic}
-                onToggle={() => {
-                  setSaveMessage(undefined);
-                  setFormState((current) => ({ ...current, isPhotoPublic: !current.isPhotoPublic }));
-                }}
-              />
-
-              {error ? <Text style={{ color: colors.danger }}>{error}</Text> : null}
-
-              {isDirty || isSaving ? (
-                <Button onPress={() => void handleSave()} disabled={isSaving}>
-                  {isSaving ? 'Saving...' : 'Save changes'}
-                </Button>
-              ) : null}
-            </>
-          ) : (
-            <Button variant="outline" onPress={() => void logout()}>
-              Sign out
-            </Button>
-          )}
         </View>
-      ) : (
-        <View
-          style={{
-            padding: spacing.lg,
-            borderRadius: 20,
-            borderWidth: 1,
-            borderColor: colors.border,
-            backgroundColor: colors.surface,
-            gap: spacing.sm,
-          }}
-        >
-          <Text style={{ color: colors.text, fontSize: typography.subtitle, fontWeight: '800' }}>
-            Stories
-          </Text>
-          <Text style={{ color: colors.muted }}>
-            Stories are intentionally out of scope for this profile version and will be added later.
-          </Text>
-        </View>
-      )}
-    </ScrollView>
+      </Modal>
+    </>
   );
 }

--- a/mobile/src/features/profile/presentation/screens/__tests__/ProfileScreen.test.tsx
+++ b/mobile/src/features/profile/presentation/screens/__tests__/ProfileScreen.test.tsx
@@ -1,6 +1,30 @@
 import React from 'react';
-import { fireEvent, render, screen } from '@testing-library/react-native';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react-native';
+import * as ImagePicker from 'expo-image-picker';
 import { ProfileScreen } from '../ProfileScreen';
+import { navigationRef } from '../../../../../app/navigation/navigationRef';
+
+const mockToastSuccess = jest.fn();
+const mockUpdateUser = jest.fn(async () => undefined);
+const mockLogout = jest.fn(async () => undefined);
+const mockAuthClear = jest.fn(async () => undefined);
+
+jest.mock('../../../../auth/application/services', () => ({
+  authService: {
+    clear: mockAuthClear,
+  },
+}));
+
+jest.mock('../../../../../shared/hooks/useToast', () => ({
+  useToast: () => ({
+    toast: {
+      success: mockToastSuccess,
+      error: jest.fn(),
+      info: jest.fn(),
+      show: jest.fn(),
+    },
+  }),
+}));
 
 jest.mock('../../../../auth', () => ({
   useAuth: () => ({
@@ -9,8 +33,10 @@ jest.mock('../../../../auth', () => ({
       email: 'traveler@example.com',
       username: 'Traveler',
       role: 'user',
+      isUsernamePublic: true,
     },
-    updateUser: jest.fn(async () => undefined),
+    updateUser: mockUpdateUser,
+    logout: mockLogout,
   }),
 }));
 
@@ -19,10 +45,12 @@ const selfProfile = {
   username: 'Traveler',
   email: 'traveler@example.com',
   totalPoints: 12,
+  publishedStoryCount: 4,
   dateJoined: '2026-01-15T10:00:00Z',
   bio: 'Collecting neighborhood memories.',
   location: 'Istanbul',
   birthDate: '1995-05-20',
+  profilePhoto: 'https://cdn.example.com/original.jpg',
   isUsernamePublic: true,
   isEmailVerified: true,
   isLocationPublic: true,
@@ -39,9 +67,15 @@ const publicProfile = {
   bio: 'I write about harbor neighborhoods.',
   location: 'Izmir',
   birthYear: 1988,
+  profilePhoto: 'https://cdn.example.com/public.jpg',
 };
 
 describe('ProfileScreen', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    navigationRef.redirectToPublic = jest.fn();
+  });
+
   it('renders a loading state while profile data is being fetched', () => {
     render(
       <ProfileScreen
@@ -52,7 +86,7 @@ describe('ProfileScreen', () => {
     expect(screen.getByLabelText('Loading profile')).toBeTruthy();
   });
 
-  it('renders self profile data with edit controls', async () => {
+  it('opens the edit profile form with photo actions and privacy toggles', async () => {
     render(
       <ProfileScreen
         mode="self"
@@ -61,21 +95,153 @@ describe('ProfileScreen', () => {
     );
 
     expect(await screen.findByText('Traveler')).toBeTruthy();
-    expect(screen.getByText('traveler@example.com')).toBeTruthy();
-    expect(screen.getAllByText('Edit profile')).toHaveLength(2);
 
-    fireEvent.press(screen.getAllByText('Edit profile').at(-1)!);
+    fireEvent.press(screen.getByText('Edit Profile'));
 
-    expect(screen.getByDisplayValue('Traveler')).toBeTruthy();
-    expect(screen.getByDisplayValue('Istanbul')).toBeTruthy();
-    expect(screen.getByDisplayValue('Collecting neighborhood memories.')).toBeTruthy();
-    expect(screen.queryByText('Save changes')).toBeNull();
+    expect(screen.getByLabelText('Username')).toBeTruthy();
+    expect(screen.getByLabelText('Location')).toBeTruthy();
+    expect(screen.getByLabelText('Bio')).toBeTruthy();
+    expect(screen.getByText('Choose Photo')).toBeTruthy();
+    expect(screen.getByText('Remove Photo')).toBeTruthy();
+    expect(screen.getAllByRole('switch')).toHaveLength(5);
   });
 
-  it('saves changes in self mode', async () => {
-    const updateCurrentProfile = jest.fn(async () => ({
+  it('shows a photo preview after selecting a valid image and can remove it before saving', async () => {
+    jest.spyOn(ImagePicker, 'launchImageLibraryAsync').mockResolvedValue({
+      canceled: false,
+      assets: [
+        {
+          uri: 'file:///picked.png',
+          fileName: 'picked.png',
+          fileSize: 400_000,
+          mimeType: 'image/png',
+        },
+      ],
+    } as ImagePicker.ImagePickerSuccessResult);
+
+    render(
+      <ProfileScreen
+        mode="self"
+        getCurrentProfile={async () => selfProfile}
+      />,
+    );
+
+    await screen.findByText('Traveler');
+    fireEvent.press(screen.getByText('Edit Profile'));
+    fireEvent.press(screen.getByText('Choose Photo'));
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('Selected profile photo')).toBeTruthy();
+    });
+
+    fireEvent.press(screen.getByText('Remove Photo'));
+
+    await waitFor(() => {
+      expect(screen.queryByLabelText('Selected profile photo')).toBeNull();
+    });
+  });
+
+  it('validates selected photo type and size before save', async () => {
+    jest.spyOn(ImagePicker, 'launchImageLibraryAsync').mockResolvedValueOnce({
+      canceled: false,
+      assets: [
+        {
+          uri: 'file:///picked.gif',
+          fileName: 'picked.gif',
+          fileSize: 100_000,
+          mimeType: 'image/gif',
+        },
+      ],
+    } as ImagePicker.ImagePickerSuccessResult);
+
+    render(
+      <ProfileScreen
+        mode="self"
+        getCurrentProfile={async () => selfProfile}
+      />,
+    );
+
+    await screen.findByText('Traveler');
+    fireEvent.press(screen.getByText('Edit Profile'));
+    fireEvent.press(screen.getByText('Choose Photo'));
+
+    expect(await screen.findByText('Profile photo must be a JPG or PNG image.')).toBeTruthy();
+
+    jest.spyOn(ImagePicker, 'launchImageLibraryAsync').mockResolvedValueOnce({
+      canceled: false,
+      assets: [
+        {
+          uri: 'file:///picked.jpg',
+          fileName: 'picked.jpg',
+          fileSize: 2_100_000,
+          mimeType: 'image/jpeg',
+        },
+      ],
+    } as ImagePicker.ImagePickerSuccessResult);
+
+    fireEvent.press(screen.getByText('Choose Photo'));
+
+    expect(await screen.findByText('Photo must be 2 MB or smaller.')).toBeTruthy();
+  });
+
+  it('validates bio length and birth date range before saving', async () => {
+    const invalidProfile = {
+      ...selfProfile,
+      birthDate: '1899-12-31',
+    };
+    const updateCurrentProfile = jest.fn(async () => invalidProfile);
+
+    render(
+      <ProfileScreen
+        mode="self"
+        getCurrentProfile={async () => invalidProfile}
+        updateCurrentProfile={updateCurrentProfile}
+      />,
+    );
+
+    await screen.findByText('Traveler');
+    fireEvent.press(screen.getByText('Edit Profile'));
+    fireEvent.changeText(screen.getByLabelText('Bio'), 'a'.repeat(281));
+    fireEvent.press(screen.getByText('Save Changes'));
+
+    expect(await screen.findByText('Bio must be 280 characters or fewer.')).toBeTruthy();
+    expect(screen.getByText('Birth date must be after 1900.')).toBeTruthy();
+    expect(updateCurrentProfile).not.toHaveBeenCalled();
+  });
+
+  it('saves profile changes, uploads the photo, and updates auth user state', async () => {
+    jest.spyOn(ImagePicker, 'launchImageLibraryAsync').mockResolvedValue({
+      canceled: false,
+      assets: [
+        {
+          uri: 'file:///picked.jpg',
+          fileName: 'picked.jpg',
+          fileSize: 350_000,
+          mimeType: 'image/jpeg',
+        },
+      ],
+    } as ImagePicker.ImagePickerSuccessResult);
+
+    const updateCurrentProfile = jest.fn(async (input) => ({
+      ...selfProfile,
+      username: input.username,
+      location: input.location,
+      bio: input.bio,
+      birthDate: input.birthDate,
+      isUsernamePublic: input.isUsernamePublic,
+      isLocationPublic: input.isLocationPublic,
+      isBirthDatePublic: input.isBirthDatePublic,
+      isPhotoPublic: input.isPhotoPublic,
+    }));
+    const uploadProfilePhoto = jest.fn(async () => ({
       ...selfProfile,
       username: 'Traveler Updated',
+      location: 'Ankara',
+      bio: 'Updated bio',
+      profilePhoto: 'https://cdn.example.com/updated.jpg',
+      isLocationPublic: false,
+      isBirthDatePublic: true,
+      isPhotoPublic: false,
     }));
 
     render(
@@ -83,25 +249,66 @@ describe('ProfileScreen', () => {
         mode="self"
         getCurrentProfile={async () => selfProfile}
         updateCurrentProfile={updateCurrentProfile}
+        uploadProfilePhoto={uploadProfilePhoto}
       />,
     );
 
     await screen.findByText('Traveler');
-    fireEvent.press(screen.getAllByText('Edit profile').at(-1)!);
+    fireEvent.press(screen.getByText('Edit Profile'));
     fireEvent.changeText(screen.getByLabelText('Username'), 'Traveler Updated');
-    expect(await screen.findByText('Save changes')).toBeTruthy();
-    fireEvent.press(screen.getByText('Save changes'));
+    fireEvent.changeText(screen.getByLabelText('Location'), 'Ankara');
+    fireEvent.changeText(screen.getByLabelText('Bio'), 'Updated bio');
 
-    expect(updateCurrentProfile).toHaveBeenCalledWith(
+    const switches = screen.getAllByRole('switch');
+    fireEvent.press(switches[0]);
+    fireEvent.press(switches[1]);
+    fireEvent.press(switches[2]);
+    fireEvent.press(switches[3]);
+    fireEvent.press(switches[4]);
+
+    fireEvent.press(screen.getByLabelText('Open birth date picker'));
+    fireEvent.press(screen.getByText('Use Date'));
+
+    fireEvent.press(screen.getByText('Choose Photo'));
+    await waitFor(() => {
+      expect(screen.getByLabelText('Selected profile photo')).toBeTruthy();
+    });
+
+    fireEvent.press(screen.getByText('Save Changes'));
+
+    await waitFor(() => {
+      expect(updateCurrentProfile).toHaveBeenCalledWith(
+        expect.objectContaining({
+          username: 'Traveler Updated',
+          location: 'Ankara',
+          bio: 'Updated bio',
+          isLocationPublic: false,
+          isBirthDatePublic: true,
+          isPhotoPublic: false,
+        }),
+      );
+    });
+
+    expect(uploadProfilePhoto).toHaveBeenCalledWith(
       expect.objectContaining({
-        username: 'Traveler Updated',
+        uri: 'file:///picked.jpg',
+        fileName: 'picked.jpg',
+        mimeType: 'image/jpeg',
       }),
     );
-    expect(await screen.findByText('Profile updated successfully.')).toBeTruthy();
+
+    await waitFor(() => {
+      expect(mockUpdateUser).toHaveBeenCalledWith(
+        expect.objectContaining({
+          username: 'Traveler Updated',
+        }),
+      );
+      expect(mockToastSuccess).toHaveBeenCalledWith('Profile updated successfully.');
+    });
   });
 
-  it('renders a public profile in read-only mode', async () => {
-    render(
+  it('renders public profile fields returned by the API and falls back to anonymous user when username is hidden', async () => {
+    const { rerender } = render(
       <ProfileScreen
         mode="public"
         userId="12"
@@ -110,25 +317,43 @@ describe('ProfileScreen', () => {
     );
 
     expect(await screen.findByText('Aylin')).toBeTruthy();
-    expect(screen.getByText('4')).toBeTruthy();
-    expect(screen.queryByText('Edit profile')).toBeNull();
-    expect(screen.queryByText('Save changes')).toBeNull();
-    expect(screen.getByText('Stories are intentionally out of scope for this profile version and will be added later.')).toBeTruthy();
-  });
+    expect(screen.getByText('Izmir')).toBeTruthy();
+    expect(screen.getByText('1988')).toBeTruthy();
+    expect(screen.getByText('I write about harbor neighborhoods.')).toBeTruthy();
+    expect(screen.queryByText('Edit Profile')).toBeNull();
 
-  it('shows anonymous user when the public profile username is hidden', async () => {
-    render(
+    rerender(
       <ProfileScreen
         mode="public"
         userId="12"
         getPublicProfile={async () => ({
           ...publicProfile,
           username: null,
+          location: null,
+          birthYear: null,
         })}
       />,
     );
 
     expect(await screen.findByText('Anonymous user')).toBeTruthy();
+    expect(screen.queryByText('Izmir')).toBeNull();
+    expect(screen.queryByText('1988')).toBeNull();
+  });
+
+  it('shows the bio privacy pending note in the edit form', async () => {
+    render(
+      <ProfileScreen
+        mode="self"
+        getCurrentProfile={async () => selfProfile}
+      />,
+    );
+
+    await screen.findByText('Traveler');
+    fireEvent.press(screen.getByText('Edit Profile'));
+
+    expect(
+      screen.getByText('Bio privacy UI is ready, but it will start working after backend support is added.'),
+    ).toBeTruthy();
   });
 
   it('shows an error state when profile loading fails', async () => {
@@ -143,5 +368,54 @@ describe('ProfileScreen', () => {
 
     expect(await screen.findByText('Profile unavailable')).toBeTruthy();
     expect(screen.getByText('Network error')).toBeTruthy();
+  });
+
+  it('renders delete account action and requires password before deletion', async () => {
+    const deleteAccount = jest.fn(async () => undefined);
+
+    render(
+      <ProfileScreen
+        mode="self"
+        getCurrentProfile={async () => selfProfile}
+        deleteAccount={deleteAccount}
+      />,
+    );
+
+    await screen.findByText('Traveler');
+    fireEvent.press(screen.getByText('Delete Account'));
+
+    expect(screen.getByText('This action cannot be undone')).toBeTruthy();
+    expect(screen.getByText('Delete My Account')).toBeTruthy();
+
+    fireEvent.press(screen.getByLabelText('Confirm account deletion'));
+
+    expect(await screen.findByText('Re-enter your password to continue.')).toBeTruthy();
+    expect(deleteAccount).not.toHaveBeenCalled();
+  });
+
+  it('can dismiss the delete account modal without triggering deletion', async () => {
+    const deleteAccount = jest.fn(async () => undefined);
+
+    render(
+      <ProfileScreen
+        mode="self"
+        getCurrentProfile={async () => selfProfile}
+        deleteAccount={deleteAccount}
+      />,
+    );
+
+    await screen.findByText('Traveler');
+    fireEvent.press(screen.getByText('Delete Account'));
+    expect(screen.getByText('This action cannot be undone')).toBeTruthy();
+
+    fireEvent.press(screen.getByText('Cancel'));
+
+    await waitFor(() => {
+      expect(screen.queryByText('This action cannot be undone')).toBeNull();
+    });
+    expect(deleteAccount).not.toHaveBeenCalled();
+    expect(mockAuthClear).not.toHaveBeenCalled();
+    expect(navigationRef.redirectToPublic).not.toHaveBeenCalled();
+    expect(mockToastSuccess).not.toHaveBeenCalled();
   });
 });

--- a/mobile/src/shared/ui/Input/Input.tsx
+++ b/mobile/src/shared/ui/Input/Input.tsx
@@ -34,6 +34,9 @@ interface InputProps {
   trailingActionAccessibilityLabel?: string;
   onTrailingActionPress?: () => void;
   trailingElement?: ReactNode;
+  multiline?: boolean;
+  numberOfLines?: number;
+  inputStyle?: StyleProp<TextStyle>;
 }
 
 export const Input = forwardRef<TextInput, InputProps>(function Input({
@@ -58,6 +61,9 @@ export const Input = forwardRef<TextInput, InputProps>(function Input({
   trailingActionAccessibilityLabel,
   onTrailingActionPress,
   trailingElement,
+  multiline = false,
+  numberOfLines,
+  inputStyle,
 }: InputProps, ref) {
   const { colors, spacing, typography } = useAppTheme();
   const hasTrailingContent = Boolean(trailingElement || (trailingActionLabel && onTrailingActionPress));
@@ -89,19 +95,25 @@ export const Input = forwardRef<TextInput, InputProps>(function Input({
         keyboardType={keyboardType}
         autoCorrect={autoCorrect}
         editable={editable}
+        multiline={multiline}
+        numberOfLines={numberOfLines}
         textContentType={textContentType}
         autoComplete={autoComplete}
         returnKeyType={returnKeyType}
         accessibilityLabel={accessibilityLabel}
         blurOnSubmit={blurOnSubmit}
         submitBehavior={submitBehavior}
-        style={{
-          flex: 1,
-          paddingHorizontal: spacing.md,
-          paddingVertical: spacing.md - 2,
-          color: colors.text,
-          fontSize: typography.body,
-        }}
+        style={[
+          {
+            flex: 1,
+            paddingHorizontal: spacing.md,
+            paddingVertical: spacing.md - 2,
+            color: colors.text,
+            fontSize: typography.body,
+            textAlignVertical: multiline ? 'top' : 'center',
+          },
+          inputStyle,
+        ]}
       />
       {trailingElement}
       {!trailingElement && trailingActionLabel && onTrailingActionPress ? (


### PR DESCRIPTION
# 📝 Description
Fixes #198 

Enhances the mobile profile experience to support fuller profile management on the profile screen.

Included in this PR:
- Added an editable profile flow from the mobile profile screen
- Added profile photo upload, preview, validation, and remove actions
- Added editable optional profile fields for location, birth date, and bio
- Added per-field privacy toggles for username, photo, location, birth date, and bio
- Added a mobile-friendly custom birth date picker with month selection, manual day/year input, range clamping, and future-date protection
- Added loading and success feedback for profile save
- Restored the mobile delete account flow in the updated profile UI
- Added and updated mobile unit tests for profile editing, validation, photo handling, public profile rendering, and delete account modal behavior

Known limitation:
- Bio privacy is currently UI-only readiness on mobile.
- The backend public profile response does not yet support bio visibility control, so the bio privacy toggle cannot be fully wired end-to-end yet.
- The UI is prepared so backend integration should be straightforward once the backend exposes the necessary field(s).

# 📊 Type of Change
- [x]  Bug fix
- [x]  New feature
- [ ]  Refactoring
- [ ]  Documentation
 
# ✅ Acceptance Criteria / Checklist
- [x] Project builds successfully
- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, especially in hard-to-understand parts
- [x] I have performed a self-review of my code
- [x] I have added/updated tests
- [x] New and existing unit tests pass locally with my changes

# 📸 Screenshots / Recordings
<!-- If applicable !-->
- Profile edit form with photo controls and privacy toggles
- Birth date picker modal with month selector and day/year entry
- Public profile rendering
- Delete account bottom sheet

# ⏱️ Estimated Review Time
- [ ] < 5 min
- [x] 5-15 min
- [ ] > 15 min
