### PR TITLE
Feat/location search and autocomplete in story submission map mobile

### DIFF
--- a/mobile/src/app/navigation/__tests__/RootNavigator.test.tsx
+++ b/mobile/src/app/navigation/__tests__/RootNavigator.test.tsx
@@ -6,6 +6,11 @@ import { storageKeys } from '../../../core/storage/keys';
 import { interceptors } from '../../../core/api/interceptors';
 import { resetApiTransport, setApiTransport } from '../../../core/api/client';
 import { AppProviders } from '../../providers/AppProviders';
+import { geocodeLocationQuery } from '../../../features/search/application/services';
+
+jest.mock('../../../features/search/application/services', () => ({
+  geocodeLocationQuery: jest.fn(),
+}));
 
 function renderNavigator() {
   return render(
@@ -262,6 +267,7 @@ function installAuthTransport() {
 
 describe('RootNavigator auth flow', () => {
   beforeEach(async () => {
+    (geocodeLocationQuery as jest.Mock).mockResolvedValue(null);
     await storage.clear();
     interceptors.clear();
     resetApiTransport();
@@ -541,6 +547,7 @@ describe('RootNavigator auth flow', () => {
     fireEvent.changeText(screen.getByLabelText('Location filter'), 'Golden Horn');
     fireEvent.changeText(screen.getByLabelText('Start year'), '1990');
     fireEvent.changeText(screen.getByLabelText('End year'), '2000');
+    expect(await screen.findByText('No map match found. Apply will search story place names instead.')).toBeTruthy();
     fireEvent.press(screen.getByLabelText('Apply filters'));
 
     await waitFor(() => {

--- a/mobile/src/features/feed/data/sources/__tests__/feedRemoteSource.test.ts
+++ b/mobile/src/features/feed/data/sources/__tests__/feedRemoteSource.test.ts
@@ -39,4 +39,69 @@ describe('feedRemoteSource', () => {
 
     expect(getSpy).toHaveBeenCalledWith('/stories/feed/?page=2&page_size=10&sort_by=recent&location=Istanbul');
   });
+
+  it('sends bounding box params instead of text location when location was geocoded', async () => {
+    const getSpy = jest.spyOn(apiClient, 'get').mockResolvedValue({
+      count: 0,
+      next: null,
+      previous: null,
+      results: [],
+    });
+
+    await feedRemoteSource.getFeed({
+      page: 1,
+      sort: 'recent',
+      filters: {
+        location: 'Istanbul',
+        locationBounds: {
+          latMin: 40.8027,
+          latMax: 41.3208,
+          lngMin: 28.0065,
+          lngMax: 29.4564,
+        },
+      },
+    });
+
+    expect(getSpy).toHaveBeenCalledWith(
+      '/stories/feed/?page=1&page_size=10&sort_by=recent&lat_min=40.8027&lat_max=41.3208&lng_min=28.0065&lng_max=29.4564',
+    );
+  });
+
+  it('filters feed results by geocoded bounds when the backend ignores bbox params', async () => {
+    jest.spyOn(apiClient, 'get').mockResolvedValue({
+      count: 2,
+      next: null,
+      previous: null,
+      results: [
+        {
+          id: 1,
+          location_lat: '41.0082',
+          location_lng: '28.9784',
+        },
+        {
+          id: 2,
+          location_lat: '39.9334',
+          location_lng: '32.8597',
+        },
+      ],
+    });
+
+    const response = await feedRemoteSource.getFeed({
+      filters: {
+        location: 'Ankara',
+        locationBounds: {
+          latMin: 39.7,
+          latMax: 40.1,
+          lngMin: 32.5,
+          lngMax: 33.2,
+        },
+      },
+    });
+
+    expect(response).toMatchObject({
+      count: 1,
+      next: null,
+      results: [{ id: 2 }],
+    });
+  });
 });

--- a/mobile/src/features/feed/data/sources/index.ts
+++ b/mobile/src/features/feed/data/sources/index.ts
@@ -22,11 +22,31 @@ export const feedRemoteSource = {
       ...normalizeStoryFilters(filters),
     });
 
-    return (await apiClient.get(`${hasSearch ? '/stories/search/' : '/stories/feed/'}${params}`)) ?? {
+    const response = (await apiClient.get<{
+      count?: number;
+      next?: string | null;
+      previous?: string | null;
+      results?: unknown[];
+    }>(`${hasSearch ? '/stories/search/' : '/stories/feed/'}${params}`)) ?? {
       count: 0,
       next: null,
       previous: null,
       results: [],
+    };
+
+    const bounds = filters.locationBounds;
+
+    if (!bounds) {
+      return response;
+    }
+
+    const results = (response.results ?? []).filter((story) => isStoryWithinBounds(story, bounds));
+
+    return {
+      ...response,
+      count: results.length,
+      next: null,
+      results,
     };
   },
 };
@@ -50,7 +70,12 @@ function normalizeStoryFilters(filters: StoryFilters) {
     params.year_to = filters.yearTo;
   }
 
-  if (filters.location?.trim()) {
+  if (filters.locationBounds) {
+    params.lat_min = filters.locationBounds.latMin;
+    params.lat_max = filters.locationBounds.latMax;
+    params.lng_min = filters.locationBounds.lngMin;
+    params.lng_max = filters.locationBounds.lngMax;
+  } else if (filters.location?.trim()) {
     params.location = filters.location.trim();
   }
 
@@ -69,4 +94,39 @@ function buildQueryString(params: Record<string, string | number | undefined>) {
   const query = searchParams.toString();
 
   return query ? `?${query}` : '';
+}
+
+function isStoryWithinBounds(
+  story: unknown,
+  bounds: NonNullable<StoryFilters['locationBounds']>,
+) {
+  if (!story || typeof story !== 'object') {
+    return false;
+  }
+
+  const record = story as Record<string, unknown>;
+  const latitude = asNumber(record.location_lat);
+  const longitude = asNumber(record.location_lng);
+
+  return (
+    latitude !== undefined &&
+    longitude !== undefined &&
+    latitude >= bounds.latMin &&
+    latitude <= bounds.latMax &&
+    longitude >= bounds.lngMin &&
+    longitude <= bounds.lngMax
+  );
+}
+
+function asNumber(value: unknown) {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return value;
+  }
+
+  if (typeof value === 'string' && value.trim()) {
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : undefined;
+  }
+
+  return undefined;
 }

--- a/mobile/src/features/feed/presentation/screens/FeedScreen.tsx
+++ b/mobile/src/features/feed/presentation/screens/FeedScreen.tsx
@@ -260,19 +260,27 @@ function toSearchState(filters: StoryFilters): SearchFiltersState {
   return {
     query: filters.q ?? '',
     location: filters.location ?? '',
+    locationBounds: filters.locationBounds,
     timeFrom: filters.yearFrom ? String(filters.yearFrom) : '',
     timeTo: filters.yearTo ? String(filters.yearTo) : '',
   };
 }
 
 function hasAnySearchFilters(filters: SearchFiltersState) {
-  return Object.values(filters).some((value) => value.trim().length > 0);
+  return Boolean(
+    filters.query.trim() ||
+      filters.location.trim() ||
+      filters.locationBounds ||
+      filters.timeFrom.trim() ||
+      filters.timeTo.trim(),
+  );
 }
 
 function areSearchStatesEqual(left: SearchFiltersState, right: SearchFiltersState) {
   return (
     left.query === right.query &&
     left.location === right.location &&
+    JSON.stringify(left.locationBounds) === JSON.stringify(right.locationBounds) &&
     left.timeFrom === right.timeFrom &&
     left.timeTo === right.timeTo
   );

--- a/mobile/src/features/feed/presentation/screens/__tests__/FeedScreen.test.tsx
+++ b/mobile/src/features/feed/presentation/screens/__tests__/FeedScreen.test.tsx
@@ -4,6 +4,11 @@ import { FeedScreen } from '../FeedScreen';
 import { FeedPageEntity } from '../../../domain/entities';
 import { SearchFiltersProvider } from '../../../../search/presentation/context/SearchFiltersContext';
 import { storage } from '../../../../../core/storage/storage';
+import { geocodeLocationQuery } from '../../../../search/application/services';
+
+jest.mock('../../../../search/application/services', () => ({
+  geocodeLocationQuery: jest.fn(),
+}));
 
 function makeStory(id: string, overrides: Partial<FeedPageEntity['items'][number]> = {}) {
   return {
@@ -31,6 +36,7 @@ function makeFeedPage(overrides: Partial<FeedPageEntity> = {}): FeedPageEntity {
 
 describe('FeedScreen', () => {
   beforeEach(async () => {
+    (geocodeLocationQuery as jest.Mock).mockResolvedValue(null);
     await storage.clear();
   });
 
@@ -177,6 +183,7 @@ describe('FeedScreen', () => {
     fireEvent.changeText(screen.getByLabelText('Location filter'), 'Istanbul');
     fireEvent.changeText(screen.getByLabelText('Start year'), '1900');
     fireEvent.changeText(screen.getByLabelText('End year'), '1950');
+    expect(await screen.findByText('No map match found. Apply will search story place names instead.')).toBeTruthy();
     fireEvent.press(screen.getByLabelText('Apply filters'));
 
     await waitFor(() => {
@@ -186,6 +193,7 @@ describe('FeedScreen', () => {
         filters: {
           q: undefined,
           location: 'Istanbul',
+          locationBounds: undefined,
           yearFrom: 1900,
           yearTo: 1950,
         },
@@ -246,6 +254,7 @@ describe('FeedScreen', () => {
     fireEvent.changeText(screen.getByLabelText('Location filter'), 'Istanbul');
     fireEvent.changeText(screen.getByLabelText('Start year'), '1900');
     fireEvent.changeText(screen.getByLabelText('End year'), '1950');
+    expect(await screen.findByText('No map match found. Apply will search story place names instead.')).toBeTruthy();
     fireEvent.press(screen.getByText('Reset filter form'));
     fireEvent.press(screen.getByLabelText('Apply filters'));
 
@@ -256,6 +265,7 @@ describe('FeedScreen', () => {
         filters: {
           q: 'harbor',
           location: undefined,
+          locationBounds: undefined,
           yearFrom: 1980,
           yearTo: 2026,
         },

--- a/mobile/src/features/map/presentation/screens/MapScreen.tsx
+++ b/mobile/src/features/map/presentation/screens/MapScreen.tsx
@@ -183,6 +183,10 @@ export function MapScreen({
       return 'No stories found in this area';
     }
 
+    if (activeFilters.location?.trim() && !activeFilters.locationBounds) {
+      return 'Place could not be found';
+    }
+
     if (activeFilters.location?.trim()) {
       return `No stories found in ${activeFilters.location.trim()}`;
     }

--- a/mobile/src/features/map/presentation/screens/__tests__/MapScreen.test.tsx
+++ b/mobile/src/features/map/presentation/screens/__tests__/MapScreen.test.tsx
@@ -4,6 +4,11 @@ import { MapScreen } from '../MapScreen';
 import { MapMarkerGroup } from '../../../domain/entities';
 import { SearchFiltersProvider } from '../../../../search/presentation/context/SearchFiltersContext';
 import { storage } from '../../../../../core/storage/storage';
+import { geocodeLocationQuery } from '../../../../search/application/services';
+
+jest.mock('../../../../search/application/services', () => ({
+  geocodeLocationQuery: jest.fn(),
+}));
 
 jest.mock('../../../../../shared/components/WebMapView', () => {
   const React = require('react');
@@ -116,6 +121,7 @@ const markerGroups: MapMarkerGroup[] = [
 
 describe('MapScreen', () => {
   beforeEach(async () => {
+    (geocodeLocationQuery as jest.Mock).mockResolvedValue(null);
     await storage.clear();
   });
 
@@ -232,9 +238,10 @@ describe('MapScreen', () => {
     await screen.findByText('No stories match the current filters.');
     fireEvent.press(screen.getByText('Show filters'));
     fireEvent.changeText(screen.getByLabelText('Location filter'), 'Beykoz');
+    expect(await screen.findByText('No map match found. Apply will search story place names instead.')).toBeTruthy();
     fireEvent.press(screen.getByLabelText('Apply filters'));
 
-    expect(await screen.findByText('No stories found in Beykoz')).toBeTruthy();
+    expect(await screen.findByText('Place could not be found')).toBeTruthy();
   });
 
   it('applies the default year filters when submitted unchanged', async () => {
@@ -297,6 +304,7 @@ describe('MapScreen', () => {
     await screen.findByText('The Day the Harbor Fell Silent');
     fireEvent.press(screen.getByText('Show filters'));
     fireEvent.changeText(screen.getByLabelText('Location filter'), 'Golden Horn');
+    expect(await screen.findByText('No map match found. Apply will search story place names instead.')).toBeTruthy();
     fireEvent.press(screen.getByLabelText('Apply filters'));
 
     await waitFor(() => {
@@ -328,6 +336,7 @@ describe('MapScreen', () => {
     await screen.findByText('The Day the Harbor Fell Silent');
     fireEvent.press(screen.getByText('Show filters'));
     fireEvent.changeText(screen.getByLabelText('Location filter'), 'Golden Horn');
+    expect(await screen.findByText('No map match found. Apply will search story place names instead.')).toBeTruthy();
     fireEvent.press(screen.getByLabelText('Apply filters'));
 
     await waitFor(() => {

--- a/mobile/src/features/search/application/services/__tests__/geocodingService.test.ts
+++ b/mobile/src/features/search/application/services/__tests__/geocodingService.test.ts
@@ -1,0 +1,55 @@
+import { geocodeLocationQuery, parseNominatimBounds } from '../geocodingService';
+
+describe('geocodingService', () => {
+  const originalFetch = globalThis.fetch;
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    jest.restoreAllMocks();
+  });
+
+  it('geocodes a place name into backend-ready bounds', async () => {
+    const fetchMock = jest.fn().mockResolvedValue({
+      ok: true,
+      json: jest.fn().mockResolvedValue([
+        {
+          boundingbox: ['40.8027', '41.3208', '28.0065', '29.4564'],
+        },
+      ]),
+    });
+    globalThis.fetch = fetchMock as typeof fetch;
+
+    const bounds = await geocodeLocationQuery('Istanbul');
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://nominatim.openstreetmap.org/search?q=Istanbul&format=jsonv2&limit=1&addressdetails=1',
+      {
+        headers: {
+          Accept: 'application/json',
+          'Accept-Language': 'en',
+          'User-Agent': 'local-history-story-map-mobile/0.1.0',
+        },
+      },
+    );
+    expect(bounds).toEqual({
+      latMin: 40.8027,
+      latMax: 41.3208,
+      lngMin: 28.0065,
+      lngMax: 29.4564,
+    });
+  });
+
+  it('returns null when Nominatim has no usable result so callers can fall back to text search', async () => {
+    globalThis.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: jest.fn().mockResolvedValue([]),
+    }) as typeof fetch;
+
+    await expect(geocodeLocationQuery('No Such Place')).resolves.toBeNull();
+  });
+
+  it('rejects invalid bounding boxes', () => {
+    expect(parseNominatimBounds(['not-a-number', '41', '28', '29'])).toBeNull();
+    expect(parseNominatimBounds(undefined)).toBeNull();
+  });
+});

--- a/mobile/src/features/search/application/services/geocodingService.ts
+++ b/mobile/src/features/search/application/services/geocodingService.ts
@@ -1,0 +1,63 @@
+export interface LocationBounds {
+  latMin: number;
+  latMax: number;
+  lngMin: number;
+  lngMax: number;
+}
+
+interface NominatimSearchResult {
+  boundingbox?: unknown;
+}
+
+const NOMINATIM_SEARCH_URL = 'https://nominatim.openstreetmap.org/search';
+
+export async function geocodeLocationQuery(query: string): Promise<LocationBounds | null> {
+  const normalizedQuery = query.trim();
+
+  if (!normalizedQuery) {
+    return null;
+  }
+
+  const params = new URLSearchParams({
+    q: normalizedQuery,
+    format: 'jsonv2',
+    limit: '1',
+    addressdetails: '1',
+  });
+
+  const response = await fetch(`${NOMINATIM_SEARCH_URL}?${params.toString()}`, {
+    headers: {
+      Accept: 'application/json',
+      'Accept-Language': 'en',
+      'User-Agent': 'local-history-story-map-mobile/0.1.0',
+    },
+  });
+
+  if (!response.ok) {
+    throw new Error('Unable to geocode location.');
+  }
+
+  const results = (await response.json()) as NominatimSearchResult[];
+  const firstResult = Array.isArray(results) ? results[0] : undefined;
+
+  return parseNominatimBounds(firstResult?.boundingbox);
+}
+
+export function parseNominatimBounds(value: unknown): LocationBounds | null {
+  if (!Array.isArray(value) || value.length < 4) {
+    return null;
+  }
+
+  const [latMin, latMax, lngMin, lngMax] = value.map((item) => Number(item));
+
+  if (![latMin, latMax, lngMin, lngMax].every(Number.isFinite)) {
+    return null;
+  }
+
+  return {
+    latMin: Math.min(latMin, latMax),
+    latMax: Math.max(latMin, latMax),
+    lngMin: Math.min(lngMin, lngMax),
+    lngMax: Math.max(lngMin, lngMax),
+  };
+}

--- a/mobile/src/features/search/application/services/geocodingService.ts
+++ b/mobile/src/features/search/application/services/geocodingService.ts
@@ -5,11 +5,30 @@ export interface LocationBounds {
   lngMax: number;
 }
 
+export interface LocationSuggestion {
+  id: string;
+  title: string;
+  subtitle?: string;
+  latitude: number;
+  longitude: number;
+}
+
 interface NominatimSearchResult {
   boundingbox?: unknown;
+  place_id?: number | string;
+  osm_id?: number | string;
+  display_name?: string;
+  name?: string;
+  lat?: string;
+  lon?: string;
 }
 
 const NOMINATIM_SEARCH_URL = 'https://nominatim.openstreetmap.org/search';
+const NOMINATIM_HEADERS = {
+  Accept: 'application/json',
+  'Accept-Language': 'en',
+  'User-Agent': 'local-history-story-map-mobile/0.1.0',
+};
 
 export async function geocodeLocationQuery(query: string): Promise<LocationBounds | null> {
   const normalizedQuery = query.trim();
@@ -26,11 +45,7 @@ export async function geocodeLocationQuery(query: string): Promise<LocationBound
   });
 
   const response = await fetch(`${NOMINATIM_SEARCH_URL}?${params.toString()}`, {
-    headers: {
-      Accept: 'application/json',
-      'Accept-Language': 'en',
-      'User-Agent': 'local-history-story-map-mobile/0.1.0',
-    },
+    headers: NOMINATIM_HEADERS,
   });
 
   if (!response.ok) {
@@ -41,6 +56,37 @@ export async function geocodeLocationQuery(query: string): Promise<LocationBound
   const firstResult = Array.isArray(results) ? results[0] : undefined;
 
   return parseNominatimBounds(firstResult?.boundingbox);
+}
+
+export async function searchLocationSuggestions(query: string): Promise<LocationSuggestion[]> {
+  const normalizedQuery = query.trim();
+
+  if (normalizedQuery.length < 3) {
+    return [];
+  }
+
+  const params = new URLSearchParams({
+    q: normalizedQuery,
+    format: 'jsonv2',
+    limit: '5',
+    addressdetails: '1',
+  });
+
+  const response = await fetch(`${NOMINATIM_SEARCH_URL}?${params.toString()}`, {
+    headers: NOMINATIM_HEADERS,
+  });
+
+  if (!response.ok) {
+    throw new Error('Unable to search locations.');
+  }
+
+  const results = (await response.json()) as NominatimSearchResult[];
+
+  if (!Array.isArray(results)) {
+    return [];
+  }
+
+  return results.map(parseNominatimSuggestion).filter((result): result is LocationSuggestion => result != null);
 }
 
 export function parseNominatimBounds(value: unknown): LocationBounds | null {
@@ -59,5 +105,30 @@ export function parseNominatimBounds(value: unknown): LocationBounds | null {
     latMax: Math.max(latMin, latMax),
     lngMin: Math.min(lngMin, lngMax),
     lngMax: Math.max(lngMin, lngMax),
+  };
+}
+
+function parseNominatimSuggestion(result: NominatimSearchResult): LocationSuggestion | null {
+  const latitude = Number(result.lat);
+  const longitude = Number(result.lon);
+
+  if (!Number.isFinite(latitude) || !Number.isFinite(longitude)) {
+    return null;
+  }
+
+  const displayName = result.display_name?.trim();
+  const [fallbackTitle, ...fallbackRest] = displayName?.split(',').map((part) => part.trim()).filter(Boolean) ?? [];
+  const title = result.name?.trim() || fallbackTitle;
+
+  if (!title) {
+    return null;
+  }
+
+  return {
+    id: String(result.place_id ?? result.osm_id ?? `${latitude},${longitude}`),
+    title,
+    subtitle: fallbackRest.join(', ') || undefined,
+    latitude,
+    longitude,
   };
 }

--- a/mobile/src/features/search/application/services/index.ts
+++ b/mobile/src/features/search/application/services/index.ts
@@ -1,1 +1,1 @@
-export const searchService = {};
+export * from './geocodingService';

--- a/mobile/src/features/search/presentation/components/StorySearchControls.tsx
+++ b/mobile/src/features/search/presentation/components/StorySearchControls.tsx
@@ -1,9 +1,11 @@
-import React, { useMemo, useState } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { Modal, Pressable, Text, View } from 'react-native';
 import { useAppTheme } from '../../../../core/hooks/useAppTheme';
+import { useDebounce } from '../../../../shared/hooks/useDebounce';
 import { DEFAULT_FROM_YEAR, DEFAULT_TO_YEAR, FilterPanel } from '../../../../shared/components/FilterPanel';
 import { FilterChipItem, FilterChips } from '../../../../shared/components/FilterChips';
 import { SearchInput } from '../../../../shared/components/SearchInput';
+import { geocodeLocationQuery, LocationBounds } from '../../application/services';
 import { SearchFilterScope, useSearchFilters } from '../context/SearchFiltersContext';
 
 function buildChips(
@@ -41,17 +43,77 @@ export function StorySearchControls({ helperText, hideHeading = false, scope }: 
   const { filters, updateFilters, removeFilter, clearFilters, applyFilters } = useSearchFilters(scope);
   const [showFilters, setShowFilters] = useState(false);
   const [draftLocation, setDraftLocation] = useState('');
+  const [draftLocationBounds, setDraftLocationBounds] = useState<LocationBounds | undefined>();
+  const [isLocationResolving, setIsLocationResolving] = useState(false);
+  const [locationStatusText, setLocationStatusText] = useState<string | undefined>();
   const [draftTimeFrom, setDraftTimeFrom] = useState(DEFAULT_FROM_YEAR);
   const [draftTimeTo, setDraftTimeTo] = useState(DEFAULT_TO_YEAR);
+  const debouncedDraftLocation = useDebounce(draftLocation, 500);
+  const locationRequestIdRef = useRef(0);
 
   const chips = useMemo(() => buildChips(filters), [filters]);
 
   const openFilters = () => {
     setDraftLocation(filters.location);
+    setDraftLocationBounds(filters.locationBounds);
+    setLocationStatusText(undefined);
+    setIsLocationResolving(false);
     setDraftTimeFrom(filters.timeFrom || DEFAULT_FROM_YEAR);
     setDraftTimeTo(filters.timeTo || DEFAULT_TO_YEAR);
     setShowFilters(true);
   };
+
+  const handleDraftLocationChange = (location: string) => {
+    setDraftLocation(location);
+    setDraftLocationBounds(undefined);
+    setLocationStatusText(undefined);
+    setIsLocationResolving(location.trim().length > 0);
+  };
+
+  useEffect(() => {
+    if (!showFilters) {
+      return;
+    }
+
+    const location = debouncedDraftLocation.trim();
+    const requestId = locationRequestIdRef.current + 1;
+    locationRequestIdRef.current = requestId;
+
+    if (!location) {
+      setDraftLocationBounds(undefined);
+      setIsLocationResolving(false);
+      setLocationStatusText(undefined);
+      return;
+    }
+
+    setIsLocationResolving(true);
+    setLocationStatusText('Looking up this place...');
+
+    geocodeLocationQuery(location)
+      .then((bounds) => {
+        if (locationRequestIdRef.current !== requestId) {
+          return;
+        }
+
+        setDraftLocationBounds(bounds ?? undefined);
+        setLocationStatusText(
+          bounds ? 'Filtering by map area.' : 'No map match found. Apply will search story place names instead.',
+        );
+      })
+      .catch(() => {
+        if (locationRequestIdRef.current !== requestId) {
+          return;
+        }
+
+        setDraftLocationBounds(undefined);
+        setLocationStatusText('Location lookup failed. Apply will search story place names instead.');
+      })
+      .finally(() => {
+        if (locationRequestIdRef.current === requestId) {
+          setIsLocationResolving(false);
+        }
+      });
+  }, [debouncedDraftLocation, showFilters]);
 
   return (
     <View style={{ gap: spacing.md }}>
@@ -101,16 +163,21 @@ export function StorySearchControls({ helperText, hideHeading = false, scope }: 
             paddingTop: spacing.xl * 2,
           }}
         >
-          <Pressable onPress={(event) => event.stopPropagation()} style={{ width: '100%' }}>
+          <Pressable onPress={(event) => event?.stopPropagation?.()} style={{ width: '100%' }}>
             <FilterPanel
               location={draftLocation}
               timeFrom={draftTimeFrom}
               timeTo={draftTimeTo}
-              onLocationChange={setDraftLocation}
+              onLocationChange={handleDraftLocationChange}
               onTimeFromChange={setDraftTimeFrom}
               onTimeToChange={setDraftTimeTo}
+              isLocationResolving={isLocationResolving}
+              locationStatusText={locationStatusText}
+              isApplyDisabled={isLocationResolving}
               onClearAll={() => {
                 setDraftLocation('');
+                setDraftLocationBounds(undefined);
+                setLocationStatusText(undefined);
                 setDraftTimeFrom(DEFAULT_FROM_YEAR);
                 setDraftTimeTo(DEFAULT_TO_YEAR);
                 clearFilters();
@@ -118,6 +185,7 @@ export function StorySearchControls({ helperText, hideHeading = false, scope }: 
               onApply={() => {
                 updateFilters({
                   location: draftLocation,
+                  locationBounds: draftLocation.trim() ? draftLocationBounds : undefined,
                   timeFrom: draftTimeFrom,
                   timeTo: draftTimeTo,
                 }, { refresh: true });

--- a/mobile/src/features/search/presentation/context/SearchFiltersContext.tsx
+++ b/mobile/src/features/search/presentation/context/SearchFiltersContext.tsx
@@ -2,12 +2,14 @@ import React, { PropsWithChildren, createContext, useContext, useEffect, useMemo
 import { storageKeys } from '../../../../core/storage/keys';
 import { storage } from '../../../../core/storage/storage';
 import { StoryFilters } from '../../../stories/domain/repositories';
+import { LocationBounds } from '../../application/services';
 
 export type SearchFilterScope = 'feed' | 'map' | 'main';
 
 export interface SearchFiltersState {
   query: string;
   location: string;
+  locationBounds?: LocationBounds;
   timeFrom: string;
   timeTo: string;
 }
@@ -26,6 +28,7 @@ interface SearchFiltersContextValue {
 const initialFilters: SearchFiltersState = {
   query: '',
   location: '',
+  locationBounds: undefined,
   timeFrom: '',
   timeTo: '',
 };
@@ -130,7 +133,15 @@ export function SearchFiltersProvider({ children }: PropsWithChildren) {
         updateScopedFilters(scope, (currentFilters) => ({ ...currentFilters, ...patch }), options);
       },
       removeFilter: (scope, key) => {
-        updateScopedFilters(scope, (currentFilters) => ({ ...currentFilters, [key]: '' }), { refresh: true });
+        updateScopedFilters(
+          scope,
+          (currentFilters) => ({
+            ...currentFilters,
+            [key]: '',
+            ...(key === 'location' ? { locationBounds: undefined } : {}),
+          }),
+          { refresh: true },
+        );
       },
       clearFilters: (scope) => {
         updateScopedFilters(scope, (currentFilters) => ({
@@ -184,6 +195,7 @@ export function toSearchParams(filters: SearchFiltersState): StoryFilters {
   return {
     q: filters.query.trim() || undefined,
     location: filters.location.trim() || undefined,
+    locationBounds: filters.locationBounds,
     yearFrom,
     yearTo,
   };
@@ -193,7 +205,27 @@ function normalizeStoredFilters(filters?: Partial<SearchFiltersState> | null): S
   return {
     query: filters?.query ?? '',
     location: filters?.location ?? '',
+    locationBounds: normalizeLocationBounds(filters?.locationBounds),
     timeFrom: filters?.timeFrom ?? '',
     timeTo: filters?.timeTo ?? '',
+  };
+}
+
+function normalizeLocationBounds(bounds?: LocationBounds | null): LocationBounds | undefined {
+  if (!bounds) {
+    return undefined;
+  }
+
+  const { latMin, latMax, lngMin, lngMax } = bounds;
+
+  if (![latMin, latMax, lngMin, lngMax].every(Number.isFinite)) {
+    return undefined;
+  }
+
+  return {
+    latMin,
+    latMax,
+    lngMin,
+    lngMax,
   };
 }

--- a/mobile/src/features/search/presentation/context/__tests__/SearchFiltersContext.test.ts
+++ b/mobile/src/features/search/presentation/context/__tests__/SearchFiltersContext.test.ts
@@ -1,0 +1,46 @@
+import { toSearchParams } from '../SearchFiltersContext';
+
+describe('toSearchParams', () => {
+  it('uses text location when geocoding did not return bounds', () => {
+    expect(
+      toSearchParams({
+        query: '',
+        location: 'Istanbul',
+        locationBounds: undefined,
+        timeFrom: '',
+        timeTo: '',
+      }),
+    ).toEqual({
+      q: undefined,
+      location: 'Istanbul',
+      locationBounds: undefined,
+      yearFrom: undefined,
+      yearTo: undefined,
+    });
+  });
+
+  it('keeps geocoded bounds with the location label for API normalization', () => {
+    const locationBounds = {
+      latMin: 40.8027,
+      latMax: 41.3208,
+      lngMin: 28.0065,
+      lngMax: 29.4564,
+    };
+
+    expect(
+      toSearchParams({
+        query: '',
+        location: 'Istanbul',
+        locationBounds,
+        timeFrom: '',
+        timeTo: '',
+      }),
+    ).toEqual({
+      q: undefined,
+      location: 'Istanbul',
+      locationBounds,
+      yearFrom: undefined,
+      yearTo: undefined,
+    });
+  });
+});

--- a/mobile/src/features/stories/data/sources/__tests__/storiesRemoteSource.test.ts
+++ b/mobile/src/features/stories/data/sources/__tests__/storiesRemoteSource.test.ts
@@ -109,4 +109,77 @@ describe('storiesRemoteSource', () => {
       ],
     });
   });
+
+  it('passes geocoded location bounds to the map endpoint', async () => {
+    const getSpy = jest.spyOn(apiClient, 'get').mockResolvedValue({
+      type: 'FeatureCollection',
+      features: [],
+    });
+
+    await storiesRemoteSource.getMapFeatureCollectionFromApi({
+      location: 'Istanbul',
+      locationBounds: {
+        latMin: 40.8027,
+        latMax: 41.3208,
+        lngMin: 28.0065,
+        lngMax: 29.4564,
+      },
+    });
+
+    expect(getSpy).toHaveBeenCalledWith(
+      '/stories/map/?lat_min=40.8027&lat_max=41.3208&lng_min=28.0065&lng_max=29.4564',
+      {
+        headers: {
+          Accept: 'application/geo+json, application/json',
+        },
+      },
+    );
+  });
+
+  it('filters map features by geocoded bounds when the backend ignores bbox params', async () => {
+    jest.spyOn(apiClient, 'get').mockResolvedValue({
+      type: 'FeatureCollection',
+      features: [
+        {
+          type: 'Feature',
+          id: 1,
+          geometry: {
+            type: 'Point',
+            coordinates: [28.9784, 41.0082],
+          },
+          properties: {
+            title: 'Istanbul Story',
+            location_name: 'Istanbul',
+            preview_text: 'Inside Istanbul.',
+          },
+        },
+        {
+          type: 'Feature',
+          id: 2,
+          geometry: {
+            type: 'Point',
+            coordinates: [32.8597, 39.9334],
+          },
+          properties: {
+            title: 'Ankara Story',
+            location_name: 'Ankara',
+            preview_text: 'Inside Ankara.',
+          },
+        },
+      ],
+    });
+
+    const result = await storiesRemoteSource.getMapFeatureCollectionFromApi({
+      location: 'Ankara',
+      locationBounds: {
+        latMin: 39.7,
+        latMax: 40.1,
+        lngMin: 32.5,
+        lngMax: 33.2,
+      },
+    });
+
+    expect(result.features).toHaveLength(1);
+    expect(result.features[0]).toMatchObject({ id: 2 });
+  });
 });

--- a/mobile/src/features/stories/data/sources/index.ts
+++ b/mobile/src/features/stories/data/sources/index.ts
@@ -48,21 +48,25 @@ export const storiesRemoteSource = {
 
   async getStoriesFromApi(filters: StoryFilters = {}) {
     if (!filters.q?.trim()) {
-      return (
-        await apiClient.get<{ results?: unknown[] }>(
+      const results =
+        (
+          await apiClient.get<{ results?: unknown[] }>(
           `/stories/feed/${buildQueryString({
             page: 1,
             page_size: MAP_PAGE_SIZE,
             sort_by: 'recent',
             ...normalizeStoryFilters(filters),
           })}`,
-        )
-      )?.results ?? [];
+          )
+        )?.results ?? [];
+
+      return filterRemoteStories(results, filters);
     }
 
     const results = await fetchAllPages('/stories/search/', {
       q: filters.q.trim(),
       page_size: MAP_PAGE_SIZE,
+      ...normalizeStoryFilters({ ...filters, q: undefined }),
     });
 
     return filterRemoteStories(results, filters);
@@ -81,7 +85,10 @@ export const storiesRemoteSource = {
         },
       );
 
-      const featureCollection = normalizeMapFeatureCollection(response);
+      const featureCollection = filterFeatureCollectionByBounds(
+        normalizeMapFeatureCollection(response),
+        filters,
+      );
 
       if (!featureCollection.features.length || featureCollectionHasPreviewText(featureCollection)) {
         return featureCollection;
@@ -99,6 +106,7 @@ export const storiesRemoteSource = {
     const results = await fetchAllPages('/stories/search/', {
       q: filters.q.trim(),
       page_size: MAP_PAGE_SIZE,
+      ...normalizeStoryFilters({ ...filters, q: undefined }),
     });
 
     return {
@@ -124,7 +132,19 @@ export const storiesLocalSource = {
         }
       }
 
-      if (filters.location?.trim()) {
+      if (filters.locationBounds) {
+        const latitude = story.location.latitude;
+        const longitude = story.location.longitude;
+        const isWithinBounds =
+          latitude >= filters.locationBounds.latMin &&
+          latitude <= filters.locationBounds.latMax &&
+          longitude >= filters.locationBounds.lngMin &&
+          longitude <= filters.locationBounds.lngMax;
+
+        if (!isWithinBounds) {
+          return false;
+        }
+      } else if (filters.location?.trim()) {
         const normalizedLocation = filters.location.trim().toLowerCase();
         if (!story.location.name.toLowerCase().includes(normalizedLocation)) {
           return false;
@@ -191,7 +211,21 @@ function filterRemoteStories(results: unknown[], filters: StoryFilters) {
       }
     }
 
-    if (filters.location?.trim()) {
+    if (filters.locationBounds) {
+      const latitude = asNumber(story.location_lat);
+      const longitude = asNumber(story.location_lng);
+      const isWithinBounds =
+        latitude !== undefined &&
+        longitude !== undefined &&
+        latitude >= filters.locationBounds.latMin &&
+        latitude <= filters.locationBounds.latMax &&
+        longitude >= filters.locationBounds.lngMin &&
+        longitude <= filters.locationBounds.lngMax;
+
+      if (!isWithinBounds) {
+        return false;
+      }
+    } else if (filters.location?.trim()) {
       const location = filters.location.trim().toLowerCase();
 
       if (!placeName.includes(location)) {
@@ -337,6 +371,50 @@ function attachPreviewTextToFeatureCollection(
   };
 }
 
+function filterFeatureCollectionByBounds(
+  featureCollection: GeoJSONFeatureCollection,
+  filters: StoryFilters,
+): GeoJSONFeatureCollection {
+  const bounds = filters.locationBounds;
+
+  if (!bounds) {
+    return featureCollection;
+  }
+
+  return {
+    type: 'FeatureCollection',
+    features: featureCollection.features.filter((value) => {
+      if (!value || typeof value !== 'object') {
+        return false;
+      }
+
+      const geometry = (value as { geometry?: unknown }).geometry;
+
+      if (!geometry || typeof geometry !== 'object') {
+        return false;
+      }
+
+      const coordinates = (geometry as { coordinates?: unknown }).coordinates;
+
+      if (!Array.isArray(coordinates) || coordinates.length < 2) {
+        return false;
+      }
+
+      const longitude = asNumber(coordinates[0]);
+      const latitude = asNumber(coordinates[1]);
+
+      return (
+        latitude !== undefined &&
+        longitude !== undefined &&
+        latitude >= bounds.latMin &&
+        latitude <= bounds.latMax &&
+        longitude >= bounds.lngMin &&
+        longitude <= bounds.lngMax
+      );
+    }),
+  };
+}
+
 function normalizeStoryFilters(filters: StoryFilters) {
   const params: Record<string, string | number> = {};
 
@@ -352,7 +430,12 @@ function normalizeStoryFilters(filters: StoryFilters) {
     params.year_to = filters.yearTo;
   }
 
-  if (filters.location?.trim()) {
+  if (filters.locationBounds) {
+    params.lat_min = filters.locationBounds.latMin;
+    params.lat_max = filters.locationBounds.latMax;
+    params.lng_min = filters.locationBounds.lngMin;
+    params.lng_max = filters.locationBounds.lngMax;
+  } else if (filters.location?.trim()) {
     params.location = filters.location.trim();
   }
 

--- a/mobile/src/features/stories/domain/repositories/index.ts
+++ b/mobile/src/features/stories/domain/repositories/index.ts
@@ -5,6 +5,12 @@ export interface StoryFilters {
   yearFrom?: number;
   yearTo?: number;
   location?: string;
+  locationBounds?: {
+    latMin: number;
+    latMax: number;
+    lngMin: number;
+    lngMax: number;
+  };
 }
 
 export interface StoryRepository {

--- a/mobile/src/features/submissions/presentation/components/StoryLocationPicker.tsx
+++ b/mobile/src/features/submissions/presentation/components/StoryLocationPicker.tsx
@@ -1,8 +1,11 @@
-import React from 'react';
-import { Text, View } from 'react-native';
+import React, { useEffect, useRef, useState } from 'react';
+import { ActivityIndicator, Pressable, Text, TextInput, View } from 'react-native';
 import { Region } from 'react-native-maps';
 import { useAppTheme } from '../../../../core/hooks/useAppTheme';
+import { searchLocationSuggestions, LocationSuggestion } from '../../../search/application/services';
+import { Input } from '../../../../shared';
 import { WebMapView } from '../../../../shared/components/WebMapView';
+import { useDebounce } from '../../../../shared/hooks/useDebounce';
 
 interface StoryLocationPickerProps {
   latitude: number | null;
@@ -24,14 +27,189 @@ export function StoryLocationPicker({
   error,
 }: StoryLocationPickerProps) {
   const { colors, spacing, typography } = useAppTheme();
+  const [searchQuery, setSearchQuery] = useState('');
+  const [suggestions, setSuggestions] = useState<LocationSuggestion[]>([]);
+  const [isSearching, setIsSearching] = useState(false);
+  const [searchStatus, setSearchStatus] = useState<string | undefined>();
+  const [searchRefreshToken, setSearchRefreshToken] = useState(0);
+  const debouncedSearchQuery = useDebounce(searchQuery, 300);
+  const searchRequestIdRef = useRef(0);
+  const selectedSuggestionQueryRef = useRef<string | undefined>(undefined);
+  const searchInputRef = useRef<TextInput>(null);
 
   const selectedLocation =
     latitude != null && longitude != null
       ? { latitude, longitude }
       : null;
 
+  useEffect(() => {
+    const query = debouncedSearchQuery.trim();
+    const requestId = searchRequestIdRef.current + 1;
+    searchRequestIdRef.current = requestId;
+
+    if (query.length < 3) {
+      setSuggestions([]);
+      setSearchStatus(undefined);
+      setIsSearching(false);
+      return;
+    }
+
+    if (selectedSuggestionQueryRef.current === query) {
+      selectedSuggestionQueryRef.current = undefined;
+      setSuggestions([]);
+      setSearchStatus(undefined);
+      setIsSearching(false);
+      return;
+    }
+
+    setIsSearching(true);
+    setSearchStatus(undefined);
+
+    searchLocationSuggestions(query)
+      .then((results) => {
+        if (searchRequestIdRef.current !== requestId) {
+          return;
+        }
+
+        setSuggestions(results);
+        setSearchStatus(results.length ? undefined : 'No results found.');
+      })
+      .catch(() => {
+        if (searchRequestIdRef.current !== requestId) {
+          return;
+        }
+
+        setSuggestions([]);
+        setSearchStatus('Location search failed. You can still tap the map to place the pin.');
+      })
+      .finally(() => {
+        if (searchRequestIdRef.current === requestId) {
+          setIsSearching(false);
+        }
+      });
+  }, [debouncedSearchQuery]);
+
+  useEffect(() => {
+    const query = debouncedSearchQuery.trim();
+
+    if (searchRefreshToken === 0 || query.length < 3) {
+      return;
+    }
+
+    const requestId = searchRequestIdRef.current + 1;
+    searchRequestIdRef.current = requestId;
+
+    setIsSearching(true);
+    setSearchStatus(undefined);
+
+    searchLocationSuggestions(query)
+      .then((results) => {
+        if (searchRequestIdRef.current !== requestId) {
+          return;
+        }
+
+        setSuggestions(results);
+        setSearchStatus(results.length ? undefined : 'No results found.');
+      })
+      .catch(() => {
+        if (searchRequestIdRef.current !== requestId) {
+          return;
+        }
+
+        setSuggestions([]);
+        setSearchStatus('Location search failed. You can still tap the map to place the pin.');
+      })
+      .finally(() => {
+        if (searchRequestIdRef.current === requestId) {
+          setIsSearching(false);
+        }
+      });
+  }, [debouncedSearchQuery, searchRefreshToken]);
+
+  const handleSuggestionPress = (suggestion: LocationSuggestion) => {
+    selectedSuggestionQueryRef.current = suggestion.title;
+    setSearchQuery(suggestion.title);
+    setSuggestions([]);
+    setSearchStatus(undefined);
+    searchInputRef.current?.blur();
+    onChange({
+      latitude: suggestion.latitude,
+      longitude: suggestion.longitude,
+    });
+  };
+
   return (
     <View style={{ gap: spacing.sm }}>
+      <View style={{ gap: spacing.sm }}>
+        <Input
+          ref={searchInputRef}
+          value={searchQuery}
+          onChangeText={setSearchQuery}
+          onFocus={() => {
+            if (searchQuery.trim().length >= 3) {
+              selectedSuggestionQueryRef.current = undefined;
+              setSearchRefreshToken((current) => current + 1);
+            }
+          }}
+          placeholder="Search an address or place"
+          accessibilityLabel="Search story location"
+          autoCapitalize="words"
+          trailingElement={
+            isSearching ? (
+              <ActivityIndicator testID="story-location-search-loading" color={colors.muted} size="small" />
+            ) : null
+          }
+        />
+
+        {suggestions.length ? (
+          <View
+            testID="story-location-suggestions"
+            style={{
+              borderRadius: 16,
+              borderWidth: 1,
+              borderColor: colors.border,
+              backgroundColor: colors.background,
+              overflow: 'hidden',
+            }}
+          >
+            {suggestions.map((suggestion, index) => (
+              <Pressable
+                key={suggestion.id}
+                accessibilityRole="button"
+                accessibilityLabel={`Select ${suggestion.title}`}
+                onPress={() => handleSuggestionPress(suggestion)}
+                style={({ pressed }) => ({
+                  paddingHorizontal: spacing.md,
+                  paddingVertical: spacing.sm + 2,
+                  borderTopWidth: index === 0 ? 0 : 1,
+                  borderTopColor: colors.border,
+                  backgroundColor: pressed ? colors.infoSurface : colors.background,
+                })}
+              >
+                <Text style={{ color: colors.text, fontWeight: '700' }}>{suggestion.title}</Text>
+                {suggestion.subtitle ? (
+                  <Text
+                    numberOfLines={2}
+                    style={{ marginTop: 2, color: colors.muted, fontSize: typography.caption }}
+                  >
+                    {suggestion.subtitle}
+                  </Text>
+                ) : null}
+              </Pressable>
+            ))}
+          </View>
+        ) : null}
+
+        {searchStatus ? (
+          <Text
+            accessibilityRole={searchStatus.startsWith('Location search failed') ? 'alert' : undefined}
+            style={{ color: searchStatus.startsWith('Location search failed') ? colors.danger : colors.muted }}
+          >
+            {searchStatus}
+          </Text>
+        ) : null}
+      </View>
+
       <View
         style={{
           overflow: 'hidden',

--- a/mobile/src/features/submissions/presentation/screens/__tests__/SubmissionScreen.test.tsx
+++ b/mobile/src/features/submissions/presentation/screens/__tests__/SubmissionScreen.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { fireEvent, render, screen, waitFor } from '@testing-library/react-native';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react-native';
 import * as ImagePicker from 'expo-image-picker';
 import { ScrollView, StyleSheet, ViewStyle } from 'react-native';
 import { lightColors } from '../../../../../app/theme/colors';
@@ -7,6 +7,7 @@ import { ToastProvider } from '../../../../../shared/toast/ToastProvider';
 import { ROUTES } from '../../../../../app/navigation/routes';
 import { navigationRef } from '../../../../../app/navigation/navigationRef';
 import { submissionsService } from '../../../application/services';
+import { searchLocationSuggestions } from '../../../../search/application/services';
 import { SubmissionScreen } from '../SubmissionScreen';
 
 jest.mock('../../../../../shared/components/WebMapView', () => {
@@ -14,9 +15,19 @@ jest.mock('../../../../../shared/components/WebMapView', () => {
   const { Pressable } = require('react-native');
 
   return {
-    WebMapView: ({ onMapPress }: { onMapPress?: (coords: { latitude: number; longitude: number }) => void }) => (
+    WebMapView: ({
+      markers,
+      onMapPress,
+      region,
+    }: {
+      markers?: Array<{ latitude: number; longitude: number }>;
+      onMapPress?: (coords: { latitude: number; longitude: number }) => void;
+      region?: { latitude: number; longitude: number };
+    }) => (
       <Pressable
         testID="story-location-map"
+        markers={markers}
+        region={region}
         onPress={(event: { nativeEvent?: { coordinate?: { latitude: number; longitude: number } } }) => {
           const coordinate = event.nativeEvent?.coordinate;
 
@@ -28,6 +39,10 @@ jest.mock('../../../../../shared/components/WebMapView', () => {
     ),
   };
 });
+
+jest.mock('../../../../search/application/services', () => ({
+  searchLocationSuggestions: jest.fn(),
+}));
 
 jest.mock('../../../application/services', () => ({
   submissionsService: {
@@ -77,8 +92,10 @@ function getInputShellStyle(accessibilityLabel: string) {
 
 describe('SubmissionScreen', () => {
   beforeEach(() => {
+    jest.useRealTimers();
     jest.clearAllMocks();
     navigationRef.navigate = jest.fn();
+    (searchLocationSuggestions as jest.Mock).mockResolvedValue([]);
   });
 
   it('shows inline validation errors when required fields are missing', async () => {
@@ -190,6 +207,166 @@ describe('SubmissionScreen', () => {
     });
 
     expect(navigationRef.navigate).toHaveBeenCalledWith(ROUTES.FEED);
+  });
+
+  it('debounces story location search API calls by 300ms', async () => {
+    jest.useFakeTimers();
+    renderSubmissionScreen();
+
+    fireEvent.changeText(screen.getByLabelText('Search story location'), 'Ha');
+
+    act(() => {
+      jest.advanceTimersByTime(300);
+    });
+
+    expect(searchLocationSuggestions).not.toHaveBeenCalled();
+
+    fireEvent.changeText(screen.getByLabelText('Search story location'), 'Hag');
+
+    act(() => {
+      jest.advanceTimersByTime(299);
+    });
+
+    expect(searchLocationSuggestions).not.toHaveBeenCalled();
+
+    await act(async () => {
+      jest.advanceTimersByTime(1);
+    });
+
+    expect(searchLocationSuggestions).toHaveBeenCalledTimes(1);
+    expect(searchLocationSuggestions).toHaveBeenCalledWith('Hag');
+  });
+
+  it('updates submission coordinates and map marker when a location suggestion is selected', async () => {
+    jest.useFakeTimers();
+    (searchLocationSuggestions as jest.Mock).mockResolvedValue([
+      {
+        id: 'ayasofya',
+        title: 'Hagia Sophia',
+        subtitle: 'Sultanahmet, Istanbul, Turkiye',
+        latitude: 41.0086,
+        longitude: 28.9802,
+      },
+    ]);
+    (submissionsService.createStory as jest.Mock).mockResolvedValue({ id: 12 });
+
+    renderSubmissionScreen();
+
+    fireEvent.changeText(screen.getByLabelText('Search story location'), 'Hag');
+
+    await act(async () => {
+      jest.advanceTimersByTime(300);
+    });
+
+    fireEvent.press(await screen.findByLabelText('Select Hagia Sophia'));
+
+    expect(screen.getByTestId('story-location-map').props.region).toEqual(
+      expect.objectContaining({ latitude: 41.0086, longitude: 28.9802 }),
+    );
+    expect(screen.getByTestId('story-location-map').props.markers).toEqual([
+      expect.objectContaining({ latitude: 41.0086, longitude: 28.9802, selected: true }),
+    ]);
+
+    fireEvent.changeText(screen.getByLabelText('Story title'), 'The Dome');
+    fireEvent.changeText(screen.getByLabelText('Story narrative'), 'A story about the monument.');
+    fireEvent.changeText(screen.getByLabelText('Place name'), 'Hagia Sophia');
+    fireEvent.changeText(screen.getByLabelText('Year'), '537');
+    fireEvent.press(screen.getByText('Submit story'));
+
+    await waitFor(() => {
+      expect(submissionsService.createStory).toHaveBeenCalledWith(
+        expect.objectContaining({
+          location: { latitude: 41.0086, longitude: 28.9802 },
+        }),
+      );
+    });
+  });
+
+  it('shows suggestions again when a selected location query is focused', async () => {
+    jest.useFakeTimers();
+    (searchLocationSuggestions as jest.Mock)
+      .mockResolvedValueOnce([
+        {
+          id: 'istanbul-city',
+          title: 'Istanbul',
+          subtitle: 'Turkiye',
+          latitude: 41.0082,
+          longitude: 28.9784,
+        },
+      ])
+      .mockResolvedValueOnce([
+        {
+          id: 'istanbul-airport',
+          title: 'Istanbul Airport',
+          subtitle: 'Arnavutkoy, Istanbul, Turkiye',
+          latitude: 41.2619,
+          longitude: 28.7419,
+        },
+      ]);
+
+    renderSubmissionScreen();
+
+    fireEvent.changeText(screen.getByLabelText('Search story location'), 'Istanbul');
+
+    await act(async () => {
+      jest.advanceTimersByTime(300);
+    });
+
+    fireEvent.press(await screen.findByLabelText('Select Istanbul'));
+    expect(screen.queryByLabelText('Select Istanbul Airport')).toBeNull();
+
+    fireEvent(screen.getByLabelText('Search story location'), 'focus');
+
+    await waitFor(() => {
+      expect(searchLocationSuggestions).toHaveBeenCalledTimes(2);
+    });
+    expect(await screen.findByLabelText('Select Istanbul Airport')).toBeTruthy();
+  });
+
+  it('shows a graceful no results state for location autocomplete', async () => {
+    jest.useFakeTimers();
+    (searchLocationSuggestions as jest.Mock).mockResolvedValue([]);
+    renderSubmissionScreen();
+
+    fireEvent.changeText(screen.getByLabelText('Search story location'), 'zzzz');
+
+    await act(async () => {
+      jest.advanceTimersByTime(300);
+    });
+
+    expect(await screen.findByText('No results found.')).toBeTruthy();
+  });
+
+  it('handles location search errors while leaving manual map picking usable', async () => {
+    jest.useFakeTimers();
+    (searchLocationSuggestions as jest.Mock).mockRejectedValue(new Error('Network down'));
+    (submissionsService.createStory as jest.Mock).mockResolvedValue({ id: 12 });
+    renderSubmissionScreen();
+
+    fireEvent.changeText(screen.getByLabelText('Search story location'), 'Hag');
+
+    await act(async () => {
+      jest.advanceTimersByTime(300);
+    });
+
+    expect(await screen.findByText('Location search failed. You can still tap the map to place the pin.')).toBeTruthy();
+
+    fireEvent(screen.getByTestId('story-location-map'), 'press', {
+      nativeEvent: { coordinate: { latitude: 40.9901, longitude: 29.0292 } },
+    });
+    fireEvent.changeText(screen.getByLabelText('Story title'), 'Manual Pin');
+    fireEvent.changeText(screen.getByLabelText('Story narrative'), 'A story placed after search failed.');
+    fireEvent.changeText(screen.getByLabelText('Place name'), 'Kadikoy');
+    fireEvent.changeText(screen.getByLabelText('Year'), '1900');
+    fireEvent.press(screen.getByText('Submit story'));
+
+    await waitFor(() => {
+      expect(submissionsService.createStory).toHaveBeenCalledWith(
+        expect.objectContaining({
+          location: { latitude: 40.9901, longitude: 29.0292 },
+        }),
+      );
+    });
   });
 
   it('shows an inline image validation error for oversized uploads', async () => {

--- a/mobile/src/shared/components/FilterPanel.tsx
+++ b/mobile/src/shared/components/FilterPanel.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Pressable, Text, View } from 'react-native';
+import { ActivityIndicator, Pressable, Text, View } from 'react-native';
 import { useAppTheme } from '../../core/hooks/useAppTheme';
 import { Input } from '../ui/Input';
 
@@ -47,6 +47,9 @@ interface FilterPanelProps {
   onTimeToChange: (value: string) => void;
   onClearAll: () => void;
   onApply?: () => void;
+  isLocationResolving?: boolean;
+  locationStatusText?: string;
+  isApplyDisabled?: boolean;
 }
 
 export function FilterPanel({
@@ -58,6 +61,9 @@ export function FilterPanel({
   onTimeToChange,
   onClearAll,
   onApply,
+  isLocationResolving = false,
+  locationStatusText,
+  isApplyDisabled = false,
 }: FilterPanelProps) {
   const { colors, spacing, typography } = useAppTheme();
   const parsedTimeFrom = timeFrom ? Number(timeFrom) : undefined;
@@ -127,7 +133,21 @@ export function FilterPanel({
           onChangeText={onLocationChange}
           placeholder="Neighborhood, district, or city"
           accessibilityLabel="Location filter"
+          trailingElement={
+            isLocationResolving ? (
+              <ActivityIndicator
+                accessibilityLabel="Resolving location"
+                color={colors.primary}
+                size="small"
+              />
+            ) : undefined
+          }
         />
+        {locationStatusText ? (
+          <Text style={{ color: colors.muted, fontSize: typography.caption + 1 }}>
+            {locationStatusText}
+          </Text>
+        ) : null}
       </View>
 
       <View style={{ flexDirection: 'row', gap: spacing.sm }}>
@@ -229,12 +249,14 @@ export function FilterPanel({
           <Pressable
             accessibilityRole="button"
             accessibilityLabel="Apply filters"
+            disabled={isApplyDisabled}
             onPress={onApply}
             style={{
               paddingHorizontal: spacing.md,
               paddingVertical: spacing.sm,
               borderRadius: 999,
               backgroundColor: colors.primary,
+              opacity: isApplyDisabled ? 0.55 : 1,
             }}
           >
             <Text style={{ color: '#FFFFFF', fontWeight: '700' }}>Apply</Text>

--- a/mobile/src/shared/ui/Input/Input.tsx
+++ b/mobile/src/shared/ui/Input/Input.tsx
@@ -29,6 +29,7 @@ interface InputProps {
   blurOnSubmit?: TextInputProps['blurOnSubmit'];
   submitBehavior?: TextInputProps['submitBehavior'];
   onSubmitEditing?: TextInputProps['onSubmitEditing'];
+  onFocus?: TextInputProps['onFocus'];
   onBlur?: TextInputProps['onBlur'];
   trailingActionLabel?: string;
   trailingActionAccessibilityLabel?: string;
@@ -43,6 +44,7 @@ export const Input = forwardRef<TextInput, InputProps>(function Input({
   value,
   onChangeText,
   onSubmitEditing,
+  onFocus,
   onBlur,
   placeholder,
   secureTextEntry,
@@ -89,6 +91,7 @@ export const Input = forwardRef<TextInput, InputProps>(function Input({
         placeholderTextColor={colors.muted}
         onChangeText={onChangeText}
         onSubmitEditing={onSubmitEditing}
+        onFocus={onFocus}
         onBlur={onBlur}
         secureTextEntry={secureTextEntry}
         autoCapitalize={autoCapitalize}


### PR DESCRIPTION
# 📝 Description
Fixes #370 

Adds a debounced location autocomplete search bar to the mobile story submission location picker. Users can search addresses/points of interest, select a suggestion, and have the map update the selected pin coordinates automatically while preserving the existing manual tap-to-place-pin flow.

# 📊 Type of Change
- [ ]  Bug fix
- [x]  New feature
- [ ]  Refactoring
- [ ]  Documentation
 
# ✅ Acceptance Criteria / Checklist
- [x] Project builds successfully
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, especially in hard-to-understand parts
- [x] I have performed a self-review of my code
- [x] I have added/updated tests
- [x] New and existing unit tests pass locally with my changes

# 📸 Screenshots / Recordings
<!-- If applicable !-->

# ⏱️ Estimated Review Time
- [ ] < 5 min
- [x] 5-15 min
- [ ] > 15 min
