### PR TITLE
Add mobile popular sorting and bookmarks

### DIFF
--- a/backend/apps/stories/serializers.py
+++ b/backend/apps/stories/serializers.py
@@ -254,6 +254,8 @@ class StoryFeedSerializer(serializers.ModelSerializer):
             'status',
             'contributor_name',
             'preview_text',
+            'like_count',
+            'save_count',
             'user_has_liked',
             'user_has_saved',
             'submitted_at',

--- a/backend/apps/stories/tests/test_serializers.py
+++ b/backend/apps/stories/tests/test_serializers.py
@@ -57,9 +57,16 @@ class TestStoryFeedSerializer:
             'id', 'title', 'location_name', 'location_lat', 'location_lng',
             'time_type', 'year', 'year_start', 'year_end', 'date_value', 'time_value',
             'status', 'contributor_name', 'preview_text',
+            'like_count', 'save_count',
             'user_has_liked', 'user_has_saved', 'submitted_at',
         }
         assert expected_fields == set(data.keys())
+
+    def test_returns_interaction_counts(self):
+        story = make_story(like_count=9, save_count=4)
+        data = StoryFeedSerializer(story).data
+        assert data['like_count'] == 9
+        assert data['save_count'] == 4
 
     def test_returns_preview_text_truncated_to_20_words(self):
         # Narrative has more than 20 words — preview must stop at exactly 20

--- a/backend/apps/stories/tests/test_views.py
+++ b/backend/apps/stories/tests/test_views.py
@@ -175,9 +175,17 @@ class TestStoryFeedView:
             'id', 'title', 'location_name', 'location_lat', 'location_lng',
             'time_type', 'year', 'year_start', 'year_end', 'date_value', 'time_value',
             'status', 'contributor_name', 'preview_text',
+            'like_count', 'save_count',
             'user_has_liked', 'user_has_saved', 'submitted_at',
         }
         assert expected_fields == set(card.keys())
+
+    def test_feed_result_contains_interaction_counts(self, client):
+        make_story(like_count=6, save_count=2)
+        response = client.get(FEED_URL)
+        card = response.data['results'][0]
+        assert card['like_count'] == 6
+        assert card['save_count'] == 2
 
     def test_returns_400_for_invalid_sort_by(self, client):
         response = client.get(FEED_URL + '?sort_by=invalid')

--- a/mobile/src/app/navigation/RootNavigator.tsx
+++ b/mobile/src/app/navigation/RootNavigator.tsx
@@ -6,7 +6,7 @@ import { ROUTES } from './routes';
 import { useAuth, AuthScreen } from '../../features/auth';
 import { useAppTheme } from '../../core/hooks/useAppTheme';
 import { ProtectedScreen } from './ProtectedScreen';
-import { FeedScreen } from '../../features/feed';
+import { FeedScreen, FeedStoryInteractionUpdate } from '../../features/feed';
 import { ProfileCompletionScreen, ProfileScreen } from '../../features/profile';
 import { SubmissionScreen } from '../../features/submissions';
 import { navigationRef } from './navigationRef';
@@ -267,6 +267,7 @@ export function RootNavigator() {
   const [currentRoute, setCurrentRoute] = useState<AppRoute>(ROUTES.FEED);
   const [activeStoryId, setActiveStoryId] = useState<string | null>(null);
   const [activeUserId, setActiveUserId] = useState<string | null>(null);
+  const [storyInteractionUpdates, setStoryInteractionUpdates] = useState<Record<string, FeedStoryInteractionUpdate>>({});
   const [hasResolvedInitialSession, setHasResolvedInitialSession] = useState(false);
   const [backStack, setBackStack] = useState<RouteSnapshot[]>([]);
   const pagerRef = useRef<ScrollView>(null);
@@ -485,6 +486,20 @@ export function RootNavigator() {
     navigateToSnapshot({ route: ROUTES.STORY_DETAIL, storyId });
   };
 
+  const handleStoryInteractionUpdated = useCallback(
+    (update: { storyId: string; likeCount: number; savedByViewer: boolean }) => {
+      setStoryInteractionUpdates((current) => ({
+        ...current,
+        [update.storyId]: {
+          ...current[update.storyId],
+          likeCount: update.likeCount,
+          savedByViewer: update.savedByViewer,
+        },
+      }));
+    },
+    [],
+  );
+
   const handleOpenUserProfile = (userId: string) => {
     if (user && String(user.id) === userId) {
       navigateToSnapshot({ route: ROUTES.PROFILE });
@@ -574,6 +589,7 @@ export function RootNavigator() {
           toast.success('Story deleted.');
           navigateToSnapshot({ route: ROUTES.FEED }, { resetStack: true, preserveCurrent: false });
         }}
+        onStoryInteractionUpdated={handleStoryInteractionUpdated}
         onOpenContributorProfile={handleOpenUserProfile}
       />
     );
@@ -629,7 +645,12 @@ export function RootNavigator() {
               fillContent
               hideHeader
             >
-              <FeedScreen onOpenStory={handleOpenStoryDetail} showSearchControls={false} searchScope="main" />
+              <FeedScreen
+                onOpenStory={handleOpenStoryDetail}
+                showSearchControls={false}
+                searchScope="main"
+                storyInteractionUpdates={storyInteractionUpdates}
+              />
             </ScreenShell>
           </View>
         </ScrollView>

--- a/mobile/src/app/navigation/RootNavigator.tsx
+++ b/mobile/src/app/navigation/RootNavigator.tsx
@@ -7,6 +7,7 @@ import { useAuth, AuthScreen } from '../../features/auth';
 import { useAppTheme } from '../../core/hooks/useAppTheme';
 import { ProtectedScreen } from './ProtectedScreen';
 import { FeedScreen, FeedStoryInteractionUpdate } from '../../features/feed';
+import { FeedSortOption } from '../../features/feed/domain/entities';
 import { ProfileCompletionScreen, ProfileScreen } from '../../features/profile';
 import { SubmissionScreen } from '../../features/submissions';
 import { navigationRef } from './navigationRef';
@@ -267,6 +268,7 @@ export function RootNavigator() {
   const [currentRoute, setCurrentRoute] = useState<AppRoute>(ROUTES.FEED);
   const [activeStoryId, setActiveStoryId] = useState<string | null>(null);
   const [activeUserId, setActiveUserId] = useState<string | null>(null);
+  const [feedSort, setFeedSort] = useState<FeedSortOption>('recent');
   const [storyInteractionUpdates, setStoryInteractionUpdates] = useState<Record<string, FeedStoryInteractionUpdate>>({});
   const [hasResolvedInitialSession, setHasResolvedInitialSession] = useState(false);
   const [backStack, setBackStack] = useState<RouteSnapshot[]>([]);
@@ -647,6 +649,8 @@ export function RootNavigator() {
             >
               <FeedScreen
                 onOpenStory={handleOpenStoryDetail}
+                initialSort={feedSort}
+                onSortChange={setFeedSort}
                 showSearchControls={false}
                 searchScope="main"
                 storyInteractionUpdates={storyInteractionUpdates}

--- a/mobile/src/app/navigation/__tests__/RootNavigator.test.tsx
+++ b/mobile/src/app/navigation/__tests__/RootNavigator.test.tsx
@@ -613,6 +613,31 @@ describe('RootNavigator auth flow', () => {
     });
   });
 
+  it('keeps the selected feed sort after returning from story detail', async () => {
+    render(
+      <AppProviders>
+        <RootNavigator />
+      </AppProviders>,
+    );
+
+    await screen.findByLabelText('Sort by Most Popular');
+    fireEvent.press(screen.getByLabelText('Sort by Most Popular'));
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('Sort by Most Popular').props.accessibilityState.selected).toBe(true);
+    });
+
+    fireEvent.press(await screen.findByLabelText('Read story: Harbor Memory'));
+    expect(await screen.findByLabelText('Go back')).toBeTruthy();
+    fireEvent.press(screen.getByLabelText('Go back'));
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('Read story: Harbor Memory')).toBeTruthy();
+      expect(screen.getByLabelText('Sort by Most Popular').props.accessibilityState.selected).toBe(true);
+      expect(screen.getByLabelText('Sort by Most Recent').props.accessibilityState.selected).toBe(false);
+    });
+  });
+
   it('opens a public profile from the contributor name on story detail', async () => {
     render(
       <AppProviders>

--- a/mobile/src/features/feed/data/mappers/__tests__/feedMappers.test.ts
+++ b/mobile/src/features/feed/data/mappers/__tests__/feedMappers.test.ts
@@ -1,0 +1,51 @@
+import { mapFeedItem, mapFeedPage } from '..';
+
+describe('feed mappers', () => {
+  it('maps backend feed card interaction metadata', () => {
+    expect(
+      mapFeedItem({
+        id: 42,
+        title: 'The City Walls',
+        location_name: 'Old City',
+        time_type: 'exact_year',
+        year: 1453,
+        preview_text: 'A story about the old city walls.',
+        submitted_at: '2026-03-18T10:00:00Z',
+        like_count: 7,
+        user_has_saved: true,
+      }),
+    ).toEqual({
+      id: '42',
+      title: 'The City Walls',
+      locationName: 'Old City',
+      timePeriod: '1453',
+      previewText: 'A story about the old city walls.',
+      submittedAt: '2026-03-18T10:00:00Z',
+      hasMedia: false,
+      likeCount: 7,
+      savedByViewer: true,
+    });
+  });
+
+  it('maps paginated feed responses', () => {
+    const page = mapFeedPage(
+      {
+        count: 1,
+        next: null,
+        results: [
+          {
+            id: 'story-1',
+            title: 'Story 1',
+            like_count: 3,
+          },
+        ],
+      },
+      1,
+      10,
+    );
+
+    expect(page.totalCount).toBe(1);
+    expect(page.hasNextPage).toBe(false);
+    expect(page.items[0].likeCount).toBe(3);
+  });
+});

--- a/mobile/src/features/feed/data/mappers/__tests__/feedMappers.test.ts
+++ b/mobile/src/features/feed/data/mappers/__tests__/feedMappers.test.ts
@@ -48,4 +48,22 @@ describe('feed mappers', () => {
     expect(page.hasNextPage).toBe(false);
     expect(page.items[0].likeCount).toBe(3);
   });
+
+  it('maps legacy like count aliases from feed payloads', () => {
+    expect(
+      mapFeedItem({
+        id: 'story-2',
+        title: 'Legacy Story',
+        likes_count: '4',
+      }).likeCount,
+    ).toBe(4);
+
+    expect(
+      mapFeedItem({
+        id: 'story-3',
+        title: 'Total Likes Story',
+        total_likes: 8,
+      }).likeCount,
+    ).toBe(8);
+  });
 });

--- a/mobile/src/features/feed/data/mappers/index.ts
+++ b/mobile/src/features/feed/data/mappers/index.ts
@@ -14,6 +14,10 @@ interface FeedApiRecord {
   images?: unknown;
   media_items?: unknown;
   has_media?: unknown;
+  like_count?: unknown;
+  likeCount?: unknown;
+  user_has_saved?: unknown;
+  savedByViewer?: unknown;
 }
 
 function asString(value: unknown, fallback = '') {
@@ -22,6 +26,10 @@ function asString(value: unknown, fallback = '') {
 
 function asNumber(value: unknown) {
   return typeof value === 'number' && Number.isFinite(value) ? value : undefined;
+}
+
+function asBoolean(value: unknown, fallback = false) {
+  return typeof value === 'boolean' ? value : fallback;
 }
 
 function asInteger(value: unknown, fallback: number) {
@@ -96,6 +104,8 @@ export function mapFeedItem(value: unknown): FeedEntity {
     previewText: getPreviewText(record),
     submittedAt: asString(record.submitted_at),
     hasMedia: hasMedia(record),
+    likeCount: asNumber(record.likeCount) ?? asNumber(record.like_count) ?? 0,
+    savedByViewer: asBoolean(record.savedByViewer, asBoolean(record.user_has_saved, false)),
   };
 }
 

--- a/mobile/src/features/feed/data/mappers/index.ts
+++ b/mobile/src/features/feed/data/mappers/index.ts
@@ -16,6 +16,8 @@ interface FeedApiRecord {
   has_media?: unknown;
   like_count?: unknown;
   likeCount?: unknown;
+  likes_count?: unknown;
+  total_likes?: unknown;
   user_has_saved?: unknown;
   savedByViewer?: unknown;
 }
@@ -25,7 +27,16 @@ function asString(value: unknown, fallback = '') {
 }
 
 function asNumber(value: unknown) {
-  return typeof value === 'number' && Number.isFinite(value) ? value : undefined;
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return value;
+  }
+
+  if (typeof value === 'string' && value.trim()) {
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : undefined;
+  }
+
+  return undefined;
 }
 
 function asBoolean(value: unknown, fallback = false) {
@@ -104,7 +115,12 @@ export function mapFeedItem(value: unknown): FeedEntity {
     previewText: getPreviewText(record),
     submittedAt: asString(record.submitted_at),
     hasMedia: hasMedia(record),
-    likeCount: asNumber(record.likeCount) ?? asNumber(record.like_count) ?? 0,
+    likeCount:
+      asNumber(record.likeCount) ??
+      asNumber(record.like_count) ??
+      asNumber(record.likes_count) ??
+      asNumber(record.total_likes) ??
+      0,
     savedByViewer: asBoolean(record.savedByViewer, asBoolean(record.user_has_saved, false)),
   };
 }

--- a/mobile/src/features/feed/data/sources/__tests__/feedRemoteSource.test.ts
+++ b/mobile/src/features/feed/data/sources/__tests__/feedRemoteSource.test.ts
@@ -57,6 +57,73 @@ describe('feedRemoteSource', () => {
     expect(getSpy).toHaveBeenCalledWith('/stories/feed/?page=2&page_size=10&sort_by=recent&location=Istanbul');
   });
 
+  it('hydrates missing feed interaction metadata from story detail', async () => {
+    const getSpy = jest.spyOn(apiClient, 'get').mockImplementation(async (url) => {
+      if (url === '/stories/feed/?page=1&page_size=10&sort_by=recent') {
+        return {
+          count: 1,
+          next: null,
+          previous: null,
+          results: [
+            {
+              id: 'story-1',
+              title: 'Legacy Feed Story',
+              user_has_saved: false,
+            },
+          ],
+        };
+      }
+
+      if (url === '/stories/story-1/') {
+        return {
+          id: 'story-1',
+          like_count: 4,
+          save_count: 2,
+          user_has_liked: true,
+          user_has_saved: true,
+        };
+      }
+
+      throw new Error(`Unexpected URL: ${url}`);
+    });
+
+    const response = await feedRemoteSource.getFeed({
+      page: 1,
+      sort: 'recent',
+      filters: {},
+    });
+
+    expect(getSpy).toHaveBeenCalledWith('/stories/feed/?page=1&page_size=10&sort_by=recent');
+    expect(getSpy).toHaveBeenCalledWith('/stories/story-1/');
+    expect(response.results?.[0]).toMatchObject({
+      id: 'story-1',
+      like_count: 4,
+      save_count: 2,
+      user_has_liked: true,
+      user_has_saved: true,
+    });
+  });
+
+  it('does not hydrate interaction metadata when the feed already includes counts', async () => {
+    const getSpy = jest.spyOn(apiClient, 'get').mockResolvedValue({
+      count: 1,
+      next: null,
+      previous: null,
+      results: [
+        {
+          id: 'story-1',
+          title: 'Current Feed Story',
+          like_count: 4,
+        },
+      ],
+    });
+
+    const response = await feedRemoteSource.getFeed({});
+
+    expect(getSpy).toHaveBeenCalledTimes(1);
+    expect(response.results?.[0]).toMatchObject({ like_count: 4 });
+  });
+
   it('sends bounding box params instead of text location when location was geocoded', async () => {
     const getSpy = jest.spyOn(apiClient, 'get').mockResolvedValue({
       count: 0,

--- a/mobile/src/features/feed/data/sources/__tests__/feedRemoteSource.test.ts
+++ b/mobile/src/features/feed/data/sources/__tests__/feedRemoteSource.test.ts
@@ -20,7 +20,24 @@ describe('feedRemoteSource', () => {
       filters: { q: 'harbor' },
     });
 
-    expect(getSpy).toHaveBeenCalledWith('/stories/search/?page=1&page_size=10&q=harbor');
+    expect(getSpy).toHaveBeenCalledWith('/stories/search/?page=1&page_size=10&sort_by=recent&q=harbor');
+  });
+
+  it('sends popular sorting to the feed endpoint', async () => {
+    const getSpy = jest.spyOn(apiClient, 'get').mockResolvedValue({
+      count: 0,
+      next: null,
+      previous: null,
+      results: [],
+    });
+
+    await feedRemoteSource.getFeed({
+      page: 1,
+      sort: 'popular',
+      filters: {},
+    });
+
+    expect(getSpy).toHaveBeenCalledWith('/stories/feed/?page=1&page_size=10&sort_by=popular');
   });
 
   it('uses the feed endpoint when no text query is provided', async () => {

--- a/mobile/src/features/feed/data/sources/index.ts
+++ b/mobile/src/features/feed/data/sources/index.ts
@@ -35,18 +35,23 @@ export const feedRemoteSource = {
     };
 
     const bounds = filters.locationBounds;
+    const responseResults = response.results ?? [];
 
     if (!bounds) {
-      return response;
+      return {
+        ...response,
+        results: await hydrateMissingInteractionMetadata(responseResults),
+      };
     }
 
-    const results = (response.results ?? []).filter((story) => isStoryWithinBounds(story, bounds));
+    const results = responseResults.filter((story) => isStoryWithinBounds(story, bounds));
+    const hydratedResults = await hydrateMissingInteractionMetadata(results);
 
     return {
       ...response,
-      count: results.length,
+      count: hydratedResults.length,
       next: null,
-      results,
+      results: hydratedResults,
     };
   },
 };
@@ -115,6 +120,58 @@ function isStoryWithinBounds(
     latitude <= bounds.latMax &&
     longitude >= bounds.lngMin &&
     longitude <= bounds.lngMax
+  );
+}
+
+async function hydrateMissingInteractionMetadata(results: unknown[]) {
+  return Promise.all(
+    results.map(async (story) => {
+      if (!shouldHydrateInteractionMetadata(story)) {
+        return story;
+      }
+
+      const record = story as Record<string, unknown>;
+      const id = typeof record.id === 'string' || typeof record.id === 'number' ? String(record.id) : undefined;
+
+      if (!id) {
+        return story;
+      }
+
+      try {
+        const detail = await apiClient.get<Record<string, unknown>>(`/stories/${id}/`);
+
+        if (!detail || typeof detail !== 'object') {
+          return story;
+        }
+
+        return {
+          ...record,
+          like_count: detail.like_count ?? detail.likeCount ?? record.like_count,
+          save_count: detail.save_count ?? detail.saveCount ?? record.save_count,
+          user_has_liked: detail.user_has_liked ?? detail.likedByViewer ?? record.user_has_liked,
+          user_has_saved: detail.user_has_saved ?? detail.savedByViewer ?? record.user_has_saved,
+        };
+      } catch {
+        return story;
+      }
+    }),
+  );
+}
+
+function shouldHydrateInteractionMetadata(story: unknown) {
+  if (!story || typeof story !== 'object') {
+    return false;
+  }
+
+  const record = story as Record<string, unknown>;
+  const hasStoryCardShape = typeof record.title === 'string';
+
+  return (
+    hasStoryCardShape &&
+    record.like_count === undefined &&
+    record.likeCount === undefined &&
+    record.likes_count === undefined &&
+    record.total_likes === undefined
   );
 }
 

--- a/mobile/src/features/feed/data/sources/index.ts
+++ b/mobile/src/features/feed/data/sources/index.ts
@@ -18,7 +18,7 @@ export const feedRemoteSource = {
     const params = buildQueryString({
       page,
       page_size: DEFAULT_PAGE_SIZE,
-      ...(hasSearch ? {} : { sort_by: sort }),
+      sort_by: sort,
       ...normalizeStoryFilters(filters),
     });
 

--- a/mobile/src/features/feed/domain/entities/index.ts
+++ b/mobile/src/features/feed/domain/entities/index.ts
@@ -1,4 +1,4 @@
-export type FeedSortOption = 'recent';
+export type FeedSortOption = 'recent' | 'popular';
 
 export interface FeedEntity {
   id: string;
@@ -8,6 +8,8 @@ export interface FeedEntity {
   previewText: string;
   submittedAt: string;
   hasMedia: boolean;
+  likeCount: number;
+  savedByViewer: boolean;
 }
 
 export interface FeedPageEntity {

--- a/mobile/src/features/feed/presentation/components/FeedCard.tsx
+++ b/mobile/src/features/feed/presentation/components/FeedCard.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Pressable, Text, View } from 'react-native';
+import { Bookmark } from 'lucide-react-native';
 import { useAppTheme } from '../../../../core/hooks/useAppTheme';
 import { FeedEntity } from '../../domain/entities';
 
@@ -54,23 +55,45 @@ export function FeedCard({ story, onPress }: FeedCardProps) {
         >
           {story.title}
         </Text>
-        {story.hasMedia ? (
+        <View style={{ flexDirection: 'row', alignItems: 'center', gap: spacing.xs }}>
           <View
-            accessibilityLabel="Has media"
+            accessibilityLabel={story.savedByViewer ? 'Bookmarked story' : 'Not bookmarked story'}
             style={{
-              paddingHorizontal: spacing.sm,
-              paddingVertical: spacing.xs,
+              width: 30,
+              height: 30,
               borderRadius: 999,
               borderWidth: 1,
-              borderColor: colors.border,
-              backgroundColor: colors.background,
+              borderColor: story.savedByViewer ? colors.primary : colors.border,
+              backgroundColor: story.savedByViewer ? colors.primary : colors.background,
+              alignItems: 'center',
+              justifyContent: 'center',
             }}
           >
-            <Text style={{ color: colors.muted, fontSize: typography.caption, fontWeight: '700' }}>
-              IMG
-            </Text>
+            <Bookmark
+              size={16}
+              color={story.savedByViewer ? colors.background : colors.muted}
+              fill={story.savedByViewer ? colors.background : 'transparent'}
+              strokeWidth={2.2}
+            />
           </View>
-        ) : null}
+          {story.hasMedia ? (
+            <View
+              accessibilityLabel="Has media"
+              style={{
+                paddingHorizontal: spacing.sm,
+                paddingVertical: spacing.xs,
+                borderRadius: 999,
+                borderWidth: 1,
+                borderColor: colors.border,
+                backgroundColor: colors.background,
+              }}
+            >
+              <Text style={{ color: colors.muted, fontSize: typography.caption, fontWeight: '700' }}>
+                IMG
+              </Text>
+            </View>
+          ) : null}
+        </View>
       </View>
 
       {story.locationName ? (
@@ -78,6 +101,18 @@ export function FeedCard({ story, onPress }: FeedCardProps) {
       ) : null}
 
       <View style={{ flexDirection: 'row', flexWrap: 'wrap', gap: spacing.sm }}>
+        <View
+          style={{
+            paddingHorizontal: spacing.sm,
+            paddingVertical: spacing.xs,
+            borderRadius: 999,
+            backgroundColor: colors.background,
+          }}
+        >
+          <Text style={{ color: colors.text, fontSize: typography.caption, fontWeight: '600' }}>
+            ♥ {story.likeCount}
+          </Text>
+        </View>
         {story.timePeriod ? (
           <View
             style={{

--- a/mobile/src/features/feed/presentation/components/__tests__/FeedCard.test.tsx
+++ b/mobile/src/features/feed/presentation/components/__tests__/FeedCard.test.tsx
@@ -11,6 +11,8 @@ const story: FeedEntity = {
   previewText: 'Once upon a time there was a bridge that spanned the river in the heart of the old city.',
   submittedAt: '2026-03-18T10:00:00Z',
   hasMedia: true,
+  likeCount: 14,
+  savedByViewer: false,
 };
 
 describe('FeedCard', () => {
@@ -21,8 +23,10 @@ describe('FeedCard', () => {
     expect(screen.getByText('Old City')).toBeTruthy();
     expect(screen.getByText('1453')).toBeTruthy();
     expect(screen.getByText('18 Mar 2026')).toBeTruthy();
+    expect(screen.getByText('♥ 14')).toBeTruthy();
     expect(screen.getByText(story.previewText)).toBeTruthy();
     expect(screen.getByLabelText('Has media')).toBeTruthy();
+    expect(screen.getByLabelText('Not bookmarked story')).toBeTruthy();
   });
 
   it('navigates when the card is pressed', () => {
@@ -38,5 +42,12 @@ describe('FeedCard', () => {
     render(<FeedCard story={{ ...story, hasMedia: false }} />);
 
     expect(screen.queryByLabelText('Has media')).toBeNull();
+  });
+
+  it('renders the filled bookmark indicator for saved stories', () => {
+    render(<FeedCard story={{ ...story, savedByViewer: true }} />);
+
+    expect(screen.getByLabelText('Bookmarked story')).toBeTruthy();
+    expect(screen.queryByLabelText('Not bookmarked story')).toBeNull();
   });
 });

--- a/mobile/src/features/feed/presentation/screens/FeedScreen.tsx
+++ b/mobile/src/features/feed/presentation/screens/FeedScreen.tsx
@@ -18,6 +18,8 @@ import { createInitialFeedUiState } from '../state/feedUiState';
 
 interface FeedScreenProps {
   initialFilters?: StoryFilters;
+  initialSort?: FeedSortOption;
+  onSortChange?: (sort: FeedSortOption) => void;
   onOpenStory?: (storyId: string) => void;
   getFeed?: typeof storyService.getFeed;
   showSearchControls?: boolean;
@@ -39,6 +41,8 @@ export interface FeedStoryInteractionUpdate {
 
 export function FeedScreen({
   initialFilters = EMPTY_FILTERS,
+  initialSort = 'recent',
+  onSortChange,
   onOpenStory,
   getFeed = storyService.getFeed,
   showSearchControls = true,
@@ -49,7 +53,7 @@ export function FeedScreen({
   const { filters, refreshToken, isHydrated, setFilters } = useSearchFilters(searchScope);
   const debouncedQuery = useDebounce(filters.query, 350);
   const [useImmediateQuery, setUseImmediateQuery] = useState(false);
-  const [state, setState] = useState(() => createInitialFeedUiState(initialFilters));
+  const [state, setState] = useState(() => createInitialFeedUiState(initialFilters, initialSort));
   const stateRef = useRef(state);
   const storyInteractionUpdatesRef = useRef(storyInteractionUpdates);
   const hasRequestedNextPage = useRef(false);
@@ -178,6 +182,7 @@ export function FeedScreen({
       return;
     }
 
+    onSortChange?.(sort);
     loadPage(1, 'initial', { filters: activeFilters, sort });
   };
 

--- a/mobile/src/features/feed/presentation/screens/FeedScreen.tsx
+++ b/mobile/src/features/feed/presentation/screens/FeedScreen.tsx
@@ -22,13 +22,20 @@ interface FeedScreenProps {
   getFeed?: typeof storyService.getFeed;
   showSearchControls?: boolean;
   searchScope?: SearchFilterScope;
+  storyInteractionUpdates?: Record<string, FeedStoryInteractionUpdate>;
 }
 
 const EMPTY_FILTERS: StoryFilters = {};
+const EMPTY_STORY_INTERACTION_UPDATES: Record<string, FeedStoryInteractionUpdate> = {};
 const SORT_OPTIONS: Array<{ value: FeedSortOption; label: string }> = [
   { value: 'recent', label: 'Most Recent' },
   { value: 'popular', label: 'Most Popular' },
 ];
+
+export interface FeedStoryInteractionUpdate {
+  likeCount?: number;
+  savedByViewer?: boolean;
+}
 
 export function FeedScreen({
   initialFilters = EMPTY_FILTERS,
@@ -36,6 +43,7 @@ export function FeedScreen({
   getFeed = storyService.getFeed,
   showSearchControls = true,
   searchScope = 'feed',
+  storyInteractionUpdates = EMPTY_STORY_INTERACTION_UPDATES,
 }: FeedScreenProps) {
   const { colors, spacing, typography } = useAppTheme();
   const { filters, refreshToken, isHydrated, setFilters } = useSearchFilters(searchScope);
@@ -43,11 +51,17 @@ export function FeedScreen({
   const [useImmediateQuery, setUseImmediateQuery] = useState(false);
   const [state, setState] = useState(() => createInitialFeedUiState(initialFilters));
   const stateRef = useRef(state);
+  const storyInteractionUpdatesRef = useRef(storyInteractionUpdates);
   const hasRequestedNextPage = useRef(false);
 
   useEffect(() => {
     stateRef.current = state;
   }, [state]);
+
+  useEffect(() => {
+    storyInteractionUpdatesRef.current = storyInteractionUpdates;
+    setState((current) => applyStoryInteractionUpdates(current, storyInteractionUpdates));
+  }, [storyInteractionUpdates]);
 
   const seedFilters = useMemo(() => toSearchState(initialFilters), [initialFilters]);
 
@@ -111,7 +125,12 @@ export function FeedScreen({
           filters: nextFilters,
         });
 
-        setState((current) => mergeFeedPage(current, response, mode));
+        setState((current) =>
+          applyStoryInteractionUpdates(
+            mergeFeedPage(current, response, mode),
+            storyInteractionUpdatesRef.current,
+          ),
+        );
       } catch (error) {
         const message = error instanceof Error ? error.message : 'Unable to load the story feed.';
 
@@ -163,13 +182,9 @@ export function FeedScreen({
   };
 
   const renderControls = () => {
-    if (!showSearchControls) {
-      return null;
-    }
-
     return (
       <View style={{ paddingHorizontal: spacing.lg, paddingTop: spacing.md, paddingBottom: spacing.sm, gap: spacing.md }}>
-        <View style={{ flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between', gap: spacing.md }}>
+        <View style={{ gap: spacing.sm }}>
           <Text style={{ color: colors.muted, fontSize: typography.caption }}>
             {state.totalCount > 0 ? `${state.totalCount} stories` : hasActiveFilters ? 'No matching stories yet' : 'Newest stories'}
           </Text>
@@ -216,7 +231,7 @@ export function FeedScreen({
           </View>
         </View>
 
-        <StorySearchControls helperText="Search by title or place." scope={searchScope} />
+        {showSearchControls ? <StorySearchControls helperText="Search by title or place." scope={searchScope} /> : null}
       </View>
     );
   };
@@ -294,6 +309,39 @@ export function FeedScreen({
       />
     </View>
   );
+}
+
+function applyStoryInteractionUpdates(
+  state: ReturnType<typeof createInitialFeedUiState>,
+  updates: Record<string, FeedStoryInteractionUpdate>,
+) {
+  if (!Object.keys(updates).length || !state.items.length) {
+    return state;
+  }
+
+  let hasChanges = false;
+  const items = state.items.map((item) => {
+    const update = updates[item.id];
+
+    if (!update) {
+      return item;
+    }
+
+    const nextItem = {
+      ...item,
+      likeCount: update.likeCount ?? item.likeCount,
+      savedByViewer: update.savedByViewer ?? item.savedByViewer,
+    };
+
+    hasChanges =
+      hasChanges ||
+      nextItem.likeCount !== item.likeCount ||
+      nextItem.savedByViewer !== item.savedByViewer;
+
+    return nextItem;
+  });
+
+  return hasChanges ? { ...state, items } : state;
 }
 
 function toSearchState(filters: StoryFilters): SearchFiltersState {

--- a/mobile/src/features/feed/presentation/screens/FeedScreen.tsx
+++ b/mobile/src/features/feed/presentation/screens/FeedScreen.tsx
@@ -29,9 +29,9 @@ interface FeedScreenProps {
 
 const EMPTY_FILTERS: StoryFilters = {};
 const EMPTY_STORY_INTERACTION_UPDATES: Record<string, FeedStoryInteractionUpdate> = {};
-const SORT_OPTIONS: Array<{ value: FeedSortOption; label: string }> = [
-  { value: 'recent', label: 'Most Recent' },
-  { value: 'popular', label: 'Most Popular' },
+const SORT_OPTIONS: Array<{ value: FeedSortOption; label: string; shortLabel: string }> = [
+  { value: 'recent', label: 'Most Recent', shortLabel: 'Recent' },
+  { value: 'popular', label: 'Most Popular', shortLabel: 'Popular' },
 ];
 
 export interface FeedStoryInteractionUpdate {
@@ -192,9 +192,12 @@ export function FeedScreen({
 
   const renderControls = () => {
     return (
-      <View style={{ paddingHorizontal: spacing.lg, paddingTop: spacing.md, paddingBottom: spacing.sm, gap: spacing.md }}>
-        <View style={{ gap: spacing.sm }}>
-          <Text style={{ color: colors.muted, fontSize: typography.caption }}>
+      <View style={{ paddingHorizontal: spacing.lg, paddingTop: spacing.sm, paddingBottom: spacing.xs, gap: spacing.sm }}>
+        <View style={{ flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between', gap: spacing.sm }}>
+          <Text
+            numberOfLines={1}
+            style={{ flex: 1, color: colors.muted, fontSize: typography.caption }}
+          >
             {state.totalCount > 0 ? `${state.totalCount} stories` : hasActiveFilters ? 'No matching stories yet' : 'Newest stories'}
           </Text>
           <View
@@ -203,7 +206,12 @@ export function FeedScreen({
             style={{
               flexDirection: 'row',
               alignItems: 'center',
-              gap: spacing.sm,
+              flexShrink: 0,
+              padding: 2,
+              borderRadius: 999,
+              borderWidth: 1,
+              borderColor: colors.border,
+              backgroundColor: colors.infoSurface,
             }}
           >
             {SORT_OPTIONS.map((option) => {
@@ -218,11 +226,9 @@ export function FeedScreen({
                   onPress={() => handleSortChange(option.value)}
                   style={{
                     borderRadius: 999,
-                    borderWidth: 1,
-                    borderColor: isSelected ? colors.primary : colors.border,
-                    paddingHorizontal: spacing.md,
-                    paddingVertical: spacing.sm,
-                    backgroundColor: isSelected ? colors.primary : colors.surface,
+                    paddingHorizontal: spacing.sm,
+                    paddingVertical: spacing.xs,
+                    backgroundColor: isSelected ? colors.primary : 'transparent',
                   }}
                 >
                   <Text
@@ -232,7 +238,7 @@ export function FeedScreen({
                       fontSize: typography.caption,
                     }}
                   >
-                    {option.label}
+                    {option.shortLabel}
                   </Text>
                 </Pressable>
               );

--- a/mobile/src/features/feed/presentation/screens/FeedScreen.tsx
+++ b/mobile/src/features/feed/presentation/screens/FeedScreen.tsx
@@ -193,11 +193,8 @@ export function FeedScreen({
             accessibilityLabel="Feed sort"
             style={{
               flexDirection: 'row',
-              borderRadius: 999,
-              borderWidth: 1,
-              borderColor: colors.border,
-              overflow: 'hidden',
-              backgroundColor: colors.infoSurface,
+              alignItems: 'center',
+              gap: spacing.sm,
             }}
           >
             {SORT_OPTIONS.map((option) => {
@@ -211,9 +208,12 @@ export function FeedScreen({
                   accessibilityState={{ selected: isSelected }}
                   onPress={() => handleSortChange(option.value)}
                   style={{
-                    paddingHorizontal: spacing.sm + 4,
-                    paddingVertical: spacing.xs + 2,
-                    backgroundColor: isSelected ? colors.primary : colors.infoSurface,
+                    borderRadius: 999,
+                    borderWidth: 1,
+                    borderColor: isSelected ? colors.primary : colors.border,
+                    paddingHorizontal: spacing.md,
+                    paddingVertical: spacing.sm,
+                    backgroundColor: isSelected ? colors.primary : colors.surface,
                   }}
                 >
                   <Text

--- a/mobile/src/features/feed/presentation/screens/FeedScreen.tsx
+++ b/mobile/src/features/feed/presentation/screens/FeedScreen.tsx
@@ -12,7 +12,7 @@ import {
   toSearchParams,
   useSearchFilters,
 } from '../../../search/presentation/context/SearchFiltersContext';
-import { FeedPageEntity } from '../../domain/entities';
+import { FeedPageEntity, FeedSortOption } from '../../domain/entities';
 import { FeedCard } from '../components/FeedCard';
 import { createInitialFeedUiState } from '../state/feedUiState';
 
@@ -25,6 +25,10 @@ interface FeedScreenProps {
 }
 
 const EMPTY_FILTERS: StoryFilters = {};
+const SORT_OPTIONS: Array<{ value: FeedSortOption; label: string }> = [
+  { value: 'recent', label: 'Most Recent' },
+  { value: 'popular', label: 'Most Popular' },
+];
 
 export function FeedScreen({
   initialFilters = EMPTY_FILTERS,
@@ -93,6 +97,7 @@ export function FeedScreen({
       setState((current) => ({
         ...current,
         filters: nextFilters,
+        sort: nextSort,
         isLoading: mode === 'initial',
         isRefreshing: mode === 'refresh',
         isLoadingMore: mode === 'append',
@@ -149,6 +154,14 @@ export function FeedScreen({
     loadPage(1, 'initial', { filters: activeFilters });
   };
 
+  const handleSortChange = (sort: FeedSortOption) => {
+    if (sort === state.sort) {
+      return;
+    }
+
+    loadPage(1, 'initial', { filters: activeFilters, sort });
+  };
+
   const renderControls = () => {
     if (!showSearchControls) {
       return null;
@@ -160,20 +173,47 @@ export function FeedScreen({
           <Text style={{ color: colors.muted, fontSize: typography.caption }}>
             {state.totalCount > 0 ? `${state.totalCount} stories` : hasActiveFilters ? 'No matching stories yet' : 'Newest stories'}
           </Text>
-          <Pressable
-            accessibilityRole="button"
-            accessibilityLabel="Sort: Most Recent"
+          <View
+            accessibilityRole="radiogroup"
+            accessibilityLabel="Feed sort"
             style={{
-              paddingHorizontal: spacing.sm + 4,
-              paddingVertical: spacing.xs + 2,
+              flexDirection: 'row',
               borderRadius: 999,
               borderWidth: 1,
               borderColor: colors.border,
+              overflow: 'hidden',
               backgroundColor: colors.infoSurface,
             }}
           >
-            <Text style={{ color: colors.text, fontWeight: '700' }}>Most Recent</Text>
-          </Pressable>
+            {SORT_OPTIONS.map((option) => {
+              const isSelected = state.sort === option.value;
+
+              return (
+                <Pressable
+                  key={option.value}
+                  accessibilityRole="radio"
+                  accessibilityLabel={`Sort by ${option.label}`}
+                  accessibilityState={{ selected: isSelected }}
+                  onPress={() => handleSortChange(option.value)}
+                  style={{
+                    paddingHorizontal: spacing.sm + 4,
+                    paddingVertical: spacing.xs + 2,
+                    backgroundColor: isSelected ? colors.primary : colors.infoSurface,
+                  }}
+                >
+                  <Text
+                    style={{
+                      color: isSelected ? colors.background : colors.text,
+                      fontWeight: '700',
+                      fontSize: typography.caption,
+                    }}
+                  >
+                    {option.label}
+                  </Text>
+                </Pressable>
+              );
+            })}
+          </View>
         </View>
 
         <StorySearchControls helperText="Search by title or place." scope={searchScope} />

--- a/mobile/src/features/feed/presentation/screens/__tests__/FeedScreen.test.tsx
+++ b/mobile/src/features/feed/presentation/screens/__tests__/FeedScreen.test.tsx
@@ -132,7 +132,23 @@ describe('FeedScreen', () => {
     });
   });
 
+  it('uses the provided initial sort for the first feed request', async () => {
+    const getFeed = jest.fn<Promise<FeedPageEntity>, [any]>().mockResolvedValue(makeFeedPage());
+
+    renderScreen(<FeedScreen getFeed={getFeed} initialSort="popular" />);
+
+    await waitFor(() => {
+      expect(getFeed).toHaveBeenCalledWith({
+        page: 1,
+        sort: 'popular',
+        filters: {},
+      });
+    });
+    expect(screen.getByLabelText('Sort by Most Popular').props.accessibilityState.selected).toBe(true);
+  });
+
   it('switches to Most Popular and persists the selected sort in state', async () => {
+    const onSortChange = jest.fn();
     const getFeed = jest
       .fn<Promise<FeedPageEntity>, [any]>()
       .mockResolvedValueOnce(makeFeedPage())
@@ -145,7 +161,7 @@ describe('FeedScreen', () => {
         }),
       );
 
-    renderScreen(<FeedScreen getFeed={getFeed} />);
+    renderScreen(<FeedScreen getFeed={getFeed} onSortChange={onSortChange} />);
 
     expect(await screen.findByText('Story 1')).toBeTruthy();
     fireEvent.press(screen.getByLabelText('Sort by Most Popular'));
@@ -159,6 +175,7 @@ describe('FeedScreen', () => {
     });
 
     expect(await screen.findByText('Popular Story')).toBeTruthy();
+    expect(onSortChange).toHaveBeenCalledWith('popular');
     expect(screen.getByLabelText('Sort by Most Popular').props.accessibilityState.selected).toBe(true);
     expect(screen.getByLabelText('Sort by Most Recent').props.accessibilityState.selected).toBe(false);
   });

--- a/mobile/src/features/feed/presentation/screens/__tests__/FeedScreen.test.tsx
+++ b/mobile/src/features/feed/presentation/screens/__tests__/FeedScreen.test.tsx
@@ -19,6 +19,8 @@ function makeStory(id: string, overrides: Partial<FeedPageEntity['items'][number
     previewText: 'A short preview about local history and memory.',
     submittedAt: '2026-03-18T10:00:00Z',
     hasMedia: false,
+    likeCount: 0,
+    savedByViewer: false,
     ...overrides,
   };
 }
@@ -58,7 +60,8 @@ describe('FeedScreen', () => {
 
     expect(await screen.findByText('Story 1')).toBeTruthy();
     expect(screen.getByText('Story 2')).toBeTruthy();
-    expect(screen.getByRole('button', { name: 'Sort: Most Recent' })).toBeTruthy();
+    expect(screen.getByLabelText('Sort by Most Recent')).toBeTruthy();
+    expect(screen.getByLabelText('Sort by Most Popular')).toBeTruthy();
     expect(screen.getByLabelText('Search stories')).toBeTruthy();
     expect(screen.queryByText('Story feed')).toBeNull();
   });
@@ -67,7 +70,7 @@ describe('FeedScreen', () => {
     renderScreen(<FeedScreen getFeed={async () => makeFeedPage()} showSearchControls={false} />);
 
     expect(await screen.findByText('Story 1')).toBeTruthy();
-    expect(screen.queryByRole('button', { name: 'Sort: Most Recent' })).toBeNull();
+    expect(screen.queryByLabelText('Sort by Most Recent')).toBeNull();
     expect(screen.queryByLabelText('Search stories')).toBeNull();
   });
 
@@ -126,6 +129,37 @@ describe('FeedScreen', () => {
         filters: {},
       });
     });
+  });
+
+  it('switches to Most Popular and persists the selected sort in state', async () => {
+    const getFeed = jest
+      .fn<Promise<FeedPageEntity>, [any]>()
+      .mockResolvedValueOnce(makeFeedPage())
+      .mockResolvedValueOnce(
+        makeFeedPage({
+          items: [
+            makeStory('popular', { title: 'Popular Story', likeCount: 42 }),
+            makeStory('quiet', { title: 'Quiet Story', likeCount: 3 }),
+          ],
+        }),
+      );
+
+    renderScreen(<FeedScreen getFeed={getFeed} />);
+
+    expect(await screen.findByText('Story 1')).toBeTruthy();
+    fireEvent.press(screen.getByLabelText('Sort by Most Popular'));
+
+    await waitFor(() => {
+      expect(getFeed).toHaveBeenLastCalledWith({
+        page: 1,
+        sort: 'popular',
+        filters: {},
+      });
+    });
+
+    expect(await screen.findByText('Popular Story')).toBeTruthy();
+    expect(screen.getByLabelText('Sort by Most Popular').props.accessibilityState.selected).toBe(true);
+    expect(screen.getByLabelText('Sort by Most Recent').props.accessibilityState.selected).toBe(false);
   });
 
   it('updates search query filters after debounce', async () => {

--- a/mobile/src/features/feed/presentation/screens/__tests__/FeedScreen.test.tsx
+++ b/mobile/src/features/feed/presentation/screens/__tests__/FeedScreen.test.tsx
@@ -66,7 +66,7 @@ describe('FeedScreen', () => {
     expect(screen.queryByText('Story feed')).toBeNull();
   });
 
-  it('hides top feed controls when search controls are disabled', async () => {
+  it('keeps sort controls visible when search controls are disabled', async () => {
     renderScreen(<FeedScreen getFeed={async () => makeFeedPage()} showSearchControls={false} />);
 
     expect(await screen.findByText('Story 1')).toBeTruthy();

--- a/mobile/src/features/feed/presentation/screens/__tests__/FeedScreen.test.tsx
+++ b/mobile/src/features/feed/presentation/screens/__tests__/FeedScreen.test.tsx
@@ -70,7 +70,8 @@ describe('FeedScreen', () => {
     renderScreen(<FeedScreen getFeed={async () => makeFeedPage()} showSearchControls={false} />);
 
     expect(await screen.findByText('Story 1')).toBeTruthy();
-    expect(screen.queryByLabelText('Sort by Most Recent')).toBeNull();
+    expect(screen.getByLabelText('Sort by Most Recent')).toBeTruthy();
+    expect(screen.getByLabelText('Sort by Most Popular')).toBeTruthy();
     expect(screen.queryByLabelText('Search stories')).toBeNull();
   });
 
@@ -160,6 +161,37 @@ describe('FeedScreen', () => {
     expect(await screen.findByText('Popular Story')).toBeTruthy();
     expect(screen.getByLabelText('Sort by Most Popular').props.accessibilityState.selected).toBe(true);
     expect(screen.getByLabelText('Sort by Most Recent').props.accessibilityState.selected).toBe(false);
+  });
+
+  it('applies story interaction updates to visible feed cards', async () => {
+    const getFeed = jest.fn<Promise<FeedPageEntity>, [any]>().mockResolvedValue(
+      makeFeedPage({
+        items: [makeStory('1', { likeCount: 0, savedByViewer: false })],
+        totalCount: 1,
+      }),
+    );
+    const { rerender } = render(
+      <SearchFiltersProvider>
+        <FeedScreen getFeed={getFeed} storyInteractionUpdates={{}} />
+      </SearchFiltersProvider>,
+    );
+
+    expect(await screen.findByText('♥ 0')).toBeTruthy();
+    expect(screen.getByLabelText('Not bookmarked story')).toBeTruthy();
+
+    rerender(
+      <SearchFiltersProvider>
+        <FeedScreen
+          getFeed={getFeed}
+          storyInteractionUpdates={{ '1': { likeCount: 1, savedByViewer: true } }}
+        />
+      </SearchFiltersProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('♥ 1')).toBeTruthy();
+      expect(screen.getByLabelText('Bookmarked story')).toBeTruthy();
+    });
   });
 
   it('updates search query filters after debounce', async () => {

--- a/mobile/src/features/feed/presentation/screens/__tests__/FeedScreen.test.tsx
+++ b/mobile/src/features/feed/presentation/screens/__tests__/FeedScreen.test.tsx
@@ -72,6 +72,8 @@ describe('FeedScreen', () => {
     expect(screen.getByText('Story 2')).toBeTruthy();
     expect(screen.getByLabelText('Sort by Most Recent')).toBeTruthy();
     expect(screen.getByLabelText('Sort by Most Popular')).toBeTruthy();
+    expect(screen.getByText('Recent')).toBeTruthy();
+    expect(screen.getByText('Popular')).toBeTruthy();
     expect(screen.getByLabelText('Search stories')).toBeTruthy();
     expect(screen.queryByText('Story feed')).toBeNull();
   });

--- a/mobile/src/features/feed/presentation/state/feedUiState.ts
+++ b/mobile/src/features/feed/presentation/state/feedUiState.ts
@@ -14,7 +14,7 @@ export interface FeedUiState {
   filters: StoryFilters;
 }
 
-export function createInitialFeedUiState(filters: StoryFilters = {}): FeedUiState {
+export function createInitialFeedUiState(filters: StoryFilters = {}, sort: FeedSortOption = 'recent'): FeedUiState {
   return {
     items: [],
     isLoading: true,
@@ -24,7 +24,7 @@ export function createInitialFeedUiState(filters: StoryFilters = {}): FeedUiStat
     page: 1,
     totalCount: 0,
     hasNextPage: false,
-    sort: 'recent',
+    sort,
     filters,
   };
 }

--- a/mobile/src/features/interactions/application/services/index.ts
+++ b/mobile/src/features/interactions/application/services/index.ts
@@ -19,4 +19,10 @@ export const interactionService = {
   async unlikeStory(storyId: string): Promise<void> {
     return repository.unlikeStory(storyId);
   },
+  async bookmarkStory(storyId: string): Promise<void> {
+    return repository.bookmarkStory(storyId);
+  },
+  async unbookmarkStory(storyId: string): Promise<void> {
+    return repository.unbookmarkStory(storyId);
+  },
 };

--- a/mobile/src/features/interactions/data/repositories/index.ts
+++ b/mobile/src/features/interactions/data/repositories/index.ts
@@ -25,4 +25,12 @@ export class InteractionRepositoryImpl implements InteractionRepository {
   async unlikeStory(storyId: string): Promise<void> {
     await interactionsRemoteSource.unlikeStory(storyId);
   }
+
+  async bookmarkStory(storyId: string): Promise<void> {
+    await interactionsRemoteSource.bookmarkStory(storyId);
+  }
+
+  async unbookmarkStory(storyId: string): Promise<void> {
+    await interactionsRemoteSource.unbookmarkStory(storyId);
+  }
 }

--- a/mobile/src/features/interactions/data/sources/__tests__/interactionsRemoteSource.test.ts
+++ b/mobile/src/features/interactions/data/sources/__tests__/interactionsRemoteSource.test.ts
@@ -1,0 +1,24 @@
+import { apiClient } from '../../../../../core/api/client';
+import { interactionsRemoteSource } from '..';
+
+describe('interactionsRemoteSource', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('bookmarks a story through the bookmark endpoint', async () => {
+    const postSpy = jest.spyOn(apiClient, 'post').mockResolvedValue({});
+
+    await interactionsRemoteSource.bookmarkStory('42');
+
+    expect(postSpy).toHaveBeenCalledWith('/stories/42/bookmark/');
+  });
+
+  it('removes a bookmark through the bookmark endpoint', async () => {
+    const deleteSpy = jest.spyOn(apiClient, 'delete').mockResolvedValue(undefined);
+
+    await interactionsRemoteSource.unbookmarkStory('42');
+
+    expect(deleteSpy).toHaveBeenCalledWith('/stories/42/bookmark/');
+  });
+});

--- a/mobile/src/features/interactions/data/sources/index.ts
+++ b/mobile/src/features/interactions/data/sources/index.ts
@@ -54,6 +54,14 @@ export const interactionsRemoteSource = {
   async unlikeStory(storyId: string) {
     await apiClient.delete(`/stories/${storyId}/like/`);
   },
+
+  async bookmarkStory(storyId: string) {
+    await apiClient.post(`/stories/${storyId}/bookmark/`);
+  },
+
+  async unbookmarkStory(storyId: string) {
+    await apiClient.delete(`/stories/${storyId}/bookmark/`);
+  },
 };
 
 export const interactionsLocalSource = {};

--- a/mobile/src/features/interactions/domain/repositories/index.ts
+++ b/mobile/src/features/interactions/domain/repositories/index.ts
@@ -6,4 +6,6 @@ export interface InteractionRepository {
   deleteComment(commentId: string): Promise<void>;
   likeStory(storyId: string): Promise<void>;
   unlikeStory(storyId: string): Promise<void>;
+  bookmarkStory(storyId: string): Promise<void>;
+  unbookmarkStory(storyId: string): Promise<void>;
 }

--- a/mobile/src/features/stories/data/mappers/__tests__/storyMappers.test.ts
+++ b/mobile/src/features/stories/data/mappers/__tests__/storyMappers.test.ts
@@ -18,6 +18,7 @@ describe('story mappers', () => {
       tags: ['Walls', 'Conquest'],
       like_count: 7,
       user_has_liked: true,
+      user_has_saved: true,
       media_items: [
         {
           id: 1,
@@ -49,6 +50,7 @@ describe('story mappers', () => {
       tags: ['Walls', 'Conquest'],
       likeCount: 7,
       likedByViewer: true,
+      savedByViewer: true,
       comments: [],
     });
   });

--- a/mobile/src/features/stories/data/mappers/index.ts
+++ b/mobile/src/features/stories/data/mappers/index.ts
@@ -53,6 +53,8 @@ interface StoryRecord {
   like_count?: unknown;
   likedByViewer?: unknown;
   user_has_liked?: unknown;
+  savedByViewer?: unknown;
+  user_has_saved?: unknown;
   comments?: unknown;
 }
 
@@ -388,6 +390,7 @@ export function mapStory(value: unknown): StoryEntity {
     tags: getTags(story),
     likeCount: asNumber(story.likeCount) ?? asNumber(story.like_count) ?? 0,
     likedByViewer: asBoolean(story.likedByViewer, asBoolean(story.user_has_liked, false)),
+    savedByViewer: asBoolean(story.savedByViewer, asBoolean(story.user_has_saved, false)),
     comments,
   };
 }

--- a/mobile/src/features/stories/domain/entities/index.ts
+++ b/mobile/src/features/stories/domain/entities/index.ts
@@ -30,6 +30,7 @@ export interface StoryEntity {
   tags?: string[];
   likeCount: number;
   likedByViewer: boolean;
+  savedByViewer: boolean;
   comments: StoryCommentPreview[];
 }
 

--- a/mobile/src/features/stories/presentation/screens/StoryScreen.tsx
+++ b/mobile/src/features/stories/presentation/screens/StoryScreen.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { Alert, Image, LayoutChangeEvent, Pressable, ScrollView, Text, View } from 'react-native';
-import { Calendar, Clock, MapPin, Trash2 } from 'lucide-react-native';
+import { Bookmark, Calendar, Clock, MapPin, Trash2 } from 'lucide-react-native';
 import { roles } from '../../../../core/auth/roles';
 import { Session } from '../../../../core/auth/session';
 import { useAppTheme } from '../../../../core/hooks/useAppTheme';
@@ -710,6 +710,56 @@ export function StoryScreen({
     }
   };
 
+  const handleBookmarkPress = async () => {
+    if (!state.story || state.isBookmarkPending) {
+      return;
+    }
+
+    if (!state.isAuthenticated) {
+      setState((current) => ({
+        ...current,
+        loginPromptVisible: true,
+      }));
+      onRequestLogin?.();
+      return;
+    }
+
+    const previousStory = state.story;
+    const savedByViewer = !previousStory.savedByViewer;
+
+    setInteractionError(undefined);
+    setState((current) => ({
+      ...current,
+      isBookmarkPending: true,
+      loginPromptVisible: false,
+      story: current.story
+        ? {
+            ...current.story,
+            savedByViewer,
+          }
+        : current.story,
+    }));
+
+    try {
+      if (savedByViewer) {
+        await interactionService.bookmarkStory(previousStory.id);
+      } else {
+        await interactionService.unbookmarkStory(previousStory.id);
+      }
+    } catch (error) {
+      setState((current) => ({
+        ...current,
+        story: previousStory,
+      }));
+      setInteractionError(extractInteractionError(error, 'Failed to update bookmark. Please try again.'));
+    } finally {
+      setState((current) => ({
+        ...current,
+        isBookmarkPending: false,
+      }));
+    }
+  };
+
   const handleCommentLoginRequest = () => {
     setState((current) => ({
       ...current,
@@ -964,39 +1014,78 @@ export function StoryScreen({
         onLayout={(event) => setNarrativeTop(event.nativeEvent.layout.y)}
       />
 
-      <Pressable
-        onPress={() => {
-          void handleLikePress();
-        }}
-        disabled={state.isLikePending}
-        style={{
-          marginTop: spacing.xl,
-          paddingVertical: spacing.md,
-          paddingHorizontal: spacing.lg,
-          borderRadius: 999,
-          alignSelf: 'flex-start',
-          backgroundColor: story.likedByViewer ? colors.primary : colors.surface,
-          borderWidth: 1,
-          borderColor: colors.primary,
-          opacity: state.isLikePending ? 0.7 : 1,
-        }}
-        accessibilityRole="button"
-        accessibilityLabel={story.likedByViewer ? 'Unlike story' : 'Like story'}
-        accessibilityState={{ disabled: state.isLikePending, selected: story.likedByViewer }}
-      >
-        <Text
-          style={{
-            color: story.likedByViewer ? colors.background : colors.primary,
-            fontWeight: '700',
+      <View style={{ marginTop: spacing.xl, flexDirection: 'row', flexWrap: 'wrap', gap: spacing.sm }}>
+        <Pressable
+          onPress={() => {
+            void handleLikePress();
           }}
+          disabled={state.isLikePending}
+          style={{
+            paddingVertical: spacing.md,
+            paddingHorizontal: spacing.lg,
+            borderRadius: 999,
+            alignSelf: 'flex-start',
+            backgroundColor: story.likedByViewer ? colors.primary : colors.surface,
+            borderWidth: 1,
+            borderColor: colors.primary,
+            opacity: state.isLikePending ? 0.7 : 1,
+          }}
+          accessibilityRole="button"
+          accessibilityLabel={story.likedByViewer ? 'Unlike story' : 'Like story'}
+          accessibilityState={{ disabled: state.isLikePending, selected: story.likedByViewer }}
         >
-          {story.likedByViewer ? '♥' : '♡'} {story.likeCount}
-        </Text>
-      </Pressable>
+          <Text
+            style={{
+              color: story.likedByViewer ? colors.background : colors.primary,
+              fontWeight: '700',
+            }}
+          >
+            {story.likedByViewer ? '♥' : '♡'} {story.likeCount}
+          </Text>
+        </Pressable>
+
+        <Pressable
+          onPress={() => {
+            void handleBookmarkPress();
+          }}
+          disabled={state.isBookmarkPending}
+          style={{
+            paddingVertical: spacing.md,
+            paddingHorizontal: spacing.lg,
+            borderRadius: 999,
+            alignSelf: 'flex-start',
+            backgroundColor: story.savedByViewer ? colors.primary : colors.surface,
+            borderWidth: 1,
+            borderColor: colors.primary,
+            opacity: state.isBookmarkPending ? 0.7 : 1,
+            flexDirection: 'row',
+            alignItems: 'center',
+            gap: spacing.xs,
+          }}
+          accessibilityRole="button"
+          accessibilityLabel={story.savedByViewer ? 'Remove bookmark' : 'Bookmark story'}
+          accessibilityState={{ disabled: state.isBookmarkPending, selected: story.savedByViewer }}
+        >
+          <Bookmark
+            size={18}
+            color={story.savedByViewer ? colors.background : colors.primary}
+            fill={story.savedByViewer ? colors.background : 'transparent'}
+            strokeWidth={2.2}
+          />
+          <Text
+            style={{
+              color: story.savedByViewer ? colors.background : colors.primary,
+              fontWeight: '700',
+            }}
+          >
+            {story.savedByViewer ? 'Saved' : 'Save'}
+          </Text>
+        </Pressable>
+      </View>
 
       {state.loginPromptVisible ? (
         <Text style={{ marginTop: spacing.sm, color: colors.muted }}>
-          Log in to like or comment on this story.
+          Log in to like, bookmark, or comment on this story.
         </Text>
       ) : null}
       {interactionError ? (

--- a/mobile/src/features/stories/presentation/screens/StoryScreen.tsx
+++ b/mobile/src/features/stories/presentation/screens/StoryScreen.tsx
@@ -24,6 +24,12 @@ interface StoryScreenProps {
   onRequestLogin?: () => void;
   onGoBack?: () => void;
   onStoryDeleted?: () => void;
+  onStoryInteractionUpdated?: (update: {
+    storyId: string;
+    likeCount: number;
+    likedByViewer: boolean;
+    savedByViewer: boolean;
+  }) => void;
   onOpenContributorProfile?: (userId: string) => void;
   getStory?: typeof storyService.getStory;
   deleteStory?: typeof storyService.deleteStory;
@@ -496,6 +502,7 @@ export function StoryScreen({
   onRequestLogin,
   onGoBack,
   onStoryDeleted,
+  onStoryInteractionUpdated,
   onOpenContributorProfile,
   getStory = storyService.getStory,
   deleteStory = storyService.deleteStory,
@@ -689,6 +696,12 @@ export function StoryScreen({
           }
         : current.story,
     }));
+    onStoryInteractionUpdated?.({
+      storyId: previousStory.id,
+      likedByViewer,
+      likeCount,
+      savedByViewer: previousStory.savedByViewer,
+    });
 
     try {
       if (likedByViewer) {
@@ -701,6 +714,12 @@ export function StoryScreen({
         ...current,
         story: previousStory,
       }));
+      onStoryInteractionUpdated?.({
+        storyId: previousStory.id,
+        likedByViewer: previousStory.likedByViewer,
+        likeCount: previousStory.likeCount,
+        savedByViewer: previousStory.savedByViewer,
+      });
       setInteractionError(extractInteractionError(error, 'Failed to update like. Please try again.'));
     } finally {
       setState((current) => ({
@@ -739,6 +758,12 @@ export function StoryScreen({
           }
         : current.story,
     }));
+    onStoryInteractionUpdated?.({
+      storyId: previousStory.id,
+      likedByViewer: previousStory.likedByViewer,
+      likeCount: previousStory.likeCount,
+      savedByViewer,
+    });
 
     try {
       if (savedByViewer) {
@@ -751,6 +776,12 @@ export function StoryScreen({
         ...current,
         story: previousStory,
       }));
+      onStoryInteractionUpdated?.({
+        storyId: previousStory.id,
+        likedByViewer: previousStory.likedByViewer,
+        likeCount: previousStory.likeCount,
+        savedByViewer: previousStory.savedByViewer,
+      });
       setInteractionError(extractInteractionError(error, 'Failed to update bookmark. Please try again.'));
     } finally {
       setState((current) => ({

--- a/mobile/src/features/stories/presentation/screens/__tests__/StoryScreen.test.tsx
+++ b/mobile/src/features/stories/presentation/screens/__tests__/StoryScreen.test.tsx
@@ -343,11 +343,14 @@ describe('StoryScreen', () => {
   });
 
   it('toggles likes for authenticated users', async () => {
+    const onStoryInteractionUpdated = jest.fn();
+
     render(
       <StoryScreen
         storyId="story-001"
         session={userSession}
         getStory={async () => baseStory}
+        onStoryInteractionUpdated={onStoryInteractionUpdated}
       />,
     );
 
@@ -358,6 +361,12 @@ describe('StoryScreen', () => {
       expect(screen.getByText('♥ 28')).toBeTruthy();
     });
     expect(interactionService.likeStory).toHaveBeenCalledWith('story-001');
+    expect(onStoryInteractionUpdated).toHaveBeenCalledWith({
+      storyId: 'story-001',
+      likedByViewer: true,
+      likeCount: 28,
+      savedByViewer: false,
+    });
   });
 
   it('prompts unauthenticated users to log in before liking', async () => {
@@ -402,11 +411,14 @@ describe('StoryScreen', () => {
   });
 
   it('bookmarks stories for authenticated users with an optimistic update', async () => {
+    const onStoryInteractionUpdated = jest.fn();
+
     render(
       <StoryScreen
         storyId="story-001"
         session={userSession}
         getStory={async () => baseStory}
+        onStoryInteractionUpdated={onStoryInteractionUpdated}
       />,
     );
 
@@ -418,6 +430,12 @@ describe('StoryScreen', () => {
       expect(screen.getByText('Saved')).toBeTruthy();
     });
     expect(interactionService.bookmarkStory).toHaveBeenCalledWith('story-001');
+    expect(onStoryInteractionUpdated).toHaveBeenCalledWith({
+      storyId: 'story-001',
+      likedByViewer: false,
+      likeCount: 27,
+      savedByViewer: true,
+    });
   });
 
   it('removes bookmarks for authenticated users with an optimistic update', async () => {

--- a/mobile/src/features/stories/presentation/screens/__tests__/StoryScreen.test.tsx
+++ b/mobile/src/features/stories/presentation/screens/__tests__/StoryScreen.test.tsx
@@ -19,6 +19,8 @@ jest.mock('../../../../interactions/application/services', () => ({
   interactionService: {
     likeStory: jest.fn(async () => undefined),
     unlikeStory: jest.fn(async () => undefined),
+    bookmarkStory: jest.fn(async () => undefined),
+    unbookmarkStory: jest.fn(async () => undefined),
     getComments: jest.fn(async () => []),
     addComment: jest.fn(async () => undefined),
     deleteComment: jest.fn(async () => undefined),
@@ -46,6 +48,7 @@ const baseStory: StoryEntity = {
   tags: ['Harbor', 'Labor'],
   likeCount: 27,
   likedByViewer: false,
+  savedByViewer: false,
   comments: [
     {
       id: 'comment-1',
@@ -373,7 +376,7 @@ describe('StoryScreen', () => {
     fireEvent.press(screen.getByText('♡ 27'));
 
     await waitFor(() => {
-      expect(screen.getByText('Log in to like or comment on this story.')).toBeTruthy();
+      expect(screen.getByText('Log in to like, bookmark, or comment on this story.')).toBeTruthy();
     });
     expect(onRequestLogin).toHaveBeenCalledTimes(1);
   });
@@ -395,6 +398,86 @@ describe('StoryScreen', () => {
     await waitFor(() => {
       expect(screen.getByText('♡ 27')).toBeTruthy();
       expect(screen.getByText('Network error')).toBeTruthy();
+    });
+  });
+
+  it('bookmarks stories for authenticated users with an optimistic update', async () => {
+    render(
+      <StoryScreen
+        storyId="story-001"
+        session={userSession}
+        getStory={async () => baseStory}
+      />,
+    );
+
+    expect(await screen.findByLabelText('Bookmark story')).toBeTruthy();
+    fireEvent.press(screen.getByLabelText('Bookmark story'));
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('Remove bookmark')).toBeTruthy();
+      expect(screen.getByText('Saved')).toBeTruthy();
+    });
+    expect(interactionService.bookmarkStory).toHaveBeenCalledWith('story-001');
+  });
+
+  it('removes bookmarks for authenticated users with an optimistic update', async () => {
+    render(
+      <StoryScreen
+        storyId="story-001"
+        session={userSession}
+        getStory={async () => ({ ...baseStory, savedByViewer: true })}
+      />,
+    );
+
+    expect(await screen.findByLabelText('Remove bookmark')).toBeTruthy();
+    fireEvent.press(screen.getByLabelText('Remove bookmark'));
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('Bookmark story')).toBeTruthy();
+      expect(screen.getByText('Save')).toBeTruthy();
+    });
+    expect(interactionService.unbookmarkStory).toHaveBeenCalledWith('story-001');
+  });
+
+  it('prompts unauthenticated users to log in before bookmarking', async () => {
+    const onRequestLogin = jest.fn();
+
+    render(
+      <StoryScreen
+        storyId="story-001"
+        session={guestSession}
+        onRequestLogin={onRequestLogin}
+        getStory={async () => baseStory}
+      />,
+    );
+
+    expect(await screen.findByLabelText('Bookmark story')).toBeTruthy();
+    fireEvent.press(screen.getByLabelText('Bookmark story'));
+
+    await waitFor(() => {
+      expect(screen.getByText('Log in to like, bookmark, or comment on this story.')).toBeTruthy();
+    });
+    expect(onRequestLogin).toHaveBeenCalledTimes(1);
+    expect(interactionService.bookmarkStory).not.toHaveBeenCalled();
+  });
+
+  it('reverts optimistic bookmarks when the API request fails', async () => {
+    (interactionService.bookmarkStory as jest.Mock).mockRejectedValueOnce(new Error('Bookmark failed'));
+
+    render(
+      <StoryScreen
+        storyId="story-001"
+        session={userSession}
+        getStory={async () => baseStory}
+      />,
+    );
+
+    expect(await screen.findByLabelText('Bookmark story')).toBeTruthy();
+    fireEvent.press(screen.getByLabelText('Bookmark story'));
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('Bookmark story')).toBeTruthy();
+      expect(screen.getByText('Bookmark failed')).toBeTruthy();
     });
   });
 

--- a/mobile/src/features/stories/presentation/state/storiesUiState.ts
+++ b/mobile/src/features/stories/presentation/state/storiesUiState.ts
@@ -6,6 +6,7 @@ export interface StoryDetailUiState {
   error?: 'not-found' | 'unknown';
   isAuthenticated: boolean;
   isLikePending: boolean;
+  isBookmarkPending: boolean;
   loginPromptVisible: boolean;
 }
 
@@ -14,6 +15,7 @@ export function createInitialStoryDetailUiState(isAuthenticated = false): StoryD
     isLoading: true,
     isAuthenticated,
     isLikePending: false,
+    isBookmarkPending: false,
     loginPromptVisible: false,
   };
 }


### PR DESCRIPTION
# 📝 Description
Fixes #213

### Summary

Adds mobile feed popular sorting and story bookmarking support.

### Changes

- Added `Most Recent` / `Most Popular` sort controls on the mobile feed
- Sorts popular feed by like count through `sort_by=popular`
- Preserves selected feed sort after opening and returning from story detail
- Adds bookmark UI on story detail with optimistic toggle behavior
- Shows bookmark state on feed cards
- Adds mobile API calls for bookmark/unbookmark
- Syncs story detail like/bookmark changes back to feed cards
- Hydrates missing feed like metadata from story detail when legacy feed payloads do not include counts
- Adds `like_count` / `save_count` to backend feed serializer for feed cards

### Tests

- `npm run typecheck`
- `npm test -- --runInBand --watchAll=false`

Full mobile suite passed: 35 suites, 214 tests.

# 📊 Type of Change
- [ ]  Bug fix
- [ ]  New feature
- [ ]  Refactoring
- [ ]  Documentation
 
# ✅ Acceptance Criteria / Checklist
- [ ] Project builds successfully
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, especially in hard-to-understand parts
- [ ] I have performed a self-review of my code
- [ ] I have added/updated tests
- [ ] New and existing unit tests pass locally with my changes

# ⏱️ Estimated Review Time
- [ ] < 5 min
- [ ] 5-15 min
- [ ] > 15 min
