### PR TITLE
test: add view-level spoofed-extension tests and fix MIME serializer state

### DIFF
--- a/backend/apps/media/serializers.py
+++ b/backend/apps/media/serializers.py
@@ -85,11 +85,13 @@ class MediaFileUploadSerializer(serializers.Serializer):
                 f'File size must not exceed {limit_mb} MB.'
             )
 
-        value._detected_mime = detected_mime
+        # Store on the serializer instance so validate() can read it without
+        # monkey-patching the file object (which may be wrapped or copied by DRF).
+        self._detected_mime = detected_mime
         return value
 
     def validate(self, attrs):
-        attrs['media_type'] = MIME_TO_MEDIA_TYPE[attrs['file']._detected_mime]
+        attrs['media_type'] = MIME_TO_MEDIA_TYPE[self._detected_mime]
         return attrs
 
 

--- a/backend/apps/media/tests/test_views.py
+++ b/backend/apps/media/tests/test_views.py
@@ -137,6 +137,21 @@ class TestStoryImageUpload:
         )
         assert response.status_code == 400
 
+    def test_spoofed_extension_returns_400(self, auth_client, story):
+        # GIF bytes disguised as a JPEG — the magic-byte check must reject it even though
+        # the filename (.jpg) and declared Content-Type (image/jpeg) both claim JPEG.
+        buf = make_image_file(name='sneaky.jpg', fmt='GIF', content_type='image/jpeg')
+        response = auth_client.post(
+            self.url.format(story_id=story.pk),
+            {'file': buf},
+            format='multipart',
+        )
+        assert response.status_code == 400
+        assert response.data['success'] is False
+        assert 'message' in response.data
+        assert 'errors' in response.data
+        assert 'file' in response.data['errors']
+
     def test_upload_oversized_file_returns_400(self, auth_client, story):
         # Build a file whose .size exceeds 2 MB (2 * 1024 * 1024 + 1 bytes)
         oversized = make_image_file(size_bytes=2 * 1024 * 1024 + 1)
@@ -283,6 +298,21 @@ class TestStoryMediaUpload:
             format='multipart',
         )
         assert response.status_code == 400
+
+    def test_spoofed_extension_returns_400(self, auth_client, story):
+        # JPEG bytes disguised as an MP3 — the magic-byte check must reject it even though
+        # the filename (.mp3) and declared Content-Type (audio/mpeg) both claim audio.
+        buf = make_image_file(name='fake.mp3', fmt='JPEG', content_type='audio/mpeg')
+        response = auth_client.post(
+            self.url.format(story_id=story.pk),
+            {'file': buf},
+            format='multipart',
+        )
+        assert response.status_code == 400
+        assert response.data['success'] is False
+        assert 'message' in response.data
+        assert 'errors' in response.data
+        assert 'file' in response.data['errors']
 
     def test_upload_stores_correct_metadata(self, auth_client, story):
         auth_client.post(


### PR DESCRIPTION
# 📝 Description
Closes #226

The core server-side MIME type validation (python-magic in `ImageUploadSerializer` and `MediaFileUploadSerializer`) was implemented in PR #434. This PR closes issue #226 by adding the two remaining items surfaced by a post-merge code review:

1. **Fix** — `MediaFileUploadSerializer.validate_file` was storing the detected MIME type on the file object itself (`value._detected_mime`). DRF may wrap or copy `InMemoryUploadedFile` objects between field-level and cross-field validation, so this was fragile. Moved to `self._detected_mime` (serializer instance state), which is safe regardless of how DRF handles the file.

2. **Tests** — Added two view-level integration tests that verify the magic-byte check fires end-to-end, not just at the serializer unit-test level:
   - `TestStoryImageUpload.test_spoofed_extension_returns_400` — sends GIF bytes with a `.jpg` filename and `image/jpeg` Content-Type; expects 400
   - `TestStoryMediaUpload.test_spoofed_extension_returns_400` — sends JPEG bytes with a `.mp3` filename and `audio/mpeg` Content-Type; expects 400
   
   Both tests also assert the full error envelope shape (`success`, `message`, `errors.file`), verifying that `common/exceptions.py` normalises the validation error correctly at the HTTP layer.

# 📊 Type of Change
- [x] Bug fix
- [ ] New feature
- [x] Refactoring

# ✅ Acceptance Criteria / Checklist
- [x] Project builds successfully
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, especially in hard-to-understand parts
- [x] I have performed a self-review of my code
- [x] I have added/updated tests
- [x] New and existing unit tests pass locally with my changes

# 📸 Screenshots / Recordings
All 67 media tests pass (`pytest apps/media/tests/ -v`).

# ⏱️ Estimated Review Time
- [x] < 5 min