### PR TITLE
feat: email verification screen with 6-digit code input

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -7,6 +7,7 @@ import { ToastProvider } from "@/context/ToastContext";
 import { Toaster } from "@/components/ui/toaster";
 import LoginPage from "@/pages/LoginPage";
 import RegisterPage from "@/pages/RegisterPage";
+import VerifyEmailPage from "@/pages/VerifyEmailPage";
 import ProfileCompletionPage from "@/pages/ProfileCompletionPage";
 import NotFoundPage from "@/pages/NotFoundPage";
 import FeedPage from "@/pages/FeedPage";
@@ -26,6 +27,7 @@ function App() {
               <Route path="/map" element={<MapPage />} />
               <Route path="/login" element={<LoginPage />} />
               <Route path="/register" element={<RegisterPage />} />
+              <Route path="/verify-email" element={<VerifyEmailPage />} />
               <Route
                 path="/complete-profile"
                 element={(

--- a/frontend/src/pages/RegisterPage.jsx
+++ b/frontend/src/pages/RegisterPage.jsx
@@ -14,7 +14,6 @@ import {
   CardFooter,
 } from "@/components/ui";
 import { register } from "@/services/authService";
-import { useAuth } from "@/hooks/useAuth";
 import { useToast } from "@/hooks/useToast";
 
 const INITIAL_FIELD_ERRORS = {
@@ -46,7 +45,6 @@ function validatePasswordStrength(password) {
 function RegisterPage() {
   const navigate = useNavigate();
   const location = useLocation();
-  const { login } = useAuth();
   const { toast } = useToast();
 
   const [username, setUsername] = useState("");
@@ -150,17 +148,11 @@ function RegisterPage() {
     setIsLoading(true);
     try {
       await register(username, email, password, confirmPassword);
-      try {
-        await login(email, password);
-        toast.success("Account created! Welcome!");
-        navigate("/complete-profile", {
-          state: { from: location.state?.from || null },
-          replace: true,
-        });
-      } catch {
-        toast.info("Account created! Please sign in to continue.");
-        navigate("/login", { state: { from: location.state?.from }, replace: true });
-      }
+      toast.success("Account created! Please verify your email.");
+      navigate("/verify-email", {
+        state: { email, from: location.state?.from || null },
+        replace: true,
+      });
     } catch (error) {
       const msg = extractApiErrors(error);
       setApiError(msg);

--- a/frontend/src/pages/VerifyEmailPage.jsx
+++ b/frontend/src/pages/VerifyEmailPage.jsx
@@ -1,0 +1,320 @@
+import { useState, useRef, useEffect, useCallback } from "react";
+import { useNavigate, useLocation, Link, Navigate } from "react-router-dom";
+import { Mail, Loader2, MapPin } from "lucide-react";
+
+import {
+  Button,
+  Card,
+  CardHeader,
+  CardTitle,
+  CardDescription,
+  CardContent,
+  CardFooter,
+} from "@/components/ui";
+import { verifyEmail, resendVerificationCode } from "@/services/authService";
+import { useToast } from "@/hooks/useToast";
+
+const CODE_LENGTH = 6;
+const RESEND_COOLDOWN_SECONDS = 60;
+
+function VerifyEmailPage() {
+  const navigate = useNavigate();
+  const location = useLocation();
+  const { toast } = useToast();
+
+  const email = location.state?.email;
+  const from = location.state?.from;
+
+  const [digits, setDigits] = useState(Array(CODE_LENGTH).fill(""));
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [isResending, setIsResending] = useState(false);
+  const [error, setError] = useState("");
+  const [isExpired, setIsExpired] = useState(false);
+  const [cooldown, setCooldown] = useState(0);
+
+  const inputsRef = useRef([]);
+
+  useEffect(() => {
+    inputsRef.current[0]?.focus();
+  }, []);
+
+  useEffect(() => {
+    if (cooldown <= 0) return undefined;
+    const timer = setInterval(() => {
+      setCooldown((prev) => (prev <= 1 ? 0 : prev - 1));
+    }, 1000);
+    return () => clearInterval(timer);
+  }, [cooldown]);
+
+  const code = digits.join("");
+  const isComplete = code.length === CODE_LENGTH && digits.every((d) => d !== "");
+
+  function clearErrors() {
+    if (error) setError("");
+    if (isExpired) setIsExpired(false);
+  }
+
+  function focusInput(index) {
+    const target = inputsRef.current[index];
+    if (target) {
+      target.focus();
+      target.select?.();
+    }
+  }
+
+  function handleDigitChange(index, value) {
+    clearErrors();
+    // Strip everything but digits; if the user pasted or typed multiple chars,
+    // spread them across subsequent boxes.
+    const cleaned = value.replace(/\D/g, "");
+    if (!cleaned) {
+      setDigits((prev) => {
+        const next = [...prev];
+        next[index] = "";
+        return next;
+      });
+      return;
+    }
+
+    setDigits((prev) => {
+      const next = [...prev];
+      for (let i = 0; i < cleaned.length && index + i < CODE_LENGTH; i += 1) {
+        next[index + i] = cleaned[i];
+      }
+      return next;
+    });
+
+    const nextIndex = Math.min(index + cleaned.length, CODE_LENGTH - 1);
+    focusInput(nextIndex);
+  }
+
+  function handleKeyDown(index, e) {
+    if (e.key === "Backspace") {
+      if (!digits[index] && index > 0) {
+        e.preventDefault();
+        setDigits((prev) => {
+          const next = [...prev];
+          next[index - 1] = "";
+          return next;
+        });
+        focusInput(index - 1);
+      }
+    } else if (e.key === "ArrowLeft" && index > 0) {
+      e.preventDefault();
+      focusInput(index - 1);
+    } else if (e.key === "ArrowRight" && index < CODE_LENGTH - 1) {
+      e.preventDefault();
+      focusInput(index + 1);
+    } else if (e.key === "Enter" && isComplete) {
+      handleSubmit();
+    }
+  }
+
+  function handlePaste(e) {
+    const text = (e.clipboardData.getData("text") || "").replace(/\D/g, "");
+    if (!text) return;
+    e.preventDefault();
+    clearErrors();
+    const next = Array(CODE_LENGTH).fill("");
+    for (let i = 0; i < Math.min(text.length, CODE_LENGTH); i += 1) {
+      next[i] = text[i];
+    }
+    setDigits(next);
+    focusInput(Math.min(text.length, CODE_LENGTH - 1));
+  }
+
+  function extractErrorMessage(err, fallback) {
+    const data = err?.response?.data;
+    return (
+      data?.errors?.code?.[0] ||
+      data?.errors?.non_field_errors?.[0] ||
+      data?.message ||
+      data?.detail ||
+      fallback
+    );
+  }
+
+  const handleSubmit = useCallback(
+    async (e) => {
+      if (e?.preventDefault) e.preventDefault();
+      if (!isComplete || isSubmitting) return;
+
+      setIsSubmitting(true);
+      setError("");
+      setIsExpired(false);
+
+      try {
+        await verifyEmail(email, code);
+        toast.success("Account verified! You can now log in.");
+        navigate("/login", {
+          replace: true,
+          state: from ? { from } : undefined,
+        });
+      } catch (err) {
+        const status = err?.response?.status;
+        const errorCode = err?.response?.data?.code;
+
+        if (status === 429) {
+          toast.error("Too many attempts. Please wait before trying again.");
+        } else if (errorCode === "expired" || status === 410) {
+          setIsExpired(true);
+          setError("Code has expired. Click to resend a new one.");
+        } else {
+          setError(
+            extractErrorMessage(err, "Invalid verification code. Please try again.")
+          );
+        }
+      } finally {
+        setIsSubmitting(false);
+      }
+    },
+    [code, email, from, isComplete, isSubmitting, navigate, toast]
+  );
+
+  async function handleResend() {
+    if (cooldown > 0 || isResending) return;
+
+    setIsResending(true);
+    setError("");
+    setIsExpired(false);
+
+    try {
+      await resendVerificationCode(email);
+      toast.success("Verification code sent. Check your email.");
+      setDigits(Array(CODE_LENGTH).fill(""));
+      focusInput(0);
+      setCooldown(RESEND_COOLDOWN_SECONDS);
+    } catch (err) {
+      if (err?.response?.status === 429) {
+        toast.error("Please wait before requesting another code.");
+        setCooldown(RESEND_COOLDOWN_SECONDS);
+      } else {
+        toast.error(
+          extractErrorMessage(err, "Failed to resend code. Please try again.")
+        );
+      }
+    } finally {
+      setIsResending(false);
+    }
+  }
+
+  if (!email) {
+    return <Navigate to="/register" replace />;
+  }
+
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-background px-4 py-12">
+      <Card className="w-full max-w-md">
+        <CardHeader className="space-y-3 text-center">
+          <div className="flex items-center justify-center gap-2">
+            <MapPin className="h-6 w-6 text-primary" />
+            <CardTitle className="text-2xl font-bold">
+              Verify your email
+            </CardTitle>
+          </div>
+          <CardDescription>
+            We sent a 6-digit verification code to{" "}
+            <span className="font-medium text-foreground">{email}</span>.
+            Enter it below to activate your account.
+          </CardDescription>
+        </CardHeader>
+
+        <CardContent>
+          {error && (
+            <div
+              role="alert"
+              className="mb-4 rounded-md border border-destructive/50 bg-destructive/10 px-4 py-3 text-sm text-destructive"
+            >
+              {error}
+            </div>
+          )}
+
+          <form onSubmit={handleSubmit} className="space-y-6" noValidate>
+            <div
+              role="group"
+              aria-label="Verification code"
+              className="flex justify-between gap-2"
+            >
+              {digits.map((digit, index) => (
+                <input
+                  key={index}
+                  ref={(el) => {
+                    inputsRef.current[index] = el;
+                  }}
+                  type="text"
+                  inputMode="numeric"
+                  autoComplete="one-time-code"
+                  maxLength={CODE_LENGTH}
+                  aria-label={`Digit ${index + 1}`}
+                  aria-invalid={!!error}
+                  value={digit}
+                  disabled={isSubmitting}
+                  onChange={(e) => handleDigitChange(index, e.target.value)}
+                  onKeyDown={(e) => handleKeyDown(index, e)}
+                  onPaste={handlePaste}
+                  onFocus={(e) => e.target.select()}
+                  className="h-14 w-full flex-1 rounded-md border border-input bg-background text-center text-xl font-semibold tracking-widest shadow-sm focus:border-ring focus:outline-none focus:ring-2 focus:ring-ring disabled:opacity-50"
+                />
+              ))}
+            </div>
+
+            <Button
+              type="submit"
+              className="w-full"
+              disabled={!isComplete || isSubmitting}
+            >
+              {isSubmitting ? (
+                <>
+                  <Loader2 className="h-4 w-4 animate-spin" />
+                  Verifying...
+                </>
+              ) : (
+                <>
+                  <Mail className="h-4 w-4" />
+                  Verify account
+                </>
+              )}
+            </Button>
+          </form>
+
+          <div className="mt-6 text-center text-sm">
+            <p className="text-muted-foreground">Didn't receive the code?</p>
+            <Button
+              type="button"
+              variant="link"
+              size="sm"
+              onClick={handleResend}
+              disabled={cooldown > 0 || isResending}
+              aria-label={
+                cooldown > 0
+                  ? `Resend available in ${cooldown} seconds`
+                  : "Resend verification code"
+              }
+              className={isExpired ? "font-semibold" : ""}
+            >
+              {isResending
+                ? "Sending..."
+                : cooldown > 0
+                  ? `Resend in ${cooldown}s`
+                  : "Resend code"}
+            </Button>
+          </div>
+        </CardContent>
+
+        <CardFooter className="justify-center">
+          <p className="text-sm text-muted-foreground">
+            Wrong email?{" "}
+            <Link
+              to="/register"
+              className="font-medium text-primary underline-offset-4 hover:underline"
+            >
+              Register again
+            </Link>
+          </p>
+        </CardFooter>
+      </Card>
+    </div>
+  );
+}
+
+export default VerifyEmailPage;

--- a/frontend/src/pages/__tests__/RegisterPage.test.jsx
+++ b/frontend/src/pages/__tests__/RegisterPage.test.jsx
@@ -221,112 +221,86 @@ describe("RegisterPage", () => {
     });
   });
 
-  // 4. Auto-login after registration
-  it("calls login with email and password after successful registration", async () => {
+  // 4. Redirect to email verification after registration
+  it("navigates to /verify-email with email in state after successful registration", async () => {
     const user = userEvent.setup();
     register.mockResolvedValue({ message: "Registration successful.", user: {} });
-    mockLogin.mockResolvedValue({ user: { id: 1, username: VALID_USERNAME } });
     renderRegisterPage();
 
     await fillForm(user);
     await user.click(screen.getByRole("button", { name: /create account/i }));
 
     await waitFor(() => {
-      expect(mockLogin).toHaveBeenCalledWith(VALID_EMAIL, VALID_PASSWORD);
-    });
-  });
-
-  it("navigates to /complete-profile after successful registration and auto-login", async () => {
-    const user = userEvent.setup();
-    register.mockResolvedValue({ message: "Registration successful.", user: {} });
-    mockLogin.mockResolvedValue({ user: { id: 1, username: VALID_USERNAME } });
-    renderRegisterPage();
-
-    await fillForm(user);
-    await user.click(screen.getByRole("button", { name: /create account/i }));
-
-    await waitFor(() => {
-      expect(mockNavigate).toHaveBeenCalledWith("/complete-profile", {
-        state: { from: null },
+      expect(mockNavigate).toHaveBeenCalledWith("/verify-email", {
+        state: { email: VALID_EMAIL, from: null },
         replace: true,
       });
     });
   });
 
-  it("passes the original destination in state when navigating to /complete-profile", async () => {
+  it("passes the original destination via state when navigating to /verify-email", async () => {
     const user = userEvent.setup();
     register.mockResolvedValue({ message: "Registration successful.", user: {} });
-    mockLogin.mockResolvedValue({ user: { id: 1, username: VALID_USERNAME } });
     renderRegisterPageWithFrom("/submit-story");
 
     await fillForm(user);
     await user.click(screen.getByRole("button", { name: /create account/i }));
 
     await waitFor(() => {
-      expect(mockNavigate).toHaveBeenCalledWith("/complete-profile", {
-        state: { from: { pathname: "/submit-story", search: "", hash: "", state: null, key: "testkey" } },
+      expect(mockNavigate).toHaveBeenCalledWith("/verify-email", {
+        state: {
+          email: VALID_EMAIL,
+          from: { pathname: "/submit-story", search: "", hash: "", state: null, key: "testkey" },
+        },
         replace: true,
       });
     });
   });
 
-  it("preserves URL search params in state when navigating to /complete-profile", async () => {
+  it("preserves URL search params via 'from' state when navigating to /verify-email", async () => {
     const user = userEvent.setup();
     register.mockResolvedValue({ message: "Registration successful.", user: {} });
-    mockLogin.mockResolvedValue({ user: { id: 1, username: VALID_USERNAME } });
     renderRegisterPageWithFrom("/map", { search: "?q=castle&year_from=1900" });
 
     await fillForm(user);
     await user.click(screen.getByRole("button", { name: /create account/i }));
 
     await waitFor(() => {
-      expect(mockNavigate).toHaveBeenCalledWith("/complete-profile", {
-        state: { from: { pathname: "/map", search: "?q=castle&year_from=1900", hash: "", state: null, key: "testkey" } },
+      expect(mockNavigate).toHaveBeenCalledWith("/verify-email", {
+        state: {
+          email: VALID_EMAIL,
+          from: { pathname: "/map", search: "?q=castle&year_from=1900", hash: "", state: null, key: "testkey" },
+        },
         replace: true,
       });
     });
   });
 
-  it("shows welcome toast on successful registration and auto-login", async () => {
+  it("shows 'please verify your email' toast after successful registration", async () => {
     const user = userEvent.setup();
     register.mockResolvedValue({ message: "Registration successful.", user: {} });
-    mockLogin.mockResolvedValue({ user: { id: 1, username: VALID_USERNAME } });
     renderRegisterPage();
 
     await fillForm(user);
     await user.click(screen.getByRole("button", { name: /create account/i }));
 
-    expect(await screen.findByText("Account created! Welcome!")).toBeInTheDocument();
+    expect(
+      await screen.findByText(/account created.*verify your email/i)
+    ).toBeInTheDocument();
   });
 
-  // 5. Auto-login failure fallback
-  it("navigates to /login with from state when auto-login fails", async () => {
+  it("does not auto-login after registration", async () => {
     const user = userEvent.setup();
     register.mockResolvedValue({ message: "Registration successful.", user: {} });
-    mockLogin.mockRejectedValue(new Error("Auto-login failed"));
-    renderRegisterPageWithFrom("/submit-story");
+    renderRegisterPage();
 
     await fillForm(user);
     await user.click(screen.getByRole("button", { name: /create account/i }));
 
     await waitFor(() => {
-      expect(mockNavigate).toHaveBeenCalledWith("/login", {
-        state: { from: { pathname: "/submit-story", search: "", hash: "", state: null, key: "testkey" } },
-        replace: true,
-      });
+      expect(mockNavigate).toHaveBeenCalled();
     });
-  });
-
-  it("shows a sign-in guidance toast when auto-login fails", async () => {
-    const user = userEvent.setup();
-    register.mockResolvedValue({ message: "Registration successful.", user: {} });
-    mockLogin.mockRejectedValue(new Error("Auto-login failed"));
-    renderRegisterPage();
-
-    await fillForm(user);
-    await user.click(screen.getByRole("button", { name: /create account/i }));
-
-    expect(await screen.findByText(/account created.*sign in/i)).toBeInTheDocument();
+    expect(mockLogin).not.toHaveBeenCalled();
   });
 
   // 6. Loading state

--- a/frontend/src/pages/__tests__/VerifyEmailPage.test.jsx
+++ b/frontend/src/pages/__tests__/VerifyEmailPage.test.jsx
@@ -1,0 +1,359 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, waitFor, act } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter, Routes, Route } from "react-router-dom";
+
+import VerifyEmailPage from "../VerifyEmailPage";
+import { ToastProvider } from "@/context/ToastContext";
+import { Toaster } from "@/components/ui/toaster";
+
+vi.mock("@/services/authService", () => ({
+  verifyEmail: vi.fn(),
+  resendVerificationCode: vi.fn(),
+}));
+
+const mockNavigate = vi.fn();
+vi.mock("react-router-dom", async () => {
+  const actual = await vi.importActual("react-router-dom");
+  return { ...actual, useNavigate: () => mockNavigate };
+});
+
+import { verifyEmail, resendVerificationCode } from "@/services/authService";
+
+const EMAIL = "test@example.com";
+
+function renderPage({ state = { email: EMAIL }, initialEntries } = {}) {
+  const entries = initialEntries ?? [{ pathname: "/verify-email", state }];
+  return render(
+    <ToastProvider>
+      <MemoryRouter initialEntries={entries}>
+        <Routes>
+          <Route path="/verify-email" element={<VerifyEmailPage />} />
+          <Route path="/register" element={<div>Register page</div>} />
+        </Routes>
+      </MemoryRouter>
+      <Toaster />
+    </ToastProvider>
+  );
+}
+
+function getCodeInputs() {
+  return screen.getAllByRole("textbox").filter((input) =>
+    /^Digit \d+$/.test(input.getAttribute("aria-label") || "")
+  );
+}
+
+async function typeCode(user, code) {
+  const inputs = getCodeInputs();
+  for (let i = 0; i < code.length; i += 1) {
+    // Focus the next empty input explicitly since jsdom doesn't carry focus
+    // through our auto-advance as reliably as a real browser.
+    inputs[i].focus();
+    await user.type(inputs[i], code[i]);
+  }
+}
+
+describe("VerifyEmailPage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  describe("rendering", () => {
+    it("renders the verification UI with the email address", () => {
+      renderPage();
+      expect(screen.getByText(/verify your email/i)).toBeInTheDocument();
+      expect(screen.getByText(EMAIL)).toBeInTheDocument();
+      expect(
+        screen.getByRole("button", { name: /verify account/i })
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole("button", { name: /resend verification code/i })
+      ).toBeInTheDocument();
+    });
+
+    it("renders six digit input boxes", () => {
+      renderPage();
+      expect(getCodeInputs()).toHaveLength(6);
+    });
+
+    it("disables submit button until all six digits are entered", async () => {
+      const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+      renderPage();
+
+      const submit = screen.getByRole("button", { name: /verify account/i });
+      expect(submit).toBeDisabled();
+
+      await typeCode(user, "12345");
+      expect(submit).toBeDisabled();
+
+      const inputs = getCodeInputs();
+      inputs[5].focus();
+      await user.type(inputs[5], "6");
+      expect(submit).toBeEnabled();
+    });
+
+    it("redirects to /register when opened without an email in state", () => {
+      renderPage({ state: undefined, initialEntries: ["/verify-email"] });
+      expect(screen.getByText(/register page/i)).toBeInTheDocument();
+    });
+  });
+
+  describe("code input", () => {
+    it("accepts only digits", async () => {
+      const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+      renderPage();
+
+      const inputs = getCodeInputs();
+      inputs[0].focus();
+      await user.type(inputs[0], "abc");
+
+      expect(inputs[0]).toHaveValue("");
+    });
+
+    it("distributes a pasted 6-digit code across the boxes", async () => {
+      const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+      renderPage();
+
+      const inputs = getCodeInputs();
+      inputs[0].focus();
+      await user.paste("654321");
+
+      expect(inputs[0]).toHaveValue("6");
+      expect(inputs[1]).toHaveValue("5");
+      expect(inputs[2]).toHaveValue("4");
+      expect(inputs[3]).toHaveValue("3");
+      expect(inputs[4]).toHaveValue("2");
+      expect(inputs[5]).toHaveValue("1");
+    });
+
+    it("moves focus back on backspace when the current box is empty", async () => {
+      const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+      renderPage();
+
+      const inputs = getCodeInputs();
+      inputs[0].focus();
+      await user.type(inputs[0], "1");
+
+      inputs[1].focus();
+      await user.keyboard("{Backspace}");
+
+      expect(inputs[0]).toHaveFocus();
+    });
+  });
+
+  describe("submit", () => {
+    it("calls verifyEmail with email and code", async () => {
+      const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+      verifyEmail.mockResolvedValue({ success: true });
+      renderPage();
+
+      await typeCode(user, "123456");
+      await user.click(screen.getByRole("button", { name: /verify account/i }));
+
+      await waitFor(() => {
+        expect(verifyEmail).toHaveBeenCalledWith(EMAIL, "123456");
+      });
+    });
+
+    it("navigates to /login with success toast on successful verification", async () => {
+      const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+      verifyEmail.mockResolvedValue({ success: true });
+      renderPage();
+
+      await typeCode(user, "123456");
+      await user.click(screen.getByRole("button", { name: /verify account/i }));
+
+      await waitFor(() => {
+        expect(mockNavigate).toHaveBeenCalledWith("/login", {
+          replace: true,
+          state: undefined,
+        });
+      });
+      expect(
+        await screen.findByText(/account verified.*you can now log in/i)
+      ).toBeInTheDocument();
+    });
+
+    it("preserves the 'from' state when navigating to /login", async () => {
+      const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+      verifyEmail.mockResolvedValue({ success: true });
+      const from = { pathname: "/submit-story", search: "", hash: "" };
+      renderPage({ state: { email: EMAIL, from } });
+
+      await typeCode(user, "123456");
+      await user.click(screen.getByRole("button", { name: /verify account/i }));
+
+      await waitFor(() => {
+        expect(mockNavigate).toHaveBeenCalledWith("/login", {
+          replace: true,
+          state: { from },
+        });
+      });
+    });
+
+    it("shows inline error on invalid code", async () => {
+      const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+      const err = new Error("Invalid");
+      err.response = { status: 400, data: { message: "Invalid verification code." } };
+      verifyEmail.mockRejectedValue(err);
+      renderPage();
+
+      await typeCode(user, "000000");
+      await user.click(screen.getByRole("button", { name: /verify account/i }));
+
+      expect(
+        await screen.findByText(/invalid verification code/i)
+      ).toBeInTheDocument();
+      const alert = screen.getByRole("alert");
+      expect(alert).toBeInTheDocument();
+    });
+
+    it("shows expired error with resend guidance when code is expired", async () => {
+      const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+      const err = new Error("Expired");
+      err.response = { status: 410, data: { code: "expired" } };
+      verifyEmail.mockRejectedValue(err);
+      renderPage();
+
+      await typeCode(user, "999999");
+      await user.click(screen.getByRole("button", { name: /verify account/i }));
+
+      expect(
+        await screen.findByText(/code has expired.*resend/i)
+      ).toBeInTheDocument();
+    });
+
+    it("shows a rate-limit toast on 429 responses", async () => {
+      const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+      const err = new Error("Too many");
+      err.response = { status: 429, data: {} };
+      verifyEmail.mockRejectedValue(err);
+      renderPage();
+
+      await typeCode(user, "123456");
+      await user.click(screen.getByRole("button", { name: /verify account/i }));
+
+      expect(
+        await screen.findByText(/too many attempts/i)
+      ).toBeInTheDocument();
+    });
+
+    it("shows loading state while the verification request is in flight", async () => {
+      const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+      verifyEmail.mockReturnValue(new Promise(() => {}));
+      renderPage();
+
+      await typeCode(user, "123456");
+      await user.click(screen.getByRole("button", { name: /verify account/i }));
+
+      await waitFor(() => {
+        const button = screen.getByRole("button", { name: /verifying/i });
+        expect(button).toBeDisabled();
+      });
+    });
+  });
+
+  describe("resend", () => {
+    it("calls resendVerificationCode with the email", async () => {
+      const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+      resendVerificationCode.mockResolvedValue({ success: true });
+      renderPage();
+
+      await user.click(
+        screen.getByRole("button", { name: /resend verification code/i })
+      );
+
+      await waitFor(() => {
+        expect(resendVerificationCode).toHaveBeenCalledWith(EMAIL);
+      });
+    });
+
+    it("starts a 60-second cooldown after a successful resend", async () => {
+      const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+      resendVerificationCode.mockResolvedValue({ success: true });
+      renderPage();
+
+      await user.click(
+        screen.getByRole("button", { name: /resend verification code/i })
+      );
+
+      const resendBtn = await screen.findByRole("button", {
+        name: /resend available in 60 seconds/i,
+      });
+      expect(resendBtn).toBeDisabled();
+      expect(resendBtn).toHaveTextContent(/resend in 60s/i);
+    });
+
+    it("decrements the cooldown each second", async () => {
+      const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+      resendVerificationCode.mockResolvedValue({ success: true });
+      renderPage();
+
+      await user.click(
+        screen.getByRole("button", { name: /resend verification code/i })
+      );
+      await screen.findByText(/resend in 60s/i);
+
+      act(() => {
+        vi.advanceTimersByTime(3000);
+      });
+
+      expect(screen.getByText(/resend in 57s/i)).toBeInTheDocument();
+    });
+
+    it("re-enables the resend button once the cooldown elapses", async () => {
+      const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+      resendVerificationCode.mockResolvedValue({ success: true });
+      renderPage();
+
+      await user.click(
+        screen.getByRole("button", { name: /resend verification code/i })
+      );
+      await screen.findByText(/resend in 60s/i);
+
+      act(() => {
+        vi.advanceTimersByTime(60000);
+      });
+
+      expect(
+        await screen.findByRole("button", { name: /resend verification code/i })
+      ).toBeEnabled();
+    });
+
+    it("shows a success toast after a successful resend", async () => {
+      const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+      resendVerificationCode.mockResolvedValue({ success: true });
+      renderPage();
+
+      await user.click(
+        screen.getByRole("button", { name: /resend verification code/i })
+      );
+
+      expect(
+        await screen.findByText(/verification code sent/i)
+      ).toBeInTheDocument();
+    });
+
+    it("enters cooldown on 429 rate-limit response", async () => {
+      const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+      const err = new Error("Too many");
+      err.response = { status: 429, data: {} };
+      resendVerificationCode.mockRejectedValue(err);
+      renderPage();
+
+      await user.click(
+        screen.getByRole("button", { name: /resend verification code/i })
+      );
+
+      await screen.findByText(/resend in 60s/i);
+      expect(
+        await screen.findByText(/please wait before requesting another code/i)
+      ).toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/src/services/__tests__/authService.test.js
+++ b/frontend/src/services/__tests__/authService.test.js
@@ -10,7 +10,13 @@ vi.mock("../tokenStore", () => ({
   clear: vi.fn(),
 }));
 
-import { login, register, logout } from "../authService";
+import {
+  login,
+  register,
+  logout,
+  verifyEmail,
+  resendVerificationCode,
+} from "../authService";
 import { setAccessToken, setRefreshToken, getRefreshToken, clear } from "../tokenStore";
 
 describe("authService", () => {
@@ -96,6 +102,50 @@ describe("authService", () => {
       await logout();
 
       expect(clear).toHaveBeenCalled();
+    });
+  });
+
+  describe("verifyEmail", () => {
+    it("POSTs email + code to /auth/verify-email/ and returns response data", async () => {
+      const responseData = { success: true, message: "Email verified." };
+      axios.post.mockResolvedValue({ data: responseData });
+
+      const result = await verifyEmail("test@example.com", "123456");
+
+      expect(axios.post).toHaveBeenCalledWith(
+        expect.stringContaining("/auth/verify-email/"),
+        { email: "test@example.com", code: "123456" }
+      );
+      expect(result).toEqual(responseData);
+    });
+
+    it("propagates API errors", async () => {
+      axios.post.mockRejectedValue(new Error("Invalid code"));
+      await expect(verifyEmail("test@example.com", "000000")).rejects.toThrow(
+        "Invalid code"
+      );
+    });
+  });
+
+  describe("resendVerificationCode", () => {
+    it("POSTs email to /auth/resend-verification/ and returns response data", async () => {
+      const responseData = { success: true, message: "Code resent." };
+      axios.post.mockResolvedValue({ data: responseData });
+
+      const result = await resendVerificationCode("test@example.com");
+
+      expect(axios.post).toHaveBeenCalledWith(
+        expect.stringContaining("/auth/resend-verification/"),
+        { email: "test@example.com" }
+      );
+      expect(result).toEqual(responseData);
+    });
+
+    it("propagates API errors", async () => {
+      axios.post.mockRejectedValue(new Error("Rate limited"));
+      await expect(resendVerificationCode("test@example.com")).rejects.toThrow(
+        "Rate limited"
+      );
     });
   });
 });

--- a/frontend/src/services/authService.js
+++ b/frontend/src/services/authService.js
@@ -31,3 +31,18 @@ export async function logout() {
     clear();
   }
 }
+
+export async function verifyEmail(email, code) {
+  const response = await axios.post(`${API_URL}/auth/verify-email/`, {
+    email,
+    code,
+  });
+  return response.data;
+}
+
+export async function resendVerificationCode(email) {
+  const response = await axios.post(`${API_URL}/auth/resend-verification/`, {
+    email,
+  });
+  return response.data;
+}


### PR DESCRIPTION
# Description
Fixes #179

Adds a dedicated email verification screen that appears between registration and account activation. After a user registers, they are redirected to `/verify-email`, where they enter a 6-digit code. On success they are sent to `/login` with a confirmation toast.

> **Backend status:** depends on backend issue #193 (email verification endpoints + `is_active=False` on register). That backend work is **not yet merged**, so this flow is not exercisable end-to-end from this PR alone — verification and resend calls will fail with 404 until `/auth/verify-email/` and `/auth/resend-verification/` ship. The UI, service layer, routing, and tests are ready to light up the moment the backend lands.

## What's included

- **`frontend/src/services/authService.js`** — two new exports:
  - `verifyEmail(email, code)` → `POST /auth/verify-email/` with `{ email, code }`.
  - `resendVerificationCode(email)` → `POST /auth/resend-verification/` with `{ email }`.
- **`frontend/src/pages/VerifyEmailPage.jsx`** — new page at `/verify-email`:
  - Six individual digit boxes with auto-focus on mount, auto-advance on typing, backspace to previous box, arrow-key navigation, and paste-across-all-boxes handling.
  - Submit button disabled until all six digits are entered.
  - Error handling: invalid code (inline alert), expired code (inline alert + emphasized resend CTA), 429 rate-limit (toast).
  - Resend button with a 60-second client-side cooldown timer that also triggers on a 429 response.
  - Redirects back to `/register` if the page is opened without an `email` in route state.
- **`frontend/src/pages/RegisterPage.jsx`** — replaces the previous auto-login success path with `navigate('/verify-email', { state: { email, from } })`. `useAuth`'s `login` is no longer needed here.
- **`frontend/src/App.jsx`** — registered `/verify-email` route.
- **Tests** — 24 new + updated unit tests (see "Testing" below).

## Behavior change

Before: `register()` → auto-login → `/complete-profile` (or `/login` on auto-login failure).
After: `register()` → `/verify-email` → `/login` on successful verification.

The `/complete-profile` onboarding is no longer reached automatically from registration. Re-plumbing it onto the post-login flow is out of scope here and should be addressed together with the backend email-verification work.

# Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Refactoring
- [ ] Documentation

# Acceptance Criteria / Checklist
- [x] Project builds successfully (`npm run build`)
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, especially in hard-to-understand parts
- [x] I have performed a self-review of my code
- [x] I have added/updated tests
- [x] New and existing unit tests pass locally with my changes

Local checks:
- `npm run lint` — passes.
- `npm run build` — passes.
- `npm run test:run` — 457/458 pass. The single failure (`StoryDetailPage > renders submitted date with 'Date added' label`) is a pre-existing locale-dependent test on `main` (same failure flagged in PR #414); unrelated to this PR.

Issue #179 acceptance criteria coverage:
- [x] Verification screen appears after successful registration.
- [x] 6-digit code input field with auto-focus and digit navigation.
- [x] Submit calls `POST /auth/verify-email/` with email and code.
- [x] On success: redirect to `/login` with success toast ("Account verified! You can now log in.").
- [x] Invalid code: inline error message displayed.
- [x] Expired code: error message with resend option (resend button gets emphasized styling).
- [x] Resend button calls resend endpoint with 60-second cooldown timer.
- [x] Loading state during verification submission.
- [x] API service functions: `authService.verifyEmail()`, `authService.resendVerificationCode()`.
- [x] Unit tests cover code input rendering, submit flow, error states (invalid / expired / 429), resend cooldown, redirect on success.

# Screenshots / Recordings
_Pending — feature is not exercisable end-to-end until the backend verification endpoints land (#193)._

# Estimated Review Time
- [ ] < 5 min
- [x] 5-15 min
- [ ] > 15 min