### PR TITLE
[Bug][Mobile] Show own profile birth date

### DIFF
--- a/mobile/src/features/profile/application/services/__tests__/userService.test.ts
+++ b/mobile/src/features/profile/application/services/__tests__/userService.test.ts
@@ -43,6 +43,7 @@ describe('userService', () => {
             username: 'Traveler',
             total_points: 5,
             published_story_count: 3,
+            birth_year: 1995,
             location: 'Istanbul',
             bio: 'Collecting neighborhood memories.',
           } as never,
@@ -59,6 +60,7 @@ describe('userService', () => {
       email: 'traveler@example.com',
       location: 'Istanbul',
       publishedStoryCount: 3,
+      birthYear: 1995,
     });
   });
 

--- a/mobile/src/features/profile/data/repositories/index.ts
+++ b/mobile/src/features/profile/data/repositories/index.ts
@@ -72,13 +72,20 @@ function mapCurrentProfile(profile: Record<string, unknown>): ProfileEntity {
   };
 }
 
-function mergePublishedStoryCount(profile: ProfileEntity, publishedStoryCount?: number) {
+function mergePublicProfileSummary(
+  profile: ProfileEntity,
+  publicProfile: Record<string, unknown>,
+) {
+  const birthYear = asNullableNumber(publicProfile.birth_year);
+  const publishedStoryCount = asNumber(publicProfile.published_story_count);
+
   return {
     ...profile,
     publishedStoryCount:
-      typeof publishedStoryCount === 'number' && Number.isFinite(publishedStoryCount)
-        ? publishedStoryCount
-        : profile.publishedStoryCount,
+      publicProfile.published_story_count === undefined
+        ? profile.publishedStoryCount
+        : publishedStoryCount,
+    birthYear: profile.birthDate ? profile.birthYear : birthYear ?? profile.birthYear,
   };
 }
 
@@ -105,10 +112,7 @@ export class ProfileRepositoryImpl implements ProfileRepository {
 
     try {
       const publicProfile = await profileRemoteSource.getPublicProfile(mappedProfile.id);
-      return mergePublishedStoryCount(
-        mappedProfile,
-        asNumber(publicProfile.published_story_count),
-      );
+      return mergePublicProfileSummary(mappedProfile, publicProfile);
     } catch {
       return mappedProfile;
     }
@@ -125,10 +129,7 @@ export class ProfileRepositoryImpl implements ProfileRepository {
 
     try {
       const publicProfile = await profileRemoteSource.getPublicProfile(mappedProfile.id);
-      return mergePublishedStoryCount(
-        mappedProfile,
-        asNumber(publicProfile.published_story_count),
-      );
+      return mergePublicProfileSummary(mappedProfile, publicProfile);
     } catch {
       return mappedProfile;
     }

--- a/mobile/src/features/profile/presentation/screens/ProfileScreen.tsx
+++ b/mobile/src/features/profile/presentation/screens/ProfileScreen.tsx
@@ -98,6 +98,25 @@ function formatBirthDateLabel(value: string) {
   });
 }
 
+function formatProfileBirthDate(value?: string | null) {
+  if (!value) {
+    return undefined;
+  }
+
+  const parsedDate = parseBirthDate(value);
+
+  if (!parsedDate) {
+    return undefined;
+  }
+
+  return parsedDate.toLocaleDateString('en-US', {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+    timeZone: 'UTC',
+  });
+}
+
 function formatDateInput(date: Date) {
   const year = date.getFullYear();
   const month = `${date.getMonth() + 1}`.padStart(2, '0');
@@ -664,6 +683,7 @@ export function ProfileScreen({
     .filter((value): value is string => Boolean(value))
     .join(' ');
   const joinedDate = formatJoinedDate(profile?.dateJoined);
+  const birthDateDisplay = isSelfMode ? formatProfileBirthDate(profile?.birthDate) : undefined;
   const isDirty = useMemo(() => {
     if (!profile) {
       return false;
@@ -765,6 +785,7 @@ export function ProfileScreen({
             {isSelfMode ? <StatChip label="Points" value={String(profile.totalPoints)} /> : null}
             <StatChip label="Stories" value={String(profile.publishedStoryCount ?? 0)} />
             {profile.location ? <StatChip label="Location" value={profile.location} /> : null}
+            {birthDateDisplay ? <StatChip label="Birth date" value={birthDateDisplay} /> : null}
             {profile.birthYear ? <StatChip label="Birth year" value={String(profile.birthYear)} /> : null}
           </View>
 

--- a/mobile/src/features/profile/presentation/screens/__tests__/ProfileScreen.test.tsx
+++ b/mobile/src/features/profile/presentation/screens/__tests__/ProfileScreen.test.tsx
@@ -125,6 +125,35 @@ describe('ProfileScreen', () => {
     expect(screen.getByText('Ada Lovelace')).toBeTruthy();
   });
 
+  it('shows the saved birth date on the signed-in user profile', async () => {
+    render(
+      <ProfileScreen
+        mode="self"
+        getCurrentProfile={async () => selfProfile}
+      />,
+    );
+
+    expect(await screen.findByText('Traveler')).toBeTruthy();
+    expect(screen.getByText('May 20, 1995')).toBeTruthy();
+  });
+
+  it('falls back to the public birth year on the signed-in user profile when the full date is unavailable', async () => {
+    render(
+      <ProfileScreen
+        mode="self"
+        getCurrentProfile={async () => ({
+          ...selfProfile,
+          birthDate: null,
+          birthYear: 1995,
+        })}
+      />,
+    );
+
+    expect(await screen.findByText('Traveler')).toBeTruthy();
+    expect(screen.getByText('1995')).toBeTruthy();
+    expect(screen.queryByText('May 20, 1995')).toBeNull();
+  });
+
   it('shows a photo preview after selecting a valid image and can remove it before saving', async () => {
     jest.spyOn(ImagePicker, 'launchImageLibraryAsync').mockResolvedValue({
       canceled: false,
@@ -343,6 +372,7 @@ describe('ProfileScreen', () => {
     expect(await screen.findByText('Aylin')).toBeTruthy();
     expect(screen.getByText('Izmir')).toBeTruthy();
     expect(screen.getByText('1988')).toBeTruthy();
+    expect(screen.queryByText('May 20, 1995')).toBeNull();
     expect(screen.getByText('I write about harbor neighborhoods.')).toBeTruthy();
     expect(screen.queryByText('Edit Profile')).toBeNull();
 


### PR DESCRIPTION
# 📝 Description
Fixes #467

Shows the signed-in user their full saved birth date on the mobile profile screen while keeping public profiles limited to the backend-provided birth year.


# 📊 Type of Change
- [x]  Bug fix
- [ ]  New feature
- [ ]  Refactoring
- [ ]  Documentation
 
# ✅ Acceptance Criteria / Checklist
- [x] Project builds successfully
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, especially in hard-to-understand parts
- [x] I have performed a self-review of my code
- [x] I have added/updated tests
- [x] New and existing unit tests pass locally with my changes

# 📸 Screenshots / Recordings


# ⏱️ Estimated Review Time
- [ ] < 5 min
- [x] 5-15 min
- [ ] > 15 min

