### PR TITLE
feat: add EDTF and ISO 8601 temporal coverage fields to story detail

### DIFF
--- a/backend/apps/stories/serializers.py
+++ b/backend/apps/stories/serializers.py
@@ -4,6 +4,7 @@ from rest_framework import serializers
 from apps.media.models import MediaItem
 from apps.stories.models import Story
 from apps.stories.services import create_story, update_story
+from apps.stories.temporal import to_edtf, to_iso8601
 from apps.tags.models import Tag
 from apps.tags.serializers import TagSerializer
 
@@ -174,17 +175,34 @@ class StoryMediaItemSerializer(serializers.ModelSerializer):
 
 class StoryDetailSerializer(StorySerializer):
     """
-    Extends StorySerializer with nested media items for GET /stories/<pk>/.
+    Extends StorySerializer with nested media items and derived temporal
+    coverage fields (EDTF and ISO 8601) for GET /stories/<pk>/.
 
     Kept separate from StorySerializer so the list endpoint does not pay
     the cost of prefetching media on every paginated row.
     """
 
     media_items = StoryMediaItemSerializer(many=True, read_only=True)
+    temporal_coverage = serializers.SerializerMethodField()
+    temporal_coverage_iso = serializers.SerializerMethodField()
 
     class Meta(StorySerializer.Meta):
-        fields = StorySerializer.Meta.fields + ['media_items']
-        read_only_fields = StorySerializer.Meta.read_only_fields + ['media_items']
+        fields = StorySerializer.Meta.fields + [
+            'media_items',
+            'temporal_coverage',
+            'temporal_coverage_iso',
+        ]
+        read_only_fields = StorySerializer.Meta.read_only_fields + [
+            'media_items',
+            'temporal_coverage',
+            'temporal_coverage_iso',
+        ]
+
+    def get_temporal_coverage(self, obj):
+        return to_edtf(obj.time_type, obj.year, obj.year_start, obj.year_end)
+
+    def get_temporal_coverage_iso(self, obj):
+        return to_iso8601(obj.time_type, obj.year, obj.year_start, obj.year_end)
 
 
 class StoryFeedSerializer(serializers.ModelSerializer):

--- a/backend/apps/stories/serializers.py
+++ b/backend/apps/stories/serializers.py
@@ -199,10 +199,16 @@ class StoryDetailSerializer(StorySerializer):
         ]
 
     def get_temporal_coverage(self, obj):
-        return to_edtf(obj.time_type, obj.year, obj.year_start, obj.year_end)
+        try:
+            return to_edtf(obj.time_type, obj.year, obj.year_start, obj.year_end)
+        except ValueError:
+            return None
 
     def get_temporal_coverage_iso(self, obj):
-        return to_iso8601(obj.time_type, obj.year, obj.year_start, obj.year_end)
+        try:
+            return to_iso8601(obj.time_type, obj.year, obj.year_start, obj.year_end)
+        except ValueError:
+            return None
 
 
 class StoryFeedSerializer(serializers.ModelSerializer):

--- a/backend/apps/stories/temporal.py
+++ b/backend/apps/stories/temporal.py
@@ -1,0 +1,64 @@
+from typing import Optional
+
+
+def to_edtf(
+    time_type: str,
+    year: Optional[int],
+    year_start: Optional[int],
+    year_end: Optional[int],
+) -> str:
+    """Convert Story time fields to an EDTF string.
+
+    For exact_year / approximate_year / decade pass `year`; year_start/year_end are ignored.
+    For year_range pass year_start and year_end; year is ignored.
+    Raises ValueError for unrecognised time_type values or None year when required.
+    """
+    if time_type == 'exact_year':
+        if year is None:
+            raise ValueError("year must not be None for time_type 'exact_year'")
+        return str(year)
+    if time_type == 'approximate_year':
+        if year is None:
+            raise ValueError("year must not be None for time_type 'approximate_year'")
+        return f"{year}~"
+    if time_type == 'decade':
+        if year is None:
+            raise ValueError("year must not be None for time_type 'decade'")
+        return f"{year // 10}X"
+    if time_type == 'year_range':
+        if year_start is None or year_end is None:
+            raise ValueError("year_start and year_end must not be None for time_type 'year_range'")
+        return f"{year_start}/{year_end}"
+    raise ValueError(f"Unknown time_type: {time_type!r}")
+
+
+def to_iso8601(
+    time_type: str,
+    year: Optional[int],
+    year_start: Optional[int],
+    year_end: Optional[int],
+) -> str:
+    """Convert Story time fields to an ISO 8601-compatible string.
+
+    For exact_year / approximate_year / decade pass `year`; year_start/year_end are ignored.
+    For year_range pass year_start and year_end; year is ignored.
+    Raises ValueError for unrecognised time_type values or None year when required.
+    """
+    if time_type == 'exact_year':
+        if year is None:
+            raise ValueError("year must not be None for time_type 'exact_year'")
+        return str(year)
+    if time_type == 'approximate_year':
+        if year is None:
+            raise ValueError("year must not be None for time_type 'approximate_year'")
+        return str(year)
+    if time_type == 'decade':
+        if year is None:
+            raise ValueError("year must not be None for time_type 'decade'")
+        # Caller must pass the decade base year (e.g. 1980 for "1980s").
+        return f"{year}/{year + 9}"
+    if time_type == 'year_range':
+        if year_start is None or year_end is None:
+            raise ValueError("year_start and year_end must not be None for time_type 'year_range'")
+        return f"{year_start}/{year_end}"
+    raise ValueError(f"Unknown time_type: {time_type!r}")

--- a/backend/apps/stories/tests/test_serializers.py
+++ b/backend/apps/stories/tests/test_serializers.py
@@ -769,3 +769,44 @@ class TestFeedQuerySerializerGeoValidation:
     def test_radius_km_above_max_is_invalid(self):
         errors = self._invalid({'latitude': 41.0, 'longitude': 29.0, 'radius_km': 501.0})
         assert 'radius_km' in errors
+
+
+# ── StoryDetailSerializer — temporal coverage fields ─────────────────────────
+
+@pytest.mark.django_db
+class TestStoryDetailSerializerTemporalCoverage:
+    def test_both_fields_present_in_output(self):
+        story = make_story(time_type=Story.TIME_EXACT, year=1950)
+        data = StoryDetailSerializer(story).data
+        assert 'temporal_coverage' in data
+        assert 'temporal_coverage_iso' in data
+
+    def test_exact_year(self):
+        story = make_story(time_type=Story.TIME_EXACT, year=1950)
+        data = StoryDetailSerializer(story).data
+        assert data['temporal_coverage'] == '1950'
+        assert data['temporal_coverage_iso'] == '1950'
+
+    def test_approximate_year(self):
+        story = make_story(time_type=Story.TIME_APPROXIMATE, year=1950)
+        data = StoryDetailSerializer(story).data
+        assert data['temporal_coverage'] == '1950~'
+        assert data['temporal_coverage_iso'] == '1950'
+
+    def test_decade(self):
+        story = make_story(time_type=Story.TIME_DECADE, year=1980)
+        data = StoryDetailSerializer(story).data
+        assert data['temporal_coverage'] == '198X'
+        assert data['temporal_coverage_iso'] == '1980/1989'
+
+    def test_year_range(self):
+        story = make_story(time_type=Story.TIME_RANGE, year=None, year_start=1940, year_end=1960)
+        data = StoryDetailSerializer(story).data
+        assert data['temporal_coverage'] == '1940/1960'
+        assert data['temporal_coverage_iso'] == '1940/1960'
+
+    def test_fields_are_read_only(self):
+        story = make_story(time_type=Story.TIME_EXACT, year=1950)
+        serializer = StoryDetailSerializer(story, data={'temporal_coverage': 'injected'}, partial=True)
+        assert serializer.is_valid()
+        assert 'temporal_coverage' not in serializer.validated_data

--- a/backend/apps/stories/tests/test_temporal.py
+++ b/backend/apps/stories/tests/test_temporal.py
@@ -1,0 +1,73 @@
+import pytest
+
+from apps.stories.temporal import to_edtf, to_iso8601
+
+
+class TestToEdtf:
+    def test_exact_year(self):
+        assert to_edtf('exact_year', 1950, None, None) == '1950'
+
+    def test_approximate_year(self):
+        assert to_edtf('approximate_year', 1950, None, None) == '1950~'
+
+    def test_decade(self):
+        assert to_edtf('decade', 1980, None, None) == '198X'
+
+    def test_decade_formula(self):
+        assert to_edtf('decade', 1990, None, None) == '199X'
+
+    def test_year_range(self):
+        assert to_edtf('year_range', None, 1940, 1960) == '1940/1960'
+
+    def test_negative_exact_year(self):
+        assert to_edtf('exact_year', -44, None, None) == '-44'
+
+    def test_negative_approximate_year(self):
+        assert to_edtf('approximate_year', -44, None, None) == '-44~'
+
+    def test_negative_decade(self):
+        # year=-40 → -40 // 10 = -4 → '-4X'
+        assert to_edtf('decade', -40, None, None) == '-4X'
+
+    def test_unknown_time_type_raises_value_error(self):
+        with pytest.raises(ValueError, match="Unknown time_type"):
+            to_edtf('century', 1900, None, None)
+
+    def test_none_year_raises_value_error_for_exact_year(self):
+        with pytest.raises(ValueError, match="year must not be None"):
+            to_edtf('exact_year', None, None, None)
+
+
+class TestToIso8601:
+    def test_exact_year(self):
+        assert to_iso8601('exact_year', 1950, None, None) == '1950'
+
+    def test_approximate_year_strips_approximation(self):
+        assert to_iso8601('approximate_year', 1950, None, None) == '1950'
+
+    def test_decade(self):
+        assert to_iso8601('decade', 1980, None, None) == '1980/1989'
+
+    def test_decade_formula(self):
+        assert to_iso8601('decade', 1990, None, None) == '1990/1999'
+
+    def test_year_range(self):
+        assert to_iso8601('year_range', None, 1940, 1960) == '1940/1960'
+
+    def test_negative_exact_year(self):
+        assert to_iso8601('exact_year', -44, None, None) == '-44'
+
+    def test_negative_approximate_year(self):
+        assert to_iso8601('approximate_year', -44, None, None) == '-44'
+
+    def test_negative_decade(self):
+        # year=-40 → '-40/-31'
+        assert to_iso8601('decade', -40, None, None) == '-40/-31'
+
+    def test_unknown_time_type_raises_value_error(self):
+        with pytest.raises(ValueError, match="Unknown time_type"):
+            to_iso8601('century', 1900, None, None)
+
+    def test_none_year_raises_value_error_for_exact_year(self):
+        with pytest.raises(ValueError, match="year must not be None"):
+            to_iso8601('exact_year', None, None, None)


### PR DESCRIPTION
# 📝 Description
Fixes #380

Adds two derived, read-only fields to the story detail response (`GET /stories/<pk>/`):

- `temporal_coverage` — EDTF (Extended Date/Time Format) string representing the story's time information (e.g. `1950`, `1950~`, `198X`, `1940/1960`)
- `temporal_coverage_iso` — ISO 8601-compatible equivalent (e.g. `1950`, `1950`, `1980/1989`, `1940/1960`)

All conversion logic lives in a standalone `temporal.py` helper with no DB dependency. No model or migration changes.

A follow-up issue for exact date (month/day) support has been opened as #460.

# 📊 Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Refactoring
- [ ] Documentation

# ✅ Acceptance Criteria / Checklist
- [x] Project builds successfully
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, especially in hard-to-understand parts
- [x] I have performed a self-review of my code
- [x] I have added/updated tests
- [x] New and existing unit tests pass locally with my changes

# 📸 Screenshots / Recordings
Example response for `GET /stories/1/` with `time_type=decade, year=1980`:
```json
{
  "temporal_coverage": "198X",
  "temporal_coverage_iso": "1980/1989"
}
```

# ⏱️ Estimated Review Time
- [ ] < 5 min
- [x] 5-15 min
- [ ] > 15 min