### PR TITLE
fix: mobile remove feed top gap

### DIFF
--- a/mobile/src/features/feed/presentation/screens/FeedScreen.tsx
+++ b/mobile/src/features/feed/presentation/screens/FeedScreen.tsx
@@ -149,31 +149,37 @@ export function FeedScreen({
     loadPage(1, 'initial', { filters: activeFilters });
   };
 
-  const renderControls = () => (
-    <View style={{ paddingHorizontal: spacing.lg, paddingTop: spacing.md, paddingBottom: spacing.sm, gap: spacing.md }}>
-      <View style={{ flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between', gap: spacing.md }}>
-        <Text style={{ color: colors.muted, fontSize: typography.caption }}>
-          {state.totalCount > 0 ? `${state.totalCount} stories` : hasActiveFilters ? 'No matching stories yet' : 'Newest stories'}
-        </Text>
-        <Pressable
-          accessibilityRole="button"
-          accessibilityLabel="Sort: Most Recent"
-          style={{
-            paddingHorizontal: spacing.sm + 4,
-            paddingVertical: spacing.xs + 2,
-            borderRadius: 999,
-            borderWidth: 1,
-            borderColor: colors.border,
-            backgroundColor: colors.infoSurface,
-          }}
-        >
-          <Text style={{ color: colors.text, fontWeight: '700' }}>Most Recent</Text>
-        </Pressable>
-      </View>
+  const renderControls = () => {
+    if (!showSearchControls) {
+      return null;
+    }
 
-      {showSearchControls ? <StorySearchControls helperText="Search by title or place." scope={searchScope} /> : null}
-    </View>
-  );
+    return (
+      <View style={{ paddingHorizontal: spacing.lg, paddingTop: spacing.md, paddingBottom: spacing.sm, gap: spacing.md }}>
+        <View style={{ flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between', gap: spacing.md }}>
+          <Text style={{ color: colors.muted, fontSize: typography.caption }}>
+            {state.totalCount > 0 ? `${state.totalCount} stories` : hasActiveFilters ? 'No matching stories yet' : 'Newest stories'}
+          </Text>
+          <Pressable
+            accessibilityRole="button"
+            accessibilityLabel="Sort: Most Recent"
+            style={{
+              paddingHorizontal: spacing.sm + 4,
+              paddingVertical: spacing.xs + 2,
+              borderRadius: 999,
+              borderWidth: 1,
+              borderColor: colors.border,
+              backgroundColor: colors.infoSurface,
+            }}
+          >
+            <Text style={{ color: colors.text, fontWeight: '700' }}>Most Recent</Text>
+          </Pressable>
+        </View>
+
+        <StorySearchControls helperText="Search by title or place." scope={searchScope} />
+      </View>
+    );
+  };
 
   if (!isHydrated) {
     return <Loader message="Restoring search filters..." />;

--- a/mobile/src/features/feed/presentation/screens/__tests__/FeedScreen.test.tsx
+++ b/mobile/src/features/feed/presentation/screens/__tests__/FeedScreen.test.tsx
@@ -57,6 +57,14 @@ describe('FeedScreen', () => {
     expect(screen.queryByText('Story feed')).toBeNull();
   });
 
+  it('hides top feed controls when search controls are disabled', async () => {
+    renderScreen(<FeedScreen getFeed={async () => makeFeedPage()} showSearchControls={false} />);
+
+    expect(await screen.findByText('Story 1')).toBeTruthy();
+    expect(screen.queryByRole('button', { name: 'Sort: Most Recent' })).toBeNull();
+    expect(screen.queryByLabelText('Search stories')).toBeNull();
+  });
+
   it('shows an empty state when no stories are returned', async () => {
     renderScreen(<FeedScreen getFeed={async () => makeFeedPage({ items: [], totalCount: 0 })} />);
 


### PR DESCRIPTION
# 📝 Description
Fixes #437 

Removes the extra empty space shown above the mobile feed when switching from `Map` to `Feed` in the main pager. The fix prevents `FeedScreen` from rendering duplicate top controls when it is already embedded under the shared mobile header/search area.

# 📊 Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Refactoring
- [ ] Documentation

# ✅ Acceptance Criteria / Checklist
- [x] Project builds successfully
- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, especially in hard-to-understand parts
- [x] I have performed a self-review of my code
- [x] I have added/updated tests
- [x] New and existing unit tests pass locally with my changes

## Additional Acceptance Criteria
- [x] On mobile, switching from `Map` to `Feed` in the main pager does not leave extra empty space above the first feed item.
- [x] The top of the feed content aligns with the shared mobile header/search area the same way the map content does.
- [x] `FeedScreen` does not render duplicate top controls when it is used with `showSearchControls={false}` in the main pager.
- [x] The standalone feed experience still shows its normal search and sort controls when `showSearchControls={true}`.
- [x] Switching between `Map` and `Feed` does not introduce visible layout jumps or inconsistent vertical spacing.
- [x] Existing feed behavior remains intact, including loading, empty, error, refresh, and pagination states.
- [x] A test covers the hidden-controls case so the spacing regression does not come back.

# 📸 Screenshots / Recordings

# ⏱️ Estimated Review Time
- [x] < 5 min
- [ ] 5-15 min
- [ ] > 15 min
