### PR TITLE
feat:geolocation-based-radius-filterin-mobile

### DIFF
--- a/mobile/app.json
+++ b/mobile/app.json
@@ -6,7 +6,16 @@
     "orientation": "portrait",
     "userInterfaceStyle": "automatic",
     "icon": "./assets/icons/storymap-icon.png",
+    "ios": {
+      "infoPlist": {
+        "NSLocationWhenInUseUsageDescription": "StoryMap uses your location to filter nearby stories."
+      }
+    },
     "android": {
+      "permissions": [
+        "ACCESS_COARSE_LOCATION",
+        "ACCESS_FINE_LOCATION"
+      ],
       "adaptiveIcon": {
         "foregroundImage": "./assets/icons/storymap-icon.png",
         "backgroundColor": "#111111"

--- a/mobile/jest.setup.ts
+++ b/mobile/jest.setup.ts
@@ -24,6 +24,22 @@ jest.mock('expo-image-picker', () => ({
   launchCameraAsync: jest.fn(async () => ({ canceled: true, assets: [] })),
 }));
 
+jest.mock('expo-location', () => ({
+  __esModule: true,
+  Accuracy: {
+    Balanced: 3,
+  },
+  requestForegroundPermissionsAsync: jest.fn(async () => ({ granted: true })),
+  hasServicesEnabledAsync: jest.fn(async () => true),
+  getCurrentPositionAsync: jest.fn(async () => ({
+    coords: {
+      latitude: 41.0082,
+      longitude: 28.9784,
+    },
+  })),
+  getLastKnownPositionAsync: jest.fn(async () => null),
+}));
+
 jest.mock('react-native-webview', () => {
   const React = require('react');
   const { View } = require('react-native');

--- a/mobile/package-lock.json
+++ b/mobile/package-lock.json
@@ -11,6 +11,7 @@
         "expo": "54.0.0",
         "expo-file-system": "~19.0.21",
         "expo-image-picker": "~17.0.10",
+        "expo-location": "~19.0.8",
         "lucide-react-native": "^1.7.0",
         "react": "19.1.0",
         "react-native": "0.81.4",
@@ -5487,6 +5488,15 @@
       "dependencies": {
         "expo-image-loader": "~6.0.0"
       },
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
+    "node_modules/expo-location": {
+      "version": "19.0.8",
+      "resolved": "https://registry.npmjs.org/expo-location/-/expo-location-19.0.8.tgz",
+      "integrity": "sha512-H/FI75VuJ1coodJbbMu82pf+Zjess8X8Xkiv9Bv58ZgPKS/2ztjC1YO1/XMcGz7+s9DrbLuMIw22dFuP4HqneA==",
+      "license": "MIT",
       "peerDependencies": {
         "expo": "*"
       }

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -15,6 +15,7 @@
     "expo": "54.0.0",
     "expo-file-system": "~19.0.21",
     "expo-image-picker": "~17.0.10",
+    "expo-location": "~19.0.8",
     "lucide-react-native": "^1.7.0",
     "react": "19.1.0",
     "react-native": "0.81.4",

--- a/mobile/src/core/services/deviceLocation.ts
+++ b/mobile/src/core/services/deviceLocation.ts
@@ -1,0 +1,39 @@
+import * as Location from 'expo-location';
+
+export interface DeviceCoordinates {
+  latitude: number;
+  longitude: number;
+}
+
+export type DeviceLocationResult =
+  | { status: 'granted'; coordinates: DeviceCoordinates }
+  | { status: 'denied' | 'unavailable' };
+
+export async function getCurrentDeviceCoordinates(): Promise<DeviceLocationResult> {
+  const permission = await Location.requestForegroundPermissionsAsync();
+
+  if (!permission.granted) {
+    return { status: 'denied' };
+  }
+
+  const servicesEnabled = await Location.hasServicesEnabledAsync();
+
+  if (!servicesEnabled) {
+    return { status: 'unavailable' };
+  }
+
+  const lastKnownPosition = await Location.getLastKnownPositionAsync();
+  const position =
+    lastKnownPosition ??
+    (await Location.getCurrentPositionAsync({
+      accuracy: Location.Accuracy.Balanced,
+    }));
+
+  return {
+    status: 'granted',
+    coordinates: {
+      latitude: position.coords.latitude,
+      longitude: position.coords.longitude,
+    },
+  };
+}

--- a/mobile/src/features/feed/data/sources/__tests__/feedRemoteSource.test.ts
+++ b/mobile/src/features/feed/data/sources/__tests__/feedRemoteSource.test.ts
@@ -67,6 +67,29 @@ describe('feedRemoteSource', () => {
     );
   });
 
+  it('sends proximity params when radius filtering is active', async () => {
+    const getSpy = jest.spyOn(apiClient, 'get').mockResolvedValue({
+      count: 0,
+      next: null,
+      previous: null,
+      results: [],
+    });
+
+    await feedRemoteSource.getFeed({
+      page: 1,
+      sort: 'recent',
+      filters: {
+        latitude: 41.0082,
+        longitude: 28.9784,
+        radiusKm: 10,
+      },
+    });
+
+    expect(getSpy).toHaveBeenCalledWith(
+      '/stories/feed/?page=1&page_size=10&sort_by=recent&latitude=41.0082&longitude=28.9784&radius_km=10',
+    );
+  });
+
   it('filters feed results by geocoded bounds when the backend ignores bbox params', async () => {
     jest.spyOn(apiClient, 'get').mockResolvedValue({
       count: 2,
@@ -102,6 +125,40 @@ describe('feedRemoteSource', () => {
       count: 1,
       next: null,
       results: [{ id: 2 }],
+    });
+  });
+
+  it('filters feed results by radius when the backend ignores proximity params', async () => {
+    jest.spyOn(apiClient, 'get').mockResolvedValue({
+      count: 2,
+      next: null,
+      previous: null,
+      results: [
+        {
+          id: 1,
+          location_lat: '41.0082',
+          location_lng: '28.9784',
+        },
+        {
+          id: 2,
+          location_lat: '39.9334',
+          location_lng: '32.8597',
+        },
+      ],
+    });
+
+    const response = await feedRemoteSource.getFeed({
+      filters: {
+        latitude: 41.0082,
+        longitude: 28.9784,
+        radiusKm: 1,
+      },
+    });
+
+    expect(response).toMatchObject({
+      count: 1,
+      next: null,
+      results: [{ id: 1 }],
     });
   });
 });

--- a/mobile/src/features/feed/data/sources/index.ts
+++ b/mobile/src/features/feed/data/sources/index.ts
@@ -34,13 +34,20 @@ export const feedRemoteSource = {
       results: [],
     };
 
+    const proximity = getProximityFilter(filters);
     const bounds = filters.locationBounds;
 
-    if (!bounds) {
+    if (!bounds && !proximity) {
       return response;
     }
 
-    const results = (response.results ?? []).filter((story) => isStoryWithinBounds(story, bounds));
+    const results = (response.results ?? []).filter((story) => {
+      if (proximity && !isStoryWithinRadius(story, proximity)) {
+        return false;
+      }
+
+      return bounds ? isStoryWithinBounds(story, bounds) : true;
+    });
 
     return {
       ...response,
@@ -77,6 +84,14 @@ function normalizeStoryFilters(filters: StoryFilters) {
     params.lng_max = filters.locationBounds.lngMax;
   } else if (filters.location?.trim()) {
     params.location = filters.location.trim();
+  }
+
+  const proximity = getProximityFilter(filters);
+
+  if (proximity) {
+    params.latitude = proximity.latitude;
+    params.longitude = proximity.longitude;
+    params.radius_km = proximity.radiusKm;
   }
 
   return params;
@@ -129,4 +144,60 @@ function asNumber(value: unknown) {
   }
 
   return undefined;
+}
+
+function hasProximityFilter(filters: StoryFilters) {
+  return (
+    filters.latitude !== undefined &&
+    filters.longitude !== undefined &&
+    filters.radiusKm !== undefined
+  );
+}
+
+function getProximityFilter(filters: StoryFilters) {
+  if (!hasProximityFilter(filters)) {
+    return undefined;
+  }
+
+  return {
+    latitude: filters.latitude as number,
+    longitude: filters.longitude as number,
+    radiusKm: filters.radiusKm as number,
+  };
+}
+
+function isStoryWithinRadius(
+  story: unknown,
+  proximity: { latitude: number; longitude: number; radiusKm: number },
+) {
+  if (!story || typeof story !== 'object') {
+    return false;
+  }
+
+  const record = story as Record<string, unknown>;
+  const latitude = asNumber(record.location_lat);
+  const longitude = asNumber(record.location_lng);
+
+  if (latitude === undefined || longitude === undefined) {
+    return false;
+  }
+
+  return haversineKm(proximity.latitude, proximity.longitude, latitude, longitude) <= proximity.radiusKm;
+}
+
+function haversineKm(startLat: number, startLng: number, endLat: number, endLng: number) {
+  const earthRadiusKm = 6371;
+  const deltaLat = toRadians(endLat - startLat);
+  const deltaLng = toRadians(endLng - startLng);
+  const startLatRad = toRadians(startLat);
+  const endLatRad = toRadians(endLat);
+  const a =
+    Math.sin(deltaLat / 2) ** 2 +
+    Math.cos(startLatRad) * Math.cos(endLatRad) * Math.sin(deltaLng / 2) ** 2;
+
+  return 2 * earthRadiusKm * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+}
+
+function toRadians(value: number) {
+  return (value * Math.PI) / 180;
 }

--- a/mobile/src/features/feed/presentation/screens/FeedScreen.tsx
+++ b/mobile/src/features/feed/presentation/screens/FeedScreen.tsx
@@ -73,7 +73,11 @@ export function FeedScreen({
   );
 
   const hasActiveFilters = Boolean(
-    activeFilters.q || activeFilters.location || activeFilters.yearFrom || activeFilters.yearTo,
+    activeFilters.q ||
+      activeFilters.location ||
+      activeFilters.yearFrom ||
+      activeFilters.yearTo ||
+      activeFilters.radiusKm,
   );
 
   const loadPage = useCallback(
@@ -261,6 +265,11 @@ function toSearchState(filters: StoryFilters): SearchFiltersState {
     query: filters.q ?? '',
     location: filters.location ?? '',
     locationBounds: filters.locationBounds,
+    proximityRadiusKm: filters.radiusKm === 1 || filters.radiusKm === 10 || filters.radiusKm === 100 ? filters.radiusKm : undefined,
+    proximityCoordinates:
+      filters.latitude !== undefined && filters.longitude !== undefined
+        ? { latitude: filters.latitude, longitude: filters.longitude }
+        : undefined,
     timeFrom: filters.yearFrom ? String(filters.yearFrom) : '',
     timeTo: filters.yearTo ? String(filters.yearTo) : '',
   };
@@ -268,9 +277,10 @@ function toSearchState(filters: StoryFilters): SearchFiltersState {
 
 function hasAnySearchFilters(filters: SearchFiltersState) {
   return Boolean(
-    filters.query.trim() ||
+      filters.query.trim() ||
       filters.location.trim() ||
       filters.locationBounds ||
+      filters.proximityRadiusKm ||
       filters.timeFrom.trim() ||
       filters.timeTo.trim(),
   );
@@ -281,6 +291,8 @@ function areSearchStatesEqual(left: SearchFiltersState, right: SearchFiltersStat
     left.query === right.query &&
     left.location === right.location &&
     JSON.stringify(left.locationBounds) === JSON.stringify(right.locationBounds) &&
+    left.proximityRadiusKm === right.proximityRadiusKm &&
+    JSON.stringify(left.proximityCoordinates) === JSON.stringify(right.proximityCoordinates) &&
     left.timeFrom === right.timeFrom &&
     left.timeTo === right.timeTo
   );

--- a/mobile/src/features/feed/presentation/screens/__tests__/FeedScreen.test.tsx
+++ b/mobile/src/features/feed/presentation/screens/__tests__/FeedScreen.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react-native';
+import * as Location from 'expo-location';
 import { FeedScreen } from '../FeedScreen';
 import { FeedPageEntity } from '../../../domain/entities';
 import { SearchFiltersProvider } from '../../../../search/presentation/context/SearchFiltersContext';
@@ -37,6 +38,15 @@ function makeFeedPage(overrides: Partial<FeedPageEntity> = {}): FeedPageEntity {
 describe('FeedScreen', () => {
   beforeEach(async () => {
     (geocodeLocationQuery as jest.Mock).mockResolvedValue(null);
+    jest.mocked(Location.requestForegroundPermissionsAsync).mockResolvedValue({ granted: true } as never);
+    jest.mocked(Location.hasServicesEnabledAsync).mockResolvedValue(true);
+    jest.mocked(Location.getLastKnownPositionAsync).mockResolvedValue(null);
+    jest.mocked(Location.getCurrentPositionAsync).mockResolvedValue({
+      coords: {
+        latitude: 41.0082,
+        longitude: 28.9784,
+      },
+    } as never);
     await storage.clear();
   });
 
@@ -205,7 +215,7 @@ describe('FeedScreen', () => {
     expect(screen.getByLabelText('Remove To: 1950')).toBeTruthy();
   });
 
-  it('applies the default year filters when submitted unchanged', async () => {
+  it('does not apply placeholder year filters when submitted unchanged', async () => {
     const getFeed = jest.fn<Promise<FeedPageEntity>, [any]>().mockResolvedValue(makeFeedPage());
 
     renderScreen(<FeedScreen getFeed={getFeed} />);
@@ -221,11 +231,102 @@ describe('FeedScreen', () => {
         filters: {
           q: undefined,
           location: undefined,
-          yearFrom: 1980,
-          yearTo: 2026,
+          yearFrom: undefined,
+          yearTo: undefined,
         },
       });
     });
+  });
+
+  it('applies proximity filters with current coordinates', async () => {
+    const getFeed = jest.fn<Promise<FeedPageEntity>, [any]>().mockResolvedValue(makeFeedPage());
+
+    renderScreen(<FeedScreen getFeed={getFeed} />);
+
+    await screen.findByText('Story 1');
+    fireEvent.press(screen.getByText('Show filters'));
+    fireEvent.press(screen.getByLabelText('Distance 10 km'));
+
+    expect(await screen.findByText('Filtering within 10 km of 41.0082, 28.9784.')).toBeTruthy();
+    fireEvent.press(screen.getByLabelText('Apply filters'));
+
+    await waitFor(() => {
+      expect(getFeed).toHaveBeenLastCalledWith({
+        page: 1,
+        sort: 'recent',
+        filters: {
+          q: undefined,
+          location: undefined,
+          locationBounds: undefined,
+          latitude: 41.0082,
+          longitude: 28.9784,
+          radiusKm: 10,
+          yearFrom: undefined,
+          yearTo: undefined,
+        },
+      });
+    });
+
+    expect(screen.getByLabelText('Remove Distance: 10 km')).toBeTruthy();
+  });
+
+  it('shows loading feedback while current location is fetched', async () => {
+    const getFeed = jest.fn<Promise<FeedPageEntity>, [any]>().mockResolvedValue(makeFeedPage());
+    jest.mocked(Location.getCurrentPositionAsync).mockReturnValue(new Promise(() => undefined) as never);
+
+    renderScreen(<FeedScreen getFeed={getFeed} />);
+
+    await screen.findByText('Story 1');
+    fireEvent.press(screen.getByText('Show filters'));
+    fireEvent.press(screen.getByLabelText('Distance 1 km'));
+
+    expect(await screen.findByText('Fetching your current location...')).toBeTruthy();
+    expect(screen.getByLabelText('Fetching current location')).toBeTruthy();
+    expect(screen.getByLabelText('Apply filters').props.accessibilityState.disabled).toBe(true);
+  });
+
+  it('shows an error when location permission is denied', async () => {
+    const getFeed = jest.fn<Promise<FeedPageEntity>, [any]>().mockResolvedValue(makeFeedPage());
+    jest.mocked(Location.requestForegroundPermissionsAsync).mockResolvedValueOnce({ granted: false } as never);
+
+    renderScreen(<FeedScreen getFeed={getFeed} />);
+
+    await screen.findByText('Story 1');
+    fireEvent.press(screen.getByText('Show filters'));
+    fireEvent.press(screen.getByLabelText('Distance 100 km'));
+
+    expect(await screen.findByText('Location disabled. Enable location permission to use proximity filtering.')).toBeTruthy();
+    expect(screen.getByLabelText('Apply filters').props.accessibilityState.disabled).toBe(true);
+  });
+
+  it('clears proximity filter state when the filter form is reset', async () => {
+    const getFeed = jest.fn<Promise<FeedPageEntity>, [any]>().mockResolvedValue(makeFeedPage());
+
+    renderScreen(<FeedScreen getFeed={getFeed} />);
+
+    await screen.findByText('Story 1');
+    fireEvent.press(screen.getByText('Show filters'));
+    fireEvent.press(screen.getByLabelText('Distance 10 km'));
+    expect(await screen.findByText('Filtering within 10 km of 41.0082, 28.9784.')).toBeTruthy();
+
+    fireEvent.press(screen.getByText('Reset filter form'));
+    fireEvent.press(screen.getByLabelText('Apply filters'));
+
+    await waitFor(() => {
+      expect(getFeed).toHaveBeenLastCalledWith({
+        page: 1,
+        sort: 'recent',
+        filters: {
+          q: undefined,
+          location: undefined,
+          locationBounds: undefined,
+          yearFrom: undefined,
+          yearTo: undefined,
+        },
+      });
+    });
+
+    expect(screen.queryByLabelText('Remove Distance: 10 km')).toBeNull();
   });
 
   it('closes the filter panel when tapping outside of it', async () => {
@@ -266,8 +367,8 @@ describe('FeedScreen', () => {
           q: 'harbor',
           location: undefined,
           locationBounds: undefined,
-          yearFrom: 1980,
-          yearTo: 2026,
+          yearFrom: undefined,
+          yearTo: undefined,
         },
       });
     });

--- a/mobile/src/features/map/presentation/components/MapCard.tsx
+++ b/mobile/src/features/map/presentation/components/MapCard.tsx
@@ -37,7 +37,7 @@ export function MapCard({
   onPreviewLayout,
 }: MapCardProps) {
   const { colors, spacing, typography } = useAppTheme();
-  const selectedMarker = markers.find((marker) => marker.id === selectedMarkerId) ?? markers[0];
+  const selectedMarker = selectedMarkerId ? markers.find((marker) => marker.id === selectedMarkerId) : undefined;
   const [currentRegion, setCurrentRegion] = useState(region);
   const mapContentKey = useMemo(
     () => (markers.length ? markers.map((marker) => `${marker.id}:${marker.latitude}:${marker.longitude}`).join('|') : 'empty'),
@@ -174,7 +174,9 @@ export function MapCard({
         </Text>
 
         {!selectedMarker ? (
-          <Text style={{ color: colors.muted }}>No stories match the current filters.</Text>
+          <Text style={{ color: colors.muted }}>
+            {markers.length ? 'Select a story marker to preview.' : 'No stories match the current filters.'}
+          </Text>
         ) : selectedMarker.isCluster ? (
           <ScrollView
             style={{ maxHeight: 240 }}

--- a/mobile/src/features/map/presentation/screens/MapScreen.tsx
+++ b/mobile/src/features/map/presentation/screens/MapScreen.tsx
@@ -75,7 +75,11 @@ export function MapScreen({
   );
 
   const hasActiveFilters = Boolean(
-    activeFilters.q || activeFilters.location || activeFilters.yearFrom || activeFilters.yearTo,
+    activeFilters.q ||
+      activeFilters.location ||
+      activeFilters.yearFrom ||
+      activeFilters.yearTo ||
+      activeFilters.radiusKm,
   );
 
   const loadMarkers = React.useCallback(async () => {
@@ -148,6 +152,14 @@ export function MapScreen({
     if (state.filters.yearFrom || state.filters.yearTo) {
       parts.push(`Years: ${state.filters.yearFrom ?? 'Any'}-${state.filters.yearTo ?? 'Any'}`);
     }
+    if (state.filters.radiusKm) {
+      const coordinates =
+        state.filters.latitude !== undefined && state.filters.longitude !== undefined
+          ? ` from ${state.filters.latitude.toFixed(4)}, ${state.filters.longitude.toFixed(4)}`
+          : '';
+
+      parts.push(`Distance: ${state.filters.radiusKm} km${coordinates}`);
+    }
 
     return parts;
   }, [state.filters]);
@@ -158,9 +170,10 @@ export function MapScreen({
   );
 
   const mapRegion = useMemo(
-    () => (hasActiveFilters ? getRegionForMarkers(state.markers, ISTANBUL_REGION) : ISTANBUL_REGION),
-    [hasActiveFilters, state.markers],
+    () => getRegionForMarkers(state.markers, ISTANBUL_REGION),
+    [state.markers],
   );
+  const fitToMarkers = state.markers.length > 0 && (!state.selectedMarkerId || hasActiveFilters);
 
   const statusStoryCount = useMemo(() => {
     if (statusIndicatorMode !== 'area' || !hasInteractedWithArea || !visibleRegion) {
@@ -225,7 +238,7 @@ export function MapScreen({
           isLoading={state.isLoading}
           error={state.error}
           statusBadgeText={statusBadgeText}
-          fitToMarkers={hasActiveFilters}
+          fitToMarkers={fitToMarkers}
           onSelectMarker={(markerId) => setState((current) => ({ ...current, selectedMarkerId: markerId }))}
           onOpenStory={(storyId) => onOpenStory?.(storyId)}
           onMarkerPress={handleMarkerPreviewRequest}
@@ -250,7 +263,7 @@ function getPreferredMarkerId(markers: MapMarkerGroup[], filters: StoryFilters) 
   const locationTerm = filters.location?.trim().toLowerCase();
 
   if (!searchTerm && !locationTerm) {
-    return markers[0]?.id;
+    return undefined;
   }
 
   const scoredMarkers = markers

--- a/mobile/src/features/map/presentation/screens/__tests__/MapScreen.test.tsx
+++ b/mobile/src/features/map/presentation/screens/__tests__/MapScreen.test.tsx
@@ -134,10 +134,13 @@ describe('MapScreen', () => {
 
     expect(screen.getByLabelText('Loading map pins')).toBeTruthy();
     expect(await screen.findByTestId('story-map')).toBeTruthy();
-    expect(screen.getByTestId('map-region-props').props.accessibilityLabel).toContain('region:41.0082:28.9784:0.32:0.48');
     await waitFor(() => {
       expect(screen.getAllByTestId('story-marker')).toHaveLength(2);
     });
+    await waitFor(() => {
+      expect(screen.getByTestId('map-region-props').props.accessibilityLabel).toContain('region:41.0192:28.96735:0.06:0.06');
+    });
+    expect(screen.getByText('Select a story marker to preview.')).toBeTruthy();
   });
 
   it('shows the selected marker preview and navigates to story detail', async () => {
@@ -145,6 +148,8 @@ describe('MapScreen', () => {
 
     renderScreen(<MapScreen getMarkerGroups={async () => markerGroups} onOpenStory={onOpenStory} />);
 
+    await screen.findByText('Select a story marker to preview.');
+    fireEvent.press(screen.getAllByTestId('story-marker')[0]);
     expect(await screen.findByText('The Day the Harbor Fell Silent')).toBeTruthy();
     fireEvent.press(screen.getByText('Read full story'));
 
@@ -154,7 +159,7 @@ describe('MapScreen', () => {
   it('shows nearby stories when a clustered marker is pressed', async () => {
     renderScreen(<MapScreen getMarkerGroups={async () => markerGroups} />);
 
-    await screen.findByText('The Day the Harbor Fell Silent');
+    await screen.findByText('Select a story marker to preview.');
     fireEvent.press(screen.getAllByTestId('story-marker')[1]);
 
     await waitFor(() => {
@@ -174,7 +179,7 @@ describe('MapScreen', () => {
       />,
     );
 
-    await screen.findByText('The Day the Harbor Fell Silent');
+    await screen.findByText('Select a story marker to preview.');
     fireEvent(screen.getByTestId('map-card-container'), 'layout', {
       nativeEvent: { layout: { x: 0, y: 240, width: 100, height: 100 } },
     });
@@ -191,7 +196,7 @@ describe('MapScreen', () => {
 
     renderScreen(<MapScreen getMarkerGroups={getMarkerGroups} />);
 
-    await screen.findByText('The Day the Harbor Fell Silent');
+    await screen.findByText('Select a story marker to preview.');
     fireEvent.changeText(screen.getByLabelText('Search stories'), 'harbor');
 
     await waitFor(() => {
@@ -213,7 +218,7 @@ describe('MapScreen', () => {
       />,
     );
 
-    await screen.findByText('The Day the Harbor Fell Silent');
+    await screen.findByText('Select a story marker to preview.');
     fireEvent.changeText(screen.getByLabelText('Search stories'), 'harbor');
 
     expect(await screen.findByText('1 story found in this area')).toBeTruthy();
@@ -223,7 +228,7 @@ describe('MapScreen', () => {
   it('fits the map to all matched stories after a search', async () => {
     renderScreen(<MapScreen getMarkerGroups={async () => markerGroups} />);
 
-    await screen.findByText('The Day the Harbor Fell Silent');
+    await screen.findByText('Select a story marker to preview.');
     fireEvent.changeText(screen.getByLabelText('Search stories'), 'market');
 
     await waitFor(() => {
@@ -244,12 +249,12 @@ describe('MapScreen', () => {
     expect(await screen.findByText('Place could not be found')).toBeTruthy();
   });
 
-  it('applies the default year filters when submitted unchanged', async () => {
+  it('does not apply placeholder year filters when submitted unchanged', async () => {
     const getMarkerGroups = jest.fn<Promise<MapMarkerGroup[]>, [any]>().mockResolvedValue(markerGroups);
 
     renderScreen(<MapScreen getMarkerGroups={getMarkerGroups} />);
 
-    await screen.findByText('The Day the Harbor Fell Silent');
+    await screen.findByText('Select a story marker to preview.');
     fireEvent.press(screen.getByText('Show filters'));
     fireEvent.press(screen.getByLabelText('Apply filters'));
 
@@ -257,8 +262,8 @@ describe('MapScreen', () => {
       expect(getMarkerGroups).toHaveBeenLastCalledWith({
         q: undefined,
         location: undefined,
-        yearFrom: 1980,
-        yearTo: 2026,
+        yearFrom: undefined,
+        yearTo: undefined,
       });
     });
   });
@@ -272,7 +277,7 @@ describe('MapScreen', () => {
       />,
     );
 
-    await screen.findByText('The Day the Harbor Fell Silent');
+    await screen.findByText('Select a story marker to preview.');
     fireEvent.changeText(screen.getByLabelText('Search stories'), 'harbor');
     expect(await screen.findByText('1 story found in this area')).toBeTruthy();
 
@@ -286,7 +291,7 @@ describe('MapScreen', () => {
   it('updates the badge when the visible map area changes', async () => {
     renderScreen(<MapScreen getMarkerGroups={async () => markerGroups} />);
 
-    await screen.findByText('The Day the Harbor Fell Silent');
+    await screen.findByText('Select a story marker to preview.');
     fireEvent.press(screen.getByTestId('map-region-empty'));
 
     expect(await screen.findByText('No stories found in this area')).toBeTruthy();
@@ -301,7 +306,7 @@ describe('MapScreen', () => {
 
     renderScreen(<MapScreen getMarkerGroups={getMarkerGroups} />);
 
-    await screen.findByText('The Day the Harbor Fell Silent');
+    await screen.findByText('Select a story marker to preview.');
     fireEvent.press(screen.getByText('Show filters'));
     fireEvent.changeText(screen.getByLabelText('Location filter'), 'Golden Horn');
     expect(await screen.findByText('No map match found. Apply will search story place names instead.')).toBeTruthy();
@@ -311,8 +316,8 @@ describe('MapScreen', () => {
       expect(getMarkerGroups).toHaveBeenLastCalledWith({
         q: undefined,
         location: 'Golden Horn',
-        yearFrom: 1980,
-        yearTo: 2026,
+        yearFrom: undefined,
+        yearTo: undefined,
       });
     });
 
@@ -322,8 +327,8 @@ describe('MapScreen', () => {
       expect(getMarkerGroups).toHaveBeenLastCalledWith({
         q: undefined,
         location: undefined,
-        yearFrom: 1980,
-        yearTo: 2026,
+        yearFrom: undefined,
+        yearTo: undefined,
       });
     });
   });
@@ -333,7 +338,7 @@ describe('MapScreen', () => {
 
     renderScreen(<MapScreen getMarkerGroups={getMarkerGroups} />);
 
-    await screen.findByText('The Day the Harbor Fell Silent');
+    await screen.findByText('Select a story marker to preview.');
     fireEvent.press(screen.getByText('Show filters'));
     fireEvent.changeText(screen.getByLabelText('Location filter'), 'Golden Horn');
     expect(await screen.findByText('No map match found. Apply will search story place names instead.')).toBeTruthy();
@@ -343,8 +348,8 @@ describe('MapScreen', () => {
       expect(getMarkerGroups).toHaveBeenLastCalledWith({
         q: undefined,
         location: 'Golden Horn',
-        yearFrom: 1980,
-        yearTo: 2026,
+        yearFrom: undefined,
+        yearTo: undefined,
       });
     });
 

--- a/mobile/src/features/search/presentation/components/StorySearchControls.tsx
+++ b/mobile/src/features/search/presentation/components/StorySearchControls.tsx
@@ -1,8 +1,12 @@
 import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { Modal, Pressable, Text, View } from 'react-native';
 import { useAppTheme } from '../../../../core/hooks/useAppTheme';
+import { DeviceCoordinates, getCurrentDeviceCoordinates } from '../../../../core/services/deviceLocation';
 import { useDebounce } from '../../../../shared/hooks/useDebounce';
-import { DEFAULT_FROM_YEAR, DEFAULT_TO_YEAR, FilterPanel } from '../../../../shared/components/FilterPanel';
+import {
+  FilterPanel,
+  ProximityRadiusOption,
+} from '../../../../shared/components/FilterPanel';
 import { FilterChipItem, FilterChips } from '../../../../shared/components/FilterChips';
 import { SearchInput } from '../../../../shared/components/SearchInput';
 import { geocodeLocationQuery, LocationBounds } from '../../application/services';
@@ -19,6 +23,10 @@ function buildChips(
 
   if (filters.location.trim()) {
     chips.push({ key: 'location', label: `Location: ${filters.location.trim()}` });
+  }
+
+  if (filters.proximityRadiusKm && filters.proximityCoordinates) {
+    chips.push({ key: 'proximityRadiusKm', label: `Distance: ${filters.proximityRadiusKm} km` });
   }
 
   if (filters.timeFrom.trim()) {
@@ -46,10 +54,16 @@ export function StorySearchControls({ helperText, hideHeading = false, scope }: 
   const [draftLocationBounds, setDraftLocationBounds] = useState<LocationBounds | undefined>();
   const [isLocationResolving, setIsLocationResolving] = useState(false);
   const [locationStatusText, setLocationStatusText] = useState<string | undefined>();
-  const [draftTimeFrom, setDraftTimeFrom] = useState(DEFAULT_FROM_YEAR);
-  const [draftTimeTo, setDraftTimeTo] = useState(DEFAULT_TO_YEAR);
+  const [draftProximityRadiusKm, setDraftProximityRadiusKm] = useState<ProximityRadiusOption | undefined>();
+  const [draftProximityCoordinates, setDraftProximityCoordinates] = useState<DeviceCoordinates | undefined>();
+  const [isProximityResolving, setIsProximityResolving] = useState(false);
+  const [proximityStatusText, setProximityStatusText] = useState<string | undefined>();
+  const [isProximityError, setIsProximityError] = useState(false);
+  const [draftTimeFrom, setDraftTimeFrom] = useState('');
+  const [draftTimeTo, setDraftTimeTo] = useState('');
   const debouncedDraftLocation = useDebounce(draftLocation, 500);
   const locationRequestIdRef = useRef(0);
+  const proximityRequestIdRef = useRef(0);
 
   const chips = useMemo(() => buildChips(filters), [filters]);
 
@@ -58,8 +72,15 @@ export function StorySearchControls({ helperText, hideHeading = false, scope }: 
     setDraftLocationBounds(filters.locationBounds);
     setLocationStatusText(undefined);
     setIsLocationResolving(false);
-    setDraftTimeFrom(filters.timeFrom || DEFAULT_FROM_YEAR);
-    setDraftTimeTo(filters.timeTo || DEFAULT_TO_YEAR);
+    setDraftProximityRadiusKm(filters.proximityRadiusKm);
+    setDraftProximityCoordinates(filters.proximityCoordinates);
+    setProximityStatusText(
+      filters.proximityRadiusKm && filters.proximityCoordinates ? 'Using your current location.' : undefined,
+    );
+    setIsProximityError(false);
+    setIsProximityResolving(false);
+    setDraftTimeFrom(filters.timeFrom);
+    setDraftTimeTo(filters.timeTo);
     setShowFilters(true);
   };
 
@@ -68,6 +89,47 @@ export function StorySearchControls({ helperText, hideHeading = false, scope }: 
     setDraftLocationBounds(undefined);
     setLocationStatusText(undefined);
     setIsLocationResolving(location.trim().length > 0);
+  };
+
+  const handleProximityRadiusChange = async (radiusKm?: ProximityRadiusOption) => {
+    const requestId = proximityRequestIdRef.current + 1;
+    proximityRequestIdRef.current = requestId;
+    setDraftProximityRadiusKm(radiusKm);
+    setIsProximityError(false);
+
+    if (!radiusKm) {
+      setDraftProximityCoordinates(undefined);
+      setIsProximityResolving(false);
+      setProximityStatusText(undefined);
+      return;
+    }
+
+    setDraftProximityCoordinates(undefined);
+    setIsProximityResolving(true);
+    setProximityStatusText('Fetching your current location...');
+
+    const result = await getCurrentDeviceCoordinates();
+
+    if (proximityRequestIdRef.current !== requestId) {
+      return;
+    }
+
+    setIsProximityResolving(false);
+
+    if (result.status === 'granted') {
+      setDraftProximityCoordinates(result.coordinates);
+      setProximityStatusText(
+        `Filtering within ${radiusKm} km of ${result.coordinates.latitude.toFixed(4)}, ${result.coordinates.longitude.toFixed(4)}.`,
+      );
+      return;
+    }
+
+    setIsProximityError(true);
+    setProximityStatusText(
+      result.status === 'denied'
+        ? 'Location disabled. Enable location permission to use proximity filtering.'
+        : 'Current location is unavailable. Try again or choose Anywhere.',
+    );
   };
 
   useEffect(() => {
@@ -171,21 +233,32 @@ export function StorySearchControls({ helperText, hideHeading = false, scope }: 
               onLocationChange={handleDraftLocationChange}
               onTimeFromChange={setDraftTimeFrom}
               onTimeToChange={setDraftTimeTo}
+              proximityRadiusKm={draftProximityRadiusKm}
+              onProximityRadiusChange={handleProximityRadiusChange}
+              isProximityResolving={isProximityResolving}
+              proximityStatusText={proximityStatusText}
+              isProximityError={isProximityError}
               isLocationResolving={isLocationResolving}
               locationStatusText={locationStatusText}
-              isApplyDisabled={isLocationResolving}
+              isApplyDisabled={isLocationResolving || isProximityResolving || Boolean(draftProximityRadiusKm && !draftProximityCoordinates)}
               onClearAll={() => {
                 setDraftLocation('');
                 setDraftLocationBounds(undefined);
                 setLocationStatusText(undefined);
-                setDraftTimeFrom(DEFAULT_FROM_YEAR);
-                setDraftTimeTo(DEFAULT_TO_YEAR);
+                setDraftProximityRadiusKm(undefined);
+                setDraftProximityCoordinates(undefined);
+                setProximityStatusText(undefined);
+                setIsProximityError(false);
+                setDraftTimeFrom('');
+                setDraftTimeTo('');
                 clearFilters();
               }}
               onApply={() => {
                 updateFilters({
                   location: draftLocation,
                   locationBounds: draftLocation.trim() ? draftLocationBounds : undefined,
+                  proximityRadiusKm: draftProximityRadiusKm,
+                  proximityCoordinates: draftProximityRadiusKm ? draftProximityCoordinates : undefined,
                   timeFrom: draftTimeFrom,
                   timeTo: draftTimeTo,
                 }, { refresh: true });

--- a/mobile/src/features/search/presentation/context/SearchFiltersContext.tsx
+++ b/mobile/src/features/search/presentation/context/SearchFiltersContext.tsx
@@ -5,11 +5,19 @@ import { StoryFilters } from '../../../stories/domain/repositories';
 import { LocationBounds } from '../../application/services';
 
 export type SearchFilterScope = 'feed' | 'map' | 'main';
+export type ProximityRadiusKm = 1 | 10 | 100;
+
+export interface ProximityCoordinates {
+  latitude: number;
+  longitude: number;
+}
 
 export interface SearchFiltersState {
   query: string;
   location: string;
   locationBounds?: LocationBounds;
+  proximityRadiusKm?: ProximityRadiusKm;
+  proximityCoordinates?: ProximityCoordinates;
   timeFrom: string;
   timeTo: string;
 }
@@ -29,6 +37,8 @@ const initialFilters: SearchFiltersState = {
   query: '',
   location: '',
   locationBounds: undefined,
+  proximityRadiusKm: undefined,
+  proximityCoordinates: undefined,
   timeFrom: '',
   timeTo: '',
 };
@@ -139,6 +149,8 @@ export function SearchFiltersProvider({ children }: PropsWithChildren) {
             ...currentFilters,
             [key]: '',
             ...(key === 'location' ? { locationBounds: undefined } : {}),
+            ...(key === 'proximityRadiusKm' ? { proximityRadiusKm: undefined, proximityCoordinates: undefined } : {}),
+            ...(key === 'proximityCoordinates' ? { proximityRadiusKm: undefined, proximityCoordinates: undefined } : {}),
           }),
           { refresh: true },
         );
@@ -192,13 +204,21 @@ export function toSearchParams(filters: SearchFiltersState): StoryFilters {
   const yearTo =
     yearToCandidate !== undefined && yearFrom !== undefined && yearToCandidate < yearFrom ? undefined : yearToCandidate;
 
-  return {
+  const params: StoryFilters = {
     q: filters.query.trim() || undefined,
     location: filters.location.trim() || undefined,
     locationBounds: filters.locationBounds,
     yearFrom,
     yearTo,
   };
+
+  if (filters.proximityRadiusKm && filters.proximityCoordinates) {
+    params.latitude = filters.proximityCoordinates.latitude;
+    params.longitude = filters.proximityCoordinates.longitude;
+    params.radiusKm = filters.proximityRadiusKm;
+  }
+
+  return params;
 }
 
 function normalizeStoredFilters(filters?: Partial<SearchFiltersState> | null): SearchFiltersState {
@@ -206,8 +226,31 @@ function normalizeStoredFilters(filters?: Partial<SearchFiltersState> | null): S
     query: filters?.query ?? '',
     location: filters?.location ?? '',
     locationBounds: normalizeLocationBounds(filters?.locationBounds),
+    proximityRadiusKm: normalizeProximityRadius(filters?.proximityRadiusKm),
+    proximityCoordinates: normalizeProximityCoordinates(filters?.proximityCoordinates),
     timeFrom: filters?.timeFrom ?? '',
     timeTo: filters?.timeTo ?? '',
+  };
+}
+
+function normalizeProximityRadius(radius?: number | null): ProximityRadiusKm | undefined {
+  return radius === 1 || radius === 10 || radius === 100 ? radius : undefined;
+}
+
+function normalizeProximityCoordinates(coordinates?: ProximityCoordinates | null): ProximityCoordinates | undefined {
+  if (!coordinates) {
+    return undefined;
+  }
+
+  const { latitude, longitude } = coordinates;
+
+  if (![latitude, longitude].every(Number.isFinite)) {
+    return undefined;
+  }
+
+  return {
+    latitude,
+    longitude,
   };
 }
 

--- a/mobile/src/features/stories/data/sources/__tests__/storiesRemoteSource.test.ts
+++ b/mobile/src/features/stories/data/sources/__tests__/storiesRemoteSource.test.ts
@@ -136,6 +136,28 @@ describe('storiesRemoteSource', () => {
     );
   });
 
+  it('passes proximity params to the map endpoint', async () => {
+    const getSpy = jest.spyOn(apiClient, 'get').mockResolvedValue({
+      type: 'FeatureCollection',
+      features: [],
+    });
+
+    await storiesRemoteSource.getMapFeatureCollectionFromApi({
+      latitude: 41.0082,
+      longitude: 28.9784,
+      radiusKm: 10,
+    });
+
+    expect(getSpy).toHaveBeenCalledWith(
+      '/stories/map/?latitude=41.0082&longitude=28.9784&radius_km=10',
+      {
+        headers: {
+          Accept: 'application/geo+json, application/json',
+        },
+      },
+    );
+  });
+
   it('filters map features by geocoded bounds when the backend ignores bbox params', async () => {
     jest.spyOn(apiClient, 'get').mockResolvedValue({
       type: 'FeatureCollection',
@@ -181,5 +203,48 @@ describe('storiesRemoteSource', () => {
 
     expect(result.features).toHaveLength(1);
     expect(result.features[0]).toMatchObject({ id: 2 });
+  });
+
+  it('filters map features by radius when the backend ignores proximity params', async () => {
+    jest.spyOn(apiClient, 'get').mockResolvedValue({
+      type: 'FeatureCollection',
+      features: [
+        {
+          type: 'Feature',
+          id: 1,
+          geometry: {
+            type: 'Point',
+            coordinates: [28.9784, 41.0082],
+          },
+          properties: {
+            title: 'Nearby Story',
+            location_name: 'Istanbul',
+            preview_text: 'Nearby.',
+          },
+        },
+        {
+          type: 'Feature',
+          id: 2,
+          geometry: {
+            type: 'Point',
+            coordinates: [32.8597, 39.9334],
+          },
+          properties: {
+            title: 'Far Story',
+            location_name: 'Ankara',
+            preview_text: 'Far away.',
+          },
+        },
+      ],
+    });
+
+    const result = await storiesRemoteSource.getMapFeatureCollectionFromApi({
+      latitude: 41.0082,
+      longitude: 28.9784,
+      radiusKm: 1,
+    });
+
+    expect(result.features).toHaveLength(1);
+    expect(result.features[0]).toMatchObject({ id: 1 });
   });
 });

--- a/mobile/src/features/stories/data/sources/index.ts
+++ b/mobile/src/features/stories/data/sources/index.ts
@@ -151,6 +151,20 @@ export const storiesLocalSource = {
         }
       }
 
+      const proximity = getProximityFilter(filters);
+
+      if (
+        proximity &&
+        haversineKm(
+          proximity.latitude,
+          proximity.longitude,
+          story.location.latitude,
+          story.location.longitude,
+        ) > proximity.radiusKm
+      ) {
+        return false;
+      }
+
       if (filters.yearFrom !== undefined || filters.yearTo !== undefined) {
         const years = extractYearsFromString(story.timePeriod);
         const minYear = years.length ? Math.min(...years) : undefined;
@@ -231,6 +245,12 @@ function filterRemoteStories(results: unknown[], filters: StoryFilters) {
       if (!placeName.includes(location)) {
         return false;
       }
+    }
+
+    const proximity = getProximityFilter(filters);
+
+    if (proximity && !isRecordWithinRadius(story, proximity)) {
+      return false;
     }
 
     if (filters.yearFrom !== undefined || filters.yearTo !== undefined) {
@@ -376,8 +396,9 @@ function filterFeatureCollectionByBounds(
   filters: StoryFilters,
 ): GeoJSONFeatureCollection {
   const bounds = filters.locationBounds;
+  const proximity = getProximityFilter(filters);
 
-  if (!bounds) {
+  if (!bounds && !proximity) {
     return featureCollection;
   }
 
@@ -403,14 +424,20 @@ function filterFeatureCollectionByBounds(
       const longitude = asNumber(coordinates[0]);
       const latitude = asNumber(coordinates[1]);
 
-      return (
-        latitude !== undefined &&
-        longitude !== undefined &&
-        latitude >= bounds.latMin &&
-        latitude <= bounds.latMax &&
-        longitude >= bounds.lngMin &&
-        longitude <= bounds.lngMax
-      );
+      if (latitude === undefined || longitude === undefined) {
+        return false;
+      }
+
+      if (proximity && haversineKm(proximity.latitude, proximity.longitude, latitude, longitude) > proximity.radiusKm) {
+        return false;
+      }
+
+      return bounds
+        ? latitude >= bounds.latMin &&
+            latitude <= bounds.latMax &&
+            longitude >= bounds.lngMin &&
+            longitude <= bounds.lngMax
+        : true;
     }),
   };
 }
@@ -437,6 +464,14 @@ function normalizeStoryFilters(filters: StoryFilters) {
     params.lng_max = filters.locationBounds.lngMax;
   } else if (filters.location?.trim()) {
     params.location = filters.location.trim();
+  }
+
+  const proximity = getProximityFilter(filters);
+
+  if (proximity) {
+    params.latitude = proximity.latitude;
+    params.longitude = proximity.longitude;
+    params.radius_km = proximity.radiusKm;
   }
 
   return params;
@@ -522,4 +557,51 @@ function featureCollectionHasPreviewText(featureCollection: GeoJSONFeatureCollec
 
     return Boolean(properties && asString(properties.preview_text));
   });
+}
+
+function getProximityFilter(filters: StoryFilters) {
+  if (
+    filters.latitude === undefined ||
+    filters.longitude === undefined ||
+    filters.radiusKm === undefined
+  ) {
+    return undefined;
+  }
+
+  return {
+    latitude: filters.latitude,
+    longitude: filters.longitude,
+    radiusKm: filters.radiusKm,
+  };
+}
+
+function isRecordWithinRadius(
+  story: StoryRecord,
+  proximity: { latitude: number; longitude: number; radiusKm: number },
+) {
+  const latitude = asNumber(story.location_lat);
+  const longitude = asNumber(story.location_lng);
+
+  if (latitude === undefined || longitude === undefined) {
+    return false;
+  }
+
+  return haversineKm(proximity.latitude, proximity.longitude, latitude, longitude) <= proximity.radiusKm;
+}
+
+function haversineKm(startLat: number, startLng: number, endLat: number, endLng: number) {
+  const earthRadiusKm = 6371;
+  const deltaLat = toRadians(endLat - startLat);
+  const deltaLng = toRadians(endLng - startLng);
+  const startLatRad = toRadians(startLat);
+  const endLatRad = toRadians(endLat);
+  const a =
+    Math.sin(deltaLat / 2) ** 2 +
+    Math.cos(startLatRad) * Math.cos(endLatRad) * Math.sin(deltaLng / 2) ** 2;
+
+  return 2 * earthRadiusKm * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+}
+
+function toRadians(value: number) {
+  return (value * Math.PI) / 180;
 }

--- a/mobile/src/features/stories/domain/repositories/index.ts
+++ b/mobile/src/features/stories/domain/repositories/index.ts
@@ -11,6 +11,9 @@ export interface StoryFilters {
     lngMin: number;
     lngMax: number;
   };
+  latitude?: number;
+  longitude?: number;
+  radiusKm?: number;
 }
 
 export interface StoryRepository {

--- a/mobile/src/shared/components/FilterPanel.tsx
+++ b/mobile/src/shared/components/FilterPanel.tsx
@@ -7,6 +7,14 @@ export const DEFAULT_FROM_YEAR = '1980';
 export const DEFAULT_TO_YEAR = '2026';
 export const MIN_YEAR = 1000;
 export const MAX_YEAR = 2030;
+export type ProximityRadiusOption = 1 | 10 | 100;
+
+const PROXIMITY_OPTIONS: Array<{ label: string; value?: ProximityRadiusOption }> = [
+  { label: 'Anywhere' },
+  { label: '1 km', value: 1 },
+  { label: '10 km', value: 10 },
+  { label: '100 km', value: 100 },
+];
 
 function normalizeYearInput(value: string) {
   if (value === '') {
@@ -47,6 +55,11 @@ interface FilterPanelProps {
   onTimeToChange: (value: string) => void;
   onClearAll: () => void;
   onApply?: () => void;
+  proximityRadiusKm?: ProximityRadiusOption;
+  onProximityRadiusChange?: (value?: ProximityRadiusOption) => void;
+  isProximityResolving?: boolean;
+  proximityStatusText?: string;
+  isProximityError?: boolean;
   isLocationResolving?: boolean;
   locationStatusText?: string;
   isApplyDisabled?: boolean;
@@ -61,6 +74,11 @@ export function FilterPanel({
   onTimeToChange,
   onClearAll,
   onApply,
+  proximityRadiusKm,
+  onProximityRadiusChange,
+  isProximityResolving = false,
+  proximityStatusText,
+  isProximityError = false,
   isLocationResolving = false,
   locationStatusText,
   isApplyDisabled = false,
@@ -146,6 +164,59 @@ export function FilterPanel({
         {locationStatusText ? (
           <Text style={{ color: colors.muted, fontSize: typography.caption + 1 }}>
             {locationStatusText}
+          </Text>
+        ) : null}
+      </View>
+
+      <View style={{ gap: spacing.sm }}>
+        <View style={{ flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center' }}>
+          <Text style={{ color: colors.text, fontWeight: '600' }}>Proximity</Text>
+          {isProximityResolving ? (
+            <ActivityIndicator
+              accessibilityLabel="Fetching current location"
+              color={colors.primary}
+              size="small"
+            />
+          ) : null}
+        </View>
+        <View style={{ flexDirection: 'row', flexWrap: 'wrap', gap: spacing.sm }}>
+          {PROXIMITY_OPTIONS.map((option) => {
+            const isSelected = proximityRadiusKm === option.value || (!proximityRadiusKm && !option.value);
+
+            return (
+              <Pressable
+                key={option.label}
+                accessibilityRole="button"
+                accessibilityLabel={`Distance ${option.label}`}
+                accessibilityState={{ selected: isSelected, disabled: isProximityResolving }}
+                disabled={isProximityResolving}
+                onPress={() => onProximityRadiusChange?.(option.value)}
+                style={({ pressed }) => ({
+                  paddingHorizontal: spacing.md,
+                  paddingVertical: spacing.sm,
+                  borderRadius: 999,
+                  borderWidth: 1,
+                  borderColor: isSelected ? colors.primary : colors.border,
+                  backgroundColor: isSelected ? colors.infoSurface : colors.surface,
+                  opacity: isProximityResolving ? 0.55 : pressed ? 0.75 : 1,
+                })}
+              >
+                <Text style={{ color: isSelected ? colors.primary : colors.text, fontWeight: '700' }}>
+                  {option.label}
+                </Text>
+              </Pressable>
+            );
+          })}
+        </View>
+        {proximityStatusText ? (
+          <Text
+            accessibilityRole={isProximityError ? 'alert' : undefined}
+            style={{
+              color: isProximityError ? colors.danger : colors.muted,
+              fontSize: typography.caption + 1,
+            }}
+          >
+            {proximityStatusText}
           </Text>
         ) : null}
       </View>

--- a/mobile/src/shared/components/__tests__/FilterPanel.test.tsx
+++ b/mobile/src/shared/components/__tests__/FilterPanel.test.tsx
@@ -29,12 +29,12 @@ describe('FilterPanel', () => {
     expect(onTimeToChange).toHaveBeenCalledWith('1950');
   });
 
-  it('shows the expected default year values when initialized', () => {
+  it('shows the default years as placeholders until selected', () => {
     render(
       <FilterPanel
         location=""
-        timeFrom={DEFAULT_FROM_YEAR}
-        timeTo={DEFAULT_TO_YEAR}
+        timeFrom=""
+        timeTo=""
         onLocationChange={jest.fn()}
         onTimeFromChange={jest.fn()}
         onTimeToChange={jest.fn()}
@@ -42,8 +42,10 @@ describe('FilterPanel', () => {
       />,
     );
 
-    expect(screen.getByLabelText('Start year').props.value).toBe(DEFAULT_FROM_YEAR);
-    expect(screen.getByLabelText('End year').props.value).toBe(DEFAULT_TO_YEAR);
+    expect(screen.getByLabelText('Start year').props.value).toBe('');
+    expect(screen.getByLabelText('Start year').props.placeholder).toBe(DEFAULT_FROM_YEAR);
+    expect(screen.getByLabelText('End year').props.value).toBe('');
+    expect(screen.getByLabelText('End year').props.placeholder).toBe(DEFAULT_TO_YEAR);
   });
 
   it('accepts only positive four-digit-or-shorter numeric years', () => {
@@ -126,6 +128,29 @@ describe('FilterPanel', () => {
         location=""
         timeFrom="1980"
         timeTo="2026"
+        onLocationChange={jest.fn()}
+        onTimeFromChange={onTimeFromChange}
+        onTimeToChange={onTimeToChange}
+        onClearAll={jest.fn()}
+      />,
+    );
+
+    fireEvent.press(screen.getByLabelText('Increase start year'));
+    fireEvent.press(screen.getByLabelText('Decrease end year'));
+
+    expect(onTimeFromChange).toHaveBeenCalledWith('1981');
+    expect(onTimeToChange).toHaveBeenCalledWith('2025');
+  });
+
+  it('activates placeholder years when step buttons are pressed from an empty value', () => {
+    const onTimeFromChange = jest.fn();
+    const onTimeToChange = jest.fn();
+
+    render(
+      <FilterPanel
+        location=""
+        timeFrom=""
+        timeTo=""
         onLocationChange={jest.fn()}
         onTimeFromChange={onTimeFromChange}
         onTimeToChange={onTimeToChange}


### PR DESCRIPTION
# 📝 Description
Fixes #391

Adds geolocation-based proximity filtering to the shared mobile search/filter flow for Feed and Map. Users can now filter stories by current location using `Anywhere`, `1 km`, `10 km`, and `100 km` options.

Also fixes the mobile map initial state so it starts by showing all story markers without auto-selecting the first story.

# 📊 Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Refactoring
- [ ] Documentation
 
# ✅ Acceptance Criteria / Checklist
- [x] Project builds successfully
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, especially in hard-to-understand parts
- [x] I have performed a self-review of my code
- [x] I have added/updated tests
- [x] New and existing unit tests pass locally with my changes

# ⏱️ Estimated Review Time
- [ ] < 5 min
- [x] 5-15 min
- [ ] > 15 min
