### PR TITLE
fix: delete user comments and story media files on hard account deletion

### DIFF
--- a/backend/apps/users/services.py
+++ b/backend/apps/users/services.py
@@ -171,25 +171,15 @@ def delete_account(user: User, hard_delete: bool, refresh_token: str = '') -> No
     """
     Deletes or deactivates a user account based on the hard_delete flag.
 
-    Hard delete order:
-      1. Profile photo file removed from disk (FileField.delete avoids orphan).
-      2. Story media files removed from disk — queryset .delete() bypasses
-         FileField.delete(), so files must be explicitly removed before the rows go.
-      3. User's comments on other people's stories deleted — Comment.author has
-         on_delete=SET_NULL, so without this step they would be anonymized instead
-         of removed, contradicting hard delete semantics.
-      4. User's own stories deleted (cascades MediaItem rows, comments on those
-         stories, likes, saved_stories, reports targeting those stories).
-      5. User row deleted (cascades UserProfile, EmailVerificationCode, Like,
-         SavedStory, UserBadge, Notification.recipient, NotificationPreference).
+    Hard delete: cleans up storage files first (profile photo, story media — queryset
+    .delete() bypasses FileField.delete()), explicitly deletes the user's comments on
+    other stories (Comment.author is SET_NULL, so they would survive otherwise), then
+    deletes the user's stories and finally the user row via cascade.
 
-    Soft delete: sets is_active=False to block login, then bulk-sets story.user=NULL
-    to anonymize community content without removing it. Comments are kept — consistent
-    with the story anonymization policy (community content outlives the account).
+    Soft delete: sets is_active=False and anonymizes the user's stories (story.user=NULL).
+    Comments and all other content are kept — community content outlives the account.
 
-    In both cases, if a non-empty refresh_token is provided it is blacklisted.
-    TokenError is silently ignored — a stale or already-blacklisted token is harmless
-    once the account is gone or inactive.
+    If a refresh_token is provided it is blacklisted; TokenError is silently ignored.
     """
     from apps.stories.models import Story  # local import to avoid circular imports
     from apps.media.models import MediaItem  # local import to avoid circular imports

--- a/backend/apps/users/services.py
+++ b/backend/apps/users/services.py
@@ -171,19 +171,29 @@ def delete_account(user: User, hard_delete: bool, refresh_token: str = '') -> No
     """
     Deletes or deactivates a user account based on the hard_delete flag.
 
-    Hard delete: removes profile photo file, explicitly deletes all user stories
-    (required because Story.user has on_delete=SET_NULL — without this the stories
-    would be anonymized instead of removed), then deletes the User row (cascades
-    UserProfile and EmailVerificationCode).
+    Hard delete order:
+      1. Profile photo file removed from disk (FileField.delete avoids orphan).
+      2. Story media files removed from disk — queryset .delete() bypasses
+         FileField.delete(), so files must be explicitly removed before the rows go.
+      3. User's comments on other people's stories deleted — Comment.author has
+         on_delete=SET_NULL, so without this step they would be anonymized instead
+         of removed, contradicting hard delete semantics.
+      4. User's own stories deleted (cascades MediaItem rows, comments on those
+         stories, likes, saved_stories, reports targeting those stories).
+      5. User row deleted (cascades UserProfile, EmailVerificationCode, Like,
+         SavedStory, UserBadge, Notification.recipient, NotificationPreference).
 
     Soft delete: sets is_active=False to block login, then bulk-sets story.user=NULL
-    to anonymize community content without removing it.
+    to anonymize community content without removing it. Comments are kept — consistent
+    with the story anonymization policy (community content outlives the account).
 
     In both cases, if a non-empty refresh_token is provided it is blacklisted.
     TokenError is silently ignored — a stale or already-blacklisted token is harmless
     once the account is gone or inactive.
     """
     from apps.stories.models import Story  # local import to avoid circular imports
+    from apps.media.models import MediaItem  # local import to avoid circular imports
+    from apps.interactions.models import Comment  # local import to avoid circular imports
 
     if refresh_token:
         try:
@@ -194,6 +204,9 @@ def delete_account(user: User, hard_delete: bool, refresh_token: str = '') -> No
 
     if hard_delete:
         delete_profile_photo(user)
+        for item in MediaItem.objects.filter(story__user=user).only('file'):
+            item.file.delete(save=False)
+        Comment.objects.filter(author=user).delete()
         Story.objects.filter(user=user).delete()
         user.delete()
     else:

--- a/backend/apps/users/tests/test_services.py
+++ b/backend/apps/users/tests/test_services.py
@@ -460,6 +460,56 @@ class TestDeleteAccount:
     def test_malformed_refresh_token_does_not_raise(self):
         delete_account(self.user, hard_delete=True, refresh_token='not-a-token')
 
+    def test_hard_delete_removes_user_comments_on_other_stories(self):
+        from apps.interactions.models import Comment
+        other_user = User.objects.create_user(
+            email='other@example.com', username='otheruser', password='Password1'
+        )
+        other_story = Story.objects.create(
+            user=other_user, title='Other', narrative='N',
+            status=Story.STATUS_PUBLISHED,
+            location_lat=Decimal('0'), location_lng=Decimal('0'),
+            location_name='P', time_type=Story.TIME_EXACT, year=2000,
+        )
+        comment = Comment.objects.create(story=other_story, author=self.user, text='Hello')
+        delete_account(self.user, hard_delete=True)
+        assert not Comment.objects.filter(pk=comment.pk).exists()
+
+    def test_hard_delete_deletes_story_media_files(self):
+        from apps.media.models import MediaItem
+        from django.core.files.base import ContentFile
+        story = self._make_story()
+        item = MediaItem.objects.create(
+            story=story,
+            file=ContentFile(b'fake media', name='test.jpg'),
+            media_type='image',
+            file_size=10,
+            original_filename='test.jpg',
+        )
+        file_name = item.file.name
+        assert default_storage.exists(file_name)
+        delete_account(self.user, hard_delete=True)
+        assert not default_storage.exists(file_name)
+
+    def test_hard_delete_with_no_comments_does_not_raise(self):
+        delete_account(self.user, hard_delete=True)
+
+    def test_soft_delete_does_not_remove_user_comments(self):
+        from apps.interactions.models import Comment
+        other_user = User.objects.create_user(
+            email='other2@example.com', username='otheruser2', password='Password1'
+        )
+        other_story = Story.objects.create(
+            user=other_user, title='Other', narrative='N',
+            status=Story.STATUS_PUBLISHED,
+            location_lat=Decimal('0'), location_lng=Decimal('0'),
+            location_name='P', time_type=Story.TIME_EXACT, year=2000,
+        )
+        comment = Comment.objects.create(story=other_story, author=self.user, text='Hello')
+        delete_account(self.user, hard_delete=False)
+        # Comment survives on soft delete — community content is preserved
+        assert Comment.objects.filter(pk=comment.pk).exists()
+
 
 # ── delete_profile_photo ──────────────────────────────────────────────────────
 


### PR DESCRIPTION
# 📝 Description
Fixes #425   
**Note:** Although the issue description may also mention likes, this fix only addresses comments and story media files. Likes were already being removed correctly through cascade behavior, so there was no issue on that side.

This PR fixes hard account deletion behavior by making sure user comments on other users’ stories are removed and story media files are deleted from storage during hard delete.

### What changed
- Updated `delete_account(...)` hard delete flow in `users/services.py`
- Explicitly delete story media files from storage before deleting story rows
- Explicitly delete the user’s comments on other users’ stories during hard delete
- Kept soft delete behavior unchanged: stories are anonymized and comments are preserved
- Added test coverage for:
  - deleting user comments on other users’ stories during hard delete
  - deleting story media files from storage during hard delete
  - preserving comments during soft delete
  - no-error behavior when no comments exist

### Why this change is needed
- `Comment.author` uses `on_delete=SET_NULL`, so without explicit deletion, comments on other users’ stories would be anonymized instead of removed, which does not match hard delete semantics
- media file rows may be deleted through queryset deletion, but storage files themselves are not automatically removed unless explicitly deleted beforehand

# 📊 Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Refactoring
- [ ] Documentation
 
# ✅ Acceptance Criteria / Checklist
- [x] Project builds successfully
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, especially in hard-to-understand parts
- [x] I have performed a self-review of my code
- [x] I have added/updated tests
- [x] New and existing unit tests pass locally with my changes

# 📸 Screenshots / Recordings
<!-- If applicable !-->

# ⏱️ Estimated Review Time
- [x] < 5 min
- [ ] 5-15 min
- [ ] > 15 min