### PR TITLE
feat: mobile profile follow flows

### DIFF
--- a/mobile/src/app/navigation/RootNavigator.tsx
+++ b/mobile/src/app/navigation/RootNavigator.tsx
@@ -374,13 +374,22 @@ export function RootNavigator() {
     navigationRef.navigate = (route) => {
       navigateToSnapshot({ route });
     };
+    navigationRef.navigateToUserProfile = (targetUserId) => {
+      if (user && String(user.id) === targetUserId) {
+        navigateToSnapshot({ route: ROUTES.PROFILE });
+        return;
+      }
+
+      navigateToSnapshot({ route: ROUTES.USER_PROFILE, userId: targetUserId });
+    };
 
     return () => {
       navigationRef.redirectToAuth = undefined;
       navigationRef.redirectToPublic = undefined;
       navigationRef.navigate = undefined;
+      navigationRef.navigateToUserProfile = undefined;
     };
-  }, [currentSnapshot, navigateToSnapshot]);
+  }, [currentSnapshot, navigateToSnapshot, user]);
 
   useEffect(() => {
     const subscription = BackHandler.addEventListener('hardwareBackPress', () => {
@@ -532,7 +541,11 @@ export function RootNavigator() {
         framed={false}
         fillContent
       >
-        <ProfileScreen mode="public" userId={activeUserId} />
+        <ProfileScreen
+          mode="public"
+          userId={activeUserId}
+          onOpenUserProfile={(targetUserId) => navigationRef.navigateToUserProfile?.(targetUserId)}
+        />
       </ScreenShell>
     );
   } else if (currentRoute === ROUTES.SUBMISSION) {

--- a/mobile/src/app/navigation/navigationRef.ts
+++ b/mobile/src/app/navigation/navigationRef.ts
@@ -8,4 +8,5 @@ export const navigationRef: {
   redirectToAuth?: AuthRedirectHandler;
   redirectToPublic?: () => void;
   navigate?: (route: AppRoute) => void;
+  navigateToUserProfile?: (userId: string) => void;
 } = {};

--- a/mobile/src/features/profile/application/services/__tests__/userService.test.ts
+++ b/mobile/src/features/profile/application/services/__tests__/userService.test.ts
@@ -74,6 +74,9 @@ describe('userService', () => {
             username: 'Aylin',
             total_points: 9,
             published_story_count: 4,
+            followers_count: 12,
+            following_count: 5,
+            is_followed_by_me: true,
             location: 'Izmir',
             bio: 'Historian',
             birth_year: 1988,
@@ -90,6 +93,107 @@ describe('userService', () => {
       username: 'Aylin',
       publishedStoryCount: 4,
       birthYear: 1988,
+      followersCount: 12,
+      followingCount: 5,
+      isFollowedByMe: true,
+    });
+  });
+
+  it('preserves an unknown follow state when the public profile omits it', async () => {
+    setApiTransport(async (method: any, config: any) => {
+      if (method === 'GET' && config.url === '/users/12/') {
+        return {
+          status: 200,
+          data: {
+            id: 12,
+            username: 'Aylin',
+            total_points: 9,
+            published_story_count: 4,
+            followers_count: 12,
+            following_count: 5,
+          } as never,
+          config,
+        };
+      }
+
+      throw new Error(`Unexpected request: ${method} ${config.url}`);
+    });
+
+    const profile = await userService.getPublicProfile('12');
+
+    expect(profile.followersCount).toBe(12);
+    expect(profile.followingCount).toBe(5);
+    expect(profile.isFollowedByMe).toBeUndefined();
+  });
+
+  it('follows and unfollows users with the expected endpoints', async () => {
+    const requests: string[] = [];
+
+    setApiTransport(async (method: any, config: any) => {
+      requests.push(`${method} ${config.url}`);
+
+      return {
+        status: method === 'DELETE' ? 204 : 201,
+        data: method === 'DELETE' ? null : { success: true, data: {} },
+        config,
+      } as never;
+    });
+
+    await userService.followUser('12');
+    await userService.unfollowUser('12');
+
+    expect(requests).toEqual([
+      'POST /users/12/follow/',
+      'DELETE /users/12/follow/',
+    ]);
+  });
+
+  it('loads followers and following lists with pagination', async () => {
+    setApiTransport(async (method: any, config: any) => {
+      if (method === 'GET' && config.url === '/users/12/followers/?page=2&page_size=20') {
+        return {
+          status: 200,
+          data: {
+            count: 2,
+            next: null,
+            previous: 'previous-page',
+            results: [
+              { id: 7, username: 'Traveler', profile_photo: 'https://cdn.example.com/user.jpg' },
+              { id: 8, username: null, profile_photo: null },
+            ],
+          } as never,
+          config,
+        };
+      }
+
+      if (method === 'GET' && config.url === '/users/12/following/?page=1&page_size=20') {
+        return {
+          status: 200,
+          data: {
+            count: 1,
+            next: 'next-page',
+            previous: null,
+            results: [{ id: 9, username: 'Aylin', profile_photo: null }],
+          } as never,
+          config,
+        };
+      }
+
+      throw new Error(`Unexpected request: ${method} ${config.url}`);
+    });
+
+    await expect(userService.getFollowers('12', 2)).resolves.toMatchObject({
+      count: 2,
+      previous: 'previous-page',
+      users: [
+        { id: '7', username: 'Traveler', profilePhoto: 'https://cdn.example.com/user.jpg' },
+        { id: '8', username: null, profilePhoto: null },
+      ],
+    });
+    await expect(userService.getFollowing('12')).resolves.toMatchObject({
+      count: 1,
+      next: 'next-page',
+      users: [{ id: '9', username: 'Aylin' }],
     });
   });
 

--- a/mobile/src/features/profile/application/services/index.ts
+++ b/mobile/src/features/profile/application/services/index.ts
@@ -1,5 +1,5 @@
 import { ProfileRepositoryImpl } from '../../data/repositories';
-import { ProfileEntity, ProfilePhotoUploadInput, UpdateProfileInput } from '../../domain/entities';
+import { FollowListResult, ProfileEntity, ProfilePhotoUploadInput, UpdateProfileInput } from '../../domain/entities';
 
 const repository = new ProfileRepositoryImpl();
 
@@ -24,5 +24,17 @@ export const userService = {
   },
   async deleteAccount(password: string, deleteStories = true): Promise<void> {
     return repository.deleteAccount(password, deleteStories);
+  },
+  async followUser(userId: string): Promise<void> {
+    return repository.followUser(userId);
+  },
+  async unfollowUser(userId: string): Promise<void> {
+    return repository.unfollowUser(userId);
+  },
+  async getFollowers(userId: string, page = 1): Promise<FollowListResult> {
+    return repository.getFollowers(userId, page);
+  },
+  async getFollowing(userId: string, page = 1): Promise<FollowListResult> {
+    return repository.getFollowing(userId, page);
   },
 };

--- a/mobile/src/features/profile/data/repositories/index.ts
+++ b/mobile/src/features/profile/data/repositories/index.ts
@@ -1,4 +1,10 @@
-import { ProfileEntity, ProfilePhotoUploadInput, UpdateProfileInput } from '../../domain/entities';
+import {
+  FollowListResult,
+  FollowUserEntity,
+  ProfileEntity,
+  ProfilePhotoUploadInput,
+  UpdateProfileInput,
+} from '../../domain/entities';
 import { ProfileRepository } from '../../domain/repositories';
 import { profileRemoteSource } from '../sources';
 
@@ -44,6 +50,24 @@ function asNullableNumber(value: unknown) {
   return null;
 }
 
+function asOptionalBoolean(value: unknown) {
+  if (typeof value === 'boolean') {
+    return value;
+  }
+
+  if (typeof value === 'string') {
+    if (value.toLowerCase() === 'true') {
+      return true;
+    }
+
+    if (value.toLowerCase() === 'false') {
+      return false;
+    }
+  }
+
+  return undefined;
+}
+
 function mapCurrentProfile(profile: Record<string, unknown>): ProfileEntity {
   const nestedProfile =
     profile.profile && typeof profile.profile === 'object'
@@ -62,6 +86,9 @@ function mapCurrentProfile(profile: Record<string, unknown>): ProfileEntity {
     location: asNullableString(nestedProfile.location),
     birthDate: asNullableString(nestedProfile.birth_date),
     profilePhoto: asNullableString(nestedProfile.profile_photo),
+    followersCount: asNumber(profile.followers_count),
+    followingCount: asNumber(profile.following_count),
+    isFollowedByMe: asOptionalBoolean(profile.is_followed_by_me),
     isUsernamePublic: Boolean(profile.is_username_public),
     isEmailVerified: Boolean(profile.is_email_verified),
     isNamePublic: nestedProfile.is_name_public === undefined ? undefined : Boolean(nestedProfile.is_name_public),
@@ -86,6 +113,9 @@ function mergePublicProfileSummary(
         ? profile.publishedStoryCount
         : publishedStoryCount,
     birthYear: profile.birthDate ? profile.birthYear : birthYear ?? profile.birthYear,
+    followersCount: asNumber(publicProfile.followers_count),
+    followingCount: asNumber(publicProfile.following_count),
+    isFollowedByMe: asOptionalBoolean(publicProfile.is_followed_by_me) ?? profile.isFollowedByMe,
   };
 }
 
@@ -102,6 +132,30 @@ function mapPublicProfile(profile: Record<string, unknown>): ProfileEntity {
     location: asNullableString(profile.location),
     birthYear: asNullableNumber(profile.birth_year),
     profilePhoto: asNullableString(profile.profile_photo),
+    followersCount: asNumber(profile.followers_count),
+    followingCount: asNumber(profile.following_count),
+    isFollowedByMe: asOptionalBoolean(profile.is_followed_by_me),
+  };
+}
+
+function mapFollowUser(user: Record<string, unknown>): FollowUserEntity {
+  return {
+    id: asString(user.id),
+    username: asNullableString(user.username),
+    profilePhoto: asNullableString(user.profile_photo),
+  };
+}
+
+function mapFollowList(payload: Record<string, unknown>): FollowListResult {
+  const results = Array.isArray(payload.results) ? payload.results : [];
+
+  return {
+    users: results
+      .filter((item): item is Record<string, unknown> => Boolean(item) && typeof item === 'object')
+      .map(mapFollowUser),
+    next: asNullableString(payload.next),
+    previous: asNullableString(payload.previous),
+    count: asNumber(payload.count),
   };
 }
 
@@ -147,5 +201,23 @@ export class ProfileRepositoryImpl implements ProfileRepository {
 
   async deleteAccount(password: string, deleteStories = true): Promise<void> {
     await profileRemoteSource.deleteAccount(password, deleteStories);
+  }
+
+  async followUser(userId: string): Promise<void> {
+    await profileRemoteSource.followUser(userId);
+  }
+
+  async unfollowUser(userId: string): Promise<void> {
+    await profileRemoteSource.unfollowUser(userId);
+  }
+
+  async getFollowers(userId: string, page = 1): Promise<FollowListResult> {
+    const payload = await profileRemoteSource.getFollowers(userId, page);
+    return mapFollowList(payload);
+  }
+
+  async getFollowing(userId: string, page = 1): Promise<FollowListResult> {
+    const payload = await profileRemoteSource.getFollowing(userId, page);
+    return mapFollowList(payload);
   }
 }

--- a/mobile/src/features/profile/data/sources/index.ts
+++ b/mobile/src/features/profile/data/sources/index.ts
@@ -124,6 +124,50 @@ export const profileRemoteSource = {
       },
     });
   },
+
+  async followUser(userId: string) {
+    await apiClient.post(`/users/${userId}/follow/`);
+  },
+
+  async unfollowUser(userId: string) {
+    await apiClient.delete<void>(`/users/${userId}/follow/`);
+  },
+
+  async getFollowers(userId: string, page = 1) {
+    return (await apiClient.get<Record<string, unknown>>(
+      `/users/${userId}/followers/${buildQueryString({ page, page_size: 20 })}`,
+    )) ?? {
+      count: 0,
+      next: null,
+      previous: null,
+      results: [],
+    };
+  },
+
+  async getFollowing(userId: string, page = 1) {
+    return (await apiClient.get<Record<string, unknown>>(
+      `/users/${userId}/following/${buildQueryString({ page, page_size: 20 })}`,
+    )) ?? {
+      count: 0,
+      next: null,
+      previous: null,
+      results: [],
+    };
+  },
 };
 
 export const profileLocalSource = {};
+
+function buildQueryString(params: Record<string, string | number | undefined>) {
+  const searchParams = new URLSearchParams();
+
+  Object.entries(params).forEach(([key, value]) => {
+    if (value !== undefined && value !== '') {
+      searchParams.append(key, String(value));
+    }
+  });
+
+  const query = searchParams.toString();
+
+  return query ? `?${query}` : '';
+}

--- a/mobile/src/features/profile/domain/entities/index.ts
+++ b/mobile/src/features/profile/domain/entities/index.ts
@@ -12,6 +12,9 @@ export interface ProfileEntity {
   birthDate?: string | null;
   birthYear?: number | null;
   profilePhoto?: string | null;
+  followersCount?: number;
+  followingCount?: number;
+  isFollowedByMe?: boolean;
   isUsernamePublic?: boolean;
   isEmailVerified?: boolean;
   isNamePublic?: boolean;
@@ -38,4 +41,17 @@ export interface UpdateProfileInput {
   isLocationPublic?: boolean;
   isBirthDatePublic?: boolean;
   isPhotoPublic?: boolean;
+}
+
+export interface FollowUserEntity {
+  id: string;
+  username: string | null;
+  profilePhoto?: string | null;
+}
+
+export interface FollowListResult {
+  users: FollowUserEntity[];
+  next: string | null;
+  previous: string | null;
+  count: number;
 }

--- a/mobile/src/features/profile/domain/repositories/index.ts
+++ b/mobile/src/features/profile/domain/repositories/index.ts
@@ -1,4 +1,4 @@
-import { ProfileEntity, ProfilePhotoUploadInput, UpdateProfileInput } from '../entities';
+import { FollowListResult, ProfileEntity, ProfilePhotoUploadInput, UpdateProfileInput } from '../entities';
 
 export interface ProfileRepository {
   getCurrentProfile(): Promise<ProfileEntity>;
@@ -7,4 +7,8 @@ export interface ProfileRepository {
   uploadProfilePhoto(input: ProfilePhotoUploadInput): Promise<ProfileEntity>;
   removeProfilePhoto(): Promise<ProfileEntity>;
   deleteAccount(password: string, deleteStories?: boolean): Promise<void>;
+  followUser(userId: string): Promise<void>;
+  unfollowUser(userId: string): Promise<void>;
+  getFollowers(userId: string, page?: number): Promise<FollowListResult>;
+  getFollowing(userId: string, page?: number): Promise<FollowListResult>;
 }

--- a/mobile/src/features/profile/presentation/screens/ProfileScreen.tsx
+++ b/mobile/src/features/profile/presentation/screens/ProfileScreen.tsx
@@ -1,6 +1,7 @@
 import * as ImagePicker from 'expo-image-picker';
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Image, Modal, Pressable, ScrollView, Text, View } from 'react-native';
+import { GestureResponderEvent } from 'react-native';
 import { navigationRef } from '../../../../app/navigation/navigationRef';
 import { limits } from '../../../../core/constants/limits';
 import { useAppTheme } from '../../../../core/hooks/useAppTheme';
@@ -9,12 +10,16 @@ import { useToast } from '../../../../shared/hooks/useToast';
 import { authService } from '../../../auth/application/services';
 import { useAuth } from '../../../auth';
 import { userService } from '../../application/services';
-import { ProfileEntity, ProfilePhotoUploadInput, UpdateProfileInput } from '../../domain/entities';
+import { FollowListResult, FollowUserEntity, ProfileEntity, ProfilePhotoUploadInput, UpdateProfileInput } from '../../domain/entities';
+import { AuthUser } from '../../../../core/auth/session';
 
 type ProfileMode = 'self' | 'public';
 
 const BIO_MAX_LENGTH = 280;
 const MIN_BIRTH_YEAR = 1900;
+const FOLLOW_STATE_LOOKUP_MAX_PAGES = 10;
+const FOLLOW_LIST_DRAG_THRESHOLD = 8;
+const followStateOverrides = new Map<string, boolean>();
 const MONTH_OPTIONS = [
   'January',
   'February',
@@ -39,6 +44,11 @@ interface ProfileScreenProps {
   uploadProfilePhoto?: typeof userService.uploadProfilePhoto;
   removeProfilePhoto?: typeof userService.removeProfilePhoto;
   deleteAccount?: typeof userService.deleteAccount;
+  followUser?: typeof userService.followUser;
+  unfollowUser?: typeof userService.unfollowUser;
+  getFollowers?: typeof userService.getFollowers;
+  getFollowing?: typeof userService.getFollowing;
+  onOpenUserProfile?: (userId: string) => void;
 }
 
 interface ProfileFormState {
@@ -65,6 +75,46 @@ interface FormErrors {
 interface PendingPhotoState extends ProfilePhotoUploadInput {
   fileSize: number;
   previewUri: string;
+}
+
+type FollowListDisplayUser = FollowUserEntity & {
+  isCurrentUser?: boolean;
+};
+
+function getFollowStateOverrideKey(currentUserId: string | number | undefined, targetUserId: string) {
+  if (currentUserId === undefined) {
+    return null;
+  }
+
+  return `${String(currentUserId)}:${targetUserId}`;
+}
+
+async function inferFollowStateFromFollowers({
+  targetUserId,
+  currentUserId,
+  getFollowers,
+}: {
+  targetUserId: string;
+  currentUserId: string;
+  getFollowers: (userId: string, page?: number) => Promise<FollowListResult>;
+}) {
+  let page = 1;
+
+  while (page <= FOLLOW_STATE_LOOKUP_MAX_PAGES) {
+    const result = await getFollowers(targetUserId, page);
+
+    if (result.users.some((followUser) => followUser.id === currentUserId)) {
+      return true;
+    }
+
+    if (!result.next) {
+      return false;
+    }
+
+    page += 1;
+  }
+
+  return undefined;
 }
 
 function formatJoinedDate(value?: string) {
@@ -395,6 +445,324 @@ function StatChip({ label, value }: { label: string; value: string }) {
   );
 }
 
+function StatButton({
+  label,
+  value,
+  onPress,
+}: {
+  label: string;
+  value: string;
+  onPress: () => void;
+}) {
+  const { colors, spacing, typography } = useAppTheme();
+
+  return (
+    <Pressable
+      accessibilityRole="button"
+      accessibilityLabel={`${value} ${label}`}
+      onPress={onPress}
+      style={({ pressed }) => ({
+        minWidth: 120,
+        padding: spacing.md,
+        borderRadius: 16,
+        borderWidth: 1,
+        borderColor: colors.border,
+        backgroundColor: colors.background,
+        gap: spacing.xs,
+        opacity: pressed ? 0.82 : 1,
+      })}
+    >
+      <Text style={{ color: colors.muted, fontSize: typography.caption, textTransform: 'uppercase' }}>
+        {label}
+      </Text>
+      <Text style={{ color: colors.text, fontSize: typography.subtitle, fontWeight: '800' }}>{value}</Text>
+    </Pressable>
+  );
+}
+
+function FollowActionButton({
+  isAuthenticated,
+  isFollowing,
+  isLoading,
+  onToggle,
+  onRequestLogin,
+}: {
+  isAuthenticated: boolean;
+  isFollowing: boolean;
+  isLoading: boolean;
+  onToggle: () => void;
+  onRequestLogin: () => void;
+}) {
+  if (!isAuthenticated) {
+    return (
+      <Button variant="outline" onPress={onRequestLogin} accessibilityLabel="Log in to follow this user">
+        Log in to follow
+      </Button>
+    );
+  }
+
+  return (
+    <Button
+      variant={isFollowing ? 'outline' : 'primary'}
+      onPress={onToggle}
+      disabled={isLoading}
+      accessibilityLabel={isFollowing ? 'Unfollow user' : 'Follow user'}
+    >
+      {isLoading ? 'Updating...' : isFollowing ? 'Following' : 'Follow'}
+    </Button>
+  );
+}
+
+function FollowListModal({
+  visible,
+  mode,
+  userId,
+  fetchFollowers,
+  fetchFollowing,
+  currentUser,
+  showCurrentUserAtTop,
+  onClose,
+  onOpenUserProfile,
+}: {
+  visible: boolean;
+  mode: 'followers' | 'following';
+  userId: string;
+  fetchFollowers: (userId: string, page?: number) => Promise<FollowListResult>;
+  fetchFollowing: (userId: string, page?: number) => Promise<FollowListResult>;
+  currentUser: AuthUser | null;
+  showCurrentUserAtTop: boolean;
+  onClose: () => void;
+  onOpenUserProfile?: (userId: string) => void;
+}) {
+  const { colors, spacing, typography } = useAppTheme();
+  const [users, setUsers] = useState<FollowUserEntity[]>([]);
+  const [page, setPage] = useState(1);
+  const [hasMore, setHasMore] = useState(false);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string>();
+  const rowPressStartRef = useRef<{ x: number; y: number } | null>(null);
+  const rowPressMovedRef = useRef(false);
+  const isFollowersMode = mode === 'followers';
+  const title = isFollowersMode ? 'Followers' : 'Following';
+  const currentUserId = currentUser?.id == null ? null : String(currentUser.id);
+  const shouldPinCurrentUser =
+    showCurrentUserAtTop && isFollowersMode && currentUserId != null && Boolean(currentUser?.username);
+  const visibleUsers = useMemo<FollowListDisplayUser[]>(() => {
+    if (!shouldPinCurrentUser || !currentUserId || !currentUser) {
+      return users;
+    }
+
+    return [
+      {
+        id: currentUserId,
+        username: currentUser.username,
+        profilePhoto: null,
+        isCurrentUser: true,
+      },
+      ...users
+        .filter((followUser) => followUser.id !== currentUserId)
+        .map((followUser) => ({ ...followUser, isCurrentUser: false })),
+    ];
+  }, [currentUser, currentUserId, shouldPinCurrentUser, users]);
+
+  const loadPage = useCallback(
+    async (nextPage: number, append: boolean) => {
+      setIsLoading(true);
+      setError(undefined);
+
+      try {
+        const result = isFollowersMode
+          ? await fetchFollowers(userId, nextPage)
+          : await fetchFollowing(userId, nextPage);
+
+        setUsers((current) => (append ? [...current, ...result.users] : result.users));
+        setHasMore(Boolean(result.next));
+        setPage(nextPage);
+      } catch (loadError) {
+        setError(loadError instanceof Error ? loadError.message : 'Unable to load users.');
+      } finally {
+        setIsLoading(false);
+      }
+    },
+    [fetchFollowers, fetchFollowing, isFollowersMode, userId],
+  );
+
+  useEffect(() => {
+    if (!visible) {
+      return;
+    }
+
+    setUsers([]);
+    setPage(1);
+    setHasMore(false);
+    void loadPage(1, false);
+  }, [loadPage, mode, visible]);
+
+  const handleRowPressIn = useCallback((event: GestureResponderEvent) => {
+    const { pageX, pageY } = event.nativeEvent;
+
+    rowPressStartRef.current = { x: pageX, y: pageY };
+    rowPressMovedRef.current = false;
+  }, []);
+
+  const handleRowTouchMove = useCallback((event: GestureResponderEvent) => {
+    const start = rowPressStartRef.current;
+
+    if (!start) {
+      return;
+    }
+
+    const { pageX, pageY } = event.nativeEvent;
+    const distance = Math.abs(pageX - start.x) + Math.abs(pageY - start.y);
+
+    if (distance > FOLLOW_LIST_DRAG_THRESHOLD) {
+      rowPressMovedRef.current = true;
+    }
+  }, []);
+
+  const handleRowPress = useCallback(
+    (targetUserId: string) => {
+      if (rowPressMovedRef.current) {
+        rowPressStartRef.current = null;
+        rowPressMovedRef.current = false;
+        return;
+      }
+
+      rowPressStartRef.current = null;
+      onClose();
+      onOpenUserProfile?.(targetUserId);
+    },
+    [onClose, onOpenUserProfile],
+  );
+
+  return (
+    <Modal animationType="slide" transparent visible={visible} onRequestClose={onClose}>
+      <View
+        style={{
+          flex: 1,
+          backgroundColor: 'rgba(10, 10, 10, 0.35)',
+          justifyContent: 'flex-end',
+        }}
+      >
+        <Pressable style={{ flex: 1 }} onPress={onClose} />
+        <View
+          style={{
+            maxHeight: '82%',
+            paddingHorizontal: spacing.lg,
+            paddingTop: spacing.lg,
+            paddingBottom: spacing.xl,
+            borderTopLeftRadius: 24,
+            borderTopRightRadius: 24,
+            backgroundColor: colors.background,
+            gap: spacing.md,
+          }}
+        >
+          <View style={{ flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between', gap: spacing.md }}>
+            <View>
+              <Text style={{ color: colors.text, fontSize: typography.subtitle, fontWeight: '800' }}>{title}</Text>
+              <Text style={{ marginTop: spacing.xs, color: colors.muted }}>
+                {isFollowersMode ? 'People who follow this user.' : 'People this user follows.'}
+              </Text>
+            </View>
+            <Button variant="outline" onPress={onClose}>
+              Close
+            </Button>
+          </View>
+
+          {isLoading && users.length === 0 ? <Loader message={`Loading ${title.toLowerCase()}...`} /> : null}
+          {error && users.length === 0 ? (
+            <ErrorState
+              title={`${title} unavailable`}
+              message={error}
+              retryLabel="Try again"
+              onRetry={() => {
+                void loadPage(1, false);
+              }}
+            />
+          ) : null}
+          {!isLoading && !error && users.length === 0 ? (
+            <Text style={{ color: colors.muted }}>
+              {isFollowersMode ? 'No followers yet.' : 'Not following anyone yet.'}
+            </Text>
+          ) : null}
+
+          {visibleUsers.length > 0 ? (
+            <ScrollView
+              style={{ maxHeight: 360, minHeight: Math.min(260, 72 * visibleUsers.length) }}
+              contentContainerStyle={{ gap: spacing.sm, paddingBottom: spacing.sm }}
+              alwaysBounceVertical
+              overScrollMode="always"
+              keyboardShouldPersistTaps="handled"
+            >
+              {visibleUsers.map((followUser) => {
+                const label = followUser.username ?? 'Anonymous user';
+                const displayLabel = followUser.isCurrentUser ? `${label} (You)` : label;
+
+                return (
+                  <Pressable
+                    key={followUser.id}
+                    accessibilityRole="button"
+                    accessibilityLabel={`Open ${displayLabel} profile`}
+                    onPressIn={handleRowPressIn}
+                    onTouchMove={handleRowTouchMove}
+                    onPress={() => handleRowPress(followUser.id)}
+                    style={({ pressed }) => ({
+                      flexDirection: 'row',
+                      alignItems: 'center',
+                      gap: spacing.md,
+                      padding: spacing.md,
+                      borderRadius: 16,
+                      borderWidth: 1,
+                      borderColor: colors.border,
+                      backgroundColor: colors.surface,
+                      opacity: pressed ? 0.82 : 1,
+                    })}
+                  >
+                    {followUser.profilePhoto ? (
+                      <Image
+                        source={{ uri: followUser.profilePhoto }}
+                        accessibilityLabel={`${displayLabel} profile photo`}
+                        style={{ width: 42, height: 42, borderRadius: 21, backgroundColor: colors.infoSurface }}
+                      />
+                    ) : (
+                      <View
+                        style={{
+                          width: 42,
+                          height: 42,
+                          borderRadius: 21,
+                          alignItems: 'center',
+                          justifyContent: 'center',
+                          backgroundColor: colors.infoSurface,
+                        }}
+                      >
+                        <Text style={{ color: colors.primary, fontWeight: '800' }}>
+                          {label.slice(0, 1).toUpperCase()}
+                        </Text>
+                      </View>
+                    )}
+                    <Text style={{ flex: 1, color: colors.text, fontWeight: '700' }}>{displayLabel}</Text>
+                  </Pressable>
+                );
+              })}
+              {hasMore ? (
+                <Button
+                  variant="outline"
+                  onPress={() => {
+                    void loadPage(page + 1, true);
+                  }}
+                  disabled={isLoading}
+                >
+                  {isLoading ? 'Loading...' : 'Load more'}
+                </Button>
+              ) : null}
+            </ScrollView>
+          ) : null}
+        </View>
+      </View>
+    </Modal>
+  );
+}
+
 function FieldCard({
   title,
   children,
@@ -433,8 +801,13 @@ export function ProfileScreen({
   uploadProfilePhoto = userService.uploadProfilePhoto,
   removeProfilePhoto = userService.removeProfilePhoto,
   deleteAccount = userService.deleteAccount,
+  followUser = userService.followUser,
+  unfollowUser = userService.unfollowUser,
+  getFollowers = userService.getFollowers,
+  getFollowing = userService.getFollowing,
+  onOpenUserProfile,
 }: ProfileScreenProps) {
-  const { user, updateUser, logout } = useAuth();
+  const { user, isAuthenticated, updateUser, logout } = useAuth();
   const { toast } = useToast();
   const { colors, spacing, typography } = useAppTheme();
   const isSelfMode = mode === 'self';
@@ -457,6 +830,12 @@ export function ProfileScreen({
   const [isDeleting, setIsDeleting] = useState(false);
   const [error, setError] = useState<string>();
   const [formErrors, setFormErrors] = useState<FormErrors>({});
+  const [followersCount, setFollowersCount] = useState(0);
+  const [followingCount, setFollowingCount] = useState(0);
+  const [isFollowing, setIsFollowing] = useState(false);
+  const [isFollowLoading, setIsFollowLoading] = useState(false);
+  const [followListMode, setFollowListMode] = useState<'followers' | 'following'>('followers');
+  const [isFollowListVisible, setIsFollowListVisible] = useState(false);
 
   const resetPhotoDraft = useCallback(() => {
     setPendingPhoto(null);
@@ -471,8 +850,30 @@ export function ProfileScreen({
       const nextProfile = isSelfMode
         ? await getCurrentProfile()
         : await getPublicProfile(userId ?? '');
+      const overrideKey = getFollowStateOverrideKey(user?.id, nextProfile.id);
+      const overriddenFollowState = overrideKey ? followStateOverrides.get(overrideKey) : undefined;
+      let resolvedFollowState =
+        overriddenFollowState ??
+        (typeof nextProfile.isFollowedByMe === 'boolean' ? nextProfile.isFollowedByMe : undefined);
+
+      if (
+        resolvedFollowState === undefined &&
+        !isSelfMode &&
+        isAuthenticated &&
+        user?.id != null &&
+        String(user.id) !== nextProfile.id
+      ) {
+        resolvedFollowState = await inferFollowStateFromFollowers({
+          targetUserId: nextProfile.id,
+          currentUserId: String(user.id),
+          getFollowers,
+        });
+      }
 
       setProfile(nextProfile);
+      setFollowersCount(nextProfile.followersCount ?? 0);
+      setFollowingCount(nextProfile.followingCount ?? 0);
+      setIsFollowing(Boolean(resolvedFollowState));
       setFormState(createFormState(nextProfile));
       resetPhotoDraft();
       setIsEditing(false);
@@ -481,7 +882,7 @@ export function ProfileScreen({
     } finally {
       setIsLoading(false);
     }
-  }, [getCurrentProfile, getPublicProfile, isSelfMode, resetPhotoDraft, userId]);
+  }, [getCurrentProfile, getFollowers, getPublicProfile, isAuthenticated, isSelfMode, resetPhotoDraft, user?.id, userId]);
 
   useEffect(() => {
     if (!isSelfMode && !userId) {
@@ -670,6 +1071,66 @@ export function ProfileScreen({
     }
   }, [deleteAccount, toast]);
 
+  const handleRequestLoginForFollow = useCallback(() => {
+    toast.info('Please sign in to follow users.');
+    navigationRef.redirectToAuth?.('unauthorized');
+  }, [toast]);
+
+  const handleToggleFollow = useCallback(async () => {
+    if (!profile || isFollowLoading) {
+      return;
+    }
+
+    const previousFollowing = isFollowing;
+    const nextFollowing = !previousFollowing;
+    const previousFollowersCount = followersCount;
+
+    setIsFollowing(nextFollowing);
+    setFollowersCount((current) => Math.max(0, current + (nextFollowing ? 1 : -1)));
+    setIsFollowLoading(true);
+
+    try {
+      if (nextFollowing) {
+        await followUser(profile.id);
+      } else {
+        await unfollowUser(profile.id);
+      }
+
+      const overrideKey = getFollowStateOverrideKey(user?.id, profile.id);
+
+      if (overrideKey) {
+        followStateOverrides.set(overrideKey, nextFollowing);
+      }
+    } catch {
+      setIsFollowing(previousFollowing);
+      setFollowersCount(previousFollowersCount);
+      toast.error(
+        nextFollowing
+          ? 'Failed to follow user. Please try again.'
+          : 'Failed to unfollow user. Please try again.',
+      );
+    } finally {
+      setIsFollowLoading(false);
+    }
+  }, [followUser, followersCount, isFollowLoading, isFollowing, profile, toast, unfollowUser, user?.id]);
+
+  const openFollowList = useCallback((modeToOpen: 'followers' | 'following') => {
+    setFollowListMode(modeToOpen);
+    setIsFollowListVisible(true);
+  }, []);
+
+  const handleOpenFollowUserProfile = useCallback(
+    (targetUserId: string) => {
+      if (onOpenUserProfile) {
+        onOpenUserProfile(targetUserId);
+        return;
+      }
+
+      navigationRef.navigateToUserProfile?.(targetUserId);
+    },
+    [onOpenUserProfile],
+  );
+
   const title = useMemo(() => {
     if (isSelfMode) {
       return 'Your profile';
@@ -784,10 +1245,30 @@ export function ProfileScreen({
             {joinedDate ? <StatChip label="Joined" value={joinedDate} /> : null}
             {isSelfMode ? <StatChip label="Points" value={String(profile.totalPoints)} /> : null}
             <StatChip label="Stories" value={String(profile.publishedStoryCount ?? 0)} />
+            <StatButton
+              label={followersCount === 1 ? 'Follower' : 'Followers'}
+              value={String(followersCount)}
+              onPress={() => openFollowList('followers')}
+            />
+            <StatButton
+              label="Following"
+              value={String(followingCount)}
+              onPress={() => openFollowList('following')}
+            />
             {profile.location ? <StatChip label="Location" value={profile.location} /> : null}
             {birthDateDisplay ? <StatChip label="Birth date" value={birthDateDisplay} /> : null}
             {profile.birthYear ? <StatChip label="Birth year" value={String(profile.birthYear)} /> : null}
           </View>
+
+          {!isSelfMode ? (
+            <FollowActionButton
+              isAuthenticated={Boolean(isAuthenticated)}
+              isFollowing={isFollowing}
+              isLoading={isFollowLoading}
+              onToggle={() => void handleToggleFollow()}
+              onRequestLogin={handleRequestLoginForFollow}
+            />
+          ) : null}
 
           {profile.bio ? (
             <FieldCard title="Bio">
@@ -1069,6 +1550,18 @@ export function ProfileScreen({
           </View>
         )}
       </ScrollView>
+
+      <FollowListModal
+        visible={isFollowListVisible}
+        mode={followListMode}
+        userId={profile.id}
+        fetchFollowers={getFollowers}
+        fetchFollowing={getFollowing}
+        currentUser={user}
+        showCurrentUserAtTop={isFollowing}
+        onClose={() => setIsFollowListVisible(false)}
+        onOpenUserProfile={handleOpenFollowUserProfile}
+      />
 
       <Modal
         animationType="slide"

--- a/mobile/src/features/profile/presentation/screens/__tests__/ProfileScreen.test.tsx
+++ b/mobile/src/features/profile/presentation/screens/__tests__/ProfileScreen.test.tsx
@@ -5,9 +5,25 @@ import { ProfileScreen } from '../ProfileScreen';
 import { navigationRef } from '../../../../../app/navigation/navigationRef';
 
 const mockToastSuccess = jest.fn();
+const mockToastError = jest.fn();
+const mockToastInfo = jest.fn();
 const mockUpdateUser = jest.fn(async () => undefined);
 const mockLogout = jest.fn(async () => undefined);
 const mockAuthClear = jest.fn(async () => undefined);
+let mockAuthUser: {
+  id: number;
+  email: string;
+  username: string;
+  role: 'user';
+  isUsernamePublic: boolean;
+} | null = {
+  id: 7,
+  email: 'traveler@example.com',
+  username: 'Traveler',
+  role: 'user',
+  isUsernamePublic: true,
+};
+let mockIsAuthenticated = true;
 
 jest.mock('../../../../auth/application/services', () => ({
   authService: {
@@ -19,8 +35,8 @@ jest.mock('../../../../../shared/hooks/useToast', () => ({
   useToast: () => ({
     toast: {
       success: mockToastSuccess,
-      error: jest.fn(),
-      info: jest.fn(),
+      error: mockToastError,
+      info: mockToastInfo,
       show: jest.fn(),
     },
   }),
@@ -28,13 +44,8 @@ jest.mock('../../../../../shared/hooks/useToast', () => ({
 
 jest.mock('../../../../auth', () => ({
   useAuth: () => ({
-    user: {
-      id: 7,
-      email: 'traveler@example.com',
-      username: 'Traveler',
-      role: 'user',
-      isUsernamePublic: true,
-    },
+    user: mockAuthUser,
+    isAuthenticated: mockIsAuthenticated,
     updateUser: mockUpdateUser,
     logout: mockLogout,
   }),
@@ -73,12 +84,24 @@ const publicProfile = {
   location: 'Izmir',
   birthYear: 1988,
   profilePhoto: 'https://cdn.example.com/public.jpg',
+  followersCount: 12,
+  followingCount: 5,
+  isFollowedByMe: false,
 };
 
 describe('ProfileScreen', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockAuthUser = {
+      id: 7,
+      email: 'traveler@example.com',
+      username: 'Traveler',
+      role: 'user',
+      isUsernamePublic: true,
+    };
+    mockIsAuthenticated = true;
     navigationRef.redirectToPublic = jest.fn();
+    navigationRef.redirectToAuth = jest.fn();
   });
 
   it('renders a loading state while profile data is being fetched', () => {
@@ -375,6 +398,8 @@ describe('ProfileScreen', () => {
     expect(screen.queryByText('May 20, 1995')).toBeNull();
     expect(screen.getByText('I write about harbor neighborhoods.')).toBeTruthy();
     expect(screen.queryByText('Edit Profile')).toBeNull();
+    expect(screen.getByText('12')).toBeTruthy();
+    expect(screen.getByText('5')).toBeTruthy();
 
     rerender(
       <ProfileScreen
@@ -392,6 +417,277 @@ describe('ProfileScreen', () => {
     expect(await screen.findByText('Anonymous user')).toBeTruthy();
     expect(screen.queryByText('Izmir')).toBeNull();
     expect(screen.queryByText('1988')).toBeNull();
+  });
+
+  it('does not render a follow button on the user own profile', async () => {
+    render(
+      <ProfileScreen
+        mode="self"
+        getCurrentProfile={async () => ({
+          ...selfProfile,
+          followersCount: 3,
+          followingCount: 2,
+        })}
+      />,
+    );
+
+    expect(await screen.findByText('Traveler')).toBeTruthy();
+    expect(screen.queryByText('Follow')).toBeNull();
+    expect(screen.queryByLabelText('Follow user')).toBeNull();
+    expect(screen.queryByLabelText('Unfollow user')).toBeNull();
+    expect(screen.getByLabelText('3 Followers')).toBeTruthy();
+    expect(screen.getByLabelText('2 Following')).toBeTruthy();
+  });
+
+  it('renders authenticated not-following state and optimistically follows', async () => {
+    const followUser = jest.fn(async () => undefined);
+
+    render(
+      <ProfileScreen
+        mode="public"
+        userId="13"
+        getPublicProfile={async () => ({
+          ...publicProfile,
+          id: '13',
+          followersCount: 10,
+          isFollowedByMe: false,
+        })}
+        followUser={followUser}
+      />,
+    );
+
+    expect(await screen.findByText('Aylin')).toBeTruthy();
+    expect(screen.getByText('Follow')).toBeTruthy();
+
+    fireEvent.press(screen.getByLabelText('Follow user'));
+
+    expect(screen.getByLabelText('Unfollow user')).toBeTruthy();
+    expect(screen.getByLabelText('11 Followers')).toBeTruthy();
+
+    await waitFor(() => {
+      expect(followUser).toHaveBeenCalledWith('13');
+    });
+  });
+
+  it('keeps the following state after leaving and returning when the profile response omits it', async () => {
+    const followUser = jest.fn(async () => undefined);
+    const getFollowers = jest.fn(async () => ({
+      count: 0,
+      next: null,
+      previous: null,
+      users: [],
+    }));
+    const firstRender = render(
+      <ProfileScreen
+        mode="public"
+        userId="30"
+        getPublicProfile={async () => ({
+          ...publicProfile,
+          id: '30',
+          followersCount: 2,
+          isFollowedByMe: false,
+        })}
+        getFollowers={getFollowers}
+        followUser={followUser}
+      />,
+    );
+
+    expect(await screen.findByText('Aylin')).toBeTruthy();
+    fireEvent.press(screen.getByLabelText('Follow user'));
+
+    await waitFor(() => {
+      expect(followUser).toHaveBeenCalledWith('30');
+    });
+
+    firstRender.unmount();
+
+    const { isFollowedByMe: _isFollowedByMe, ...profileWithoutFollowState } = publicProfile;
+
+    render(
+      <ProfileScreen
+        mode="public"
+        userId="30"
+        getPublicProfile={async () => ({
+          ...profileWithoutFollowState,
+          id: '30',
+          followersCount: 3,
+        })}
+        getFollowers={getFollowers}
+      />,
+    );
+
+    expect(await screen.findByText('Aylin')).toBeTruthy();
+    expect(screen.getByLabelText('Unfollow user')).toBeTruthy();
+  });
+
+  it('infers following state from followers when the profile response omits it', async () => {
+    const getFollowers = jest.fn(async () => ({
+      count: 10,
+      next: null,
+      previous: null,
+      users: [
+        { id: '22', username: 'Deniz', profilePhoto: null },
+        { id: '7', username: null, profilePhoto: null },
+      ],
+    }));
+    const { isFollowedByMe: _isFollowedByMe, ...profileWithoutFollowState } = publicProfile;
+
+    render(
+      <ProfileScreen
+        mode="public"
+        userId="31"
+        getPublicProfile={async () => ({
+          ...profileWithoutFollowState,
+          id: '31',
+          followersCount: 10,
+        })}
+        getFollowers={getFollowers}
+      />,
+    );
+
+    expect(await screen.findByText('Aylin')).toBeTruthy();
+    expect(screen.getByLabelText('Unfollow user')).toBeTruthy();
+    expect(getFollowers).toHaveBeenCalledWith('31', 1);
+  });
+
+  it('renders authenticated following state and rolls back when unfollow fails', async () => {
+    const unfollowUser = jest.fn(async () => {
+      throw new Error('Network error');
+    });
+
+    render(
+      <ProfileScreen
+        mode="public"
+        userId="12"
+        getPublicProfile={async () => ({
+          ...publicProfile,
+          followersCount: 10,
+          isFollowedByMe: true,
+        })}
+        unfollowUser={unfollowUser}
+      />,
+    );
+
+    expect(await screen.findByText('Aylin')).toBeTruthy();
+    expect(screen.getByLabelText('Unfollow user')).toBeTruthy();
+
+    fireEvent.press(screen.getByLabelText('Unfollow user'));
+
+    await waitFor(() => {
+      expect(unfollowUser).toHaveBeenCalledWith('12');
+      expect(mockToastError).toHaveBeenCalledWith('Failed to unfollow user. Please try again.');
+    });
+    expect(screen.getByLabelText('Unfollow user')).toBeTruthy();
+    expect(screen.getByLabelText('10 Followers')).toBeTruthy();
+  });
+
+  it('renders unauthenticated follow state as a login prompt', async () => {
+    mockAuthUser = null;
+    mockIsAuthenticated = false;
+
+    render(
+      <ProfileScreen
+        mode="public"
+        userId="12"
+        getPublicProfile={async () => publicProfile}
+      />,
+    );
+
+    expect(await screen.findByText('Aylin')).toBeTruthy();
+    fireEvent.press(screen.getByText('Log in to follow'));
+
+    expect(mockToastInfo).toHaveBeenCalledWith('Please sign in to follow users.');
+    expect(navigationRef.redirectToAuth).toHaveBeenCalledWith('unauthorized');
+  });
+
+  it('opens followers list and navigates from a list entry', async () => {
+    const onOpenUserProfile = jest.fn();
+
+    render(
+      <ProfileScreen
+        mode="public"
+        userId="12"
+        getPublicProfile={async () => publicProfile}
+        getFollowers={async () => ({
+          count: 1,
+          next: null,
+          previous: null,
+          users: [{ id: '20', username: 'Deniz', profilePhoto: null }],
+        })}
+        onOpenUserProfile={onOpenUserProfile}
+      />,
+    );
+
+    expect(await screen.findByText('Aylin')).toBeTruthy();
+    fireEvent.press(screen.getByLabelText('12 Followers'));
+
+    expect(await screen.findByText('Deniz')).toBeTruthy();
+    fireEvent.press(screen.getByLabelText('Open Deniz profile'));
+
+    expect(onOpenUserProfile).toHaveBeenCalledWith('20');
+  });
+
+  it('does not navigate when a follower row is dragged like a scroll gesture', async () => {
+    const onOpenUserProfile = jest.fn();
+
+    render(
+      <ProfileScreen
+        mode="public"
+        userId="12"
+        getPublicProfile={async () => publicProfile}
+        getFollowers={async () => ({
+          count: 2,
+          next: null,
+          previous: null,
+          users: [
+            { id: '20', username: 'Deniz', profilePhoto: null },
+            { id: '21', username: 'Ece', profilePhoto: null },
+          ],
+        })}
+        onOpenUserProfile={onOpenUserProfile}
+      />,
+    );
+
+    expect(await screen.findByText('Aylin')).toBeTruthy();
+    fireEvent.press(screen.getByLabelText('12 Followers'));
+
+    const row = await screen.findByLabelText('Open Deniz profile');
+    fireEvent(row, 'pressIn', { nativeEvent: { pageX: 0, pageY: 0 } });
+    fireEvent(row, 'touchMove', { nativeEvent: { pageX: 0, pageY: 32 } });
+    fireEvent.press(row);
+
+    expect(onOpenUserProfile).not.toHaveBeenCalled();
+    expect(screen.getByText('Deniz')).toBeTruthy();
+  });
+
+  it('shows the signed-in follower with the local username and You label when public username is hidden', async () => {
+    render(
+      <ProfileScreen
+        mode="public"
+        userId="12"
+        getPublicProfile={async () => ({
+          ...publicProfile,
+          isFollowedByMe: true,
+        })}
+        getFollowers={async () => ({
+          count: 2,
+          next: null,
+          previous: null,
+          users: [
+            { id: '20', username: 'Deniz', profilePhoto: null },
+            { id: '7', username: null, profilePhoto: null },
+          ],
+        })}
+      />,
+    );
+
+    expect(await screen.findByText('Aylin')).toBeTruthy();
+    fireEvent.press(screen.getByLabelText('12 Followers'));
+
+    expect(await screen.findByText('Traveler (You)')).toBeTruthy();
+    expect(screen.getByText('Deniz')).toBeTruthy();
+    expect(screen.queryByText('Anonymous user')).toBeNull();
+    expect(screen.getByLabelText('Open Traveler (You) profile')).toBeTruthy();
   });
 
   it('shows the bio privacy pending note in the edit form', async () => {

--- a/mobile/src/shared/ui/Button/Button.tsx
+++ b/mobile/src/shared/ui/Button/Button.tsx
@@ -8,6 +8,7 @@ interface ButtonProps extends PropsWithChildren {
   fullWidth?: boolean;
   style?: ViewStyle;
   variant?: 'primary' | 'outline' | 'ghost';
+  accessibilityLabel?: string;
 }
 
 export function Button({
@@ -17,6 +18,7 @@ export function Button({
   fullWidth = false,
   style,
   variant = 'primary',
+  accessibilityLabel,
 }: ButtonProps) {
   const { colors, spacing } = useAppTheme();
   const isPrimary = variant === 'primary';
@@ -24,6 +26,8 @@ export function Button({
 
   return (
     <Pressable
+      accessibilityRole="button"
+      accessibilityLabel={accessibilityLabel}
       onPress={disabled ? undefined : onPress}
       disabled={disabled}
       style={({ pressed }) => ({


### PR DESCRIPTION
# 📝 Description
Fixes #390

Implements the mobile follow/unfollow experience for user profiles. This PR adds the profile data-layer support for follow/unfollow endpoints, follower/following pagination, public profile follow counters, and `is_followed_by_me` mapping. It also wires the public profile UI with Follow/Following actions, optimistic updates with rollback, follower/following count buttons, and a mobile modal list where entries navigate to user profiles.

The PR also includes fixes found while testing the flow:
- Keeps follow state stable after navigating away and returning, even when the profile response omits or lags `is_followed_by_me`.
- Falls back to checking the followers list when the relationship state is unknown.
- Shows the signed-in user as their local username plus `(You)` instead of `Anonymous user` when their public username is private.
- Prevents accidental profile navigation when users drag follower/following rows to scroll short lists.

# 📊 Type of Change
- [x]  Bug fix
- [x]  New feature
- [ ]  Refactoring
- [ ]  Documentation
 
# ✅ Acceptance Criteria / Checklist
- [x] Project builds successfully
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, especially in hard-to-understand parts
- [x] I have performed a self-review of my code
- [x] I have added/updated tests
- [x] New and existing unit tests pass locally with my changes

# 📸 Screenshots / Recordings
Not included. Changes are covered by mobile component and service tests.

# ⏱️ Estimated Review Time
- [ ] < 5 min
- [ ] 5-15 min
- [x] > 15 min

# 🧪 Validation
- `npm run typecheck`
- `npm test -- --runInBand`
- `npm test -- --runInBand src/features/profile/application/services/__tests__/userService.test.ts src/features/profile/presentation/screens/__tests__/ProfileScreen.test.tsx`
