### PR TITLE
feat: add tag filter param to feed, map, and search endpoints

### DIFF
--- a/backend/apps/stories/serializers.py
+++ b/backend/apps/stories/serializers.py
@@ -261,6 +261,8 @@ class FeedQuerySerializer(serializers.Serializer):
     year_to = serializers.IntegerField(required=False)
     # Substring match against location_name — partial values like "galata" are valid
     location = serializers.CharField(required=False, allow_blank=False)
+    # Exact (case-insensitive) match against tag name — use the tag slug, e.g. "ottoman-era"
+    tag = serializers.CharField(required=False, allow_blank=False)
 
     def validate(self, data):
         year_from = data.get('year_from')
@@ -324,6 +326,8 @@ class SearchQuerySerializer(serializers.Serializer):
     year_to = serializers.IntegerField(required=False)
     # Substring match against location_name — partial values like "galata" are valid
     location = serializers.CharField(required=False, allow_blank=False)
+    # Exact (case-insensitive) match against tag name — use the tag slug, e.g. "ottoman-era"
+    tag = serializers.CharField(required=False, allow_blank=False)
 
     def validate(self, data):
         year_from = data.get('year_from')

--- a/backend/apps/stories/services.py
+++ b/backend/apps/stories/services.py
@@ -26,7 +26,7 @@ def delete_story(story: Story) -> None:
     story.delete()
 
 
-def get_story_feed(sort_by='recent', year_from=None, year_to=None, location=None):
+def get_story_feed(sort_by='recent', year_from=None, year_to=None, location=None, tag=None):
     """
     Return a queryset of published stories with optional sorting and filtering.
 
@@ -37,6 +37,8 @@ def get_story_feed(sort_by='recent', year_from=None, year_to=None, location=None
 
     Location filtering is a case-insensitive substring match on location_name so
     that partial queries like "galata" match "Galata Bridge".
+
+    tag filters to stories that carry the exact tag name (case-insensitive).
 
     sort_by='popular' is reserved for when the interactions app provides like_count
     data. Until then only 'recent' is supported.
@@ -58,6 +60,9 @@ def get_story_feed(sort_by='recent', year_from=None, year_to=None, location=None
     if location:
         qs = qs.filter(location_name__icontains=location)
 
+    if tag:
+        qs = qs.filter(story_tags__tag__name__iexact=tag).distinct()
+
     if sort_by == 'recent':
         qs = qs.order_by('-submitted_at')
 
@@ -66,11 +71,11 @@ def get_story_feed(sort_by='recent', year_from=None, year_to=None, location=None
     return qs
 
 
-def get_story_search(q: str, sort_by='recent', year_from=None, year_to=None, location=None):
+def get_story_search(q: str, sort_by='recent', year_from=None, year_to=None, location=None, tag=None):
     """Return published stories whose title or location_name contains q (case-insensitive).
 
     Accepts the same optional filter params as get_story_feed so search results
-    can be narrowed by year range and location in addition to the text query.
+    can be narrowed by year range, location, and tag in addition to the text query.
 
     Returns an empty queryset if q is blank or whitespace-only — callers should
     validate q before calling, but the service is safe to call directly.
@@ -98,6 +103,9 @@ def get_story_search(q: str, sort_by='recent', year_from=None, year_to=None, loc
 
     if location:
         qs = qs.filter(location_name__icontains=location)
+
+    if tag:
+        qs = qs.filter(story_tags__tag__name__iexact=tag).distinct()
 
     if sort_by == 'recent':
         qs = qs.order_by('-submitted_at')

--- a/backend/apps/stories/tests/test_services.py
+++ b/backend/apps/stories/tests/test_services.py
@@ -4,6 +4,7 @@ import pytest
 
 from apps.stories.models import Story
 from apps.stories.services import create_story, delete_story, get_story_feed, get_story_search, update_story
+from apps.tags.models import StoryTag, Tag
 from apps.users.models import User
 
 
@@ -291,6 +292,87 @@ class TestGetStorySearch:
         qs = get_story_search('Tower', year_from=1800, year_to=1950, location='Galata')
         assert qs.count() == 1
         assert qs.first().title == 'Tower in Galata'
+
+
+# ── get_story_feed — tag filter ───────────────────────────────────────────────
+
+@pytest.mark.django_db
+class TestGetStoryFeedTagFilter:
+    def test_feed_tag_filter_returns_matching_stories(self):
+        tagged = make_story(title='Tagged Story')
+        make_story(title='Untagged Story')
+        tag = Tag.objects.create(name='folklore')
+        StoryTag.objects.create(story=tagged, tag=tag)
+        qs = get_story_feed(tag='folklore')
+        assert qs.count() == 1
+        assert qs.first().title == 'Tagged Story'
+
+    def test_feed_tag_filter_excludes_non_matching_stories(self):
+        story = make_story()
+        tag = Tag.objects.create(name='ottoman-era')
+        StoryTag.objects.create(story=story, tag=tag)
+        assert get_story_feed(tag='folklore').count() == 0
+
+    def test_feed_tag_filter_is_case_insensitive(self):
+        story = make_story()
+        tag = Tag.objects.create(name='ottoman-era')
+        StoryTag.objects.create(story=story, tag=tag)
+        assert get_story_feed(tag='Ottoman-Era').count() == 1
+        assert get_story_feed(tag='OTTOMAN-ERA').count() == 1
+
+    def test_feed_tag_filter_combined_with_year_filter(self):
+        match = make_story(title='Match', year=1950)
+        no_match = make_story(title='Too Early', year=1800)
+        tag = Tag.objects.create(name='folklore')
+        StoryTag.objects.create(story=match, tag=tag)
+        StoryTag.objects.create(story=no_match, tag=tag)
+        qs = get_story_feed(tag='folklore', year_from=1900)
+        assert qs.count() == 1
+        assert qs.first().title == 'Match'
+
+    def test_feed_tag_filter_combined_with_location_filter(self):
+        match = make_story(title='Match', location_name='Istanbul')
+        no_match = make_story(title='Wrong Location', location_name='Ankara')
+        tag = Tag.objects.create(name='folklore')
+        StoryTag.objects.create(story=match, tag=tag)
+        StoryTag.objects.create(story=no_match, tag=tag)
+        qs = get_story_feed(tag='folklore', location='Istanbul')
+        assert qs.count() == 1
+        assert qs.first().title == 'Match'
+
+    def test_feed_tag_filter_does_not_return_duplicates(self):
+        story = make_story()
+        tag1 = Tag.objects.create(name='folklore')
+        tag2 = Tag.objects.create(name='ottoman-era')
+        StoryTag.objects.create(story=story, tag=tag1)
+        StoryTag.objects.create(story=story, tag=tag2)
+        # Filtering by one tag on a story that has multiple tags must not produce duplicates
+        assert get_story_feed(tag='folklore').count() == 1
+
+
+# ── get_story_search — tag filter ────────────────────────────────────────────
+
+@pytest.mark.django_db
+class TestGetStorySearchTagFilter:
+    def test_search_tag_param_narrows_results(self):
+        tagged = make_story(title='Istanbul Tale')
+        make_story(title='Istanbul Lore')
+        tag = Tag.objects.create(name='folklore')
+        StoryTag.objects.create(story=tagged, tag=tag)
+        qs = get_story_search('Istanbul', tag='folklore')
+        assert qs.count() == 1
+        assert qs.first().title == 'Istanbul Tale'
+
+    def test_search_tag_param_excludes_untagged(self):
+        make_story(title='Istanbul Tale')
+        assert get_story_search('Istanbul', tag='folklore').count() == 0
+
+    def test_search_tag_and_q_both_must_match(self):
+        # Story matches tag but neither title nor location_name matches q — should not appear
+        tagged = make_story(title='Ankara Chronicle', location_name='Ankara')
+        tag = Tag.objects.create(name='folklore')
+        StoryTag.objects.create(story=tagged, tag=tag)
+        assert get_story_search('Istanbul', tag='folklore').count() == 0
 
 
 # ── delete_story ──────────────────────────────────────────────────────────────

--- a/backend/apps/stories/tests/test_views.py
+++ b/backend/apps/stories/tests/test_views.py
@@ -8,6 +8,7 @@ from rest_framework.test import APIClient
 from apps.interactions.models import Like, SavedStory
 from apps.media.models import MediaItem, MediaType
 from apps.stories.models import Story
+from apps.tags.models import StoryTag, Tag
 from apps.users.models import RoleChoices, User
 
 FEED_URL = '/stories/feed/'
@@ -189,6 +190,31 @@ class TestStoryFeedView:
     def test_returns_400_when_year_from_greater_than_year_to(self, client):
         response = client.get(FEED_URL + '?year_from=2000&year_to=1900')
         assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+    def test_feed_tag_filter_returns_only_tagged_stories(self, client):
+        tagged = make_story(title='Tagged')
+        make_story(title='Untagged')
+        tag = Tag.objects.create(name='folklore')
+        StoryTag.objects.create(story=tagged, tag=tag)
+        response = client.get(FEED_URL + '?tag=folklore')
+        assert response.data['count'] == 1
+        assert response.data['results'][0]['title'] == 'Tagged'
+
+    def test_feed_tag_filter_returns_empty_when_no_match(self, client):
+        make_story(title='Untagged')
+        Tag.objects.create(name='folklore')
+        response = client.get(FEED_URL + '?tag=folklore')
+        assert response.data['count'] == 0
+
+    def test_feed_tag_and_location_filter_combined(self, client):
+        match = make_story(title='Match', location_name='Istanbul')
+        no_match = make_story(title='Wrong Location', location_name='Ankara')
+        tag = Tag.objects.create(name='folklore')
+        StoryTag.objects.create(story=match, tag=tag)
+        StoryTag.objects.create(story=no_match, tag=tag)
+        response = client.get(FEED_URL + '?tag=folklore&location=Istanbul')
+        assert response.data['count'] == 1
+        assert response.data['results'][0]['title'] == 'Match'
 
 
 # ── GET /stories/ ─────────────────────────────────────────────────────────────
@@ -382,6 +408,28 @@ class TestStorySearchView:
         response = client.get(SEARCH_URL + '?q=Istanbul&sort_by=invalid')
         assert response.status_code == status.HTTP_400_BAD_REQUEST
 
+    def test_search_tag_filter_narrows_results(self, client):
+        tagged = make_story(title='Istanbul Tale')
+        make_story(title='Istanbul Lore')
+        tag = Tag.objects.create(name='folklore')
+        StoryTag.objects.create(story=tagged, tag=tag)
+        response = client.get(SEARCH_URL + '?q=Istanbul&tag=folklore')
+        assert response.data['count'] == 1
+        assert response.data['results'][0]['title'] == 'Istanbul Tale'
+
+    def test_search_tag_filter_returns_empty_when_tag_missing(self, client):
+        make_story(title='Istanbul Tale')
+        response = client.get(SEARCH_URL + '?q=Istanbul&tag=folklore')
+        assert response.data['count'] == 0
+
+    def test_search_tag_and_q_both_must_match(self, client):
+        # Story has the tag but q does not match its title or location_name
+        story = make_story(title='Ankara Chronicle', location_name='Ankara')
+        tag = Tag.objects.create(name='folklore')
+        StoryTag.objects.create(story=story, tag=tag)
+        response = client.get(SEARCH_URL + '?q=Istanbul&tag=folklore')
+        assert response.data['count'] == 0
+
 
 # ── GET /stories/map/ ─────────────────────────────────────────────────────────
 
@@ -470,6 +518,20 @@ class TestStoryMapView:
         response = client.get(MAP_URL)
         if response.data['features']:
             assert 'narrative' not in response.data['features'][0]['properties']
+
+    def test_map_tag_filter_returns_only_tagged_stories(self, client):
+        tagged = make_story(title='Tagged')
+        make_story(title='Untagged')
+        tag = Tag.objects.create(name='ottoman-era')
+        StoryTag.objects.create(story=tagged, tag=tag)
+        response = client.get(MAP_URL + '?tag=ottoman-era')
+        assert len(response.data['features']) == 1
+        assert response.data['features'][0]['properties']['title'] == 'Tagged'
+
+    def test_map_tag_filter_returns_empty_when_no_match(self, client):
+        make_story(title='Untagged')
+        response = client.get(MAP_URL + '?tag=ottoman-era')
+        assert len(response.data['features']) == 0
 
 
 # ── StoryDetailView — media_items ─────────────────────────────────────────────

--- a/backend/apps/stories/views.py
+++ b/backend/apps/stories/views.py
@@ -38,6 +38,7 @@ class StoryFeedView(APIView):
       year_from  — include stories from this year onwards
       year_to    — include stories up to and including this year
       location   — case-insensitive substring match against location_name
+      tag        — exact tag name filter (case-insensitive), e.g. "ottoman-era"
       page       — page number (default 1)
       page_size  — results per page (default 10, max 100)
     """
@@ -55,6 +56,7 @@ class StoryFeedView(APIView):
             year_from=params.get('year_from'),
             year_to=params.get('year_to'),
             location=params.get('location'),
+            tag=params.get('tag'),
         )
         if request.user.is_authenticated:
             qs = annotate_user_interactions(qs, request.user)
@@ -79,6 +81,7 @@ class StoryMapView(APIView):
       year_from  — include stories from this year onwards
       year_to    — include stories up to and including this year
       location   — case-insensitive substring match against location_name
+      tag        — exact tag name filter (case-insensitive), e.g. "ottoman-era"
     """
 
     permission_classes = [AllowAny]
@@ -92,6 +95,7 @@ class StoryMapView(APIView):
             year_from=params.get('year_from'),
             year_to=params.get('year_to'),
             location=params.get('location'),
+            tag=params.get('tag'),
         )
 
         serializer = StoryMapGeoJSONSerializer(qs, many=True)
@@ -109,7 +113,8 @@ class StorySearchView(APIView):
     title and location_name. Open to guests and authenticated users alike.
 
     Query params:
-      q — required, min 1 character after stripping whitespace
+      q        — required, min 1 character after stripping whitespace
+      tag      — optional exact tag name filter (case-insensitive), e.g. "ottoman-era"
     """
 
     permission_classes = [AllowAny]
@@ -125,6 +130,7 @@ class StorySearchView(APIView):
             year_from=params.get('year_from'),
             year_to=params.get('year_to'),
             location=params.get('location'),
+            tag=params.get('tag'),
         )
         if request.user.is_authenticated:
             qs = annotate_user_interactions(qs, request.user)


### PR DESCRIPTION
## 📝 Description

Fixes #216
This PR adds support for **tag-based filtering** in the story discovery endpoints.

With this change, the `tag` query parameter can now be used in:
- `GET /stories/feed/`
- `GET /stories/map/`
- `GET /stories/search/`

The related serializers, views, and service functions were updated so that stories can be filtered by an exact tag name in a case-insensitive way. Combined filtering behavior with existing parameters such as year, location, and search query is preserved.

In addition, tests were added to cover tag filtering behavior in both the service and view layers, including combined filter scenarios and duplicate-prevention cases.


# 📊 Type of Change
- [ ]  Bug fix
- [x]  New feature
- [ ]  Refactoring
- [ ]  Documentation
 
# ✅ Acceptance Criteria / Checklist
- [x] Project builds successfully
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, especially in hard-to-understand parts
- [x] I have performed a self-review of my code
- [x] I have added/updated tests
- [x] New and existing unit tests pass locally with my changes

# 📸 Screenshots / Recordings
<!-- If applicable !-->
# ⏱️ Estimated Review Time
- [ ] < 5 min
- [x] 5-15 min
- [ ] > 15 min
