### PR TITLE
Feat/tag endpoints

### DIFF
--- a/backend/apps/tags/admin.py
+++ b/backend/apps/tags/admin.py
@@ -1,1 +1,12 @@
-# admin.py — tags
+from django.contrib import admin
+
+from .models import Tag
+
+
+@admin.register(Tag)
+class TagAdmin(admin.ModelAdmin):
+    """Admin view for Tag — supports search and filtering by predefined status."""
+
+    list_display = ['name', 'is_predefined', 'story_count']
+    list_filter = ['is_predefined']
+    search_fields = ['name']

--- a/backend/apps/tags/migrations/0002_seed_predefined_tags.py
+++ b/backend/apps/tags/migrations/0002_seed_predefined_tags.py
@@ -1,0 +1,27 @@
+from django.db import migrations
+
+from apps.tags.predefined import PREDEFINED_TAGS
+
+
+def seed_predefined_tags(apps, schema_editor):
+    Tag = apps.get_model('tags', 'Tag')
+    for name in PREDEFINED_TAGS:
+        Tag.objects.update_or_create(name=name, defaults={'is_predefined': True})
+
+
+def unseed_predefined_tags(apps, schema_editor):
+    # On reverse: mark these tags as no longer predefined rather than deleting them,
+    # since user-created stories may already reference them via StoryTag.
+    Tag = apps.get_model('tags', 'Tag')
+    Tag.objects.filter(name__in=PREDEFINED_TAGS).update(is_predefined=False)
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('tags', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.RunPython(seed_predefined_tags, reverse_code=unseed_predefined_tags),
+    ]

--- a/backend/apps/tags/predefined.py
+++ b/backend/apps/tags/predefined.py
@@ -1,0 +1,12 @@
+PREDEFINED_TAGS = [
+    'architecture',
+    'art',
+    'childhood',
+    'culture',
+    'daily-life',
+    'religion',
+    'war',
+    'food',
+    'natural-disasters',
+    'history',
+]

--- a/backend/apps/tags/serializers.py
+++ b/backend/apps/tags/serializers.py
@@ -1,23 +1,8 @@
-import re
-
+from django.core.exceptions import ValidationError as DjangoValidationError
 from rest_framework import serializers
 
 from .models import Tag
-
-
-def _normalize_name(value: str) -> str:
-    """
-    Normalize a raw tag input into lowercase-with-hyphens slug format.
-    Spaces and underscores become hyphens; non-alphanumeric characters are
-    dropped; consecutive hyphens are collapsed; leading/trailing hyphens
-    are stripped.
-    """
-    value = value.strip().lower()
-    value = re.sub(r'[\s_]+', '-', value)
-    value = re.sub(r'[^a-z0-9\-]', '', value)
-    value = re.sub(r'-{2,}', '-', value)
-    value = value.strip('-')
-    return value
+from .services import normalize_tag_name
 
 
 class TagSerializer(serializers.ModelSerializer):
@@ -27,25 +12,22 @@ class TagSerializer(serializers.ModelSerializer):
         model = Tag
         fields = ['id', 'name', 'is_predefined', 'story_count']
         read_only_fields = ['id', 'is_predefined', 'story_count']
-        # Duplicate detection is the service layer's responsibility (returns 200
+        # Duplicate detection is the service layer's responsibility (POST returns 200
         # for existing tags instead of 400), so we drop the auto-added UniqueValidator.
         extra_kwargs = {'name': {'validators': []}}
 
     def validate_name(self, value: str) -> str:
-        normalized = _normalize_name(value)
+        normalized = normalize_tag_name(value)
         if not normalized:
             raise serializers.ValidationError(
                 'Tag name is empty after normalization. Provide at least one alphanumeric character.'
             )
         # Delegate format enforcement to the model validator so the regex
-        # is not duplicated here.
+        # is not duplicated here. validate_unique=False because the service
+        # layer handles idempotent creation (get_or_create).
         tag = Tag(name=normalized)
         try:
-            # validate_unique=False: duplicate detection is the service layer's job.
             tag.full_clean(exclude=['id'], validate_unique=False)
-        except Exception as exc:
-            # Surface only the name-related messages.
-            raise serializers.ValidationError(
-                exc.message_dict.get('name', [str(exc)])
-            ) from exc
+        except DjangoValidationError as exc:
+            raise serializers.ValidationError(exc.message_dict.get('name', exc.messages)) from exc
         return normalized

--- a/backend/apps/tags/serializers.py
+++ b/backend/apps/tags/serializers.py
@@ -1,1 +1,50 @@
-# serializers.py — tags
+import re
+
+from rest_framework import serializers
+
+from .models import Tag
+
+
+def _normalize_name(value: str) -> str:
+    """
+    Normalize a raw tag input into lowercase-with-hyphens slug format.
+    Spaces and underscores become hyphens; non-alphanumeric characters are
+    dropped; consecutive hyphens are collapsed; leading/trailing hyphens
+    are stripped.
+    """
+    value = value.strip().lower()
+    value = re.sub(r'[\s_]+', '-', value)
+    value = re.sub(r'[^a-z0-9\-]', '', value)
+    value = re.sub(r'-{2,}', '-', value)
+    value = value.strip('-')
+    return value
+
+
+class TagSerializer(serializers.ModelSerializer):
+    """Serializes Tag objects for list, create, and nested use."""
+
+    class Meta:
+        model = Tag
+        fields = ['id', 'name', 'is_predefined', 'story_count']
+        read_only_fields = ['id', 'is_predefined', 'story_count']
+        # Duplicate detection is the service layer's responsibility (returns 200
+        # for existing tags instead of 400), so we drop the auto-added UniqueValidator.
+        extra_kwargs = {'name': {'validators': []}}
+
+    def validate_name(self, value: str) -> str:
+        normalized = _normalize_name(value)
+        if not normalized:
+            raise serializers.ValidationError(
+                'Tag name is empty after normalization. Provide at least one alphanumeric character.'
+            )
+        # Delegate format enforcement to the model validator so the regex
+        # is not duplicated here.
+        tag = Tag(name=normalized)
+        try:
+            tag.full_clean(exclude=['id'])
+        except Exception as exc:
+            # Surface only the name-related messages.
+            raise serializers.ValidationError(
+                exc.message_dict.get('name', [str(exc)])
+            ) from exc
+        return normalized

--- a/backend/apps/tags/serializers.py
+++ b/backend/apps/tags/serializers.py
@@ -41,7 +41,8 @@ class TagSerializer(serializers.ModelSerializer):
         # is not duplicated here.
         tag = Tag(name=normalized)
         try:
-            tag.full_clean(exclude=['id'])
+            # validate_unique=False: duplicate detection is the service layer's job.
+            tag.full_clean(exclude=['id'], validate_unique=False)
         except Exception as exc:
             # Surface only the name-related messages.
             raise serializers.ValidationError(

--- a/backend/apps/tags/services.py
+++ b/backend/apps/tags/services.py
@@ -1,1 +1,48 @@
-# services.py — tags
+import re
+
+from django.db.models import QuerySet
+
+from .models import Tag
+
+
+def normalize_tag_name(name: str) -> str:
+    """Lowercase, spaces/underscores→hyphens, drop non-alphanumeric, collapse hyphens."""
+    name = name.strip().lower()
+    name = re.sub(r'[\s_]+', '-', name)
+    name = re.sub(r'[^a-z0-9\-]', '', name)
+    name = re.sub(r'-{2,}', '-', name)
+    return name.strip('-')
+
+
+def list_tags(*, is_predefined=None, q=None) -> QuerySet:
+    """
+    Return Tag queryset with optional filters.
+    is_predefined=True/False filters the flag; None returns all.
+    q applies a case-insensitive name__icontains filter.
+    Ordered by -story_count then name for autocomplete relevance.
+    """
+    qs = Tag.objects.all()
+    if is_predefined is not None:
+        qs = qs.filter(is_predefined=is_predefined)
+    if q:
+        qs = qs.filter(name__icontains=q)
+    return qs.order_by('-story_count', 'name')
+
+
+def create_tag(validated_data: dict, *, is_predefined: bool = False) -> tuple:
+    """
+    Create a tag if the normalized slug does not already exist.
+    is_predefined is applied only on creation; an existing tag's flag is never overwritten.
+    Returns (tag, created).
+    """
+    name = normalize_tag_name(validated_data['name'])
+    tag, created = Tag.objects.get_or_create(
+        name=name,
+        defaults={'is_predefined': is_predefined},
+    )
+    return tag, created
+
+
+def delete_tag(tag: Tag) -> None:
+    """Delete the tag. StoryTag rows cascade via FK."""
+    tag.delete()

--- a/backend/apps/tags/tests/test_models.py
+++ b/backend/apps/tags/tests/test_models.py
@@ -22,31 +22,31 @@ def _make_story(user, title='T'):
 @pytest.mark.django_db
 class TestTag:
     def test_tag_can_be_created(self):
-        tag = Tag.objects.create(name='history')
+        tag = Tag.objects.create(name='model-test-tag')
         assert tag.pk is not None
 
     def test_is_predefined_defaults_to_false(self):
-        tag = Tag.objects.create(name='history')
+        tag = Tag.objects.create(name='model-test-tag')
         assert tag.is_predefined is False
 
     def test_story_count_defaults_to_zero(self):
-        tag = Tag.objects.create(name='history')
+        tag = Tag.objects.create(name='model-test-tag')
         assert tag.story_count == 0
 
     def test_str_returns_name(self):
-        tag = Tag.objects.create(name='history')
-        assert str(tag) == 'history'
+        tag = Tag.objects.create(name='model-test-tag')
+        assert str(tag) == 'model-test-tag'
 
     def test_tag_name_must_be_unique(self):
-        Tag.objects.create(name='history')
+        Tag.objects.create(name='model-test-tag')
         with pytest.raises(IntegrityError):
             with transaction.atomic():
-                Tag.objects.create(name='history')
+                Tag.objects.create(name='model-test-tag')
 
     # ── Format validation (req. 1.3.6.4) ─────────────────────────────────────
 
     def test_valid_single_lowercase_word(self):
-        Tag(name='history').full_clean()  # must not raise
+        Tag(name='model-test-tag').full_clean()  # must not raise
 
     def test_valid_hyphen_separated_words(self):
         Tag(name='ottoman-era').full_clean()  # must not raise

--- a/backend/apps/tags/tests/test_serializers.py
+++ b/backend/apps/tags/tests/test_serializers.py
@@ -1,0 +1,94 @@
+import pytest
+
+from apps.tags.serializers import TagSerializer
+
+
+@pytest.mark.django_db
+class TestTagSerializer:
+    def test_valid_slug_format_is_accepted(self):
+        s = TagSerializer(data={'name': 'ottoman-era'})
+        assert s.is_valid(), s.errors
+
+    def test_valid_single_word_is_accepted(self):
+        s = TagSerializer(data={'name': 'history'})
+        assert s.is_valid(), s.errors
+
+    def test_valid_name_with_digits_is_accepted(self):
+        s = TagSerializer(data={'name': '19th-century'})
+        assert s.is_valid(), s.errors
+
+    # ── Normalization ────────────────────────────────────────────────────────
+
+    def test_uppercase_is_normalized_to_lowercase(self):
+        s = TagSerializer(data={'name': 'Ottoman'})
+        assert s.is_valid(), s.errors
+        assert s.validated_data['name'] == 'ottoman'
+
+    def test_spaces_are_converted_to_hyphens(self):
+        s = TagSerializer(data={'name': 'ottoman era'})
+        assert s.is_valid(), s.errors
+        assert s.validated_data['name'] == 'ottoman-era'
+
+    def test_underscores_are_converted_to_hyphens(self):
+        s = TagSerializer(data={'name': 'ottoman_era'})
+        assert s.is_valid(), s.errors
+        assert s.validated_data['name'] == 'ottoman-era'
+
+    def test_mixed_case_spaces_normalized(self):
+        s = TagSerializer(data={'name': 'Ottoman Era'})
+        assert s.is_valid(), s.errors
+        assert s.validated_data['name'] == 'ottoman-era'
+
+    def test_special_characters_are_stripped(self):
+        s = TagSerializer(data={'name': 'ottoman@era!'})
+        assert s.is_valid(), s.errors
+        assert s.validated_data['name'] == 'ottomanera'
+
+    def test_leading_and_trailing_hyphens_are_stripped(self):
+        s = TagSerializer(data={'name': '-ottoman-'})
+        assert s.is_valid(), s.errors
+        assert s.validated_data['name'] == 'ottoman'
+
+    def test_consecutive_hyphens_are_collapsed(self):
+        s = TagSerializer(data={'name': 'otto--man'})
+        assert s.is_valid(), s.errors
+        assert s.validated_data['name'] == 'otto-man'
+
+    # ── Rejection ───────────────────────────────────────────────────────────
+
+    def test_empty_string_is_rejected(self):
+        s = TagSerializer(data={'name': ''})
+        assert not s.is_valid()
+        assert 'name' in s.errors
+
+    def test_whitespace_only_is_rejected(self):
+        s = TagSerializer(data={'name': '   '})
+        assert not s.is_valid()
+        assert 'name' in s.errors
+
+    def test_all_special_chars_is_rejected(self):
+        s = TagSerializer(data={'name': '!@#$%'})
+        assert not s.is_valid()
+        assert 'name' in s.errors
+
+    def test_missing_name_field_is_rejected(self):
+        s = TagSerializer(data={})
+        assert not s.is_valid()
+        assert 'name' in s.errors
+
+    # ── Read-only fields ─────────────────────────────────────────────────────
+
+    def test_id_is_read_only(self):
+        s = TagSerializer(data={'name': 'history', 'id': 999})
+        assert s.is_valid()
+        assert 'id' not in s.validated_data
+
+    def test_is_predefined_is_read_only(self):
+        s = TagSerializer(data={'name': 'history', 'is_predefined': True})
+        assert s.is_valid()
+        assert 'is_predefined' not in s.validated_data
+
+    def test_story_count_is_read_only(self):
+        s = TagSerializer(data={'name': 'history', 'story_count': 100})
+        assert s.is_valid()
+        assert 'story_count' not in s.validated_data

--- a/backend/apps/tags/tests/test_services.py
+++ b/backend/apps/tags/tests/test_services.py
@@ -1,0 +1,141 @@
+import pytest
+
+from apps.tags.models import Tag
+from apps.tags.services import create_tag, delete_tag, list_tags, normalize_tag_name
+
+
+class TestNormalizeTagName:
+    def test_lowercase(self):
+        assert normalize_tag_name('Ottoman') == 'ottoman'
+
+    def test_spaces_to_hyphens(self):
+        assert normalize_tag_name('daily life') == 'daily-life'
+
+    def test_underscores_to_hyphens(self):
+        assert normalize_tag_name('daily_life') == 'daily-life'
+
+    def test_strips_special_characters(self):
+        assert normalize_tag_name('ottoman@era!') == 'ottomanera'
+
+    def test_collapses_consecutive_hyphens(self):
+        assert normalize_tag_name('otto--man') == 'otto-man'
+
+    def test_strips_leading_and_trailing_hyphens(self):
+        assert normalize_tag_name('-history-') == 'history'
+
+    def test_mixed_input(self):
+        assert normalize_tag_name('  Ottoman ERA  ') == 'ottoman-era'
+
+
+@pytest.mark.django_db
+class TestListTags:
+    def test_returns_created_tags(self):
+        Tag.objects.create(name='svc-test-alpha')
+        Tag.objects.create(name='svc-test-beta')
+        names = list(list_tags().values_list('name', flat=True))
+        assert 'svc-test-alpha' in names
+        assert 'svc-test-beta' in names
+
+    def test_filters_predefined_true(self):
+        Tag.objects.create(name='svc-predefined-tag', is_predefined=True)
+        Tag.objects.create(name='svc-user-tag', is_predefined=False)
+        result = list(list_tags(is_predefined=True).values_list('name', flat=True))
+        assert 'svc-predefined-tag' in result
+        assert 'svc-user-tag' not in result
+
+    def test_filters_predefined_false(self):
+        Tag.objects.create(name='svc-predefined-tag2', is_predefined=True)
+        Tag.objects.create(name='svc-user-tag2', is_predefined=False)
+        result = list(list_tags(is_predefined=False).values_list('name', flat=True))
+        assert 'svc-user-tag2' in result
+        assert 'svc-predefined-tag2' not in result
+
+    def test_filters_by_q(self):
+        Tag.objects.create(name='svc-unique-qtest-era')
+        Tag.objects.create(name='svc-unique-other')
+        result = list(list_tags(q='qtest').values_list('name', flat=True))
+        assert result == ['svc-unique-qtest-era']
+
+    def test_combined_filter_predefined_and_q(self):
+        Tag.objects.create(name='svc-combo-user', is_predefined=False)
+        Tag.objects.create(name='svc-combo-admin', is_predefined=True)
+        result = list(list_tags(is_predefined=False, q='svc-combo').values_list('name', flat=True))
+        assert result == ['svc-combo-user']
+
+    def test_ordered_by_story_count_desc_then_name(self):
+        Tag.objects.create(name='svc-ord-zebra', story_count=5)
+        Tag.objects.create(name='svc-ord-alpha', story_count=10)
+        Tag.objects.create(name='svc-ord-beta', story_count=5)
+        names = list(list_tags(q='svc-ord').values_list('name', flat=True))
+        assert names == ['svc-ord-alpha', 'svc-ord-beta', 'svc-ord-zebra']
+
+    def test_q_is_case_insensitive(self):
+        Tag.objects.create(name='svc-case-ottoman')
+        result = list_tags(q='SVC-CASE')
+        assert result.count() == 1
+
+
+@pytest.mark.django_db
+class TestCreateTag:
+    def test_creates_new_tag(self):
+        tag, created = create_tag({'name': 'svc-brand-new'})
+        assert created is True
+        assert tag.name == 'svc-brand-new'
+        assert Tag.objects.filter(name='svc-brand-new').exists()
+
+    def test_duplicate_returns_existing_tag(self):
+        Tag.objects.create(name='svc-existing')
+        tag, created = create_tag({'name': 'svc-existing'})
+        assert created is False
+        assert tag.name == 'svc-existing'
+        assert Tag.objects.filter(name='svc-existing').count() == 1
+
+    def test_normalizes_name_before_lookup(self):
+        Tag.objects.create(name='svc-norm-era')
+        tag, created = create_tag({'name': 'SVC NORM ERA'})
+        assert created is False
+        assert tag.name == 'svc-norm-era'
+
+    def test_admin_flag_sets_is_predefined_on_creation(self):
+        tag, created = create_tag({'name': 'svc-admin-tag'}, is_predefined=True)
+        assert created is True
+        assert tag.is_predefined is True
+
+    def test_user_creation_sets_is_predefined_false(self):
+        tag, _ = create_tag({'name': 'svc-user-created'})
+        assert tag.is_predefined is False
+
+    def test_does_not_overwrite_is_predefined_on_existing_tag(self):
+        Tag.objects.create(name='svc-keep-predefined', is_predefined=True)
+        tag, created = create_tag({'name': 'svc-keep-predefined'}, is_predefined=False)
+        assert created is False
+        assert tag.is_predefined is True
+
+
+@pytest.mark.django_db
+class TestDeleteTag:
+    def test_deletes_tag(self):
+        tag = Tag.objects.create(name='svc-to-delete')
+        delete_tag(tag)
+        assert not Tag.objects.filter(name='svc-to-delete').exists()
+
+    def test_cascade_deletes_story_tags(self):
+        from decimal import Decimal
+
+        from apps.stories.models import Story
+        from apps.tags.models import StoryTag
+        from apps.users.models import User
+
+        user = User.objects.create_user(
+            email='tagger-svc@example.com', username='tagger-svc', password='Pass1234',
+        )
+        story = Story.objects.create(
+            user=user, title='T', narrative='N',
+            status=Story.STATUS_PUBLISHED,
+            location_lat=Decimal('0'), location_lng=Decimal('0'),
+            location_name='P', time_type=Story.TIME_EXACT, year=2000,
+        )
+        tag = Tag.objects.create(name='svc-cascade-tag')
+        st = StoryTag.objects.create(story=story, tag=tag)
+        delete_tag(tag)
+        assert not StoryTag.objects.filter(pk=st.pk).exists()

--- a/backend/apps/tags/tests/test_views.py
+++ b/backend/apps/tags/tests/test_views.py
@@ -1,1 +1,178 @@
-# tests/test_views.py — tags
+import pytest
+from rest_framework import status
+from rest_framework.test import APIClient
+
+from apps.tags.models import Tag
+from apps.users.models import RoleChoices, User
+
+TAG_LIST_URL = '/tags/'
+
+
+def tag_detail_url(pk):
+    return f'/tags/{pk}/'
+
+
+def make_user(email='viewuser@example.com', username='viewuser', role=RoleChoices.REGISTERED_USER):
+    return User.objects.create_user(email=email, username=username, password='Pass1234', role=role)
+
+
+def make_admin(email='viewadmin@example.com', username='viewadmin'):
+    return User.objects.create_user(
+        email=email, username=username, password='Pass1234',
+        role=RoleChoices.ADMIN, is_staff=True,
+    )
+
+
+@pytest.mark.django_db
+class TestTagListView:
+    def test_unauthenticated_can_list_tags(self):
+        client = APIClient()
+        response = client.get(TAG_LIST_URL)
+        assert response.status_code == status.HTTP_200_OK
+
+    def test_returns_all_tags_by_default(self):
+        Tag.objects.create(name='view-tag-a')
+        Tag.objects.create(name='view-tag-b')
+        client = APIClient()
+        response = client.get(TAG_LIST_URL)
+        names = [t['name'] for t in response.data]
+        assert 'view-tag-a' in names
+        assert 'view-tag-b' in names
+
+    def test_is_predefined_true_returns_only_predefined(self):
+        Tag.objects.create(name='view-pre-tag', is_predefined=True)
+        Tag.objects.create(name='view-user-tag', is_predefined=False)
+        client = APIClient()
+        response = client.get(TAG_LIST_URL, {'is_predefined': 'true'})
+        assert response.status_code == status.HTTP_200_OK
+        names = [t['name'] for t in response.data]
+        assert 'view-pre-tag' in names
+        assert 'view-user-tag' not in names
+
+    def test_is_predefined_false_returns_only_user_created(self):
+        Tag.objects.create(name='view-pre-tag2', is_predefined=True)
+        Tag.objects.create(name='view-user-tag2', is_predefined=False)
+        client = APIClient()
+        response = client.get(TAG_LIST_URL, {'is_predefined': 'false'})
+        assert response.status_code == status.HTTP_200_OK
+        names = [t['name'] for t in response.data]
+        assert 'view-user-tag2' in names
+        assert 'view-pre-tag2' not in names
+
+    def test_q_filters_by_name(self):
+        Tag.objects.create(name='view-unique-qfilter')
+        Tag.objects.create(name='view-other-tag')
+        client = APIClient()
+        response = client.get(TAG_LIST_URL, {'q': 'unique-qfilter'})
+        assert response.status_code == status.HTTP_200_OK
+        names = [t['name'] for t in response.data]
+        assert names == ['view-unique-qfilter']
+
+    def test_combined_is_predefined_and_q_filter(self):
+        Tag.objects.create(name='view-combo-user', is_predefined=False)
+        Tag.objects.create(name='view-combo-admin', is_predefined=True)
+        client = APIClient()
+        response = client.get(TAG_LIST_URL, {'is_predefined': 'false', 'q': 'view-combo'})
+        assert response.status_code == status.HTTP_200_OK
+        names = [t['name'] for t in response.data]
+        assert names == ['view-combo-user']
+
+    def test_response_contains_expected_fields(self):
+        Tag.objects.create(name='view-field-check')
+        client = APIClient()
+        response = client.get(TAG_LIST_URL, {'q': 'view-field-check'})
+        tag = response.data[0]
+        assert set(tag.keys()) == {'id', 'name', 'is_predefined', 'story_count'}
+
+
+@pytest.mark.django_db
+class TestTagCreateView:
+    def test_registered_user_creates_new_tag(self):
+        user = make_user()
+        client = APIClient()
+        client.force_authenticate(user=user)
+        response = client.post(TAG_LIST_URL, {'name': 'view-new-tag'}, format='json')
+        assert response.status_code == status.HTTP_201_CREATED
+        assert response.data['name'] == 'view-new-tag'
+        assert response.data['is_predefined'] is False
+
+    def test_duplicate_returns_200_with_existing_tag(self):
+        Tag.objects.create(name='view-dup-tag')
+        user = make_user(email='dupuser@example.com', username='dupuser')
+        client = APIClient()
+        client.force_authenticate(user=user)
+        response = client.post(TAG_LIST_URL, {'name': 'view-dup-tag'}, format='json')
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data['name'] == 'view-dup-tag'
+
+    def test_mixed_case_input_normalized_and_matched(self):
+        Tag.objects.create(name='view-norm-tag')
+        user = make_user(email='normuser@example.com', username='normuser')
+        client = APIClient()
+        client.force_authenticate(user=user)
+        response = client.post(TAG_LIST_URL, {'name': 'View Norm Tag'}, format='json')
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data['name'] == 'view-norm-tag'
+
+    def test_admin_creates_tag_with_is_predefined_true(self):
+        admin = make_admin()
+        client = APIClient()
+        client.force_authenticate(user=admin)
+        response = client.post(TAG_LIST_URL, {'name': 'view-admin-tag'}, format='json')
+        assert response.status_code == status.HTTP_201_CREATED
+        assert response.data['is_predefined'] is True
+
+    def test_unauthenticated_cannot_create_tag(self):
+        client = APIClient()
+        response = client.post(TAG_LIST_URL, {'name': 'view-unauth-tag'}, format='json')
+        assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
+    def test_invalid_name_after_normalization_returns_400(self):
+        user = make_user(email='baduser@example.com', username='baduser')
+        client = APIClient()
+        client.force_authenticate(user=user)
+        response = client.post(TAG_LIST_URL, {'name': '!@#$%'}, format='json')
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+    def test_is_predefined_field_in_request_is_ignored(self):
+        user = make_user(email='ignoreuser@example.com', username='ignoreuser')
+        client = APIClient()
+        client.force_authenticate(user=user)
+        response = client.post(
+            TAG_LIST_URL, {'name': 'view-ignore-flag', 'is_predefined': True}, format='json',
+        )
+        assert response.status_code == status.HTTP_201_CREATED
+        assert response.data['is_predefined'] is False
+
+
+@pytest.mark.django_db
+class TestTagDeleteView:
+    def test_admin_deletes_tag(self):
+        tag = Tag.objects.create(name='view-delete-me')
+        admin = make_admin()
+        client = APIClient()
+        client.force_authenticate(user=admin)
+        response = client.delete(tag_detail_url(tag.pk))
+        assert response.status_code == status.HTTP_204_NO_CONTENT
+        assert not Tag.objects.filter(pk=tag.pk).exists()
+
+    def test_registered_user_cannot_delete_tag(self):
+        tag = Tag.objects.create(name='view-no-delete')
+        user = make_user(email='nodelete@example.com', username='nodelete')
+        client = APIClient()
+        client.force_authenticate(user=user)
+        response = client.delete(tag_detail_url(tag.pk))
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+
+    def test_unauthenticated_cannot_delete_tag(self):
+        tag = Tag.objects.create(name='view-unauth-delete')
+        client = APIClient()
+        response = client.delete(tag_detail_url(tag.pk))
+        assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
+    def test_delete_unknown_pk_returns_404(self):
+        admin = make_admin(email='admin404@example.com', username='admin404')
+        client = APIClient()
+        client.force_authenticate(user=admin)
+        response = client.delete(tag_detail_url(99999))
+        assert response.status_code == status.HTTP_404_NOT_FOUND

--- a/backend/apps/tags/urls.py
+++ b/backend/apps/tags/urls.py
@@ -1,1 +1,10 @@
-# urls.py — tags
+from django.urls import path
+
+from .views import TagDetailView, TagListCreateView
+
+app_name = 'tags'
+
+urlpatterns = [
+    path('', TagListCreateView.as_view(), name='tag-list-create'),
+    path('<int:pk>/', TagDetailView.as_view(), name='tag-detail'),
+]

--- a/backend/apps/tags/views.py
+++ b/backend/apps/tags/views.py
@@ -1,1 +1,48 @@
-# views.py — tags
+from rest_framework import generics, status
+from rest_framework.permissions import AllowAny
+from rest_framework.response import Response
+
+from apps.users.models import RoleChoices
+from common.permissions import IsAdminUser, IsRegisteredUser
+
+from .models import Tag
+from .serializers import TagSerializer
+from .services import create_tag, delete_tag, list_tags
+
+
+class TagListCreateView(generics.ListCreateAPIView):
+    """
+    GET  AllowAny         — list tags; supports ?is_predefined=true/false and ?q=<search>.
+    POST IsRegisteredUser — create tag (idempotent); admin caller gets is_predefined=True.
+    """
+
+    serializer_class = TagSerializer
+
+    def get_permissions(self):
+        if self.request.method == 'POST':
+            return [IsRegisteredUser()]
+        return [AllowAny()]
+
+    def get_queryset(self):
+        raw = self.request.query_params.get('is_predefined')
+        flag = {'true': True, 'false': False}.get(raw)
+        q = self.request.query_params.get('q', '').strip() or None
+        return list_tags(is_predefined=flag, q=q)
+
+    def create(self, request, *args, **kwargs):
+        serializer = self.get_serializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        is_predefined = request.user.role == RoleChoices.ADMIN
+        tag, created = create_tag(serializer.validated_data, is_predefined=is_predefined)
+        code = status.HTTP_201_CREATED if created else status.HTTP_200_OK
+        return Response(TagSerializer(tag).data, status=code)
+
+
+class TagDetailView(generics.DestroyAPIView):
+    """DELETE IsAdminUser — delete tag by pk."""
+
+    permission_classes = [IsAdminUser]
+    queryset = Tag.objects.all()
+
+    def perform_destroy(self, instance):
+        delete_tag(instance)

--- a/backend/config/urls.py
+++ b/backend/config/urls.py
@@ -10,6 +10,7 @@ urlpatterns = [
     path('', include('apps.interactions.urls', namespace='interactions')),
     path('', include('apps.media.urls', namespace='media')),
     path('stories/', include('apps.stories.urls', namespace='stories')),
+    path('tags/', include('apps.tags.urls', namespace='tags')),
 ]
 
 if settings.DEBUG and 'debug_toolbar' in settings.INSTALLED_APPS:


### PR DESCRIPTION
# 📝 Description
Fixes #209

This PR adds foundational tag management support to the backend by implementing three tag endpoints with clear access restrictions and reusable service-layer logic.

### Implemented endpoints

| Method | URL | Access | Behavior |
|---|---|---|---|
| GET | `/tags/` | Everyone | Lists tags, with optional `?is_predefined=` and `?q=` filters |
| POST | `/tags/` | Authenticated registered users | Creates a tag idempotently (`201` if newly created, `200` if it already exists); if the caller is an admin, the created tag is marked as `is_predefined=True` |
| DELETE | `/tags/<pk>/` | Admin only | Deletes the selected tag |

### Authentication / authorization behavior
This PR intentionally applies different permission rules per endpoint:
- **GET `/tags/`** is public so tags can be used freely in selection, filtering, and autocomplete flows
- **POST `/tags/`** requires an authenticated registered user, so anonymous users cannot create tags
- **DELETE `/tags/<pk>/`** is restricted to admins only, so tag removal remains an administrative action

### What changed
- Added `TagSerializer` with normalization and validation for tag names
- Added predefined tag list support and seed migration
- Added service-layer functions for listing, creating, normalizing, and deleting tags
- Added `TagListCreateView` and `TagDetailView`
- Registered `/tags/` and `/tags/<pk>/` URL routes
- Implemented idempotent tag creation behavior
- Added filtering support for:
  - `?is_predefined=true/false`
  - `?q=<search>`
- Added test coverage for model, serializer, service, and view behavior

### Notes
- `POST /tags/` is idempotent by design:
  - returns **201 Created** when a new tag is created
  - returns **200 OK** when the normalized tag already exists
- The `is_predefined` field is not client-controlled through the request body
  - for regular users, created tags remain `is_predefined=False`
  - for admins, newly created tags are marked as `is_predefined=True`

# 📊 Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Refactoring
- [ ] Documentation
 
# ✅ Acceptance Criteria / Checklist
- [x] Project builds successfully
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, especially in hard-to-understand parts
- [x] I have performed a self-review of my code
- [x] I have added/updated tests
- [x] New and existing unit tests pass locally with my changes

# ⏱️ Estimated Review Time
- [ ] < 5 min
- [x] 5-15 min
- [ ] > 15 min