### PR TITLE
fix: increase timeout for flaky RootNavigator auth test

### DIFF
--- a/mobile/src/app/navigation/__tests__/RootNavigator.test.tsx
+++ b/mobile/src/app/navigation/__tests__/RootNavigator.test.tsx
@@ -280,7 +280,7 @@ describe('RootNavigator auth flow', () => {
 
     expect(await screen.findByText('Please sign in to submit a story.')).toBeTruthy();
     expect(screen.getByLabelText('Submission')).toBeTruthy();
-  });
+  }, 10000);
 
   it('opens the main pager on the feed tab by default', async () => {
     renderNavigator();


### PR DESCRIPTION
# 📝 Description
Fixes #444 

Increases the timeout only for the flaky `RootNavigator` auth-flow test in mobile so it does not intermittently fail in CI due to Jest's default 5000 ms limit.

# 📊 Type of Change
- [x]  Bug fix
- [ ]  New feature
- [ ]  Refactoring
- [ ]  Documentation
 
# ✅ Acceptance Criteria / Checklist
- [ ] Project builds successfully
- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, especially in hard-to-understand parts
- [x] I have performed a self-review of my code
- [ ] I have added/updated tests
- [x] New and existing unit tests pass locally with my changes

# 📸 Screenshots / Recordings
Not applicable.

# ⏱️ Estimated Review Time
- [x] < 5 min
- [ ] 5-15 min
- [ ] > 15 min
