### PR TITLE
feat: add GET /users/:id/bookmarks/ saved stories endpoint

### DIFF
--- a/backend/apps/stories/services.py
+++ b/backend/apps/stories/services.py
@@ -1,6 +1,21 @@
-from django.db.models import Q
+from django.db.models import Exists, OuterRef, Q
 
+from apps.interactions.models import Like, SavedStory
 from apps.stories.models import Story
+
+
+def annotate_user_interactions(qs, user):
+    """
+    Annotate a Story queryset with _user_has_liked and _user_has_saved boolean flags
+    for the given authenticated user.
+
+    Uses Exists subqueries so both checks are folded into the main SQL query,
+    avoiding N+1 when serializing paginated lists.
+    """
+    return qs.annotate(
+        _user_has_liked=Exists(Like.objects.filter(story=OuterRef('pk'), user=user)),
+        _user_has_saved=Exists(SavedStory.objects.filter(story=OuterRef('pk'), user=user)),
+    )
 
 
 def create_story(user, validated_data: dict) -> Story:

--- a/backend/apps/stories/views.py
+++ b/backend/apps/stories/views.py
@@ -1,29 +1,13 @@
-from django.db.models import Exists, OuterRef
 from rest_framework import generics
 from rest_framework.permissions import AllowAny, IsAuthenticated
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
-from apps.interactions.models import Like, SavedStory
 from apps.stories.models import Story
 from apps.stories.serializers import FeedQuerySerializer, SearchQuerySerializer, StoryDetailSerializer, StoryFeedSerializer, StoryMapGeoJSONSerializer, StorySerializer
-from apps.stories.services import delete_story, get_story_feed, get_story_search
+from apps.stories.services import annotate_user_interactions, delete_story, get_story_feed, get_story_search
 from common.pagination import StoryPagination
 from common.permissions import IsOwnerOrAdmin
-
-
-def annotate_user_interactions(qs, user):
-    """
-    Annotate a Story queryset with _user_has_liked and _user_has_saved boolean flags
-    for the given authenticated user.
-
-    Uses Exists subqueries so both checks are folded into the main SQL query,
-    avoiding N+1 when serializing paginated lists.
-    """
-    return qs.annotate(
-        _user_has_liked=Exists(Like.objects.filter(story=OuterRef('pk'), user=user)),
-        _user_has_saved=Exists(SavedStory.objects.filter(story=OuterRef('pk'), user=user)),
-    )
 
 
 class StoryFeedView(APIView):

--- a/backend/apps/users/profile_urls.py
+++ b/backend/apps/users/profile_urls.py
@@ -6,6 +6,7 @@ from apps.users.views import (
     FollowingListView,
     FollowView,
     ProfilePhotoView,
+    UserBookmarksView,
     UserPublicProfileView,
 )
 
@@ -21,4 +22,5 @@ urlpatterns = [
     path('<int:user_id>/follow/', FollowView.as_view(), name='user-follow'),
     path('<int:user_id>/followers/', FollowerListView.as_view(), name='user-followers'),
     path('<int:user_id>/following/', FollowingListView.as_view(), name='user-following'),
+    path('<int:user_id>/bookmarks/', UserBookmarksView.as_view(), name='user-bookmarks'),
 ]

--- a/backend/apps/users/services.py
+++ b/backend/apps/users/services.py
@@ -8,7 +8,7 @@ from django.http import Http404
 
 from rest_framework_simplejwt.exceptions import TokenError
 from rest_framework_simplejwt.tokens import RefreshToken
-from rest_framework.exceptions import AuthenticationFailed, ValidationError
+from rest_framework.exceptions import AuthenticationFailed, PermissionDenied, ValidationError
 
 from apps.users.models import EmailVerificationCode, Follow, User, UserProfile
 
@@ -344,7 +344,6 @@ def get_user_bookmarks(user_id: int, requesting_user):
     ordering column is needed.
     """
     from apps.stories.models import Story
-    from rest_framework.exceptions import PermissionDenied
 
     try:
         User.objects.get(pk=user_id, is_active=True)

--- a/backend/apps/users/services.py
+++ b/backend/apps/users/services.py
@@ -330,3 +330,33 @@ def unfollow_user(follower: User, followed_id: int) -> None:
     if not User.objects.filter(pk=followed_id).exists():
         raise Http404
     Follow.objects.filter(follower=follower, followed_id=followed_id).delete()
+
+
+def get_user_bookmarks(user_id: int, requesting_user):
+    """
+    Return a published Story queryset saved by user_id, ordered most-recently-bookmarked first.
+
+    Raises Http404 if the target user does not exist or is inactive.
+    Raises PermissionDenied if the requesting user is not the owner.
+
+    Local imports avoid circular dependencies between the users, interactions, and stories apps.
+    The ordering traverses saved_by (Story → SavedStory) via the reverse FK so no separate
+    ordering column is needed.
+    """
+    from apps.stories.models import Story
+    from rest_framework.exceptions import PermissionDenied
+
+    try:
+        User.objects.get(pk=user_id, is_active=True)
+    except User.DoesNotExist:
+        raise Http404
+
+    if requesting_user.pk != user_id:
+        raise PermissionDenied
+
+    return (
+        Story.objects
+        .filter(saved_by__user_id=user_id, status=Story.STATUS_PUBLISHED)
+        .select_related('user')
+        .order_by('-saved_by__saved_at')
+    )

--- a/backend/apps/users/tests/test_services.py
+++ b/backend/apps/users/tests/test_services.py
@@ -1,8 +1,10 @@
+import datetime
 import io
 from decimal import Decimal
 
 import pytest
 from django.core.files.storage import default_storage
+from django.utils import timezone
 from django.core.files.uploadedfile import InMemoryUploadedFile
 from django.http import Http404
 from PIL import Image
@@ -703,8 +705,6 @@ class TestGetUserBookmarks:
         assert qs.count() == 0
 
     def test_ordered_most_recently_saved_first(self, user, second_user):
-        import datetime
-        from django.utils import timezone
         story1 = _make_published_story(second_user, title='Older Story')
         story2 = _make_published_story(second_user, title='Newer Story')
         ss1 = SavedStory.objects.create(user=user, story=story1)

--- a/backend/apps/users/tests/test_services.py
+++ b/backend/apps/users/tests/test_services.py
@@ -703,9 +703,14 @@ class TestGetUserBookmarks:
         assert qs.count() == 0
 
     def test_ordered_most_recently_saved_first(self, user, second_user):
+        import datetime
+        from django.utils import timezone
         story1 = _make_published_story(second_user, title='Older Story')
         story2 = _make_published_story(second_user, title='Newer Story')
-        SavedStory.objects.create(user=user, story=story1)
+        ss1 = SavedStory.objects.create(user=user, story=story1)
+        SavedStory.objects.filter(pk=ss1.pk).update(
+            saved_at=timezone.now() - datetime.timedelta(seconds=5)
+        )
         SavedStory.objects.create(user=user, story=story2)
         result = list(get_user_bookmarks(user.pk, user))
         assert result[0] == story2

--- a/backend/apps/users/tests/test_services.py
+++ b/backend/apps/users/tests/test_services.py
@@ -6,7 +6,7 @@ from django.core.files.storage import default_storage
 from django.core.files.uploadedfile import InMemoryUploadedFile
 from django.http import Http404
 from PIL import Image
-from rest_framework.exceptions import AuthenticationFailed, ValidationError
+from rest_framework.exceptions import AuthenticationFailed, PermissionDenied, ValidationError
 
 from apps.users.models import EmailVerificationCode, Follow, User, UserProfile
 from apps.users.services import (
@@ -15,6 +15,7 @@ from apps.users.services import (
     follow_user,
     get_own_profile,
     get_public_profile,
+    get_user_bookmarks,
     login_user,
     logout_user,
     register_user,
@@ -22,6 +23,7 @@ from apps.users.services import (
     update_own_profile,
     upload_profile_photo,
 )
+from apps.interactions.models import SavedStory
 from apps.stories.models import Story
 
 
@@ -664,3 +666,66 @@ class TestGetPublicProfileFollowCounts:
         self.other.save()
         user = get_public_profile(self.subject.pk)
         assert user.following_count == 0
+
+
+# ── get_user_bookmarks ────────────────────────────────────────────────────────
+
+def _make_published_story(user, title='Test Story'):
+    return Story.objects.create(
+        user=user,
+        title=title,
+        narrative='Narrative text.',
+        status=Story.STATUS_PUBLISHED,
+        location_lat=Decimal('41.0'),
+        location_lng=Decimal('29.0'),
+        location_name='Istanbul',
+        time_type=Story.TIME_EXACT,
+        year=2000,
+    )
+
+
+@pytest.mark.django_db
+class TestGetUserBookmarks:
+    def test_returns_bookmarked_stories(self, user, story):
+        SavedStory.objects.create(user=user, story=story)
+        qs = get_user_bookmarks(user.pk, user)
+        assert story in qs
+
+    def test_returns_only_published_stories(self, user, story):
+        SavedStory.objects.create(user=user, story=story)
+        story.status = Story.STATUS_REMOVED
+        story.save()
+        qs = get_user_bookmarks(user.pk, user)
+        assert story not in qs
+
+    def test_empty_when_no_bookmarks(self, user):
+        qs = get_user_bookmarks(user.pk, user)
+        assert qs.count() == 0
+
+    def test_ordered_most_recently_saved_first(self, user, second_user):
+        story1 = _make_published_story(second_user, title='Older Story')
+        story2 = _make_published_story(second_user, title='Newer Story')
+        SavedStory.objects.create(user=user, story=story1)
+        SavedStory.objects.create(user=user, story=story2)
+        result = list(get_user_bookmarks(user.pk, user))
+        assert result[0] == story2
+        assert result[1] == story1
+
+    def test_only_returns_own_bookmarks(self, user, second_user, story):
+        SavedStory.objects.create(user=second_user, story=story)
+        qs = get_user_bookmarks(user.pk, user)
+        assert qs.count() == 0
+
+    def test_nonexistent_user_raises_404(self, user):
+        with pytest.raises(Http404):
+            get_user_bookmarks(99999, user)
+
+    def test_inactive_user_raises_404(self, user, second_user):
+        second_user.is_active = False
+        second_user.save()
+        with pytest.raises(Http404):
+            get_user_bookmarks(second_user.pk, user)
+
+    def test_non_owner_raises_permission_denied(self, user, second_user):
+        with pytest.raises(PermissionDenied):
+            get_user_bookmarks(user.pk, second_user)

--- a/backend/apps/users/tests/test_views.py
+++ b/backend/apps/users/tests/test_views.py
@@ -1,15 +1,18 @@
+import datetime
 import io
 import os
 from decimal import Decimal
 
 import pytest
 from django.core.files.uploadedfile import InMemoryUploadedFile
+from django.utils import timezone
 from PIL import Image
 from rest_framework import status
 from rest_framework.test import APIClient
 
-from apps.users.models import Follow, User
+from apps.interactions.models import SavedStory
 from apps.stories.models import Story
+from apps.users.models import Follow, User
 
 
 def _make_image_file(fmt='JPEG'):
@@ -930,3 +933,93 @@ class TestPublicProfileFollowCounts:
         second_user.save()
         response = client.get(f'/users/{registered_user.pk}/')
         assert response.data['following_count'] == 0
+
+
+# ── GET /users/<user_id>/bookmarks/ ──────────────────────────────────────────
+
+@pytest.mark.django_db
+class TestUserBookmarksView:
+    url = '/users/{user_id}/bookmarks/'
+
+    def _make_story(self, user, title='Story'):
+        return Story.objects.create(
+            user=user,
+            title=title,
+            narrative='Narrative text.',
+            status=Story.STATUS_PUBLISHED,
+            location_lat=Decimal('41.0'),
+            location_lng=Decimal('29.0'),
+            location_name='Istanbul',
+            time_type=Story.TIME_EXACT,
+            year=2000,
+        )
+
+    def test_owner_retrieves_bookmarks_returns_200(self, auth_client, registered_user):
+        story = self._make_story(registered_user)
+        SavedStory.objects.create(user=registered_user, story=story)
+        response = auth_client.get(self.url.format(user_id=registered_user.pk))
+        assert response.status_code == 200
+        assert response.data['count'] == 1
+
+    def test_response_is_paginated(self, auth_client, registered_user):
+        response = auth_client.get(self.url.format(user_id=registered_user.pk))
+        assert response.status_code == 200
+        for key in ['count', 'next', 'previous', 'results']:
+            assert key in response.data
+
+    def test_empty_bookmarks_returns_empty_results(self, auth_client, registered_user):
+        response = auth_client.get(self.url.format(user_id=registered_user.pk))
+        assert response.status_code == 200
+        assert response.data['count'] == 0
+        assert response.data['results'] == []
+
+    def test_results_ordered_most_recently_saved_first(self, auth_client, registered_user, second_user):
+        story1 = self._make_story(second_user, title='Older')
+        story2 = self._make_story(second_user, title='Newer')
+        ss1 = SavedStory.objects.create(user=registered_user, story=story1)
+        SavedStory.objects.filter(pk=ss1.pk).update(
+            saved_at=timezone.now() - datetime.timedelta(seconds=5)
+        )
+        SavedStory.objects.create(user=registered_user, story=story2)
+        response = auth_client.get(self.url.format(user_id=registered_user.pk))
+        ids = [r['id'] for r in response.data['results']]
+        assert ids == [story2.pk, story1.pk]
+
+    def test_removed_stories_excluded(self, auth_client, registered_user):
+        story = self._make_story(registered_user)
+        SavedStory.objects.create(user=registered_user, story=story)
+        story.status = Story.STATUS_REMOVED
+        story.save()
+        response = auth_client.get(self.url.format(user_id=registered_user.pk))
+        assert response.data['count'] == 0
+
+    def test_response_contains_story_feed_fields(self, auth_client, registered_user):
+        story = self._make_story(registered_user)
+        SavedStory.objects.create(user=registered_user, story=story)
+        response = auth_client.get(self.url.format(user_id=registered_user.pk))
+        result = response.data['results'][0]
+        for field in ['id', 'title', 'location_name', 'preview_text', 'submitted_at']:
+            assert field in result
+        assert result['user_has_saved'] is True
+        assert result['user_has_liked'] is False
+
+    def test_unauthenticated_returns_401(self, client, registered_user):
+        response = client.get(self.url.format(user_id=registered_user.pk))
+        assert response.status_code == 401
+
+    def test_other_user_returns_403(self, client, registered_user, second_user):
+        client.force_authenticate(user=second_user)
+        response = client.get(self.url.format(user_id=registered_user.pk))
+        assert response.status_code == 403
+
+    def test_user_not_found_returns_404(self, auth_client):
+        response = auth_client.get(self.url.format(user_id=99999))
+        assert response.status_code == 404
+
+    def test_inactive_user_returns_404(self, auth_client, second_user):
+        # Deactivate the TARGET user (not the requester) — Http404 is raised
+        # before PermissionDenied in get_user_bookmarks, so this returns 404.
+        second_user.is_active = False
+        second_user.save()
+        response = auth_client.get(self.url.format(user_id=second_user.pk))
+        assert response.status_code == 404

--- a/backend/apps/users/tests/test_views.py
+++ b/backend/apps/users/tests/test_views.py
@@ -327,7 +327,6 @@ class TestUserPublicProfileView:
 
     def test_birth_year_hidden_when_flag_false(self, client, registered_user):
         from apps.users.models import UserProfile
-        import datetime
         UserProfile.objects.create(
             user=registered_user,
             birth_date=datetime.date(1990, 1, 1),
@@ -339,7 +338,6 @@ class TestUserPublicProfileView:
     def test_birth_year_returns_integer_year_only(self, client, registered_user):
         # Req. 1.2.3.1: public profile exposes birth *year* only, not full date
         from apps.users.models import UserProfile
-        import datetime
         UserProfile.objects.create(
             user=registered_user,
             birth_date=datetime.date(1990, 5, 20),

--- a/backend/apps/users/views.py
+++ b/backend/apps/users/views.py
@@ -5,6 +5,7 @@ from rest_framework.throttling import ScopedRateThrottle
 from rest_framework.views import APIView
 
 from apps.stories.serializers import StoryFeedSerializer
+from apps.stories.services import annotate_user_interactions
 from apps.users.serializers import (
     CurrentUserSerializer,
     DeleteAccountSerializer,
@@ -193,7 +194,7 @@ class UserBookmarksView(APIView):
     permission_classes = [IsRegisteredUser]
 
     def get(self, request, user_id):
-        qs = get_user_bookmarks(user_id, request.user)
+        qs = annotate_user_interactions(get_user_bookmarks(user_id, request.user), request.user)
         paginator = StoryPagination()
         page = paginator.paginate_queryset(qs, request)
         serializer = StoryFeedSerializer(page, many=True, context={'request': request})

--- a/backend/apps/users/views.py
+++ b/backend/apps/users/views.py
@@ -4,8 +4,7 @@ from rest_framework.response import Response
 from rest_framework.throttling import ScopedRateThrottle
 from rest_framework.views import APIView
 
-from common.pagination import StoryPagination
-
+from apps.stories.serializers import StoryFeedSerializer
 from apps.users.serializers import (
     CurrentUserSerializer,
     DeleteAccountSerializer,
@@ -27,6 +26,7 @@ from apps.users.services import (
     get_following,
     get_own_profile,
     get_public_profile,
+    get_user_bookmarks,
     login_user,
     logout_user,
     register_user,
@@ -34,6 +34,7 @@ from apps.users.services import (
     update_own_profile,
     upload_profile_photo,
 )
+from common.pagination import StoryPagination
 from common.permissions import IsRegisteredUser
 
 
@@ -183,4 +184,17 @@ class FollowingListView(APIView):
         paginator = StoryPagination()
         page = paginator.paginate_queryset(qs, request)
         serializer = FollowedUserSerializer(page, many=True, context={'request': request})
+        return paginator.get_paginated_response(serializer.data)
+
+
+class UserBookmarksView(APIView):
+    """GET /users/<user_id>/bookmarks/ — owner's saved stories, paginated, newest bookmark first."""
+
+    permission_classes = [IsRegisteredUser]
+
+    def get(self, request, user_id):
+        qs = get_user_bookmarks(user_id, request.user)
+        paginator = StoryPagination()
+        page = paginator.paginate_queryset(qs, request)
+        serializer = StoryFeedSerializer(page, many=True, context={'request': request})
         return paginator.get_paginated_response(serializer.data)


### PR DESCRIPTION
# 📝 Description
Fixes #219

Implements `GET /users/:id/bookmarks/` — an owner-only paginated list of a user's saved stories, ordered by most recently bookmarked first.

**Behavior:**
- Returns `200` with a paginated `StoryFeedSerializer` response for the authenticated owner
- Returns `401` for unauthenticated requests
- Returns `403` for authenticated non-owners
- Returns `404` for nonexistent or inactive users
- Removed/draft stories are automatically excluded (only `STATUS_PUBLISHED` stories appear)
- `annotate_user_interactions` is applied before serialization to avoid N+1 queries on `user_has_liked` / `user_has_saved` fields

**Architecture:** Ownership enforcement lives in the service layer (`get_user_bookmarks` raises `PermissionDenied`). The view remains a thin orchestrator — service, annotate, paginate, serialize.

# 📊 Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Refactoring
- [ ] Documentation

# ✅ Acceptance Criteria / Checklist
- [x] Project builds successfully
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, especially in hard-to-understand parts
- [x] I have performed a self-review of my code
- [x] I have added/updated tests
- [x] New and existing unit tests pass locally with my changes

# 📸 Screenshots / Recordings
N/A — backend-only change

# ⏱️ Estimated Review Time
- [ ] < 5 min
- [x] 5-15 min
- [ ] > 15 min
