### PR TITLE
feat: implement CSP header, API rate limiting, and Argon2 password hashing

### DIFF
--- a/backend/apps/users/tests/test_views.py
+++ b/backend/apps/users/tests/test_views.py
@@ -171,6 +171,19 @@ class TestLoginView:
         })
         assert 'password' not in response.data.get('user', {})
 
+    def test_login_rate_limit_returns_429_after_limit(self, client):
+        from django.core.cache import cache
+        from unittest.mock import patch
+        cache.clear()
+        # Patch get_rate directly: override_settings doesn't reliably flush DRF's
+        # api_settings cache in all test-suite orderings.
+        with patch('rest_framework.throttling.ScopedRateThrottle.get_rate', return_value='10/minute'):
+            for _ in range(10):
+                client.post('/auth/login/', {'email': 'x@example.com', 'password': 'wrong'})
+            response = client.post('/auth/login/', {'email': 'x@example.com', 'password': 'wrong'})
+        cache.clear()
+        assert response.status_code == status.HTTP_429_TOO_MANY_REQUESTS
+
 
 @pytest.mark.django_db
 class TestLogoutView:

--- a/backend/apps/users/views.py
+++ b/backend/apps/users/views.py
@@ -1,6 +1,7 @@
 from rest_framework import status
 from rest_framework.permissions import AllowAny, IsAuthenticated
 from rest_framework.response import Response
+from rest_framework.throttling import ScopedRateThrottle
 from rest_framework.views import APIView
 
 from apps.users.serializers import (
@@ -50,6 +51,8 @@ class RegisterView(APIView):
 
 class LoginView(APIView):
     permission_classes = [AllowAny]
+    throttle_classes = [ScopedRateThrottle]
+    throttle_scope = 'login'
 
     def post(self, request):
         serializer = LoginSerializer(data=request.data)

--- a/backend/config/settings/base.py
+++ b/backend/config/settings/base.py
@@ -98,6 +98,13 @@ DATABASES = {
 # Custom user model
 AUTH_USER_MODEL = 'users.User'
 
+# Password hashing — Argon2 first (NIST SP 800-63B), PBKDF2 as legacy fallback.
+# Existing PBKDF2 hashes are transparently re-hashed to Argon2 on next successful login.
+PASSWORD_HASHERS = [
+    'django.contrib.auth.hashers.Argon2PasswordHasher',
+    'django.contrib.auth.hashers.PBKDF2PasswordHasher',
+]
+
 # Password validation
 AUTH_PASSWORD_VALIDATORS = [
     {'NAME': 'django.contrib.auth.password_validation.UserAttributeSimilarityValidator'},
@@ -137,6 +144,16 @@ REST_FRAMEWORK = {
     ],
     'DEFAULT_SCHEMA_CLASS': 'drf_spectacular.openapi.AutoSchema',
     'EXCEPTION_HANDLER': 'common.exceptions.custom_exception_handler',
+    # Rate limiting (RFC 6585 — 429 Too Many Requests)
+    'DEFAULT_THROTTLE_CLASSES': [
+        'rest_framework.throttling.AnonRateThrottle',
+        'rest_framework.throttling.UserRateThrottle',
+    ],
+    'DEFAULT_THROTTLE_RATES': {
+        'anon': '60/minute',
+        'user': '300/minute',
+        'login': '10/minute',
+    },
 }
 
 # SimpleJWT

--- a/backend/config/settings/test.py
+++ b/backend/config/settings/test.py
@@ -40,3 +40,18 @@ STORAGES = {
 PASSWORD_HASHERS = [
     'django.contrib.auth.hashers.MD5PasswordHasher',
 ]
+
+# Disable throttling in tests. LoginView sets throttle_classes directly on the class,
+# so it bypasses DEFAULT_THROTTLE_CLASSES. The login rate must also be set very high
+# so the ScopedRateThrottle on LoginView never fires during fixture setup.
+# Individual rate-limit tests override DEFAULT_THROTTLE_RATES to a low limit via
+# override_settings and cache.clear() before/after to isolate state.
+REST_FRAMEWORK = {  # noqa: F405
+    **REST_FRAMEWORK,  # noqa: F405
+    'DEFAULT_THROTTLE_CLASSES': [],
+    'DEFAULT_THROTTLE_RATES': {
+        'anon': '10000/minute',
+        'user': '10000/minute',
+        'login': '10000/minute',
+    },
+}

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -23,6 +23,12 @@ server {
     # image uploads silently with 413. MVP allows 2 MB images; 10 MB gives headroom.
     client_max_body_size 10M;
 
+    # Content Security Policy (W3C CSP Level 2/3).
+    # Report-Only during development/staging to surface violations before enforcement.
+    add_header Content-Security-Policy-Report-Only
+        "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https://tile.openstreetmap.org; font-src 'self'; connect-src 'self' https://storymap.page; frame-ancestors 'none';"
+        always;
+
     # ── React SPA ─────────────────────────────────────────────────────────────
     # Unknown paths fall back to index.html so React Router handles them.
     root /usr/share/nginx/html;

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -8,3 +8,4 @@ django-environ==0.11.*
 Pillow==10.*
 python-magic==0.4.*
 django-cors-headers==4.*
+argon2-cffi==23.*


### PR DESCRIPTION
# 📝 Description
Fixes #388

Implements all three security standards from the Use of Standards wiki (B.5–B.7):

**B.5 — Content Security Policy (W3C CSP Level 2/3)**
- `nginx/nginx.conf`: adds `Content-Security-Policy-Report-Only` header on all responses
- Covers `default-src`, `script-src`, `style-src`, `img-src` (includes OSM tiles), `font-src`, `connect-src`, `frame-ancestors`
- Report-Only mode surfaces violations before switching to enforcement

**B.6 — API Rate Limiting (RFC 6585 — 429 Too Many Requests)**
- `REST_FRAMEWORK` throttle config: `AnonRateThrottle` (60/min), `UserRateThrottle` (300/min)
- `LoginView` gets `ScopedRateThrottle` with `login` scope (10/min) to limit brute-force
- Test settings disable throttling globally; rate-limit test patches `get_rate` directly to avoid DRF `api_settings` cache interactions

**B.7 — Argon2 Password Hashing (NIST SP 800-63B)**
- `argon2-cffi` added to `requirements/base.txt`
- `Argon2PasswordHasher` set as primary hasher; `PBKDF2PasswordHasher` kept as legacy fallback
- Existing PBKDF2 hashes re-hash to Argon2 on next successful login — no data migration needed
- Test settings already use `MD5PasswordHasher` for speed — no test changes needed

# 📊 Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Refactoring
- [ ] Documentation

# ✅ Acceptance Criteria / Checklist
- [x] Project builds successfully
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, especially in hard-to-understand parts
- [x] I have performed a self-review of my code
- [x] I have added/updated tests
- [x] New and existing unit tests pass locally with my changes

# ⏱️ Estimated Review Time
- [x] < 5 min
- [ ] 5-15 min
- [ ] > 15 min