### PR TITLE
feat: add POST/DELETE /stories/:id/bookmark/ endpoints

### DIFF
--- a/backend/apps/interactions/serializers.py
+++ b/backend/apps/interactions/serializers.py
@@ -1,6 +1,6 @@
 from rest_framework import serializers
 
-from apps.interactions.models import Comment, Like
+from apps.interactions.models import Comment, Like, SavedStory
 
 
 class CommentCreateSerializer(serializers.Serializer):
@@ -33,3 +33,11 @@ class LikeResponseSerializer(serializers.ModelSerializer):
     class Meta:
         model = Like
         fields = ['id', 'story_id', 'created_at']
+
+
+class BookmarkResponseSerializer(serializers.ModelSerializer):
+    """Read-only representation of a SavedStory returned in API responses."""
+
+    class Meta:
+        model = SavedStory
+        fields = ['id', 'story_id', 'saved_at']

--- a/backend/apps/interactions/services.py
+++ b/backend/apps/interactions/services.py
@@ -116,16 +116,19 @@ def add_bookmark(user, story_id):
 
 def remove_bookmark(user, story_id):
     """
-    Delete the SavedStory for a published story if it exists.
+    Delete the SavedStory for a story if it exists.
 
-    Raises Http404 if the story does not exist or is not published.
+    Raises Http404 only if the story does not exist at all.
     Idempotent — no exception if the user has not bookmarked the story.
+
+    Status-agnostic by design: a user must be able to remove their own bookmark
+    even after a story is removed or unpublished.
 
     Uses instance.delete() (not queryset .filter().delete()) so that the post_delete
     signal fires and Story.save_count is decremented atomically.
     """
     try:
-        story = Story.objects.get(pk=story_id, status=Story.STATUS_PUBLISHED)
+        story = Story.objects.get(pk=story_id)
     except Story.DoesNotExist:
         raise Http404
 

--- a/backend/apps/interactions/services.py
+++ b/backend/apps/interactions/services.py
@@ -3,7 +3,7 @@ from django.http import Http404
 
 from rest_framework.exceptions import ValidationError
 
-from apps.interactions.models import Comment, Like
+from apps.interactions.models import Comment, Like, SavedStory
 from apps.stories.models import Story
 
 
@@ -88,3 +88,49 @@ def remove_like(user, story_id):
         raise Http404
 
     like.delete()
+
+
+def add_bookmark(user, story_id):
+    """
+    Create and return a SavedStory for a published story.
+
+    Raises Http404 if the story does not exist or is not published.
+    Uses get_or_create (idempotent) — returns (bookmark, created).
+    transaction.atomic() creates a savepoint so a MySQL UniqueConstraint
+    IntegrityError does not break the outer transaction.
+    """
+    try:
+        story = Story.objects.get(pk=story_id, status=Story.STATUS_PUBLISHED)
+    except Story.DoesNotExist:
+        raise Http404
+
+    try:
+        with transaction.atomic():
+            bookmark, created = SavedStory.objects.get_or_create(user=user, story=story)
+    except IntegrityError:
+        bookmark = SavedStory.objects.get(user=user, story=story)
+        created = False
+
+    return bookmark, created
+
+
+def remove_bookmark(user, story_id):
+    """
+    Delete the SavedStory for a published story if it exists.
+
+    Raises Http404 if the story does not exist or is not published.
+    Idempotent — no exception if the user has not bookmarked the story.
+
+    Uses instance.delete() (not queryset .filter().delete()) so that the post_delete
+    signal fires and Story.save_count is decremented atomically.
+    """
+    try:
+        story = Story.objects.get(pk=story_id, status=Story.STATUS_PUBLISHED)
+    except Story.DoesNotExist:
+        raise Http404
+
+    try:
+        bookmark = SavedStory.objects.get(user=user, story=story)
+        bookmark.delete()
+    except SavedStory.DoesNotExist:
+        pass

--- a/backend/apps/interactions/tests/test_services.py
+++ b/backend/apps/interactions/tests/test_services.py
@@ -241,14 +241,16 @@ class TestRemoveBookmark:
         with pytest.raises(Http404):
             remove_bookmark(user, 99999)
 
-    def test_removed_story_raises_404(self, user, story):
+    def test_removed_story_can_be_unbookmarked(self, user, story):
+        SavedStory.objects.create(user=user, story=story)
         story.status = Story.STATUS_REMOVED
         story.save()
-        with pytest.raises(Http404):
-            remove_bookmark(user, story.pk)
+        remove_bookmark(user, story.pk)  # must not raise
+        assert not SavedStory.objects.filter(user=user, story=story).exists()
 
-    def test_draft_story_raises_404(self, user, story):
+    def test_draft_story_can_be_unbookmarked(self, user, story):
+        SavedStory.objects.create(user=user, story=story)
         story.status = Story.STATUS_DRAFT
         story.save()
-        with pytest.raises(Http404):
-            remove_bookmark(user, story.pk)
+        remove_bookmark(user, story.pk)  # must not raise
+        assert not SavedStory.objects.filter(user=user, story=story).exists()

--- a/backend/apps/interactions/tests/test_services.py
+++ b/backend/apps/interactions/tests/test_services.py
@@ -4,8 +4,16 @@ import pytest
 from django.http import Http404
 from rest_framework.exceptions import ValidationError
 
-from apps.interactions.models import Comment, Like
-from apps.interactions.services import add_like, create_comment, delete_comment, get_story_comments, remove_like
+from apps.interactions.models import Comment, Like, SavedStory
+from apps.interactions.services import (
+    add_bookmark,
+    add_like,
+    create_comment,
+    delete_comment,
+    get_story_comments,
+    remove_bookmark,
+    remove_like,
+)
 from apps.stories.models import Story
 
 
@@ -153,3 +161,94 @@ class TestRemoveLike:
         story.save()
         with pytest.raises(Http404):
             remove_like(user, story.pk)
+
+
+# ── add_bookmark / remove_bookmark ───────────────────────────────────────────
+
+
+@pytest.mark.django_db
+class TestAddBookmark:
+    def test_creates_saved_story(self, user, story):
+        bookmark, created = add_bookmark(user, story.pk)
+        assert created is True
+        assert SavedStory.objects.filter(pk=bookmark.pk).exists()
+
+    def test_returns_saved_story_instance(self, user, story):
+        bookmark, created = add_bookmark(user, story.pk)
+        assert isinstance(bookmark, SavedStory)
+
+    def test_bookmark_linked_to_correct_story(self, user, story):
+        bookmark, _ = add_bookmark(user, story.pk)
+        assert bookmark.story_id == story.pk
+
+    def test_bookmark_linked_to_correct_user(self, user, story):
+        bookmark, _ = add_bookmark(user, story.pk)
+        assert bookmark.user_id == user.pk
+
+    def test_increments_save_count(self, user, story):
+        add_bookmark(user, story.pk)
+        story.refresh_from_db()
+        assert story.save_count == 1
+
+    def test_duplicate_returns_existing_not_created(self, user, story):
+        b1, _ = add_bookmark(user, story.pk)
+        b2, created = add_bookmark(user, story.pk)
+        assert created is False
+        assert b1.pk == b2.pk
+
+    def test_duplicate_does_not_double_increment_save_count(self, user, story):
+        add_bookmark(user, story.pk)
+        add_bookmark(user, story.pk)
+        story.refresh_from_db()
+        assert story.save_count == 1
+
+    def test_nonexistent_story_raises_404(self, user):
+        with pytest.raises(Http404):
+            add_bookmark(user, 99999)
+
+    def test_removed_story_raises_404(self, user, story):
+        story.status = Story.STATUS_REMOVED
+        story.save()
+        with pytest.raises(Http404):
+            add_bookmark(user, story.pk)
+
+    def test_draft_story_raises_404(self, user, story):
+        story.status = Story.STATUS_DRAFT
+        story.save()
+        with pytest.raises(Http404):
+            add_bookmark(user, story.pk)
+
+
+@pytest.mark.django_db
+class TestRemoveBookmark:
+    def test_deletes_saved_story_row(self, user, story):
+        SavedStory.objects.create(user=user, story=story)
+        remove_bookmark(user, story.pk)
+        assert not SavedStory.objects.filter(user=user, story=story).exists()
+
+    def test_decrements_save_count(self, user, story):
+        SavedStory.objects.create(user=user, story=story)
+        story.save_count = 1
+        story.save()
+        remove_bookmark(user, story.pk)
+        story.refresh_from_db()
+        assert story.save_count == 0
+
+    def test_not_bookmarked_is_noop(self, user, story):
+        remove_bookmark(user, story.pk)  # must not raise
+
+    def test_nonexistent_story_raises_404(self, user):
+        with pytest.raises(Http404):
+            remove_bookmark(user, 99999)
+
+    def test_removed_story_raises_404(self, user, story):
+        story.status = Story.STATUS_REMOVED
+        story.save()
+        with pytest.raises(Http404):
+            remove_bookmark(user, story.pk)
+
+    def test_draft_story_raises_404(self, user, story):
+        story.status = Story.STATUS_DRAFT
+        story.save()
+        with pytest.raises(Http404):
+            remove_bookmark(user, story.pk)

--- a/backend/apps/interactions/tests/test_views.py
+++ b/backend/apps/interactions/tests/test_views.py
@@ -3,7 +3,7 @@ import pytest
 
 from rest_framework.test import APIClient
 
-from apps.interactions.models import Comment, Like
+from apps.interactions.models import Comment, Like, SavedStory
 from apps.stories.models import Story
 from apps.users.models import RoleChoices, User
 
@@ -319,3 +319,92 @@ class TestStoryCommentList:
         response = client.get(self.url.format(story_id=story.pk))
         assert response.data['count'] == 1
         assert response.data['results'][0]['text'] == 'For first story'
+
+
+# ── POST /stories/<story_id>/bookmark/ ───────────────────────────────────────
+
+@pytest.mark.django_db
+class TestStoryBookmark:
+    url = '/stories/{story_id}/bookmark/'
+
+    def test_bookmark_success_returns_201(self, auth_client, story):
+        response = auth_client.post(self.url.format(story_id=story.pk))
+        assert response.status_code == 201
+        assert response.data['bookmark']['story_id'] == story.pk
+        assert SavedStory.objects.filter(story=story).count() == 1
+
+    def test_bookmark_increments_save_count(self, auth_client, story):
+        auth_client.post(self.url.format(story_id=story.pk))
+        story.refresh_from_db()
+        assert story.save_count == 1
+
+    def test_bookmark_response_contains_expected_fields(self, auth_client, story):
+        response = auth_client.post(self.url.format(story_id=story.pk))
+        assert response.status_code == 201
+        for field in ['id', 'story_id', 'saved_at']:
+            assert field in response.data['bookmark']
+
+    def test_duplicate_bookmark_returns_200(self, auth_client, story):
+        auth_client.post(self.url.format(story_id=story.pk))
+        response = auth_client.post(self.url.format(story_id=story.pk))
+        assert response.status_code == 200
+        assert SavedStory.objects.filter(story=story).count() == 1
+
+    def test_duplicate_bookmark_does_not_increment_save_count(self, auth_client, story):
+        auth_client.post(self.url.format(story_id=story.pk))
+        auth_client.post(self.url.format(story_id=story.pk))
+        story.refresh_from_db()
+        assert story.save_count == 1
+
+    def test_bookmark_unauthenticated_returns_401(self, client, story):
+        response = client.post(self.url.format(story_id=story.pk))
+        assert response.status_code == 401
+
+    def test_bookmark_story_not_found_returns_404(self, auth_client):
+        response = auth_client.post(self.url.format(story_id=99999))
+        assert response.status_code == 404
+
+    def test_bookmark_removed_story_returns_404(self, auth_client, story):
+        story.status = Story.STATUS_REMOVED
+        story.save()
+        response = auth_client.post(self.url.format(story_id=story.pk))
+        assert response.status_code == 404
+
+
+# ── DELETE /stories/<story_id>/bookmark/ ─────────────────────────────────────
+
+@pytest.mark.django_db
+class TestStoryUnbookmark:
+    url = '/stories/{story_id}/bookmark/'
+
+    def test_unbookmark_success_returns_204(self, auth_client, user, story):
+        SavedStory.objects.create(user=user, story=story)
+        response = auth_client.delete(self.url.format(story_id=story.pk))
+        assert response.status_code == 204
+        assert not SavedStory.objects.filter(user=user, story=story).exists()
+
+    def test_unbookmark_decrements_save_count(self, auth_client, user, story):
+        SavedStory.objects.create(user=user, story=story)
+        story.save_count = 1
+        story.save()
+        auth_client.delete(self.url.format(story_id=story.pk))
+        story.refresh_from_db()
+        assert story.save_count == 0
+
+    def test_unbookmark_not_bookmarked_returns_204(self, auth_client, story):
+        response = auth_client.delete(self.url.format(story_id=story.pk))
+        assert response.status_code == 204
+
+    def test_unbookmark_unauthenticated_returns_401(self, client, story):
+        response = client.delete(self.url.format(story_id=story.pk))
+        assert response.status_code == 401
+
+    def test_unbookmark_story_not_found_returns_404(self, auth_client):
+        response = auth_client.delete(self.url.format(story_id=99999))
+        assert response.status_code == 404
+
+    def test_unbookmark_removed_story_returns_404(self, auth_client, story):
+        story.status = Story.STATUS_REMOVED
+        story.save()
+        response = auth_client.delete(self.url.format(story_id=story.pk))
+        assert response.status_code == 404

--- a/backend/apps/interactions/tests/test_views.py
+++ b/backend/apps/interactions/tests/test_views.py
@@ -403,8 +403,8 @@ class TestStoryUnbookmark:
         response = auth_client.delete(self.url.format(story_id=99999))
         assert response.status_code == 404
 
-    def test_unbookmark_removed_story_returns_404(self, auth_client, story):
+    def test_unbookmark_removed_story_returns_204(self, auth_client, story):
         story.status = Story.STATUS_REMOVED
         story.save()
         response = auth_client.delete(self.url.format(story_id=story.pk))
-        assert response.status_code == 404
+        assert response.status_code == 204

--- a/backend/apps/interactions/urls.py
+++ b/backend/apps/interactions/urls.py
@@ -1,6 +1,11 @@
 from django.urls import path
 
-from apps.interactions.views import CommentDeleteView, StoryCommentListCreateView, StoryLikeView
+from apps.interactions.views import (
+    CommentDeleteView,
+    StoryBookmarkView,
+    StoryCommentListCreateView,
+    StoryLikeView,
+)
 
 app_name = 'interactions'
 
@@ -8,4 +13,5 @@ urlpatterns = [
     path('stories/<int:story_id>/comments/', StoryCommentListCreateView.as_view(), name='comment-list-create'),
     path('comments/<int:comment_id>/', CommentDeleteView.as_view(), name='comment-delete'),
     path('stories/<int:story_id>/like/', StoryLikeView.as_view(), name='story-like'),
+    path('stories/<int:story_id>/bookmark/', StoryBookmarkView.as_view(), name='story-bookmark'),
 ]

--- a/backend/apps/interactions/views.py
+++ b/backend/apps/interactions/views.py
@@ -7,11 +7,20 @@ from rest_framework.views import APIView
 from apps.interactions.models import Comment
 from apps.interactions.permissions import IsCommentAuthorOrAdmin
 from apps.interactions.serializers import (
+    BookmarkResponseSerializer,
     CommentCreateSerializer,
     CommentResponseSerializer,
     LikeResponseSerializer,
 )
-from apps.interactions.services import add_like, create_comment, delete_comment, get_story_comments, remove_like
+from apps.interactions.services import (
+    add_bookmark,
+    add_like,
+    create_comment,
+    delete_comment,
+    get_story_comments,
+    remove_bookmark,
+    remove_like,
+)
 from common.pagination import StoryPagination
 from common.permissions import IsRegisteredUser
 
@@ -81,4 +90,32 @@ class StoryLikeView(APIView):
 
     def delete(self, request, story_id):
         remove_like(request.user, story_id)
+        return Response(status=status.HTTP_204_NO_CONTENT)
+
+
+class StoryBookmarkView(APIView):
+    """
+    POST   /stories/<story_id>/bookmark/ — bookmark a published story.
+    DELETE /stories/<story_id>/bookmark/ — remove an existing bookmark.
+    Both require authentication.
+
+    POST returns 201 on creation, 200 if already bookmarked (idempotent).
+    DELETE always returns 204 regardless of whether a bookmark existed.
+    """
+
+    permission_classes = [IsRegisteredUser]
+
+    def post(self, request, story_id):
+        bookmark, created = add_bookmark(request.user, story_id)
+        http_status = status.HTTP_201_CREATED if created else status.HTTP_200_OK
+        return Response(
+            {
+                'message': 'Story bookmarked successfully.',
+                'bookmark': BookmarkResponseSerializer(bookmark).data,
+            },
+            status=http_status,
+        )
+
+    def delete(self, request, story_id):
+        remove_bookmark(request.user, story_id)
         return Response(status=status.HTTP_204_NO_CONTENT)


### PR DESCRIPTION
# 📝 Description
Fixes #218

Implements `POST /stories/:id/bookmark/` and `DELETE /stories/:id/bookmark/` endpoints for adding and removing story bookmarks.

**Behavior:**
- `POST` returns `201` on first bookmark, `200` on a duplicate (idempotent — no second row created)
- `DELETE` always returns `204` regardless of whether a bookmark existed (idempotent)
- Both endpoints require a registered user (`IsRegisteredUser`)
- `Story.save_count` is kept in sync via Django post_save/post_delete signals (already wired to `SavedStory`)
- `transaction.atomic()` savepoint used on `get_or_create` to prevent MySQL `IntegrityError` from breaking the outer transaction

No migration required — the `SavedStory` model with its `UniqueConstraint` and signals already existed.

# 📊 Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Refactoring
- [ ] Documentation

# ✅ Acceptance Criteria / Checklist
- [x] Project builds successfully
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, especially in hard-to-understand parts
- [x] I have performed a self-review of my code
- [x] I have added/updated tests
- [x] New and existing unit tests pass locally with my changes

# 📸 Screenshots / Recordings
N/A — backend-only change

# ⏱️ Estimated Review Time
- [ ] < 5 min
- [x] 5-15 min
- [ ] > 15 min