### PR TITLE
Feat/ current-location radius filtering

### DIFF
--- a/backend/apps/stories/serializers.py
+++ b/backend/apps/stories/serializers.py
@@ -274,7 +274,9 @@ class FeedQuerySerializer(serializers.Serializer):
 
     All fields are optional — omitting them returns the full published feed
     with default sort. year_from and year_to are validated together to ensure
-    the range is logically consistent.
+    the range is logically consistent. latitude, longitude, and radius_km must
+    all be provided together to enable radius filtering; supplying a partial set
+    is rejected.
     """
 
     SORT_RECENT = 'recent'
@@ -288,6 +290,10 @@ class FeedQuerySerializer(serializers.Serializer):
     location = serializers.CharField(required=False, allow_blank=False)
     # Exact (case-insensitive) match against tag name — use the tag slug, e.g. "ottoman-era"
     tag = serializers.CharField(required=False, allow_blank=False)
+    latitude = serializers.FloatField(required=False, min_value=-90.0, max_value=90.0)
+    longitude = serializers.FloatField(required=False, min_value=-180.0, max_value=180.0)
+    # Minimum of 0.001 km — a zero radius would always return empty results
+    radius_km = serializers.FloatField(required=False, min_value=0.001)
 
     def validate(self, data):
         year_from = data.get('year_from')
@@ -296,6 +302,15 @@ class FeedQuerySerializer(serializers.Serializer):
             raise serializers.ValidationError(
                 {'year_to': 'year_to must be greater than or equal to year_from.'}
             )
+
+        geo_fields = {'latitude', 'longitude', 'radius_km'}
+        provided = {k for k in geo_fields if data.get(k) is not None}
+        if provided and provided != geo_fields:
+            missing = geo_fields - provided
+            raise serializers.ValidationError(
+                {f: 'Required when performing radius filtering.' for f in missing}
+            )
+
         return data
 
 
@@ -331,34 +346,14 @@ class StoryMapGeoJSONSerializer(serializers.BaseSerializer):
         }
 
 
-class SearchQuerySerializer(serializers.Serializer):
+class SearchQuerySerializer(FeedQuerySerializer):
     """
     Validates query parameters for the story search endpoint.
 
-    q is required. The filter params (sort_by, year_from, year_to, location) are
-    optional and mirror those accepted by FeedQuerySerializer so search results
-    can be narrowed with the same filters as the feed.
+    q is required. All filter params from FeedQuerySerializer (sort_by, year_from,
+    year_to, location, tag, latitude, longitude, radius_km) are inherited so search
+    results can be narrowed with the same filters as the feed.
     """
-
-    SORT_RECENT = 'recent'
-    SORT_POPULAR = 'popular'
-    SORT_CHOICES = [SORT_RECENT, SORT_POPULAR]
 
     # strip_whitespace=True (default) means a whitespace-only value becomes '' and fails min_length
     q = serializers.CharField(required=True, min_length=1)
-    sort_by = serializers.ChoiceField(choices=SORT_CHOICES, default=SORT_RECENT, required=False)
-    year_from = serializers.IntegerField(required=False)
-    year_to = serializers.IntegerField(required=False)
-    # Substring match against location_name — partial values like "galata" are valid
-    location = serializers.CharField(required=False, allow_blank=False)
-    # Exact (case-insensitive) match against tag name — use the tag slug, e.g. "ottoman-era"
-    tag = serializers.CharField(required=False, allow_blank=False)
-
-    def validate(self, data):
-        year_from = data.get('year_from')
-        year_to = data.get('year_to')
-        if year_from is not None and year_to is not None and year_from > year_to:
-            raise serializers.ValidationError(
-                {'year_to': 'year_to must be greater than or equal to year_from.'}
-            )
-        return data

--- a/backend/apps/stories/serializers.py
+++ b/backend/apps/stories/serializers.py
@@ -292,8 +292,9 @@ class FeedQuerySerializer(serializers.Serializer):
     tag = serializers.CharField(required=False, allow_blank=False)
     latitude = serializers.FloatField(required=False, min_value=-90.0, max_value=90.0)
     longitude = serializers.FloatField(required=False, min_value=-180.0, max_value=180.0)
-    # Minimum of 0.001 km — a zero radius would always return empty results
-    radius_km = serializers.FloatField(required=False, min_value=0.001)
+    # Minimum of 0.001 km — a zero radius would always return empty results.
+    # Maximum of 500 km — uncapped radius would force a full table scan into memory.
+    radius_km = serializers.FloatField(required=False, min_value=0.001, max_value=500.0)
 
     def validate(self, data):
         year_from = data.get('year_from')

--- a/backend/apps/stories/services.py
+++ b/backend/apps/stories/services.py
@@ -54,7 +54,16 @@ def delete_story(story: Story) -> None:
     story.delete()
 
 
-def get_story_feed(sort_by='recent', year_from=None, year_to=None, location=None, tag=None):
+def get_story_feed(
+    sort_by='recent',
+    year_from=None,
+    year_to=None,
+    location=None,
+    tag=None,
+    latitude=None,
+    longitude=None,
+    radius_km=None,
+):
     """
     Return a queryset of published stories with optional sorting and filtering.
 
@@ -65,6 +74,12 @@ def get_story_feed(sort_by='recent', year_from=None, year_to=None, location=None
 
     Location filtering is a case-insensitive substring match on location_name so
     that partial queries like "galata" match "Galata Bridge".
+
+    When latitude, longitude, and radius_km are all provided, a two-step geo filter
+    is applied: a DB bounding-box pre-filter (using the story_coords_idx index) narrows
+    candidates, then an exact haversine check in Python discards bounding-box corners.
+    The result remains a queryset (via pk__in) so annotate_user_interactions and
+    paginator slicing continue to work without change.
 
     sort_by — 'recent' (default) orders by submission date; 'popular' orders by like_count
     """
@@ -88,20 +103,34 @@ def get_story_feed(sort_by='recent', year_from=None, year_to=None, location=None
     if tag:
         qs = qs.filter(story_tags__tag__name__iexact=tag).distinct()
 
+    if latitude is not None and longitude is not None and radius_km is not None:
+        qs = _apply_radius_filter(qs, latitude, longitude, radius_km)
+
     if sort_by == 'recent':
         qs = qs.order_by('-submitted_at')
-        
+
     elif sort_by == 'popular':
         qs = qs.order_by('-like_count')
 
     return qs
 
 
-def get_story_search(q: str, sort_by='recent', year_from=None, year_to=None, location=None, tag=None):
+def get_story_search(
+    q: str,
+    sort_by='recent',
+    year_from=None,
+    year_to=None,
+    location=None,
+    tag=None,
+    latitude=None,
+    longitude=None,
+    radius_km=None,
+):
     """Return published stories whose title or location_name contains q (case-insensitive).
 
     Accepts the same optional filter params as get_story_feed so search results
-    can be narrowed by year range, location, and tag in addition to the text query.
+    can be narrowed by year range, location, tag, and radius in addition to the
+    text query.
 
     Returns an empty queryset if q is blank or whitespace-only — callers should
     validate q before calling, but the service is safe to call directly.
@@ -133,9 +162,38 @@ def get_story_search(q: str, sort_by='recent', year_from=None, year_to=None, loc
     if tag:
         qs = qs.filter(story_tags__tag__name__iexact=tag).distinct()
 
+    if latitude is not None and longitude is not None and radius_km is not None:
+        qs = _apply_radius_filter(qs, latitude, longitude, radius_km)
+
     if sort_by == 'recent':
         qs = qs.order_by('-submitted_at')
 
     # TODO: add sort_by='popular' ordered by like_count once interactions app is implemented
 
     return qs
+
+
+def _apply_radius_filter(qs, latitude: float, longitude: float, radius_km: float):
+    """
+    Narrow a Story queryset to stories within radius_km of (latitude, longitude).
+
+    Uses a bounding-box DB pre-filter to leverage story_coords_idx, then a Python
+    haversine pass to discard bounding-box corners. Returns a queryset (via pk__in)
+    so the caller can continue chaining annotate, paginate, etc.
+    """
+    from common.utils.geo import bounding_box, haversine_km
+
+    bbox = bounding_box(latitude, longitude, radius_km)
+    candidates = qs.filter(
+        location_lat__gte=bbox.lat_min,
+        location_lat__lte=bbox.lat_max,
+        location_lng__gte=bbox.lng_min,
+        location_lng__lte=bbox.lng_max,
+    ).only('pk', 'location_lat', 'location_lng')
+
+    matching_ids = [
+        story.pk
+        for story in candidates
+        if haversine_km(latitude, longitude, float(story.location_lat), float(story.location_lng)) <= radius_km
+    ]
+    return qs.filter(pk__in=matching_ids)

--- a/backend/apps/stories/services.py
+++ b/backend/apps/stories/services.py
@@ -183,7 +183,11 @@ def _apply_radius_filter(qs, latitude: float, longitude: float, radius_km: float
     """
     from common.utils.geo import bounding_box, haversine_km
 
+    # NOTE: bounding_box clamps to ±180° — stories across the antimeridian are excluded.
+    # This is acceptable for this project's geographic scope (Turkey / Istanbul area).
     bbox = bounding_box(latitude, longitude, radius_km)
+    # .only() is safe after .distinct() (added by tag filter) — Django appends it to the
+    # column selection, not to the DISTINCT key columns.
     candidates = qs.filter(
         location_lat__gte=bbox.lat_min,
         location_lat__lte=bbox.lat_max,

--- a/backend/apps/stories/tests/test_serializers.py
+++ b/backend/apps/stories/tests/test_serializers.py
@@ -762,3 +762,10 @@ class TestFeedQuerySerializerGeoValidation:
             data={'q': 'bridge', 'latitude': 41.0, 'longitude': 29.0, 'radius_km': 2.0}
         )
         assert s.is_valid(), s.errors
+
+    def test_radius_km_at_max_is_valid(self):
+        self._valid({'latitude': 41.0, 'longitude': 29.0, 'radius_km': 500.0})
+
+    def test_radius_km_above_max_is_invalid(self):
+        errors = self._invalid({'latitude': 41.0, 'longitude': 29.0, 'radius_km': 501.0})
+        assert 'radius_km' in errors

--- a/backend/apps/stories/tests/test_serializers.py
+++ b/backend/apps/stories/tests/test_serializers.py
@@ -5,7 +5,7 @@ import pytest
 from apps.stories.models import Story
 from apps.interactions.models import Like, SavedStory
 from apps.media.models import MediaItem, MediaType
-from apps.stories.serializers import SearchQuerySerializer, StoryDetailSerializer, StoryFeedSerializer, StoryMapGeoJSONSerializer, StorySerializer
+from apps.stories.serializers import FeedQuerySerializer, SearchQuerySerializer, StoryDetailSerializer, StoryFeedSerializer, StoryMapGeoJSONSerializer, StorySerializer
 from apps.tags.models import StoryTag, Tag
 from apps.users.models import User
 
@@ -638,3 +638,127 @@ class TestStorySerializerTags:
         s = self._serializer({'tag_ids': []}, instance=story)
         assert s.is_valid(), s.errors
         assert s.validated_data['tag_ids'] == []
+
+
+# ── FeedQuerySerializer geo validation ────────────────────────────────────────
+
+class TestFeedQuerySerializerGeoValidation:
+    """Tests for latitude/longitude/radius_km cross-field validation."""
+
+    def _valid(self, data):
+        s = FeedQuerySerializer(data=data)
+        assert s.is_valid(), s.errors
+        return s.validated_data
+
+    def _invalid(self, data):
+        s = FeedQuerySerializer(data=data)
+        assert not s.is_valid()
+        return s.errors
+
+    # ── Positive cases ────────────────────────────────────────────────────────
+
+    def test_all_three_geo_params_is_valid(self):
+        self._valid({'latitude': 41.015, 'longitude': 28.979, 'radius_km': 1.0})
+
+    def test_no_geo_params_is_valid(self):
+        self._valid({})
+
+    def test_no_geo_params_with_other_filters_is_valid(self):
+        self._valid({'sort_by': 'popular', 'year_from': 1900, 'year_to': 2000})
+
+    def test_radius_km_accepts_common_values(self):
+        for radius in [0.5, 1.0, 2.0, 5.0, 10.0]:
+            self._valid({'latitude': 41.0, 'longitude': 29.0, 'radius_km': radius})
+
+    def test_geo_params_combined_with_year_filter_is_valid(self):
+        self._valid({
+            'latitude': 41.0, 'longitude': 29.0, 'radius_km': 1.0,
+            'year_from': 1900, 'year_to': 2000,
+        })
+
+    def test_geo_params_combined_with_tag_filter_is_valid(self):
+        self._valid({'latitude': 41.0, 'longitude': 29.0, 'radius_km': 1.0, 'tag': 'ottoman'})
+
+    # ── Partial geo param sets rejected ──────────────────────────────────────
+
+    def test_latitude_only_is_invalid(self):
+        errors = self._invalid({'latitude': 41.0})
+        assert 'longitude' in errors
+        assert 'radius_km' in errors
+
+    def test_longitude_only_is_invalid(self):
+        errors = self._invalid({'longitude': 29.0})
+        assert 'latitude' in errors
+        assert 'radius_km' in errors
+
+    def test_radius_km_only_is_invalid(self):
+        errors = self._invalid({'radius_km': 1.0})
+        assert 'latitude' in errors
+        assert 'longitude' in errors
+
+    def test_latitude_and_longitude_without_radius_is_invalid(self):
+        errors = self._invalid({'latitude': 41.0, 'longitude': 29.0})
+        assert 'radius_km' in errors
+
+    def test_latitude_and_radius_without_longitude_is_invalid(self):
+        errors = self._invalid({'latitude': 41.0, 'radius_km': 1.0})
+        assert 'longitude' in errors
+
+    def test_longitude_and_radius_without_latitude_is_invalid(self):
+        errors = self._invalid({'longitude': 29.0, 'radius_km': 1.0})
+        assert 'latitude' in errors
+
+    # ── Field-level range validation ──────────────────────────────────────────
+
+    def test_latitude_above_90_is_invalid(self):
+        errors = self._invalid({'latitude': 91.0, 'longitude': 29.0, 'radius_km': 1.0})
+        assert 'latitude' in errors
+
+    def test_latitude_below_minus_90_is_invalid(self):
+        errors = self._invalid({'latitude': -91.0, 'longitude': 29.0, 'radius_km': 1.0})
+        assert 'latitude' in errors
+
+    def test_latitude_at_boundary_values_is_valid(self):
+        self._valid({'latitude': 90.0, 'longitude': 0.0, 'radius_km': 1.0})
+        self._valid({'latitude': -90.0, 'longitude': 0.0, 'radius_km': 1.0})
+
+    def test_longitude_above_180_is_invalid(self):
+        errors = self._invalid({'latitude': 41.0, 'longitude': 181.0, 'radius_km': 1.0})
+        assert 'longitude' in errors
+
+    def test_longitude_below_minus_180_is_invalid(self):
+        errors = self._invalid({'latitude': 41.0, 'longitude': -181.0, 'radius_km': 1.0})
+        assert 'longitude' in errors
+
+    def test_longitude_at_boundary_values_is_valid(self):
+        self._valid({'latitude': 0.0, 'longitude': 180.0, 'radius_km': 1.0})
+        self._valid({'latitude': 0.0, 'longitude': -180.0, 'radius_km': 1.0})
+
+    def test_radius_km_of_zero_is_invalid(self):
+        errors = self._invalid({'latitude': 41.0, 'longitude': 29.0, 'radius_km': 0.0})
+        assert 'radius_km' in errors
+
+    def test_radius_km_negative_is_invalid(self):
+        errors = self._invalid({'latitude': 41.0, 'longitude': 29.0, 'radius_km': -1.0})
+        assert 'radius_km' in errors
+
+    def test_geo_and_year_cross_field_validation_coexist(self):
+        # Both cross-field checks must run independently
+        errors = self._invalid({
+            'latitude': 41.0, 'longitude': 29.0, 'radius_km': 1.0,
+            'year_from': 2000, 'year_to': 1900,
+        })
+        assert 'year_to' in errors
+
+    # ── SearchQuerySerializer inherits geo validation ─────────────────────────
+
+    def test_search_serializer_inherits_geo_validation(self):
+        s = SearchQuerySerializer(data={'q': 'bridge', 'latitude': 41.0})
+        assert not s.is_valid()
+        assert 'longitude' in s.errors or 'radius_km' in s.errors
+
+    def test_search_serializer_accepts_all_three_geo_params(self):
+        s = SearchQuerySerializer(
+            data={'q': 'bridge', 'latitude': 41.0, 'longitude': 29.0, 'radius_km': 2.0}
+        )
+        assert s.is_valid(), s.errors

--- a/backend/apps/stories/tests/test_services.py
+++ b/backend/apps/stories/tests/test_services.py
@@ -3,7 +3,7 @@ from decimal import Decimal
 import pytest
 
 from apps.stories.models import Story
-from apps.stories.services import create_story, delete_story, get_story_feed, get_story_search, update_story
+from apps.stories.services import annotate_user_interactions, create_story, delete_story, get_story_feed, get_story_search, update_story
 from apps.tags.models import StoryTag, Tag
 from apps.users.models import User
 
@@ -454,3 +454,133 @@ class TestUpdateStoryWithTags:
         tag.refresh_from_db()
         assert tag.story_count == 0
 
+
+# ── Geo radius filter helpers ─────────────────────────────────────────────────
+
+# Center point: Istanbul, Galata Tower area
+CENTER_LAT = 41.025580
+CENTER_LNG = 28.974180
+
+# Precomputed coordinate offsets (moving north along the same longitude):
+#   ~0.5 km north  → lat + 0.004493  (well within 1 km)
+#   ~3.0 km north  → lat + 0.026958  (inside 5 km, outside 1 km)
+#   ~50 km north   → lat + 0.449246  (outside any test radius)
+NEAR_LAT  = 41.030073   # ~0.5 km from center
+NEAR_LNG  = CENTER_LNG
+
+MID_LAT   = 41.052538   # ~3 km from center
+MID_LNG   = CENTER_LNG
+
+FAR_LAT   = 41.474826   # ~50 km from center
+FAR_LNG   = CENTER_LNG
+
+
+def make_geo_story(lat, lng, **kwargs):
+    defaults = dict(
+        title='Geo Story',
+        narrative='A geo narrative.',
+        location_lat=str(lat),
+        location_lng=str(lng),
+        location_name='Test Location',
+        time_type=Story.TIME_EXACT,
+        year=1950,
+        status=Story.STATUS_PUBLISHED,
+    )
+    defaults.update(kwargs)
+    return Story.objects.create(**defaults)
+
+
+# ── get_story_feed geo filtering ──────────────────────────────────────────────
+
+@pytest.mark.django_db
+class TestGetStoryFeedGeoFilter:
+    def test_returns_story_within_radius(self):
+        near = make_geo_story(NEAR_LAT, NEAR_LNG)
+        qs = get_story_feed(latitude=CENTER_LAT, longitude=CENTER_LNG, radius_km=1.0)
+        assert near in qs
+
+    def test_excludes_story_outside_radius(self):
+        far = make_geo_story(FAR_LAT, FAR_LNG)
+        qs = get_story_feed(latitude=CENTER_LAT, longitude=CENTER_LNG, radius_km=1.0)
+        assert far not in qs
+
+    def test_larger_radius_includes_more_stories(self):
+        make_geo_story(NEAR_LAT, NEAR_LNG, title='Near')
+        make_geo_story(MID_LAT, MID_LNG, title='Mid')
+        make_geo_story(FAR_LAT, FAR_LNG, title='Far')
+        qs_1km = get_story_feed(latitude=CENTER_LAT, longitude=CENTER_LNG, radius_km=1.0)
+        qs_5km = get_story_feed(latitude=CENTER_LAT, longitude=CENTER_LNG, radius_km=5.0)
+        assert qs_5km.count() > qs_1km.count()
+
+    def test_omitting_geo_params_returns_all_stories(self):
+        make_geo_story(NEAR_LAT, NEAR_LNG)
+        make_geo_story(FAR_LAT, FAR_LNG)
+        qs = get_story_feed()
+        assert qs.count() == 2
+
+    def test_geo_filter_combined_with_year_filter(self):
+        near_old = make_geo_story(NEAR_LAT, NEAR_LNG, year=1900, title='NearOld')
+        near_new = make_geo_story(NEAR_LAT, NEAR_LNG, year=2000, title='NearNew')
+        qs = get_story_feed(latitude=CENTER_LAT, longitude=CENTER_LNG, radius_km=1.0, year_from=1950)
+        assert near_new in qs
+        assert near_old not in qs
+
+    def test_geo_filter_combined_with_tag_filter(self):
+        tag = Tag.objects.create(name='geo-svc-tag')
+        near_tagged = make_geo_story(NEAR_LAT, NEAR_LNG, title='NearTagged')
+        StoryTag.objects.create(story=near_tagged, tag=tag)
+        near_untagged = make_geo_story(NEAR_LAT, NEAR_LNG, title='NearUntagged')
+        qs = get_story_feed(latitude=CENTER_LAT, longitude=CENTER_LNG, radius_km=1.0, tag='geo-svc-tag')
+        assert near_tagged in qs
+        assert near_untagged not in qs
+
+    def test_geo_filter_result_is_queryset_compatible_with_annotate(self):
+        user = User.objects.create_user(email='geo@example.com', username='geouser', password='Password1')
+        make_geo_story(NEAR_LAT, NEAR_LNG)
+        qs = get_story_feed(latitude=CENTER_LAT, longitude=CENTER_LNG, radius_km=1.0)
+        # annotate_user_interactions calls .annotate() — must not raise on the result
+        annotated = annotate_user_interactions(qs, user)
+        assert annotated.count() >= 0
+
+    def test_geo_filter_returns_empty_when_no_stories_within_radius(self):
+        make_geo_story(FAR_LAT, FAR_LNG)
+        qs = get_story_feed(latitude=CENTER_LAT, longitude=CENTER_LNG, radius_km=1.0)
+        assert qs.count() == 0
+
+    def test_geo_filter_excludes_draft_stories_within_radius(self):
+        make_geo_story(NEAR_LAT, NEAR_LNG, status=Story.STATUS_DRAFT)
+        qs = get_story_feed(latitude=CENTER_LAT, longitude=CENTER_LNG, radius_km=1.0)
+        assert qs.count() == 0
+
+
+# ── get_story_search geo filtering ───────────────────────────────────────────
+
+@pytest.mark.django_db
+class TestGetStorySearchGeoFilter:
+    def test_returns_matching_story_within_radius(self):
+        near = make_geo_story(NEAR_LAT, NEAR_LNG, title='Ancient Tower')
+        qs = get_story_search('Ancient', latitude=CENTER_LAT, longitude=CENTER_LNG, radius_km=1.0)
+        assert near in qs
+
+    def test_excludes_matching_story_outside_radius(self):
+        far = make_geo_story(FAR_LAT, FAR_LNG, title='Ancient Tower')
+        qs = get_story_search('Ancient', latitude=CENTER_LAT, longitude=CENTER_LNG, radius_km=1.0)
+        assert far not in qs
+
+    def test_geo_filter_does_not_include_non_matching_nearby_story(self):
+        make_geo_story(NEAR_LAT, NEAR_LNG, title='Unrelated Story')
+        qs = get_story_search('Ancient', latitude=CENTER_LAT, longitude=CENTER_LNG, radius_km=1.0)
+        assert qs.count() == 0
+
+    def test_omitting_geo_params_returns_all_matching_stories(self):
+        make_geo_story(NEAR_LAT, NEAR_LNG, title='Ancient Near')
+        make_geo_story(FAR_LAT, FAR_LNG, title='Ancient Far')
+        qs = get_story_search('Ancient')
+        assert qs.count() == 2
+
+    def test_geo_filter_result_is_queryset_compatible_with_annotate(self):
+        user = User.objects.create_user(email='geosearch@example.com', username='geosearch', password='Password1')
+        make_geo_story(NEAR_LAT, NEAR_LNG, title='Ancient Tower')
+        qs = get_story_search('Ancient', latitude=CENTER_LAT, longitude=CENTER_LNG, radius_km=1.0)
+        annotated = annotate_user_interactions(qs, user)
+        assert annotated.count() >= 0

--- a/backend/apps/stories/tests/test_services.py
+++ b/backend/apps/stories/tests/test_services.py
@@ -538,9 +538,18 @@ class TestGetStoryFeedGeoFilter:
         user = User.objects.create_user(email='geo@example.com', username='geouser', password='Password1')
         make_geo_story(NEAR_LAT, NEAR_LNG)
         qs = get_story_feed(latitude=CENTER_LAT, longitude=CENTER_LNG, radius_km=1.0)
-        # annotate_user_interactions calls .annotate() — must not raise on the result
         annotated = annotate_user_interactions(qs, user)
-        assert annotated.count() >= 0
+        stories = list(annotated)
+        assert len(stories) > 0
+        assert hasattr(stories[0], '_user_has_liked')
+        assert hasattr(stories[0], '_user_has_saved')
+
+    def test_geo_filter_preserves_sort_by_popular_ordering(self):
+        popular = make_geo_story(NEAR_LAT, NEAR_LNG, title='Popular', like_count=10)
+        unpopular = make_geo_story(NEAR_LAT, NEAR_LNG, title='Unpopular', like_count=0)
+        qs = list(get_story_feed(latitude=CENTER_LAT, longitude=CENTER_LNG, radius_km=1.0, sort_by='popular'))
+        assert qs[0].pk == popular.pk
+        assert qs[1].pk == unpopular.pk
 
     def test_geo_filter_returns_empty_when_no_stories_within_radius(self):
         make_geo_story(FAR_LAT, FAR_LNG)
@@ -583,4 +592,7 @@ class TestGetStorySearchGeoFilter:
         make_geo_story(NEAR_LAT, NEAR_LNG, title='Ancient Tower')
         qs = get_story_search('Ancient', latitude=CENTER_LAT, longitude=CENTER_LNG, radius_km=1.0)
         annotated = annotate_user_interactions(qs, user)
-        assert annotated.count() >= 0
+        stories = list(annotated)
+        assert len(stories) > 0
+        assert hasattr(stories[0], '_user_has_liked')
+        assert hasattr(stories[0], '_user_has_saved')

--- a/backend/apps/stories/tests/test_views.py
+++ b/backend/apps/stories/tests/test_views.py
@@ -755,3 +755,178 @@ class TestStoryTagAssignment:
         response = client.get(self._detail_url(story.pk))
         assert response.status_code == status.HTTP_200_OK
         assert 'tags' in response.data
+
+
+# ── Geo radius filter view tests ──────────────────────────────────────────────
+
+# Center: Istanbul, Galata Tower area
+_GEO_CENTER_LAT = 41.025580
+_GEO_CENTER_LNG = 28.974180
+
+# ~0.5 km north (inside 1 km radius)
+_GEO_NEAR_LAT = 41.030073
+_GEO_NEAR_LNG = _GEO_CENTER_LNG
+
+# ~50 km north (outside any reasonable test radius)
+_GEO_FAR_LAT = 41.474826
+_GEO_FAR_LNG = _GEO_CENTER_LNG
+
+
+def make_geo_story(lat, lng, **kwargs):
+    defaults = dict(
+        title='Geo Story',
+        narrative='A geo narrative.',
+        location_lat=str(lat),
+        location_lng=str(lng),
+        location_name='Test Location',
+        time_type=Story.TIME_EXACT,
+        year=1950,
+        status=Story.STATUS_PUBLISHED,
+    )
+    defaults.update(kwargs)
+    return Story.objects.create(**defaults)
+
+
+@pytest.mark.django_db
+class TestStoryFeedViewGeoFilter:
+    def _geo_params(self, radius_km=1.0):
+        return f'latitude={_GEO_CENTER_LAT}&longitude={_GEO_CENTER_LNG}&radius_km={radius_km}'
+
+    def test_geo_filter_returns_only_nearby_stories(self, client):
+        make_geo_story(_GEO_NEAR_LAT, _GEO_NEAR_LNG, title='Near Story')
+        make_geo_story(_GEO_FAR_LAT, _GEO_FAR_LNG, title='Far Story')
+        response = client.get(f'{FEED_URL}?{self._geo_params()}')
+        assert response.status_code == status.HTTP_200_OK
+        titles = [s['title'] for s in response.data['results']]
+        assert 'Near Story' in titles
+        assert 'Far Story' not in titles
+
+    def test_geo_filter_unauthenticated_returns_200(self, client):
+        response = client.get(f'{FEED_URL}?{self._geo_params()}')
+        assert response.status_code == status.HTTP_200_OK
+
+    def test_geo_filter_empty_results_when_no_stories_nearby(self, client):
+        make_geo_story(_GEO_FAR_LAT, _GEO_FAR_LNG)
+        response = client.get(f'{FEED_URL}?{self._geo_params()}')
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data['count'] == 0
+
+    def test_geo_filter_latitude_only_returns_400(self, client):
+        response = client.get(f'{FEED_URL}?latitude={_GEO_CENTER_LAT}')
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+    def test_geo_filter_latitude_and_longitude_without_radius_returns_400(self, client):
+        response = client.get(f'{FEED_URL}?latitude={_GEO_CENTER_LAT}&longitude={_GEO_CENTER_LNG}')
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+    def test_geo_filter_invalid_latitude_returns_400(self, client):
+        response = client.get(f'{FEED_URL}?latitude=91&longitude={_GEO_CENTER_LNG}&radius_km=1')
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+    def test_geo_filter_invalid_longitude_returns_400(self, client):
+        response = client.get(f'{FEED_URL}?latitude={_GEO_CENTER_LAT}&longitude=200&radius_km=1')
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+    def test_geo_filter_zero_radius_returns_400(self, client):
+        response = client.get(f'{FEED_URL}?latitude={_GEO_CENTER_LAT}&longitude={_GEO_CENTER_LNG}&radius_km=0')
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+    def test_geo_filter_negative_radius_returns_400(self, client):
+        response = client.get(f'{FEED_URL}?latitude={_GEO_CENTER_LAT}&longitude={_GEO_CENTER_LNG}&radius_km=-1')
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+    def test_geo_filter_combined_with_year_filter(self, client):
+        make_geo_story(_GEO_NEAR_LAT, _GEO_NEAR_LNG, year=1900, title='OldNear')
+        make_geo_story(_GEO_NEAR_LAT, _GEO_NEAR_LNG, year=2000, title='NewNear')
+        response = client.get(f'{FEED_URL}?{self._geo_params()}&year_from=1950')
+        assert response.status_code == status.HTTP_200_OK
+        titles = [s['title'] for s in response.data['results']]
+        assert 'NewNear' in titles
+        assert 'OldNear' not in titles
+
+    def test_geo_filter_combined_with_tag_filter(self, client):
+        tag = Tag.objects.create(name='view-geo-tag')
+        near_tagged = make_geo_story(_GEO_NEAR_LAT, _GEO_NEAR_LNG, title='TaggedNear')
+        StoryTag.objects.create(story=near_tagged, tag=tag)
+        make_geo_story(_GEO_NEAR_LAT, _GEO_NEAR_LNG, title='UntaggedNear')
+        response = client.get(f'{FEED_URL}?{self._geo_params()}&tag=view-geo-tag')
+        assert response.status_code == status.HTTP_200_OK
+        titles = [s['title'] for s in response.data['results']]
+        assert 'TaggedNear' in titles
+        assert 'UntaggedNear' not in titles
+
+
+@pytest.mark.django_db
+class TestStoryMapViewGeoFilter:
+    def _geo_params(self, radius_km=1.0):
+        return f'latitude={_GEO_CENTER_LAT}&longitude={_GEO_CENTER_LNG}&radius_km={radius_km}'
+
+    def _feature_ids(self, response):
+        return [f['id'] for f in response.data['features']]
+
+    def test_geo_filter_returns_only_nearby_features(self, client):
+        near = make_geo_story(_GEO_NEAR_LAT, _GEO_NEAR_LNG)
+        far = make_geo_story(_GEO_FAR_LAT, _GEO_FAR_LNG)
+        response = client.get(f'{MAP_URL}?{self._geo_params()}')
+        assert response.status_code == status.HTTP_200_OK
+        ids = self._feature_ids(response)
+        assert near.pk in ids
+        assert far.pk not in ids
+
+    def test_geo_filter_unauthenticated_returns_200(self, client):
+        response = client.get(f'{MAP_URL}?{self._geo_params()}')
+        assert response.status_code == status.HTTP_200_OK
+
+    def test_geo_filter_missing_one_param_returns_400(self, client):
+        response = client.get(f'{MAP_URL}?latitude={_GEO_CENTER_LAT}&longitude={_GEO_CENTER_LNG}')
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+    def test_geo_filter_invalid_latitude_returns_400(self, client):
+        response = client.get(f'{MAP_URL}?latitude=91&longitude={_GEO_CENTER_LNG}&radius_km=1')
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+    def test_geo_filter_empty_results_when_no_stories_nearby(self, client):
+        make_geo_story(_GEO_FAR_LAT, _GEO_FAR_LNG)
+        response = client.get(f'{MAP_URL}?{self._geo_params()}')
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data['features'] == []
+
+    def test_geo_filter_returns_geojson_feature_collection(self, client):
+        make_geo_story(_GEO_NEAR_LAT, _GEO_NEAR_LNG)
+        response = client.get(f'{MAP_URL}?{self._geo_params()}')
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data['type'] == 'FeatureCollection'
+        assert response.data['features'][0]['type'] == 'Feature'
+
+
+@pytest.mark.django_db
+class TestStorySearchViewGeoFilter:
+    def _geo_params(self, radius_km=1.0):
+        return f'latitude={_GEO_CENTER_LAT}&longitude={_GEO_CENTER_LNG}&radius_km={radius_km}'
+
+    def test_geo_filter_returns_only_nearby_matching_stories(self, client):
+        make_geo_story(_GEO_NEAR_LAT, _GEO_NEAR_LNG, title='Ancient Tower')
+        make_geo_story(_GEO_FAR_LAT, _GEO_FAR_LNG, title='Ancient Ruins')
+        response = client.get(f'{SEARCH_URL}?q=Ancient&{self._geo_params()}')
+        assert response.status_code == status.HTTP_200_OK
+        titles = [s['title'] for s in response.data['results']]
+        assert 'Ancient Tower' in titles
+        assert 'Ancient Ruins' not in titles
+
+    def test_geo_filter_unauthenticated_returns_200(self, client):
+        response = client.get(f'{SEARCH_URL}?q=story&{self._geo_params()}')
+        assert response.status_code == status.HTTP_200_OK
+
+    def test_geo_filter_missing_one_param_returns_400(self, client):
+        response = client.get(f'{SEARCH_URL}?q=story&latitude={_GEO_CENTER_LAT}')
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+    def test_geo_filter_invalid_latitude_returns_400(self, client):
+        response = client.get(f'{SEARCH_URL}?q=story&latitude=91&longitude={_GEO_CENTER_LNG}&radius_km=1')
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+    def test_geo_filter_empty_results_when_no_matching_stories_nearby(self, client):
+        make_geo_story(_GEO_FAR_LAT, _GEO_FAR_LNG, title='Ancient Far')
+        response = client.get(f'{SEARCH_URL}?q=Ancient&{self._geo_params()}')
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data['count'] == 0

--- a/backend/apps/stories/views.py
+++ b/backend/apps/stories/views.py
@@ -23,6 +23,9 @@ class StoryFeedView(APIView):
       year_to    — include stories up to and including this year
       location   — case-insensitive substring match against location_name
       tag        — exact tag name filter (case-insensitive), e.g. "ottoman-era"
+      latitude   — WGS-84 latitude of user's position (-90 to 90)
+      longitude  — WGS-84 longitude of user's position (-180 to 180)
+      radius_km  — filter radius in kilometres (must be provided with latitude + longitude)
       page       — page number (default 1)
       page_size  — results per page (default 10, max 100)
     """
@@ -41,6 +44,9 @@ class StoryFeedView(APIView):
             year_to=params.get('year_to'),
             location=params.get('location'),
             tag=params.get('tag'),
+            latitude=params.get('latitude'),
+            longitude=params.get('longitude'),
+            radius_km=params.get('radius_km'),
         )
         if request.user.is_authenticated:
             qs = annotate_user_interactions(qs, request.user)
@@ -66,6 +72,9 @@ class StoryMapView(APIView):
       year_to    — include stories up to and including this year
       location   — case-insensitive substring match against location_name
       tag        — exact tag name filter (case-insensitive), e.g. "ottoman-era"
+      latitude   — WGS-84 latitude of user's position (-90 to 90)
+      longitude  — WGS-84 longitude of user's position (-180 to 180)
+      radius_km  — filter radius in kilometres (must be provided with latitude + longitude)
     """
 
     permission_classes = [AllowAny]
@@ -80,6 +89,9 @@ class StoryMapView(APIView):
             year_to=params.get('year_to'),
             location=params.get('location'),
             tag=params.get('tag'),
+            latitude=params.get('latitude'),
+            longitude=params.get('longitude'),
+            radius_km=params.get('radius_km'),
         )
 
         serializer = StoryMapGeoJSONSerializer(qs, many=True)
@@ -115,6 +127,9 @@ class StorySearchView(APIView):
             year_to=params.get('year_to'),
             location=params.get('location'),
             tag=params.get('tag'),
+            latitude=params.get('latitude'),
+            longitude=params.get('longitude'),
+            radius_km=params.get('radius_km'),
         )
         if request.user.is_authenticated:
             qs = annotate_user_interactions(qs, request.user)

--- a/backend/common/tests/test_geo.py
+++ b/backend/common/tests/test_geo.py
@@ -1,0 +1,116 @@
+import math
+
+import pytest
+
+from common.utils.geo import BoundingBox, bounding_box, haversine_km
+
+# Istanbul and Ankara coordinates for a real-world distance check
+ISTANBUL_LAT, ISTANBUL_LNG = 41.015137, 28.979530
+ANKARA_LAT, ANKARA_LNG = 39.925533, 32.866287
+ISTANBUL_ANKARA_KM = 351.0  # approximate great-circle distance
+
+
+class TestHaversineKm:
+    def test_same_point_returns_zero(self):
+        assert haversine_km(41.0, 28.9, 41.0, 28.9) == 0.0
+
+    def test_known_distance_istanbul_to_ankara(self):
+        distance = haversine_km(ISTANBUL_LAT, ISTANBUL_LNG, ANKARA_LAT, ANKARA_LNG)
+        assert distance == pytest.approx(ISTANBUL_ANKARA_KM, rel=0.01)
+
+    def test_symmetry(self):
+        d1 = haversine_km(ISTANBUL_LAT, ISTANBUL_LNG, ANKARA_LAT, ANKARA_LNG)
+        d2 = haversine_km(ANKARA_LAT, ANKARA_LNG, ISTANBUL_LAT, ISTANBUL_LNG)
+        assert d1 == pytest.approx(d2)
+
+    def test_returns_positive_value_for_distinct_points(self):
+        assert haversine_km(0.0, 0.0, 1.0, 1.0) > 0.0
+
+    def test_one_degree_latitude_is_approximately_111km(self):
+        # One degree of latitude is ~111.32 km at any longitude
+        distance = haversine_km(0.0, 0.0, 1.0, 0.0)
+        assert distance == pytest.approx(111.195, rel=0.005)
+
+    def test_equator_crossing(self):
+        # Crossing the equator should work without sign errors
+        distance = haversine_km(-0.5, 0.0, 0.5, 0.0)
+        assert distance == pytest.approx(111.195, rel=0.01)
+
+
+class TestBoundingBox:
+    CENTER_LAT = 41.015137
+    CENTER_LNG = 28.979530
+    RADIUS_KM = 5.0
+
+    def _box(self, radius_km=None):
+        return bounding_box(self.CENTER_LAT, self.CENTER_LNG, radius_km or self.RADIUS_KM)
+
+    def test_returns_bounding_box_namedtuple(self):
+        result = self._box()
+        assert isinstance(result, BoundingBox)
+
+    def test_lat_min_less_than_lat_max(self):
+        box = self._box()
+        assert box.lat_min < box.lat_max
+
+    def test_lng_min_less_than_lng_max(self):
+        box = self._box()
+        assert box.lng_min < box.lng_max
+
+    def test_center_point_is_within_box(self):
+        box = self._box()
+        assert box.lat_min <= self.CENTER_LAT <= box.lat_max
+        assert box.lng_min <= self.CENTER_LNG <= box.lng_max
+
+    def test_larger_radius_produces_larger_box(self):
+        box_1km = bounding_box(self.CENTER_LAT, self.CENTER_LNG, 1.0)
+        box_10km = bounding_box(self.CENTER_LAT, self.CENTER_LNG, 10.0)
+        assert (box_10km.lat_max - box_10km.lat_min) > (box_1km.lat_max - box_1km.lat_min)
+        assert (box_10km.lng_max - box_10km.lng_min) > (box_1km.lng_max - box_1km.lng_min)
+
+    def test_near_north_pole_does_not_raise(self):
+        # Should not raise ZeroDivisionError even near the pole
+        box = bounding_box(89.9, 0.0, 1.0)
+        assert box.lat_min <= 89.9 <= box.lat_max
+
+    def test_near_south_pole_does_not_raise(self):
+        box = bounding_box(-89.9, 0.0, 1.0)
+        assert box.lat_min <= -89.9 <= box.lat_max
+
+    def test_lat_clamped_to_90(self):
+        # A very large radius should not produce lat values beyond ±90
+        box = bounding_box(89.0, 0.0, 5000.0)
+        assert box.lat_max <= 90.0
+        assert box.lat_min >= -90.0
+
+    def test_lng_clamped_to_180(self):
+        # A point near the antimeridian with a large radius should clamp to ±180
+        box = bounding_box(0.0, 179.0, 500.0)
+        assert box.lng_max <= 180.0
+
+    def test_lng_clamped_to_minus_180(self):
+        box = bounding_box(0.0, -179.0, 500.0)
+        assert box.lng_min >= -180.0
+
+    def test_points_within_radius_are_inside_box(self):
+        # The bounding box is an over-approximation: every point truly inside the
+        # circle must lie within the box (but not vice-versa).
+        center_lat, center_lng, radius_km = 41.0, 29.0, 2.0
+        box = bounding_box(center_lat, center_lng, radius_km)
+
+        # Generate a grid of points known to be inside the radius
+        # by computing offsets slightly smaller than radius_km
+        step_km = 0.4
+        for dlat_km in range(-4, 5):
+            for dlng_km in range(-4, 5):
+                dlat = math.degrees(dlat_km * step_km / 6371.0)
+                dlng = math.degrees(dlng_km * step_km / (6371.0 * math.cos(math.radians(center_lat))))
+                pt_lat = center_lat + dlat
+                pt_lng = center_lng + dlng
+                if haversine_km(center_lat, center_lng, pt_lat, pt_lng) <= radius_km:
+                    assert box.lat_min <= pt_lat <= box.lat_max, (
+                        f"Point ({pt_lat}, {pt_lng}) inside radius but outside bounding box lat"
+                    )
+                    assert box.lng_min <= pt_lng <= box.lng_max, (
+                        f"Point ({pt_lat}, {pt_lng}) inside radius but outside bounding box lng"
+                    )

--- a/backend/common/utils/geo.py
+++ b/backend/common/utils/geo.py
@@ -1,1 +1,38 @@
-# Geographic utilities (haversine, bounding box)
+import math
+from typing import NamedTuple
+
+EARTH_RADIUS_KM = 6371.0
+
+
+class BoundingBox(NamedTuple):
+    lat_min: float
+    lat_max: float
+    lng_min: float
+    lng_max: float
+
+
+def haversine_km(lat1: float, lng1: float, lat2: float, lng2: float) -> float:
+    """Return great-circle distance in km between two (lat, lng) points."""
+    dlat = math.radians(lat2 - lat1)
+    dlng = math.radians(lng2 - lng1)
+    a = (
+        math.sin(dlat / 2) ** 2
+        + math.cos(math.radians(lat1))
+        * math.cos(math.radians(lat2))
+        * math.sin(dlng / 2) ** 2
+    )
+    return EARTH_RADIUS_KM * 2 * math.asin(math.sqrt(a))
+
+
+def bounding_box(center_lat: float, center_lng: float, radius_km: float) -> BoundingBox:
+    """Return a rectangular bounding box (over-approximation) around center point with given radius."""
+    lat_delta = math.degrees(radius_km / EARTH_RADIUS_KM)
+    # cos(90°) == 0 would cause division by zero; clamp to avoid it near poles
+    safe_lat = min(abs(center_lat), 89.9999)
+    lng_delta = math.degrees(radius_km / (EARTH_RADIUS_KM * math.cos(math.radians(safe_lat))))
+    return BoundingBox(
+        lat_min=max(center_lat - lat_delta, -90.0),
+        lat_max=min(center_lat + lat_delta, 90.0),
+        lng_min=max(center_lng - lng_delta, -180.0),
+        lng_max=min(center_lng + lng_delta, 180.0),
+    )

--- a/backend/common/utils/geo.py
+++ b/backend/common/utils/geo.py
@@ -25,7 +25,12 @@ def haversine_km(lat1: float, lng1: float, lat2: float, lng2: float) -> float:
 
 
 def bounding_box(center_lat: float, center_lng: float, radius_km: float) -> BoundingBox:
-    """Return a rectangular bounding box (over-approximation) around center point with given radius."""
+    """Return a rectangular bounding box (over-approximation) around center point with given radius.
+
+    NOTE: Antimeridian wrap (center near ±180° longitude) is not supported. When the
+    box would cross ±180°, it is clamped and stories on the far side of the antimeridian
+    are silently excluded. This is acceptable for this project's geographic scope (Turkey).
+    """
     lat_delta = math.degrees(radius_km / EARTH_RADIUS_KM)
     # cos(90°) == 0 would cause division by zero; clamp to avoid it near poles
     safe_lat = min(abs(center_lat), 89.9999)


### PR DESCRIPTION
# 📝 Description

Fixes #387

This PR adds **current-location radius filtering** support to the backend story discovery endpoints by extending the feed, map, and search flows with geographic filter parameters.

The main change is that the relevant query serializers, service-layer functions, and views now support `latitude`, `longitude`, and `radius_km` parameters. These three parameters must be provided together to activate radius filtering, and the validation layer now enforces that rule. Additional field-level validation also ensures that latitude and longitude stay within valid geographic ranges, and that `radius_km` remains within a safe and practical range. In particular, the radius is capped at **500 km** to avoid unbounded scans and keep the feature aligned with the project’s actual geographic scope. 

On the service side, both `get_story_feed(...)` and `get_story_search(...)` were extended to accept the new geographic filter arguments. The radius filtering is implemented as a two-step process:

1. a **bounding-box database pre-filter** is applied first, so the indexed coordinate fields can narrow down candidate stories efficiently,
2. then an exact **haversine distance** check is performed in Python to keep only the stories that truly fall within the requested radius. 

This keeps the final result as a queryset, which means the existing annotation, ordering, and pagination behavior can continue to work without being rewritten. The implementation also preserves compatibility with the current filter structure, so current-location filtering can be combined with existing filters such as year and tag. The same geo-filtering behavior is now applied consistently across:

* the feed endpoint,
* the map endpoint,
* and the search endpoint. 

To support this cleanly, a new shared geographic utility module was added under `common/utils/geo.py`. It provides:

* a `haversine_km(...)` helper for exact great-circle distance calculation,
* and a `bounding_box(...)` helper for the indexed pre-filter step. 

This PR also includes substantial test coverage:

* serializer tests for geo parameter validation,
* service tests for radius filtering behavior and filter combinations,
* view tests for feed, map, and search endpoint behavior,
* and direct utility tests for the haversine and bounding-box helpers. 

Overall, this PR delivers backend support for location-based radius filtering in a way that is reusable, validated, performance-conscious, and consistent across the project’s story discovery endpoints.

# 📊 Type of Change

*  [ ] Bug fix
*  [x] New feature
*  [ ] Refactoring
*  [ ] Documentation

# ✅ Acceptance Criteria / Checklist

* [x] Project builds successfully
* [x] My code follows the style guidelines of this project
* [x] I have commented my code, especially in hard-to-understand parts
* [x] I have performed a self-review of my code
* [x] I have added/updated tests
* [x] New and existing unit tests pass locally with my changes



# ⏱️ Estimated Review Time

* [ ] < 5 min
* [ ] 5-15 min
* [x] > 15 min
