### PR TITLE
Improve story detail layout

### DIFF
--- a/mobile/src/features/stories/presentation/screens/StoryScreen.tsx
+++ b/mobile/src/features/stories/presentation/screens/StoryScreen.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useMemo, useRef, useState } from 'react';
-import { Alert, Image, Pressable, ScrollView, Text, View } from 'react-native';
+import { Alert, Image, LayoutChangeEvent, Pressable, ScrollView, Text, View } from 'react-native';
+import { Trash2 } from 'lucide-react-native';
 import { roles } from '../../../../core/auth/roles';
 import { Session } from '../../../../core/auth/session';
 import { useAppTheme } from '../../../../core/hooks/useAppTheme';
@@ -45,38 +46,18 @@ function getDisplayNameWithYouLabel(name: string, isCurrentUser: boolean) {
   return isCurrentUser ? `${name} (You)` : name;
 }
 
-function StoryMetaRow({ label, value }: { label: string; value: string }) {
-  const { colors, spacing, typography } = useAppTheme();
+function getReadingTimeLabel(paragraphs: string[]) {
+  const wordCount = paragraphs.join(' ').trim().split(/\s+/).filter(Boolean).length;
+  const minutes = Math.max(1, Math.ceil(wordCount / 200));
 
-  return (
-    <View
-      style={{
-        width: '48%',
-        padding: spacing.md,
-        borderRadius: 14,
-        backgroundColor: colors.surface,
-        borderWidth: 1,
-        borderColor: colors.border,
-      }}
-    >
-      <Text style={{ color: colors.muted, fontSize: typography.caption, textTransform: 'uppercase' }}>
-        {label}
-      </Text>
-      <Text
-        style={{
-          marginTop: spacing.xs,
-          color: colors.text,
-          fontSize: typography.body,
-          fontWeight: '600',
-        }}
-      >
-        {value}
-      </Text>
-    </View>
-  );
+  return `${minutes} min read`;
 }
 
-function StoryMetaActionRow({
+function shouldCollapseNarrative(paragraphs: string[]) {
+  return paragraphs.length > 2 || paragraphs.join(' ').length > 520;
+}
+
+function StoryMetaItem({
   label,
   value,
   onPress,
@@ -87,35 +68,122 @@ function StoryMetaActionRow({
 }) {
   const { colors, spacing, typography } = useAppTheme();
 
-  return (
-    <Pressable
-      accessibilityRole={onPress ? 'button' : undefined}
-      accessibilityLabel={onPress ? `Open profile: ${value}` : undefined}
-      disabled={!onPress}
-      onPress={onPress}
-      style={{
-        width: '48%',
-        padding: spacing.md,
-        borderRadius: 14,
-        backgroundColor: colors.surface,
-        borderWidth: 1,
-        borderColor: colors.border,
-      }}
-    >
-      <Text style={{ color: colors.muted, fontSize: typography.caption, textTransform: 'uppercase' }}>
+  const content = (
+    <>
+      <Text
+        style={{
+          color: colors.muted,
+          fontSize: typography.caption,
+          fontWeight: '700',
+          textTransform: 'uppercase',
+        }}
+      >
         {label}
       </Text>
       <Text
+        numberOfLines={2}
         style={{
           marginTop: spacing.xs,
           color: onPress ? colors.primary : colors.text,
           fontSize: typography.body,
-          fontWeight: '600',
+          fontWeight: '700',
         }}
       >
         {value}
       </Text>
-    </Pressable>
+    </>
+  );
+
+  const shellStyle = {
+    flexGrow: 1,
+    flexBasis: 150,
+    minHeight: 64,
+    paddingVertical: spacing.sm,
+    paddingHorizontal: spacing.md,
+    borderRadius: 12,
+    backgroundColor: colors.surface,
+    borderWidth: 1,
+    borderColor: colors.border,
+    justifyContent: 'center' as const,
+  };
+
+  if (onPress) {
+    return (
+      <Pressable
+        accessibilityRole="button"
+        accessibilityLabel={`Open profile: ${value}`}
+        onPress={onPress}
+        style={shellStyle}
+      >
+        {content}
+      </Pressable>
+    );
+  }
+
+  return (
+    <View style={shellStyle}>
+      {content}
+    </View>
+  );
+}
+
+function StoryNarrative({
+  story,
+  isExpanded,
+  onToggleExpanded,
+  onLayout,
+}: {
+  story: StoryEntity;
+  isExpanded: boolean;
+  onToggleExpanded: () => void;
+  onLayout: (event: LayoutChangeEvent) => void;
+}) {
+  const { colors, spacing, typography } = useAppTheme();
+  const canCollapse = shouldCollapseNarrative(story.narrative);
+  const visibleParagraphs = canCollapse && !isExpanded ? story.narrative.slice(0, 2) : story.narrative;
+
+  return (
+    <View onLayout={onLayout} style={{ marginTop: spacing.lg }}>
+      <Text style={{ color: colors.text, fontSize: typography.subtitle, fontWeight: '700' }}>
+        Full story
+      </Text>
+      {visibleParagraphs.map((paragraph, index) => (
+        <Text
+          key={`${story.id}-paragraph-${index + 1}`}
+          numberOfLines={canCollapse && !isExpanded && index === visibleParagraphs.length - 1 ? 4 : undefined}
+          style={{
+            marginTop: spacing.sm,
+            color: colors.text,
+            fontSize: typography.body,
+            lineHeight: 24,
+          }}
+        >
+          {paragraph}
+        </Text>
+      ))}
+      {canCollapse ? (
+        <Pressable
+          accessibilityRole="button"
+          accessibilityLabel={isExpanded ? 'Show less story content' : 'Read more story content'}
+          onPress={onToggleExpanded}
+          style={({ pressed }) => ({
+            marginTop: spacing.md,
+            alignSelf: 'flex-start',
+            paddingVertical: spacing.sm,
+            paddingHorizontal: spacing.md,
+            borderRadius: 999,
+            borderWidth: 1,
+            borderColor: colors.border,
+            backgroundColor: colors.surface,
+            opacity: pressed ? 0.85 : 1,
+          })}
+        >
+          <Text style={{ color: colors.primary, fontWeight: '800' }}>
+            {isExpanded ? 'Show less' : 'Read more'}
+          </Text>
+        </Pressable>
+      ) : null}
+    </View>
   );
 }
 
@@ -372,6 +440,9 @@ export function StoryScreen({
   const [confirmDeleteId, setConfirmDeleteId] = useState<string>();
   const [interactionError, setInteractionError] = useState<string>();
   const [contributorVisibilityOverride, setContributorVisibilityOverride] = useState<string | null>(null);
+  const [isNarrativeExpanded, setIsNarrativeExpanded] = useState(false);
+  const [narrativeTop, setNarrativeTop] = useState(0);
+  const scrollViewRef = useRef<ScrollView>(null);
   const deletedCommentIdsRef = useRef<Set<string>>(new Set());
 
   useEffect(() => {
@@ -387,6 +458,8 @@ export function StoryScreen({
     setConfirmDeleteId(undefined);
     setInteractionError(undefined);
     setContributorVisibilityOverride(null);
+    setIsNarrativeExpanded(false);
+    setNarrativeTop(0);
     deletedCommentIdsRef.current = new Set();
 
     loadStoryDetail(storyId, session?.role, getStory).then((nextState) => {
@@ -644,6 +717,7 @@ export function StoryScreen({
   const contributorName = contributorVisibilityOverride ?? getResolvedContributorName(story);
   const contributorDisplayName = getDisplayNameWithYouLabel(contributorName, isStoryOwner);
   const canOpenContributorProfile = Boolean(story.contributorUserId);
+  const readingTimeLabel = getReadingTimeLabel(story.narrative);
 
   const promptDeleteStory = () => {
     if (!canDeleteStory || isStoryDeleting) {
@@ -665,8 +739,21 @@ export function StoryScreen({
     ]);
   };
 
+  const handleToggleNarrative = () => {
+    setIsNarrativeExpanded((current) => {
+      if (current) {
+        requestAnimationFrame(() => {
+          scrollViewRef.current?.scrollTo({ y: Math.max(0, narrativeTop - spacing.md), animated: true });
+        });
+      }
+
+      return !current;
+    });
+  };
+
   return (
     <ScrollView
+      ref={scrollViewRef}
       contentContainerStyle={{
         padding: spacing.lg,
         backgroundColor: colors.background,
@@ -676,14 +763,26 @@ export function StoryScreen({
         {story.title}
       </Text>
       {canDeleteStory ? (
-        <View style={{ marginTop: spacing.md, alignItems: 'flex-start' }}>
-          <Button
+        <View style={{ marginTop: spacing.sm, alignItems: 'flex-start' }}>
+          <Pressable
+            accessibilityRole="button"
+            accessibilityLabel={isStoryDeleting ? 'Deleting story' : 'Delete story'}
             onPress={promptDeleteStory}
             disabled={isStoryDeleting}
-            style={{ backgroundColor: colors.danger }}
+            style={({ pressed }) => ({
+              width: 42,
+              height: 42,
+              borderRadius: 999,
+              alignItems: 'center',
+              justifyContent: 'center',
+              backgroundColor: colors.dangerSurface,
+              borderWidth: 1,
+              borderColor: colors.danger,
+              opacity: pressed || isStoryDeleting ? 0.65 : 1,
+            })}
           >
-            {isStoryDeleting ? 'Deleting story...' : 'Delete story'}
-          </Button>
+            <Trash2 size={19} color={colors.danger} strokeWidth={2.4} />
+          </Pressable>
         </View>
       ) : null}
       {storyDeleteError ? (
@@ -692,16 +791,13 @@ export function StoryScreen({
 
       <View
         style={{
-          marginTop: spacing.lg,
+          marginTop: spacing.md,
           flexDirection: 'row',
           flexWrap: 'wrap',
-          justifyContent: 'space-between',
-          gap: spacing.md,
+          gap: spacing.sm,
         }}
       >
-        <StoryMetaRow label="Location" value={story.location.name} />
-        <StoryMetaRow label="Time period" value={story.timePeriod} />
-        <StoryMetaActionRow
+        <StoryMetaItem
           label="Contributor"
           value={contributorDisplayName}
           onPress={
@@ -712,7 +808,10 @@ export function StoryScreen({
               : undefined
           }
         />
-        <StoryMetaRow label="Submitted" value={formatDate(story.submittedAt)} />
+        <StoryMetaItem label="Submitted" value={formatDate(story.submittedAt)} />
+        <StoryMetaItem label="Reading time" value={readingTimeLabel} />
+        <StoryMetaItem label="Location" value={story.location.name} />
+        <StoryMetaItem label="Time period" value={story.timePeriod} />
       </View>
 
       {story.mediaUrl ? (
@@ -753,24 +852,12 @@ export function StoryScreen({
         )
       ) : null}
 
-      <View style={{ marginTop: spacing.xl }}>
-        <Text style={{ color: colors.text, fontSize: typography.subtitle, fontWeight: '700' }}>
-          Full story
-        </Text>
-        {story.narrative.map((paragraph, index) => (
-          <Text
-            key={`${story.id}-paragraph-${index + 1}`}
-            style={{
-              marginTop: spacing.md,
-              color: colors.text,
-              fontSize: typography.body,
-              lineHeight: 25,
-            }}
-          >
-            {paragraph}
-          </Text>
-        ))}
-      </View>
+      <StoryNarrative
+        story={story}
+        isExpanded={isNarrativeExpanded}
+        onToggleExpanded={handleToggleNarrative}
+        onLayout={(event) => setNarrativeTop(event.nativeEvent.layout.y)}
+      />
 
       <Pressable
         onPress={() => {

--- a/mobile/src/features/stories/presentation/screens/StoryScreen.tsx
+++ b/mobile/src/features/stories/presentation/screens/StoryScreen.tsx
@@ -61,7 +61,7 @@ function StoryMetaSeparator() {
   const { colors, spacing, typography } = useAppTheme();
 
   return (
-    <Text style={{ marginHorizontal: spacing.xs, color: colors.muted, fontSize: typography.body }}>
+    <Text style={{ color: colors.muted, fontSize: typography.body, marginRight: spacing.sm }}>
       {'·'}
     </Text>
   );
@@ -128,6 +128,17 @@ function StoryMetaText({ value }: { value: string }) {
   );
 }
 
+function StoryMetaLineItem({ value, withSeparator = false }: { value: string; withSeparator?: boolean }) {
+  const { spacing } = useAppTheme();
+
+  return (
+    <View style={{ flexDirection: 'row', alignItems: 'center', marginRight: spacing.md, marginTop: spacing.xs }}>
+      {withSeparator ? <StoryMetaSeparator /> : null}
+      <StoryMetaText value={value} />
+    </View>
+  );
+}
+
 function StoryMetaRow({
   contributorName,
   contributorPhotoUrl,
@@ -148,25 +159,15 @@ function StoryMetaRow({
   const { spacing } = useAppTheme();
 
   return (
-    <ScrollView
-      horizontal
-      showsHorizontalScrollIndicator={false}
-      style={{ marginTop: spacing.sm }}
-      contentContainerStyle={{
-        alignItems: 'center',
-        paddingRight: spacing.lg,
-      }}
-    >
+    <View style={{ marginTop: spacing.sm }}>
       <StoryContributorMeta value={contributorName} photoUrl={contributorPhotoUrl} onPress={onContributorPress} />
-      <StoryMetaSeparator />
-      <StoryMetaText value={submittedAt} />
-      <StoryMetaSeparator />
-      <StoryMetaText value={readingTimeLabel} />
-      <StoryMetaSeparator />
-      <StoryMetaText value={locationName} />
-      <StoryMetaSeparator />
-      <StoryMetaText value={timePeriod} />
-    </ScrollView>
+      <View style={{ marginTop: spacing.sm, flexDirection: 'row', flexWrap: 'wrap', alignItems: 'center' }}>
+        <StoryMetaLineItem value={locationName} />
+        <StoryMetaLineItem value={timePeriod} withSeparator />
+        <StoryMetaLineItem value={`Date added: ${submittedAt}`} withSeparator />
+        <StoryMetaLineItem value={readingTimeLabel} withSeparator />
+      </View>
+    </View>
   );
 }
 

--- a/mobile/src/features/stories/presentation/screens/StoryScreen.tsx
+++ b/mobile/src/features/stories/presentation/screens/StoryScreen.tsx
@@ -57,55 +57,49 @@ function shouldCollapseNarrative(paragraphs: string[]) {
   return paragraphs.length > 2 || paragraphs.join(' ').length > 520;
 }
 
-function StoryMetaItem({
-  label,
+function StoryMetaSeparator() {
+  const { colors, spacing, typography } = useAppTheme();
+
+  return (
+    <Text style={{ marginHorizontal: spacing.xs, color: colors.muted, fontSize: typography.body }}>
+      {'·'}
+    </Text>
+  );
+}
+
+function StoryContributorMeta({
   value,
+  photoUrl,
   onPress,
 }: {
-  label: string;
   value: string;
+  photoUrl?: string | null;
   onPress?: () => void;
 }) {
   const { colors, spacing, typography } = useAppTheme();
 
   const content = (
-    <>
+    <View style={{ flexDirection: 'row', alignItems: 'center', gap: spacing.xs }}>
+      {photoUrl ? (
+        <Image
+          source={{ uri: photoUrl }}
+          style={{ width: 22, height: 22, borderRadius: 999, backgroundColor: colors.surface }}
+          accessibilityIgnoresInvertColors
+          accessibilityLabel={`${value} profile photo`}
+        />
+      ) : null}
       <Text
+        numberOfLines={1}
         style={{
-          color: colors.muted,
-          fontSize: typography.caption,
-          fontWeight: '700',
-          textTransform: 'uppercase',
-        }}
-      >
-        {label}
-      </Text>
-      <Text
-        numberOfLines={2}
-        style={{
-          marginTop: spacing.xs,
-          color: onPress ? colors.primary : colors.text,
+          color: onPress ? colors.primary : colors.muted,
           fontSize: typography.body,
           fontWeight: '700',
         }}
       >
         {value}
       </Text>
-    </>
+    </View>
   );
-
-  const shellStyle = {
-    flexGrow: 1,
-    flexBasis: 150,
-    minHeight: 64,
-    paddingVertical: spacing.sm,
-    paddingHorizontal: spacing.md,
-    borderRadius: 12,
-    backgroundColor: colors.surface,
-    borderWidth: 1,
-    borderColor: colors.border,
-    justifyContent: 'center' as const,
-  };
 
   if (onPress) {
     return (
@@ -113,17 +107,67 @@ function StoryMetaItem({
         accessibilityRole="button"
         accessibilityLabel={`Open profile: ${value}`}
         onPress={onPress}
-        style={shellStyle}
+        style={({ pressed }) => ({
+          opacity: pressed ? 0.75 : 1,
+        })}
       >
         {content}
       </Pressable>
     );
   }
 
+  return content;
+}
+
+function StoryMetaText({ value }: { value: string }) {
+  const { colors, typography } = useAppTheme();
+
   return (
-    <View style={shellStyle}>
-      {content}
-    </View>
+    <Text numberOfLines={1} style={{ color: colors.muted, fontSize: typography.body, fontWeight: '600' }}>
+      {value}
+    </Text>
+  );
+}
+
+function StoryMetaRow({
+  contributorName,
+  contributorPhotoUrl,
+  submittedAt,
+  readingTimeLabel,
+  locationName,
+  timePeriod,
+  onContributorPress,
+}: {
+  contributorName: string;
+  contributorPhotoUrl?: string | null;
+  submittedAt: string;
+  readingTimeLabel: string;
+  locationName: string;
+  timePeriod: string;
+  onContributorPress?: () => void;
+}) {
+  const { spacing } = useAppTheme();
+
+  return (
+    <ScrollView
+      horizontal
+      showsHorizontalScrollIndicator={false}
+      style={{ marginTop: spacing.sm }}
+      contentContainerStyle={{
+        alignItems: 'center',
+        paddingRight: spacing.lg,
+      }}
+    >
+      <StoryContributorMeta value={contributorName} photoUrl={contributorPhotoUrl} onPress={onContributorPress} />
+      <StoryMetaSeparator />
+      <StoryMetaText value={submittedAt} />
+      <StoryMetaSeparator />
+      <StoryMetaText value={readingTimeLabel} />
+      <StoryMetaSeparator />
+      <StoryMetaText value={locationName} />
+      <StoryMetaSeparator />
+      <StoryMetaText value={timePeriod} />
+    </ScrollView>
   );
 }
 
@@ -440,6 +484,7 @@ export function StoryScreen({
   const [confirmDeleteId, setConfirmDeleteId] = useState<string>();
   const [interactionError, setInteractionError] = useState<string>();
   const [contributorVisibilityOverride, setContributorVisibilityOverride] = useState<string | null>(null);
+  const [contributorPhotoUrl, setContributorPhotoUrl] = useState<string | null>(null);
   const [isNarrativeExpanded, setIsNarrativeExpanded] = useState(false);
   const [narrativeTop, setNarrativeTop] = useState(0);
   const scrollViewRef = useRef<ScrollView>(null);
@@ -458,6 +503,7 @@ export function StoryScreen({
     setConfirmDeleteId(undefined);
     setInteractionError(undefined);
     setContributorVisibilityOverride(null);
+    setContributorPhotoUrl(null);
     setIsNarrativeExpanded(false);
     setNarrativeTop(0);
     deletedCommentIdsRef.current = new Set();
@@ -505,6 +551,7 @@ export function StoryScreen({
     const story = state.story;
     if (!story?.contributorUserId) {
       setContributorVisibilityOverride(story?.contributorName === 'Deleted user' ? 'Deleted user' : null);
+      setContributorPhotoUrl(null);
       return () => {
         isMounted = false;
       };
@@ -516,12 +563,14 @@ export function StoryScreen({
 
     if (isOwnStory) {
       setContributorVisibilityOverride(null);
+      setContributorPhotoUrl(null);
       return () => {
         isMounted = false;
       };
     }
 
     setContributorVisibilityOverride(story.contributorName === 'Deleted user' ? 'Deleted user' : null);
+    setContributorPhotoUrl(null);
 
     getPublicProfile(story.contributorUserId)
       .then((profile) => {
@@ -530,6 +579,7 @@ export function StoryScreen({
         }
 
         setContributorVisibilityOverride(!profile.username ? 'Anonymous' : null);
+        setContributorPhotoUrl(profile.username ? profile.profilePhoto ?? null : null);
       })
       .catch(() => undefined);
 
@@ -789,30 +839,21 @@ export function StoryScreen({
         <Text style={{ marginTop: spacing.sm, color: colors.danger }}>{storyDeleteError}</Text>
       ) : null}
 
-      <View
-        style={{
-          marginTop: spacing.md,
-          flexDirection: 'row',
-          flexWrap: 'wrap',
-          gap: spacing.sm,
-        }}
-      >
-        <StoryMetaItem
-          label="Contributor"
-          value={contributorDisplayName}
-          onPress={
-            canOpenContributorProfile
-              ? () => {
-                  onOpenContributorProfile?.(story.contributorUserId!);
-                }
-              : undefined
-          }
-        />
-        <StoryMetaItem label="Submitted" value={formatDate(story.submittedAt)} />
-        <StoryMetaItem label="Reading time" value={readingTimeLabel} />
-        <StoryMetaItem label="Location" value={story.location.name} />
-        <StoryMetaItem label="Time period" value={story.timePeriod} />
-      </View>
+      <StoryMetaRow
+        contributorName={contributorDisplayName}
+        contributorPhotoUrl={contributorPhotoUrl}
+        submittedAt={formatDate(story.submittedAt)}
+        readingTimeLabel={readingTimeLabel}
+        locationName={story.location.name}
+        timePeriod={story.timePeriod}
+        onContributorPress={
+          canOpenContributorProfile
+            ? () => {
+                onOpenContributorProfile?.(story.contributorUserId!);
+              }
+            : undefined
+        }
+      />
 
       {story.mediaUrl ? (
         hasImageError ? (

--- a/mobile/src/features/stories/presentation/screens/StoryScreen.tsx
+++ b/mobile/src/features/stories/presentation/screens/StoryScreen.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { Alert, Image, LayoutChangeEvent, Pressable, ScrollView, Text, View } from 'react-native';
-import { Trash2 } from 'lucide-react-native';
+import { Calendar, Clock, MapPin, Trash2 } from 'lucide-react-native';
 import { roles } from '../../../../core/auth/roles';
 import { Session } from '../../../../core/auth/session';
 import { useAppTheme } from '../../../../core/hooks/useAppTheme';
@@ -90,12 +90,15 @@ function StoryContributorMeta({
       ) : null}
       <Text
         style={{
-          color: onPress ? colors.primary : colors.muted,
+          color: colors.muted,
           fontSize: typography.body,
-          fontWeight: '700',
+          fontWeight: '600',
         }}
       >
-        {value}
+        by{' '}
+        <Text style={{ color: onPress ? colors.primary : colors.muted, fontWeight: '700' }}>
+          {value}
+        </Text>
       </Text>
     </View>
   );
@@ -128,12 +131,21 @@ function StoryMetaText({ value }: { value: string }) {
   );
 }
 
-function StoryMetaLineItem({ value, withSeparator = false }: { value: string; withSeparator?: boolean }) {
+function StoryMetaLineItem({
+  value,
+  icon,
+  withSeparator = false,
+}: {
+  value: string;
+  icon?: React.ReactNode;
+  withSeparator?: boolean;
+}) {
   const { spacing } = useAppTheme();
 
   return (
     <View style={{ flexDirection: 'row', alignItems: 'center', marginRight: spacing.md, marginTop: spacing.xs }}>
       {withSeparator ? <StoryMetaSeparator /> : null}
+      {icon ? <View style={{ marginRight: spacing.xs }}>{icon}</View> : null}
       <StoryMetaText value={value} />
     </View>
   );
@@ -156,16 +168,30 @@ function StoryMetaRow({
   timePeriod: string;
   onContributorPress?: () => void;
 }) {
-  const { spacing } = useAppTheme();
+  const { colors, spacing } = useAppTheme();
+  const iconColor = colors.muted;
+  const iconSize = 17;
 
   return (
     <View style={{ marginTop: spacing.sm }}>
       <StoryContributorMeta value={contributorName} photoUrl={contributorPhotoUrl} onPress={onContributorPress} />
       <View style={{ marginTop: spacing.sm, flexDirection: 'row', flexWrap: 'wrap', alignItems: 'center' }}>
-        <StoryMetaLineItem value={locationName} />
-        <StoryMetaLineItem value={timePeriod} withSeparator />
-        <StoryMetaLineItem value={`Date added: ${submittedAt}`} withSeparator />
-        <StoryMetaLineItem value={readingTimeLabel} withSeparator />
+        <StoryMetaLineItem value={locationName} icon={<MapPin size={iconSize} color={iconColor} strokeWidth={2.1} />} />
+        <StoryMetaLineItem
+          value={timePeriod}
+          icon={<Calendar size={iconSize} color={iconColor} strokeWidth={2.1} />}
+          withSeparator
+        />
+        <StoryMetaLineItem
+          value={`Date added: ${submittedAt}`}
+          icon={<Calendar size={iconSize} color={iconColor} strokeWidth={2.1} />}
+          withSeparator
+        />
+        <StoryMetaLineItem
+          value={readingTimeLabel}
+          icon={<Clock size={iconSize} color={iconColor} strokeWidth={2.1} />}
+          withSeparator
+        />
       </View>
     </View>
   );

--- a/mobile/src/features/stories/presentation/screens/StoryScreen.tsx
+++ b/mobile/src/features/stories/presentation/screens/StoryScreen.tsx
@@ -89,7 +89,6 @@ function StoryContributorMeta({
         />
       ) : null}
       <Text
-        numberOfLines={1}
         style={{
           color: onPress ? colors.primary : colors.muted,
           fontSize: typography.body,
@@ -123,7 +122,7 @@ function StoryMetaText({ value }: { value: string }) {
   const { colors, typography } = useAppTheme();
 
   return (
-    <Text numberOfLines={1} style={{ color: colors.muted, fontSize: typography.body, fontWeight: '600' }}>
+    <Text style={{ color: colors.muted, fontSize: typography.body, fontWeight: '600' }}>
       {value}
     </Text>
   );

--- a/mobile/src/features/stories/presentation/screens/__tests__/StoryScreen.test.tsx
+++ b/mobile/src/features/stories/presentation/screens/__tests__/StoryScreen.test.tsx
@@ -125,6 +125,7 @@ describe('StoryScreen', () => {
     expect(screen.getByText(baseStory.timePeriod)).toBeTruthy();
     expect(screen.getByText(baseStory.contributorName)).toBeTruthy();
     expect(screen.getByText('18 Mar 2026')).toBeTruthy();
+    expect(screen.getByText('1 min read')).toBeTruthy();
     expect(screen.getByText(baseStory.narrative[0])).toBeTruthy();
     expect(screen.getByText(baseStory.narrative[1])).toBeTruthy();
     expect(screen.getByLabelText(`${baseStory.title} media`)).toBeTruthy();
@@ -510,6 +511,7 @@ describe('StoryScreen', () => {
 
     await screen.findByText(baseStory.title);
     expect(screen.queryByText('Delete story')).toBeNull();
+    expect(screen.queryByLabelText('Delete story')).toBeNull();
 
     rerender(
       <StoryScreen
@@ -519,7 +521,7 @@ describe('StoryScreen', () => {
       />,
     );
 
-    expect(await screen.findByText('Delete story')).toBeTruthy();
+    expect(await screen.findByLabelText('Delete story')).toBeTruthy();
 
     rerender(
       <StoryScreen
@@ -529,7 +531,7 @@ describe('StoryScreen', () => {
       />,
     );
 
-    expect(await screen.findByText('Delete story')).toBeTruthy();
+    expect(await screen.findByLabelText('Delete story')).toBeTruthy();
   });
 
   it('confirms and deletes the story for authorized users', async () => {
@@ -547,7 +549,7 @@ describe('StoryScreen', () => {
       />,
     );
 
-    fireEvent.press(await screen.findByText('Delete story'));
+    fireEvent.press(await screen.findByLabelText('Delete story'));
 
     expect(alertSpy).toHaveBeenCalledWith(
       'Delete story?',
@@ -587,7 +589,7 @@ describe('StoryScreen', () => {
       />,
     );
 
-    fireEvent.press(await screen.findByText('Delete story'));
+    fireEvent.press(await screen.findByLabelText('Delete story'));
 
     const buttons = alertSpy.mock.calls[0]?.[2];
     const deleteButton = buttons?.find((button) => button.text === 'Delete');
@@ -599,6 +601,34 @@ describe('StoryScreen', () => {
     expect(await screen.findByText('Deletion failed on server')).toBeTruthy();
 
     alertSpy.mockRestore();
+  });
+
+  it('collapses long narratives and expands them on request', async () => {
+    const longStory = {
+      ...baseStory,
+      narrative: [
+        'The first paragraph sets the scene beside the water.',
+        'The second paragraph gives enough detail to preview the story without overwhelming the screen.',
+        'The third paragraph should stay hidden until the reader asks for the full story.',
+      ],
+    };
+
+    render(<StoryScreen storyId="story-001" getStory={async () => longStory} />);
+
+    expect(await screen.findByText(longStory.title)).toBeTruthy();
+    expect(screen.getByText(longStory.narrative[0])).toBeTruthy();
+    expect(screen.getByText(longStory.narrative[1])).toBeTruthy();
+    expect(screen.queryByText(longStory.narrative[2])).toBeNull();
+
+    fireEvent.press(screen.getByText('Read more'));
+
+    expect(screen.getByText(longStory.narrative[2])).toBeTruthy();
+    expect(screen.getByText('Show less')).toBeTruthy();
+
+    fireEvent.press(screen.getByText('Show less'));
+
+    expect(screen.queryByText(longStory.narrative[2])).toBeNull();
+    expect(screen.getByText('Read more')).toBeTruthy();
   });
 
   it('prompts unauthenticated users when they try to comment', async () => {

--- a/mobile/src/features/stories/presentation/screens/__tests__/StoryScreen.test.tsx
+++ b/mobile/src/features/stories/presentation/screens/__tests__/StoryScreen.test.tsx
@@ -124,7 +124,7 @@ describe('StoryScreen', () => {
     expect(screen.getAllByText(baseStory.location.name)).toHaveLength(2);
     expect(screen.getByText(baseStory.timePeriod)).toBeTruthy();
     expect(screen.getByText(baseStory.contributorName)).toBeTruthy();
-    expect(screen.getByText('18 Mar 2026')).toBeTruthy();
+    expect(screen.getByText('Date added: 18 Mar 2026')).toBeTruthy();
     expect(screen.getByText('1 min read')).toBeTruthy();
     expect(screen.getByText(baseStory.narrative[0])).toBeTruthy();
     expect(screen.getByText(baseStory.narrative[1])).toBeTruthy();

--- a/mobile/src/features/stories/presentation/screens/__tests__/StoryScreen.test.tsx
+++ b/mobile/src/features/stories/presentation/screens/__tests__/StoryScreen.test.tsx
@@ -152,6 +152,24 @@ describe('StoryScreen', () => {
     expect(onOpenContributorProfile).toHaveBeenCalledWith('22');
   });
 
+  it('shows the contributor profile photo when public profile metadata includes one', async () => {
+    render(
+      <StoryScreen
+        storyId="story-001"
+        getStory={async () => baseStory}
+        getPublicProfile={async () => ({
+          id: '22',
+          username: 'Aylin Demir',
+          totalPoints: 0,
+          profilePhoto: 'https://example.com/profile.jpg',
+        })}
+      />,
+    );
+
+    expect(await screen.findByText(baseStory.title)).toBeTruthy();
+    expect(await screen.findByLabelText(`${baseStory.contributorName} profile photo`)).toBeTruthy();
+  });
+
   it('keeps the profile action for anonymous contributors', async () => {
     const onOpenContributorProfile = jest.fn();
 


### PR DESCRIPTION
# 📝 Description

Fixes #373 

This PR improves the visual structure and usability of the mobile Story Detail Page.

It reorganizes the story metadata into a more compact and scannable layout, adds a reading time indicator, and reduces excessive initial scrolling for long stories by introducing a `Read more / Show less` interaction.

The story delete action is also updated from a text button to a trash icon button while preserving the existing confirmation flow and delete behavior.

Main changes include:

- cleaner metadata layout for contributor, submitted date, reading time, location, and time period
- calculated reading time display
- collapsed preview for long story narratives
- `Read more` interaction to expand full story content
- `Show less` interaction to collapse content again
- scroll recovery when collapsing, so the story section remains visible
- trash icon button for story deletion
- updated tests for metadata, delete action, and narrative expand/collapse behavior

Existing functionality such as contributor profile navigation, likes, comments, story deletion confirmation, and error handling is preserved.

# 📊 Type of Change

- [x] New feature
- [x] Bug fix
- [ ] Refactoring
- [ ] Documentation

# ✅ Acceptance Criteria / Checklist

- [ ] Code builds successfully
- [ ] Style guidelines are followed
- [ ] Code has been self-reviewed
- [ ] Tests have been added/updated
- [ ] Local tests pass
- [ ] Story Detail metadata is cleaner and easier to scan
- [ ] Long story content no longer causes excessive initial scrolling
- [ ] Read More / Show Less interaction works correctly
- [ ] Delete button is replaced with a trash icon
- [ ] Delete confirmation behavior is preserved

# 🧪 Tests

- [x] `npm test -- --runTestsByPath src/features/stories/presentation/screens/__tests__/StoryScreen.test.tsx --runInBand`
- [x] `npm run typecheck`
- [x] `git diff --check`

# ⏱️ Estimated Review Time

- [ ] <5 min
- [ ] 5–15 min
- [x] >15 min
