### PR TITLE
feat: mobile consume GeoJSON feature collection in map view

### DIFF
--- a/mobile/src/features/stories/data/mappers/__tests__/storyMappers.test.ts
+++ b/mobile/src/features/stories/data/mappers/__tests__/storyMappers.test.ts
@@ -1,4 +1,4 @@
-import { mapStory, mapStoryComment } from '..';
+import { mapGeoJSONStoryMapPin, mapStory, mapStoryComment } from '..';
 
 describe('story mappers', () => {
   it('maps the backend story detail payload into the mobile story entity', () => {
@@ -79,6 +79,34 @@ describe('story mappers', () => {
       authorName: 'Deleted account',
       body: 'Great story!',
       createdAt: '2026-03-20T12:00:00Z',
+    });
+  });
+
+  it('maps a GeoJSON feature into the mobile story map pin shape', () => {
+    expect(
+      mapGeoJSONStoryMapPin({
+        type: 'Feature',
+        id: 42,
+        geometry: {
+          type: 'Point',
+          coordinates: [28.9784, 41.0082],
+        },
+        properties: {
+          title: 'The City Walls',
+          location_name: 'Old City',
+          time_type: 'exact_year',
+          year: 1453,
+          preview_text: 'First paragraph.',
+        },
+      }),
+    ).toEqual({
+      id: '42',
+      title: 'The City Walls',
+      previewText: 'First paragraph.',
+      placeName: 'Old City',
+      timePeriod: '1453',
+      latitude: 41.0082,
+      longitude: 28.9784,
     });
   });
 });

--- a/mobile/src/features/stories/data/mappers/index.ts
+++ b/mobile/src/features/stories/data/mappers/index.ts
@@ -41,6 +41,12 @@ interface StoryRecord {
   comments?: unknown;
 }
 
+interface StoryMapFeatureRecord {
+  id?: unknown;
+  geometry?: unknown;
+  properties?: unknown;
+}
+
 function isCommentPreview(value: unknown): value is StoryCommentPreview {
   if (!value || typeof value !== 'object') {
     return false;
@@ -243,6 +249,15 @@ function getContributorName(value: StoryRecord) {
   return 'Anonymous';
 }
 
+function formatTimePeriodFromProperties(properties: Record<string, unknown>) {
+  return formatTimePeriod({
+    time_type: properties.time_type,
+    year: properties.year,
+    year_start: properties.year_start,
+    year_end: properties.year_end,
+  });
+}
+
 export function mapStory(value: unknown): StoryEntity {
   if (!value || typeof value !== 'object') {
     throw new Error('Invalid story payload.');
@@ -338,6 +353,41 @@ export function mapStoryMapPin(value: unknown): StoryMapPin {
     timePeriod: summary.timePeriod,
     latitude: summary.latitude,
     longitude: summary.longitude,
+  };
+}
+
+export function mapGeoJSONStoryMapPin(value: unknown): StoryMapPin {
+  if (!value || typeof value !== 'object') {
+    throw new Error('Invalid story map pin payload.');
+  }
+
+  const feature = value as StoryMapFeatureRecord;
+  const id = asIdentifier(feature.id);
+  const properties =
+    feature.properties && typeof feature.properties === 'object'
+      ? (feature.properties as Record<string, unknown>)
+      : undefined;
+  const geometry =
+    feature.geometry && typeof feature.geometry === 'object'
+      ? (feature.geometry as Record<string, unknown>)
+      : undefined;
+  const coordinates = Array.isArray(geometry?.coordinates) ? geometry.coordinates : undefined;
+  const longitude = asNumber(coordinates?.[0]);
+  const latitude = asNumber(coordinates?.[1]);
+  const title = asString(properties?.title);
+
+  if (!id || !title || latitude === undefined || longitude === undefined) {
+    throw new Error('Invalid story map pin payload.');
+  }
+
+  return {
+    id,
+    title,
+    previewText: asString(properties?.preview_text),
+    placeName: asString(properties?.location_name),
+    timePeriod: formatTimePeriodFromProperties(properties ?? {}),
+    latitude,
+    longitude,
   };
 }
 

--- a/mobile/src/features/stories/data/repositories/__tests__/StoryRepository.test.ts
+++ b/mobile/src/features/stories/data/repositories/__tests__/StoryRepository.test.ts
@@ -65,26 +65,39 @@ describe('StoryRepositoryImpl', () => {
     expect(deleteStorySpy).toHaveBeenCalledWith('42');
   });
 
-  it('falls back to the story feed when the map endpoint returns no pins', async () => {
-    jest.spyOn(storiesRemoteSource, 'getMapStoriesFromApi').mockResolvedValue([]);
-    jest.spyOn(storiesRemoteSource, 'getStoriesFromApi').mockResolvedValue([
-      {
-        id: 7,
-        title: 'Bosphorus Memory',
-        preview_text: 'A waterfront story.',
-        location_name: 'Istanbul',
-        location_lat: '41.0082',
-        location_lng: '28.9784',
-        time_period: '1980s',
-      },
-      {
-        id: 8,
-        title: 'Missing Coordinates',
-        preview_text: 'This one should not become a pin.',
-        location_name: 'Unknown',
-        time_period: '1990s',
-      },
-    ]);
+  it('maps a GeoJSON FeatureCollection into mobile story pins', async () => {
+    jest.spyOn(storiesRemoteSource, 'getMapFeatureCollectionFromApi').mockResolvedValue({
+      type: 'FeatureCollection',
+      features: [
+        {
+          type: 'Feature',
+          id: 7,
+          geometry: {
+            type: 'Point',
+            coordinates: [28.9784, 41.0082],
+          },
+          properties: {
+            title: 'Bosphorus Memory',
+            preview_text: 'A waterfront story.',
+            location_name: 'Istanbul',
+            time_type: 'decade',
+            year: 1980,
+          },
+        },
+        {
+          type: 'Feature',
+          id: 8,
+          geometry: {
+            type: 'Point',
+            coordinates: ['invalid', 41.1],
+          },
+          properties: {
+            title: 'Missing Coordinates',
+            location_name: 'Unknown',
+          },
+        },
+      ],
+    });
 
     const repository = new StoryRepositoryImpl();
     const result = await repository.getMapPins();
@@ -100,5 +113,16 @@ describe('StoryRepositoryImpl', () => {
         longitude: 28.9784,
       },
     ]);
+  });
+
+  it('returns an empty list when the GeoJSON FeatureCollection is empty', async () => {
+    jest.spyOn(storiesRemoteSource, 'getMapFeatureCollectionFromApi').mockResolvedValue({
+      type: 'FeatureCollection',
+      features: [],
+    });
+
+    const repository = new StoryRepositoryImpl();
+
+    await expect(repository.getMapPins()).resolves.toEqual([]);
   });
 });

--- a/mobile/src/features/stories/data/repositories/index.ts
+++ b/mobile/src/features/stories/data/repositories/index.ts
@@ -1,6 +1,6 @@
 import { StoryEntity, StoryMapPin, StorySummaryEntity } from '../../domain/entities';
 import { StoryFilters, StoryRepository } from '../../domain/repositories';
-import { mapStory, mapStoryComment, mapStoryMapPin, mapStorySummary } from '../mappers';
+import { mapGeoJSONStoryMapPin, mapStory, mapStoryComment, mapStoryMapPin, mapStorySummary } from '../mappers';
 import { storiesLocalSource, storiesRemoteSource } from '../sources';
 import { env } from '../../../../app/config/env';
 
@@ -49,7 +49,14 @@ export class StoryRepositoryImpl implements StoryRepository {
 
   async getMapPins(filters: StoryFilters = {}): Promise<StoryMapPin[]> {
     try {
-      const remotePins = await this.getRemoteMapPins(filters);
+      const featureCollection = await storiesRemoteSource.getMapFeatureCollectionFromApi(filters);
+      const remotePins = featureCollection.features.flatMap((feature) => {
+        try {
+          return [mapGeoJSONStoryMapPin(feature)];
+        } catch {
+          return [];
+        }
+      });
 
       if (env.environment === 'development') {
         return mergeById(remotePins, storiesLocalSource.getStories(filters).map(mapStoryMapPin));
@@ -60,24 +67,6 @@ export class StoryRepositoryImpl implements StoryRepository {
       const response = await storiesRemoteSource.getStories(filters);
       return response.map(mapStoryMapPin);
     }
-  }
-
-  private async getRemoteMapPins(filters: StoryFilters) {
-    const mapStories = await storiesRemoteSource.getMapStoriesFromApi(filters);
-
-    if (mapStories.length > 0) {
-      return mapStories.map(mapStoryMapPin);
-    }
-
-    const stories = await storiesRemoteSource.getStoriesFromApi(filters);
-
-    return stories.flatMap((story) => {
-      try {
-        return [mapStoryMapPin(story)];
-      } catch {
-        return [];
-      }
-    });
   }
 }
 

--- a/mobile/src/features/stories/data/sources/__tests__/storiesRemoteSource.test.ts
+++ b/mobile/src/features/stories/data/sources/__tests__/storiesRemoteSource.test.ts
@@ -1,0 +1,112 @@
+import { storiesRemoteSource } from '..';
+import { apiClient } from '../../../../../core/api/client';
+
+describe('storiesRemoteSource', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('attaches preview text to GeoJSON features when the map endpoint omits it', async () => {
+    const getSpy = jest.spyOn(apiClient, 'get')
+      .mockResolvedValueOnce({
+        type: 'FeatureCollection',
+        features: [
+          {
+            type: 'Feature',
+            id: 7,
+            geometry: {
+              type: 'Point',
+              coordinates: [28.9784, 41.0082],
+            },
+            properties: {
+              title: 'Bosphorus Memory',
+              location_name: 'Istanbul',
+              time_type: 'decade',
+              year: 1980,
+            },
+          },
+        ],
+      })
+      .mockResolvedValueOnce({
+        next: null,
+        results: [
+          {
+            id: 7,
+            preview_text: 'A waterfront story.',
+          },
+        ],
+      });
+
+    const result = await storiesRemoteSource.getMapFeatureCollectionFromApi();
+
+    expect(getSpy).toHaveBeenNthCalledWith(1, '/stories/map/', {
+      headers: {
+        Accept: 'application/geo+json, application/json',
+      },
+    });
+    expect(getSpy).toHaveBeenNthCalledWith(2, '/stories/feed/?page_size=100&sort_by=recent&page=1');
+    expect(result).toEqual({
+      type: 'FeatureCollection',
+      features: [
+        {
+          type: 'Feature',
+          id: 7,
+          geometry: {
+            type: 'Point',
+            coordinates: [28.9784, 41.0082],
+          },
+          properties: {
+            title: 'Bosphorus Memory',
+            location_name: 'Istanbul',
+            time_type: 'decade',
+            year: 1980,
+            preview_text: 'A waterfront story.',
+          },
+        },
+      ],
+    });
+  });
+
+  it('normalizes the legacy map response shape without an extra enrichment request', async () => {
+    const getSpy = jest.spyOn(apiClient, 'get').mockResolvedValue({
+      results: [
+        {
+          id: 7,
+          title: 'Bosphorus Memory',
+          preview_text: 'A waterfront story.',
+          location_name: 'Istanbul',
+          location_lat: '41.0082',
+          location_lng: '28.9784',
+          time_type: 'decade',
+          year: 1980,
+        },
+      ],
+    });
+
+    const result = await storiesRemoteSource.getMapFeatureCollectionFromApi();
+
+    expect(getSpy).toHaveBeenCalledTimes(1);
+    expect(result).toEqual({
+      type: 'FeatureCollection',
+      features: [
+        {
+          type: 'Feature',
+          id: 7,
+          geometry: {
+            type: 'Point',
+            coordinates: [28.9784, 41.0082],
+          },
+          properties: {
+            title: 'Bosphorus Memory',
+            location_name: 'Istanbul',
+            time_type: 'decade',
+            year: 1980,
+            year_start: undefined,
+            year_end: undefined,
+            preview_text: 'A waterfront story.',
+          },
+        },
+      ],
+    });
+  });
+});

--- a/mobile/src/features/stories/data/sources/index.ts
+++ b/mobile/src/features/stories/data/sources/index.ts
@@ -4,6 +4,20 @@ import { StoryFilters } from '../../domain/repositories';
 
 const storiesFixture: StoryEntity[] = [];
 type StoryRecord = Record<string, unknown>;
+type StoryMapFeatureRecord = {
+  id?: unknown;
+  properties?: unknown;
+};
+type GeoJSONFeatureCollection = {
+  type: 'FeatureCollection';
+  features: unknown[];
+};
+const MAP_PAGE_SIZE = 100;
+const GEOJSON_ACCEPT_HEADER = 'application/geo+json, application/json';
+const EMPTY_FEATURE_COLLECTION: GeoJSONFeatureCollection = {
+  type: 'FeatureCollection',
+  features: [],
+};
 
 export const storiesRemoteSource = {
   async getStory(id: string) {
@@ -38,7 +52,7 @@ export const storiesRemoteSource = {
         await apiClient.get<{ results?: unknown[] }>(
           `/stories/feed/${buildQueryString({
             page: 1,
-            page_size: 100,
+            page_size: MAP_PAGE_SIZE,
             sort_by: 'recent',
             ...normalizeStoryFilters(filters),
           })}`,
@@ -48,31 +62,51 @@ export const storiesRemoteSource = {
 
     const results = await fetchAllPages('/stories/search/', {
       q: filters.q.trim(),
-      page_size: 100,
+      page_size: MAP_PAGE_SIZE,
     });
 
     return filterRemoteStories(results, filters);
   },
 
-  async getMapStoriesFromApi(filters: StoryFilters = {}) {
+  async getMapFeatureCollectionFromApi(filters: StoryFilters = {}) {
     if (!filters.q?.trim()) {
-      return (
-        await apiClient.get<{ results?: unknown[] }>(
-          `/stories/map/${buildQueryString({
-            page: 1,
-            page_size: 100,
-            ...normalizeStoryFilters(filters),
-          })}`,
-        )
-      )?.results ?? [];
+      const response = await apiClient.get<GeoJSONFeatureCollection | { results?: unknown[] }>(
+        `/stories/map/${buildQueryString({
+          ...normalizeStoryFilters(filters),
+        })}`,
+        {
+          headers: {
+            Accept: GEOJSON_ACCEPT_HEADER,
+          },
+        },
+      );
+
+      const featureCollection = normalizeMapFeatureCollection(response);
+
+      if (!featureCollection.features.length || featureCollectionHasPreviewText(featureCollection)) {
+        return featureCollection;
+      }
+
+      const stories = await fetchAllPages('/stories/feed/', {
+        page_size: MAP_PAGE_SIZE,
+        sort_by: 'recent',
+        ...normalizeStoryFilters(filters),
+      });
+
+      return attachPreviewTextToFeatureCollection(featureCollection, stories);
     }
 
     const results = await fetchAllPages('/stories/search/', {
       q: filters.q.trim(),
-      page_size: 100,
+      page_size: MAP_PAGE_SIZE,
     });
 
-    return filterRemoteStories(results, filters).filter(hasCoordinates);
+    return {
+      type: 'FeatureCollection',
+      features: filterRemoteStories(results, filters)
+        .filter(hasCoordinates)
+        .map(storyToFeature),
+    };
   },
 };
 
@@ -192,6 +226,117 @@ function hasCoordinates(value: unknown) {
   return asNumber(story.location_lat) !== undefined && asNumber(story.location_lng) !== undefined;
 }
 
+function storyToFeature(value: unknown) {
+  if (!value || typeof value !== 'object') {
+    throw new Error('Invalid story map feature payload.');
+  }
+
+  const story = value as StoryRecord;
+  const id = typeof story.id === 'string' || typeof story.id === 'number' ? story.id : undefined;
+  const latitude = asNumber(story.location_lat);
+  const longitude = asNumber(story.location_lng);
+
+  if (id === undefined || latitude === undefined || longitude === undefined || !asString(story.title)) {
+    throw new Error('Invalid story map feature payload.');
+  }
+
+  return {
+    type: 'Feature',
+    id,
+    geometry: {
+      type: 'Point',
+      coordinates: [longitude, latitude],
+    },
+    properties: {
+      title: asString(story.title),
+      location_name: asString(story.location_name),
+      time_type: story.time_type,
+      year: story.year,
+      year_start: story.year_start,
+      year_end: story.year_end,
+      preview_text: asString(story.preview_text),
+    },
+  };
+}
+
+function normalizeMapFeatureCollection(
+  response: GeoJSONFeatureCollection | { results?: unknown[] } | null,
+): GeoJSONFeatureCollection {
+  if (!response) {
+    return EMPTY_FEATURE_COLLECTION;
+  }
+
+  if (isGeoJSONFeatureCollection(response)) {
+    return {
+      type: 'FeatureCollection',
+      features: response.features,
+    };
+  }
+
+  if (isLegacyMapResponse(response)) {
+    return {
+      type: 'FeatureCollection',
+      features: response.results.filter(hasCoordinates).map(storyToFeature),
+    };
+  }
+
+  throw new Error('Invalid map response payload.');
+}
+
+function attachPreviewTextToFeatureCollection(
+  featureCollection: GeoJSONFeatureCollection,
+  stories: unknown[],
+): GeoJSONFeatureCollection {
+  const previewTextById = new Map<string, string>();
+
+  stories.forEach((value) => {
+    if (!value || typeof value !== 'object') {
+      return;
+    }
+
+    const story = value as StoryRecord;
+    const id =
+      typeof story.id === 'string' || typeof story.id === 'number' ? String(story.id) : undefined;
+    const previewText = asString(story.preview_text);
+
+    if (!id || !previewText) {
+      return;
+    }
+
+    previewTextById.set(id, previewText);
+  });
+
+  return {
+    type: 'FeatureCollection',
+    features: featureCollection.features.map((value) => {
+      if (!value || typeof value !== 'object') {
+        return value;
+      }
+
+      const feature = value as StoryMapFeatureRecord;
+      const featureId =
+        typeof feature.id === 'string' || typeof feature.id === 'number' ? String(feature.id) : undefined;
+      const properties =
+        feature.properties && typeof feature.properties === 'object'
+          ? (feature.properties as Record<string, unknown>)
+          : undefined;
+      const previewText = featureId ? previewTextById.get(featureId) : undefined;
+
+      if (!properties || !previewText || asString(properties.preview_text)) {
+        return value;
+      }
+
+      return {
+        ...feature,
+        properties: {
+          ...properties,
+          preview_text: previewText,
+        },
+      };
+    }),
+  };
+}
+
 function normalizeStoryFilters(filters: StoryFilters) {
   const params: Record<string, string | number> = {};
 
@@ -261,4 +406,37 @@ function asNumber(value: unknown) {
   }
 
   return undefined;
+}
+
+function isGeoJSONFeatureCollection(value: unknown): value is GeoJSONFeatureCollection {
+  return Boolean(
+    value &&
+      typeof value === 'object' &&
+      (value as { type?: unknown }).type === 'FeatureCollection' &&
+      Array.isArray((value as { features?: unknown }).features),
+  );
+}
+
+function isLegacyMapResponse(value: unknown): value is { results: unknown[] } {
+  return Boolean(
+    value &&
+      typeof value === 'object' &&
+      Array.isArray((value as { results?: unknown }).results),
+  );
+}
+
+function featureCollectionHasPreviewText(featureCollection: GeoJSONFeatureCollection) {
+  return featureCollection.features.every((value) => {
+    if (!value || typeof value !== 'object') {
+      return false;
+    }
+
+    const feature = value as StoryMapFeatureRecord;
+    const properties =
+      feature.properties && typeof feature.properties === 'object'
+        ? (feature.properties as Record<string, unknown>)
+        : undefined;
+
+    return Boolean(properties && asString(properties.preview_text));
+  });
 }


### PR DESCRIPTION
# 📝 Description
Fixes #377 

Updates the mobile map data flow to consume the backend GeoJSON `FeatureCollection` contract used by `/stories/map/`, while preserving the existing native map experience.

### What changed
- Switched the mobile map source/repository flow to read GeoJSON from the backend instead of the legacy flat pin response.
- Added GeoJSON-to-`StoryMapPin` mapping so the existing `MapMarkerGroup`, `MapScreen`, and `MapCard` flow stays intact.
- Handled GeoJSON coordinate ordering correctly by converting `[longitude, latitude]` into the app’s `latitude` / `longitude` fields.
- Preserved preview-card behavior by enriching GeoJSON features with `preview_text` when needed, so marker selection and story-detail navigation continue to work as before.
- Added tests for:
  - mapping a mock GeoJSON feature into a mobile map pin
  - consuming a mock `FeatureCollection` in the repository layer
  - handling an empty `FeatureCollection`
  - preserving compatibility with the current map UI flow

# 📊 Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Refactoring
- [ ] Documentation
 
# ✅ Acceptance Criteria / Checklist
- [x] Project builds successfully
- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, especially in hard-to-understand parts
- [x] I have performed a self-review of my code
- [x] I have added/updated tests
- [x] New and existing unit tests pass locally with my changes

# 📸 Screenshots / Recordings
<!-- Not applicable — this change preserves the existing mobile map UI and behavior while updating the underlying data contract. -->

# ⏱️ Estimated Review Time
- [ ] < 5 min
- [x] 5-15 min
- [ ] > 15 min
