### PR TITLE
feat: add mobile mixed media story submission and playback

### DIFF
--- a/mobile/app.config.js
+++ b/mobile/app.config.js
@@ -8,6 +8,11 @@ module.exports = () => {
 
   return {
     ...expoConfig,
+    plugins: [
+      ...(expoConfig.plugins ?? []),
+      'expo-video',
+      'expo-audio',
+    ],
     android: {
       ...androidConfig,
       config: {

--- a/mobile/jest.setup.ts
+++ b/mobile/jest.setup.ts
@@ -17,12 +17,57 @@ jest.mock('expo-image-picker', () => ({
   __esModule: true,
   MediaTypeOptions: {
     Images: 'images',
+    Videos: 'videos',
   },
   requestMediaLibraryPermissionsAsync: jest.fn(async () => ({ granted: true })),
   requestCameraPermissionsAsync: jest.fn(async () => ({ granted: true })),
   launchImageLibraryAsync: jest.fn(async () => ({ canceled: true, assets: [] })),
   launchCameraAsync: jest.fn(async () => ({ canceled: true, assets: [] })),
 }));
+
+jest.mock('expo-document-picker', () => ({
+  __esModule: true,
+  getDocumentAsync: jest.fn(async () => ({ canceled: true, assets: [] })),
+}));
+
+jest.mock('expo-audio', () => ({
+  __esModule: true,
+  useAudioPlayer: jest.fn(() => ({
+    play: jest.fn(),
+    pause: jest.fn(),
+    seekTo: jest.fn(async () => undefined),
+  })),
+  useAudioPlayerStatus: jest.fn(() => ({
+    currentTime: 0,
+    duration: 0,
+    playing: false,
+    didJustFinish: false,
+    isLoaded: false,
+  })),
+}));
+
+jest.mock('expo-video', () => {
+  const React = require('react');
+  const { View } = require('react-native');
+
+  return {
+    __esModule: true,
+    useVideoPlayer: jest.fn(() => ({})),
+    VideoView: ({ children, ...props }: { children?: React.ReactNode }) =>
+      React.createElement(View, props, children),
+  };
+});
+
+jest.mock('@react-native-community/slider', () => {
+  const React = require('react');
+  const { View } = require('react-native');
+
+  return {
+    __esModule: true,
+    default: ({ children, ...props }: { children?: React.ReactNode }) =>
+      React.createElement(View, props, children),
+  };
+});
 
 jest.mock('expo-location', () => ({
   __esModule: true,

--- a/mobile/package-lock.json
+++ b/mobile/package-lock.json
@@ -8,10 +8,14 @@
       "name": "local-history-story-map-mobile",
       "version": "0.1.0",
       "dependencies": {
+        "@react-native-community/slider": "5.0.1",
         "expo": "54.0.0",
+        "expo-audio": "~1.1.1",
+        "expo-document-picker": "~14.0.8",
         "expo-file-system": "~19.0.21",
         "expo-image-picker": "~17.0.10",
         "expo-location": "~19.0.8",
+        "expo-video": "~3.0.16",
         "lucide-react-native": "^1.7.0",
         "react": "19.1.0",
         "react-native": "0.81.4",
@@ -1761,17 +1765,17 @@
       }
     },
     "node_modules/@expo/image-utils": {
-      "version": "0.8.12",
-      "resolved": "https://registry.npmjs.org/@expo/image-utils/-/image-utils-0.8.12.tgz",
-      "integrity": "sha512-3KguH7kyKqq7pNwLb9j6BBdD/bjmNwXZG/HPWT6GWIXbwrvAJt2JNyYTP5agWJ8jbbuys1yuCzmkX+TU6rmI7A==",
+      "version": "0.8.13",
+      "resolved": "https://registry.npmjs.org/@expo/image-utils/-/image-utils-0.8.13.tgz",
+      "integrity": "sha512-1I//yBQeTY6p0u1ihqGNDAr35EbSG8uFEupFrIF0jd++h9EWH33521yZJU1yE+mwGlzCb61g3ehu78siMhXBlA==",
       "license": "MIT",
       "dependencies": {
+        "@expo/require-utils": "^55.0.4",
         "@expo/spawn-async": "^1.7.2",
         "chalk": "^4.0.0",
         "getenv": "^2.0.0",
         "jimp-compact": "0.16.1",
         "parse-png": "^2.1.0",
-        "resolve-from": "^5.0.0",
         "semver": "^7.6.0"
       }
     },
@@ -2121,6 +2125,25 @@
         "@xmldom/xmldom": "^0.8.8",
         "base64-js": "^1.2.3",
         "xmlbuilder": "^15.1.1"
+      }
+    },
+    "node_modules/@expo/require-utils": {
+      "version": "55.0.4",
+      "resolved": "https://registry.npmjs.org/@expo/require-utils/-/require-utils-55.0.4.tgz",
+      "integrity": "sha512-JAANvXqV7MOysWeVWgaiDzikoyDjJWOV/ulOW60Zb3kXJfrx2oZOtGtDXDFKD1mXuahQgoM5QOjuZhF7gFRNjA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.20.0",
+        "@babel/core": "^7.25.2",
+        "@babel/plugin-transform-modules-commonjs": "^7.24.8"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0 || ^5.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
       }
     },
     "node_modules/@expo/schema-utils": {
@@ -2861,6 +2884,12 @@
       "engines": {
         "node": ">=14"
       }
+    },
+    "node_modules/@react-native-community/slider": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@react-native-community/slider/-/slider-5.0.1.tgz",
+      "integrity": "sha512-K3JRWkIW4wQ79YJ6+BPZzp1SamoikxfPRw7Yw4B4PElEQmqZFrmH9M5LxvIo460/3QSrZF/wCgi3qizJt7g/iw==",
+      "license": "MIT"
     },
     "node_modules/@react-native/assets-registry": {
       "version": "0.81.4",
@@ -5461,6 +5490,72 @@
         }
       }
     },
+    "node_modules/expo-asset": {
+      "version": "55.0.16",
+      "resolved": "https://registry.npmjs.org/expo-asset/-/expo-asset-55.0.16.tgz",
+      "integrity": "sha512-5IJyfJtYqvKGg04NKGQWiCIoK/fULDL9m15mXPPyfabD1jsToVj2hnWmo1r2SWNNmMwtQxi6jTpcGwVo2nLDxg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@expo/image-utils": "^0.8.13",
+        "expo-constants": "~55.0.15"
+      },
+      "peerDependencies": {
+        "expo": "*",
+        "react": "*",
+        "react-native": "*"
+      }
+    },
+    "node_modules/expo-audio": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/expo-audio/-/expo-audio-1.1.1.tgz",
+      "integrity": "sha512-CPCpJ+0AEHdzWROc0f00Zh6e+irLSl2ALos/LPvxEeIcJw1APfBa4DuHPkL4CQCWsVe7EnUjFpdwpqsEUWcP0g==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*",
+        "expo-asset": "*",
+        "react": "*",
+        "react-native": "*"
+      }
+    },
+    "node_modules/expo-constants": {
+      "version": "55.0.15",
+      "resolved": "https://registry.npmjs.org/expo-constants/-/expo-constants-55.0.15.tgz",
+      "integrity": "sha512-w394fcZLJjeKN+9ZnJzL/HiarE1nwZFDa+3S9frevh6Ur+MAAs9QDrcXhDrV8T3xqRzzYaqsP6Z8TFZ4efWN1A==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@expo/env": "~2.1.1"
+      },
+      "peerDependencies": {
+        "expo": "*",
+        "react-native": "*"
+      }
+    },
+    "node_modules/expo-constants/node_modules/@expo/env": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@expo/env/-/env-2.1.1.tgz",
+      "integrity": "sha512-rVvHC4I6xlPcg+mAO09ydUi2Wjv1ZytpLmHOSzvXzBAz9mMrJggqCe4s4dubjJvi/Ino/xQCLhbaLCnTtLpikg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "chalk": "^4.0.0",
+        "debug": "^4.3.4",
+        "getenv": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=20.12.0"
+      }
+    },
+    "node_modules/expo-document-picker": {
+      "version": "14.0.8",
+      "resolved": "https://registry.npmjs.org/expo-document-picker/-/expo-document-picker-14.0.8.tgz",
+      "integrity": "sha512-3tyQKpPqWWFlI8p9RiMX1+T1Zge5mEKeBuXWp1h8PEItFMUDSiOJbQ112sfdC6Hxt8wSxreV9bCRl/NgBdt+fA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
     "node_modules/expo-file-system": {
       "version": "19.0.21",
       "resolved": "https://registry.npmjs.org/expo-file-system/-/expo-file-system-19.0.21.tgz",
@@ -5570,6 +5665,17 @@
         "invariant": "^2.2.4"
       },
       "peerDependencies": {
+        "react": "*",
+        "react-native": "*"
+      }
+    },
+    "node_modules/expo-video": {
+      "version": "3.0.16",
+      "resolved": "https://registry.npmjs.org/expo-video/-/expo-video-3.0.16.tgz",
+      "integrity": "sha512-H1HlxcHGomZItqisGfW3YL/G9BHtNBfVSimDJcLuyxyU87wFnV8loO9tCjuhufkfh/aTa2sW5BYAjLjg9DvnBQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*",
         "react": "*",
         "react-native": "*"
       }
@@ -11212,7 +11318,7 @@
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -12,10 +12,14 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "@react-native-community/slider": "5.0.1",
     "expo": "54.0.0",
+    "expo-audio": "~1.1.1",
+    "expo-document-picker": "~14.0.8",
     "expo-file-system": "~19.0.21",
     "expo-image-picker": "~17.0.10",
     "expo-location": "~19.0.8",
+    "expo-video": "~3.0.16",
     "lucide-react-native": "^1.7.0",
     "react": "19.1.0",
     "react-native": "0.81.4",

--- a/mobile/src/core/constants/limits.ts
+++ b/mobile/src/core/constants/limits.ts
@@ -1,5 +1,7 @@
 export const limits = {
   maxTagsPerStory: 3,
   maxStoryImageBytes: 2 * 1024 * 1024,
+  maxStoryAudioBytes: 10 * 1024 * 1024,
+  maxStoryVideoBytes: 50 * 1024 * 1024,
   maxProfilePhotoMb: 2,
 };

--- a/mobile/src/features/stories/data/mappers/__tests__/storyMappers.test.ts
+++ b/mobile/src/features/stories/data/mappers/__tests__/storyMappers.test.ts
@@ -46,6 +46,14 @@ describe('story mappers', () => {
       submittedAt: '2026-03-18T10:00:00Z',
       mediaUrl: 'https://example.com/photo.jpg',
       mediaAltText: 'Stone city walls at sunset',
+      mediaItems: [
+        {
+          id: '1',
+          type: 'image',
+          url: 'https://example.com/photo.jpg',
+          altText: 'Stone city walls at sunset',
+        },
+      ],
       tags: ['Walls', 'Conquest'],
       likeCount: 7,
       likedByViewer: true,
@@ -72,7 +80,37 @@ describe('story mappers', () => {
     expect(result.contributorName).toBe('Anonymous');
     expect(result.isContributorAnonymous).toBe(false);
     expect(result.mediaUrl).toBeUndefined();
+    expect(result.mediaItems).toEqual([]);
     expect(result.tags).toEqual([]);
+  });
+
+  it('maps image, audio, and video media items in display order', () => {
+    const result = mapStory({
+      id: 55,
+      user: 7,
+      title: 'Mixed Media Memory',
+      narrative: 'A private contribution.',
+      status: 'published',
+      location_name: 'Kadikoy',
+      location_lat: '40.9903',
+      location_lng: '29.0290',
+      time_type: 'exact_year',
+      year: 1984,
+      contributor_name: 'Aylin',
+      submitted_at: '2026-03-18T10:00:00Z',
+      media_items: [
+        { id: 3, media_type: 'video', url: 'https://example.com/story.mp4', order: 2 },
+        { id: 1, media_type: 'image', url: 'https://example.com/story.jpg', alt_text: 'Story photo', order: 0 },
+        { id: 2, media_type: 'audio', url: 'https://example.com/story.mp3', order: 1 },
+      ],
+    });
+
+    expect(result.mediaItems).toEqual([
+      { id: '1', type: 'image', url: 'https://example.com/story.jpg', altText: 'Story photo' },
+      { id: '2', type: 'audio', url: 'https://example.com/story.mp3', altText: undefined },
+      { id: '3', type: 'video', url: 'https://example.com/story.mp4', altText: undefined },
+    ]);
+    expect(result.mediaUrl).toBe('https://example.com/story.jpg');
   });
 
   it('maps normalized anonymous stories with the anonymous contributor label', () => {
@@ -98,7 +136,30 @@ describe('story mappers', () => {
     expect(result.timePeriod).toBe('1980/1989');
     expect(result.temporalCoverageIso8601).toBe('1980/1989');
     expect(result.mediaUrl).toBeUndefined();
+    expect(result.mediaItems).toEqual([]);
     expect(result.tags).toEqual([]);
+  });
+
+  it('treats contributor visibility off as anonymous profile-hidden story', () => {
+    const result = mapStory({
+      id: 54,
+      user: 7,
+      title: 'Visibility Off',
+      narrative: 'A private contribution.',
+      status: 'published',
+      location_name: 'Kadikoy',
+      location_lat: '40.9903',
+      location_lng: '29.0290',
+      time_type: 'exact_year',
+      year: 1984,
+      contributor_visible: false,
+      contributor_name: null,
+      submitted_at: '2026-03-18T10:00:00Z',
+    });
+
+    expect(result.contributorName).toBe('Anonymous');
+    expect(result.isContributorAnonymous).toBe(true);
+    expect(result.contributorUserId).toBe('7');
   });
 
   it('maps backend comments into the mobile comment shape', () => {

--- a/mobile/src/features/stories/data/mappers/index.ts
+++ b/mobile/src/features/stories/data/mappers/index.ts
@@ -2,6 +2,8 @@ import {
   StoryCommentPreview,
   StoryEntity,
   StoryLocation,
+  StoryMediaItem,
+  StoryMediaType,
   StoryMapPin,
   StorySummaryEntity,
 } from '../../domain/entities';
@@ -36,6 +38,8 @@ interface StoryRecord {
   temporal_coverage_iso8601?: unknown;
   contributorName?: unknown;
   contributor_name?: unknown;
+  contributor_visible?: unknown;
+  contributorVisible?: unknown;
   contributor_visibility?: unknown;
   contributorVisibility?: unknown;
   is_anonymous?: unknown;
@@ -284,6 +288,52 @@ function getPrimaryMediaAltText(value: StoryRecord) {
   return asString(firstImage?.alt_text) || asString(firstImage?.altText) || asString(firstImage?.caption) || undefined;
 }
 
+function isStoryMediaType(value: unknown): value is StoryMediaType {
+  return value === 'image' || value === 'audio' || value === 'video';
+}
+
+function getMediaItems(value: StoryRecord): StoryMediaItem[] {
+  const explicitMediaUrl = asString(value.mediaUrl) || asString(value.media_url);
+  const explicitAltText = asString(value.mediaAltText) || asString(value.media_alt_text) || undefined;
+  type OrderedStoryMediaItem = StoryMediaItem & { order: number };
+  const normalizedItems = Array.isArray(value.media_items)
+    ? (value.media_items as StoryMediaItemRecord[])
+        .reduce<OrderedStoryMediaItem[]>((items, item, index) => {
+          const type = item?.media_type ?? item?.mediaType;
+          const url = asString(item?.url);
+
+          if (!isStoryMediaType(type) || !url) {
+            return items;
+          }
+
+          items.push({
+            id: asStringId(item.id) ?? `${type}-${index}`,
+            type,
+            url,
+            altText: asString(item.alt_text) || asString(item.altText) || asString(item.caption) || undefined,
+            order: asNumber(item.order) ?? index,
+          });
+          return items;
+        }, [])
+        .sort((left, right) => left.order - right.order)
+        .map(({ order: _order, ...item }) => item)
+    : [];
+
+  if (explicitMediaUrl && !normalizedItems.some((item) => item.type === 'image' && item.url === explicitMediaUrl)) {
+    return [
+      {
+        id: 'primary-image',
+        type: 'image',
+        url: explicitMediaUrl,
+        altText: explicitAltText,
+      },
+      ...normalizedItems,
+    ];
+  }
+
+  return normalizedItems;
+}
+
 function getTags(value: StoryRecord | Record<string, unknown>) {
   let rawTags: unknown[] = [];
 
@@ -315,13 +365,13 @@ function getTemporalCoverageIso8601(value: StoryRecord | Record<string, unknown>
 
 function isAnonymousStory(value: StoryRecord) {
   const visibility = asString(value.contributor_visibility) || asString(value.contributorVisibility);
-  const contributorName = asString(value.contributorName) || asString(value.contributor_name);
 
   return (
     visibility === 'anonymous' ||
+    value.contributor_visible === false ||
+    value.contributorVisible === false ||
     value.is_anonymous === true ||
-    value.isAnonymous === true ||
-    contributorName.trim().toLowerCase() === 'anonymous'
+    value.isAnonymous === true
   );
 }
 
@@ -366,6 +416,7 @@ export function mapStory(value: unknown): StoryEntity {
   const comments = Array.isArray(story.comments) && story.comments.every(isCommentPreview) ? story.comments : [];
   const contributorName = getContributorName(story);
   const isContributorAnonymous = isAnonymousStory(story);
+  const mediaItems = getMediaItems(story);
 
   if (!id || typeof story.title !== 'string' || !narrative.length || !location.name || !submittedAt) {
     throw new Error('Invalid story payload.');
@@ -385,6 +436,7 @@ export function mapStory(value: unknown): StoryEntity {
     submittedAt,
     mediaUrl: getPrimaryMediaUrl(story),
     mediaAltText: getPrimaryMediaAltText(story),
+    mediaItems,
     tags: getTags(story),
     likeCount: asNumber(story.likeCount) ?? asNumber(story.like_count) ?? 0,
     likedByViewer: asBoolean(story.likedByViewer, asBoolean(story.user_has_liked, false)),

--- a/mobile/src/features/stories/domain/entities/index.ts
+++ b/mobile/src/features/stories/domain/entities/index.ts
@@ -13,6 +13,15 @@ export interface StoryLocation {
   longitude: number;
 }
 
+export type StoryMediaType = 'image' | 'audio' | 'video';
+
+export interface StoryMediaItem {
+  id: string;
+  type: StoryMediaType;
+  url: string;
+  altText?: string;
+}
+
 export interface StoryEntity {
   id: string;
   contributorUserId?: string;
@@ -27,6 +36,7 @@ export interface StoryEntity {
   submittedAt: string;
   mediaUrl?: string;
   mediaAltText?: string;
+  mediaItems?: StoryMediaItem[];
   tags?: string[];
   likeCount: number;
   likedByViewer: boolean;

--- a/mobile/src/features/stories/presentation/screens/StoryScreen.tsx
+++ b/mobile/src/features/stories/presentation/screens/StoryScreen.tsx
@@ -1,13 +1,16 @@
 import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { Alert, Image, LayoutChangeEvent, Pressable, ScrollView, Text, View } from 'react-native';
-import { Calendar, Clock, MapPin, Trash2 } from 'lucide-react-native';
+import Slider from '@react-native-community/slider';
+import { Calendar, Clock, MapPin, Pause, Play, Trash2, Volume2 } from 'lucide-react-native';
+import { useAudioPlayer, useAudioPlayerStatus } from 'expo-audio';
+import { VideoView, useVideoPlayer } from 'expo-video';
 import { roles } from '../../../../core/auth/roles';
 import { Session } from '../../../../core/auth/session';
 import { useAppTheme } from '../../../../core/hooks/useAppTheme';
 import { interactionService } from '../../../interactions/application/services';
 import { StoryCommentEntity } from '../../../interactions/domain/entities';
 import { storyService } from '../../application/services';
-import { StoryEntity } from '../../domain/entities';
+import { StoryEntity, StoryMediaItem } from '../../domain/entities';
 import { ErrorState } from '../../../../shared/ui/ErrorState';
 import { Button } from '../../../../shared/ui/Button';
 import { Input } from '../../../../shared/ui/Input';
@@ -259,6 +262,272 @@ function StoryNarrative({
           </Text>
         </Pressable>
       ) : null}
+    </View>
+  );
+}
+
+function formatPlaybackTime(seconds: number) {
+  if (!Number.isFinite(seconds) || seconds <= 0) {
+    return '0:00';
+  }
+
+  const totalSeconds = Math.floor(seconds);
+  const minutes = Math.floor(totalSeconds / 60);
+  const remainingSeconds = totalSeconds % 60;
+  return `${minutes}:${String(remainingSeconds).padStart(2, '0')}`;
+}
+
+function StoryAudioPreview({ item, title }: { item: StoryMediaItem; title: string }) {
+  const { colors, spacing, typography } = useAppTheme();
+  const player = useAudioPlayer({ uri: item.url }, { updateInterval: 250 });
+  const status = useAudioPlayerStatus(player);
+  const [scrubTime, setScrubTime] = useState(0);
+  const [isScrubbing, setIsScrubbing] = useState(false);
+  const [pendingSeekTime, setPendingSeekTime] = useState<number | null>(null);
+  const shouldResumeAfterScrubRef = useRef(false);
+  const duration = status.duration || 0;
+  const displayedTime = isScrubbing ? scrubTime : pendingSeekTime ?? status.currentTime;
+  const label = `${title} audio`;
+
+  useEffect(() => {
+    if (pendingSeekTime == null) {
+      return;
+    }
+
+    if (Math.abs(status.currentTime - pendingSeekTime) < 0.35) {
+      setPendingSeekTime(null);
+    }
+  }, [pendingSeekTime, status.currentTime]);
+
+  const togglePlayback = () => {
+    if (status.playing) {
+      player.pause();
+      return;
+    }
+
+    if (status.didJustFinish) {
+      void player.seekTo(0);
+    }
+    player.play();
+  };
+
+  return (
+    <View
+      accessibilityLabel={label}
+      style={{
+        minHeight: 150,
+        borderRadius: 18,
+        backgroundColor: '#111827',
+        padding: spacing.md,
+        justifyContent: 'space-between',
+        gap: spacing.md,
+      }}
+    >
+      <View style={{ flexDirection: 'row', alignItems: 'center', gap: spacing.md }}>
+        <Pressable
+          accessibilityRole="button"
+          accessibilityLabel={status.playing ? 'Pause story audio' : 'Play story audio'}
+          onPress={togglePlayback}
+          style={({ pressed }) => ({
+            width: 58,
+            height: 58,
+            borderRadius: 999,
+            alignItems: 'center',
+            justifyContent: 'center',
+            backgroundColor: colors.background,
+            opacity: pressed ? 0.85 : 1,
+          })}
+        >
+          {status.playing ? (
+            <Pause size={26} color="#111827" fill="#111827" />
+          ) : (
+            <Play size={26} color="#111827" fill="#111827" style={{ marginLeft: 2 }} />
+          )}
+        </Pressable>
+        <View style={{ flex: 1, gap: spacing.xs }}>
+          <Text style={{ color: colors.background, fontSize: typography.body, fontWeight: '800' }}>
+            Story audio
+          </Text>
+          <View style={{ flexDirection: 'row', alignItems: 'center', gap: spacing.xs }}>
+            <Volume2 size={16} color="#cbd5e1" />
+            <Text style={{ color: '#cbd5e1', fontSize: typography.caption, fontWeight: '600' }}>
+              Oral history attachment
+            </Text>
+          </View>
+        </View>
+      </View>
+      <View style={{ gap: spacing.xs }}>
+        <Slider
+          accessibilityLabel="Seek story audio"
+          disabled={duration <= 0}
+          minimumValue={0}
+          maximumValue={Math.max(duration, 0)}
+          value={Math.min(displayedTime, duration || displayedTime)}
+          minimumTrackTintColor={colors.primary}
+          maximumTrackTintColor="#334155"
+          thumbTintColor={colors.background}
+          tapToSeek
+          onSlidingStart={(value) => {
+            setPendingSeekTime(null);
+            shouldResumeAfterScrubRef.current = status.playing;
+            if (status.playing) {
+              player.pause();
+            }
+            setIsScrubbing(true);
+            setScrubTime(value);
+          }}
+          onValueChange={(value) => {
+            setScrubTime(value);
+          }}
+          onSlidingComplete={(value) => {
+            setScrubTime(value);
+            setIsScrubbing(false);
+            if (duration > 0) {
+              setPendingSeekTime(value);
+              void player.seekTo(value).then(() => {
+                if (shouldResumeAfterScrubRef.current) {
+                  player.play();
+                }
+                shouldResumeAfterScrubRef.current = false;
+              });
+              return;
+            }
+            setPendingSeekTime(null);
+            shouldResumeAfterScrubRef.current = false;
+          }}
+          style={{
+            width: '100%',
+            height: 36,
+          }}
+        />
+        <View style={{ flexDirection: 'row', justifyContent: 'space-between' }}>
+          <Text style={{ color: '#cbd5e1', fontSize: typography.caption, fontWeight: '700' }}>
+            {formatPlaybackTime(displayedTime)}
+          </Text>
+          <Text style={{ color: '#cbd5e1', fontSize: typography.caption, fontWeight: '700' }}>
+            {status.isLoaded && duration > 0 ? formatPlaybackTime(duration) : '--:--'}
+          </Text>
+        </View>
+      </View>
+    </View>
+  );
+}
+
+function StoryVideoPreview({ item, title }: { item: StoryMediaItem; title: string }) {
+  const player = useVideoPlayer({ uri: item.url });
+
+  return (
+    <VideoView
+      accessibilityLabel={`${title} video`}
+      player={player}
+      nativeControls
+      contentFit="contain"
+      allowsFullscreen
+      style={{
+        height: 280,
+        width: '100%',
+        borderRadius: 16,
+        backgroundColor: '#111827',
+      }}
+    />
+  );
+}
+
+function StoryAudioVideoPreview({ item, title }: { item: StoryMediaItem; title: string }) {
+  const { colors, spacing, typography } = useAppTheme();
+
+  return (
+    <View
+      style={{
+        marginTop: spacing.md,
+        padding: spacing.sm,
+        borderRadius: 16,
+        borderWidth: 1,
+        borderColor: colors.border,
+        backgroundColor: colors.surface,
+        shadowColor: '#000000',
+        shadowOpacity: 0.08,
+        shadowRadius: 12,
+        shadowOffset: { width: 0, height: 6 },
+        elevation: 2,
+        gap: spacing.sm,
+      }}
+    >
+      <Text style={{ color: colors.text, fontSize: typography.caption, fontWeight: '800', textTransform: 'uppercase' }}>
+        {item.type === 'audio' ? 'Audio' : 'Video'}
+      </Text>
+      {item.type === 'audio' ? <StoryAudioPreview item={item} title={title} /> : <StoryVideoPreview item={item} title={title} />}
+    </View>
+  );
+}
+
+function StoryMediaGallery({
+  story,
+  hasImageError,
+  onImageError,
+}: {
+  story: StoryEntity;
+  hasImageError: boolean;
+  onImageError: () => void;
+}) {
+  const { colors, spacing } = useAppTheme();
+  const mediaItems = story.mediaItems?.length
+    ? story.mediaItems
+    : story.mediaUrl
+      ? [{ id: 'primary-image', type: 'image' as const, url: story.mediaUrl, altText: story.mediaAltText }]
+      : [];
+
+  if (!mediaItems.length) {
+    return null;
+  }
+
+  return (
+    <View style={{ marginTop: spacing.xl }}>
+      {mediaItems.map((item) => {
+        if (item.type === 'image') {
+          if (hasImageError) {
+            return (
+              <View
+                key={item.id}
+                style={{
+                  width: '100%',
+                  height: 220,
+                  borderRadius: 20,
+                  borderWidth: 1,
+                  borderColor: colors.border,
+                  backgroundColor: colors.surface,
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                  padding: spacing.lg,
+                }}
+              >
+                <Text style={{ color: colors.text, fontWeight: '700' }}>Story image unavailable</Text>
+                <Text style={{ marginTop: spacing.sm, color: colors.muted, textAlign: 'center' }}>
+                  The image URL could not be loaded on this device.
+                </Text>
+              </View>
+            );
+          }
+
+          return (
+            <Image
+              key={item.id}
+              source={{ uri: item.url }}
+              style={{
+                width: '100%',
+                height: 220,
+                borderRadius: 20,
+                backgroundColor: colors.surface,
+              }}
+              resizeMode="cover"
+              accessibilityLabel={item.altText || `${story.title} media`}
+              onError={onImageError}
+            />
+          );
+        }
+
+        return <StoryAudioVideoPreview key={item.id} item={item} title={story.title} />;
+      })}
     </View>
   );
 }
@@ -919,43 +1188,11 @@ export function StoryScreen({
         </View>
       ) : null}
 
-      {story.mediaUrl ? (
-        hasImageError ? (
-          <View
-            style={{
-              marginTop: spacing.xl,
-              width: '100%',
-              height: 220,
-              borderRadius: 20,
-              borderWidth: 1,
-              borderColor: colors.border,
-              backgroundColor: colors.surface,
-              alignItems: 'center',
-              justifyContent: 'center',
-              padding: spacing.lg,
-            }}
-          >
-            <Text style={{ color: colors.text, fontWeight: '700' }}>Story image unavailable</Text>
-            <Text style={{ marginTop: spacing.sm, color: colors.muted, textAlign: 'center' }}>
-              The image URL could not be loaded on this device.
-            </Text>
-          </View>
-        ) : (
-          <Image
-            source={{ uri: story.mediaUrl }}
-            style={{
-              marginTop: spacing.xl,
-              width: '100%',
-              height: 220,
-              borderRadius: 20,
-              backgroundColor: colors.surface,
-            }}
-            resizeMode="cover"
-            accessibilityLabel={story.mediaAltText || `${story.title} media`}
-            onError={() => setHasImageError(true)}
-          />
-        )
-      ) : null}
+      <StoryMediaGallery
+        story={story}
+        hasImageError={hasImageError}
+        onImageError={() => setHasImageError(true)}
+      />
 
       <StoryNarrative
         story={story}

--- a/mobile/src/features/stories/presentation/screens/StoryScreen.tsx
+++ b/mobile/src/features/stories/presentation/screens/StoryScreen.tsx
@@ -1,10 +1,9 @@
 import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { Alert, Image, LayoutChangeEvent, Pressable, ScrollView, Text, View } from 'react-native';
 import Slider from '@react-native-community/slider';
-import { Calendar, Clock, MapPin, Pause, Play, Trash2, Volume2 } from 'lucide-react-native';
+import { Bookmark, Calendar, Clock, MapPin, Pause, Play, Trash2, Volume2 } from 'lucide-react-native';
 import { useAudioPlayer, useAudioPlayerStatus } from 'expo-audio';
 import { VideoView, useVideoPlayer } from 'expo-video';
-import { Bookmark, Calendar, Clock, MapPin, Trash2 } from 'lucide-react-native';
 import { roles } from '../../../../core/auth/roles';
 import { Session } from '../../../../core/auth/session';
 import { useAppTheme } from '../../../../core/hooks/useAppTheme';

--- a/mobile/src/features/stories/presentation/screens/__tests__/StoryScreen.test.tsx
+++ b/mobile/src/features/stories/presentation/screens/__tests__/StoryScreen.test.tsx
@@ -137,6 +137,39 @@ describe('StoryScreen', () => {
     expect(screen.getByTestId('story-location-map')).toBeTruthy();
   });
 
+  it('renders audio and video media on story detail', async () => {
+    render(
+      <StoryScreen
+        storyId="story-001"
+        getStory={async () => ({
+          ...baseStory,
+          mediaItems: [
+            {
+              id: 'image-1',
+              type: 'image',
+              url: 'https://example.com/story.jpg',
+            },
+            {
+              id: 'audio-1',
+              type: 'audio',
+              url: 'https://example.com/story.mp3',
+            },
+            {
+              id: 'video-1',
+              type: 'video',
+              url: 'https://example.com/story.mp4',
+            },
+          ],
+        })}
+      />,
+    );
+
+    expect(await screen.findByText(baseStory.title)).toBeTruthy();
+    expect(screen.getByLabelText(`${baseStory.title} media`)).toBeTruthy();
+    expect(screen.getByLabelText(`${baseStory.title} audio`)).toBeTruthy();
+    expect(screen.getByLabelText(`${baseStory.title} video`)).toBeTruthy();
+  });
+
   it('opens the contributor profile when the contributor name is pressed', async () => {
     const onOpenContributorProfile = jest.fn();
 

--- a/mobile/src/features/submissions/application/services/__tests__/submissionsService.test.ts
+++ b/mobile/src/features/submissions/application/services/__tests__/submissionsService.test.ts
@@ -1,0 +1,80 @@
+import { resetApiTransport, setApiTransport } from '../../../../../core/api/client';
+import { submissionsService } from '..';
+
+function getFormField(formData: FormData, name: string) {
+  if (typeof (formData as unknown as { get?: (key: string) => unknown }).get === 'function') {
+    return (formData as unknown as { get: (key: string) => unknown }).get(name);
+  }
+
+  const parts = (formData as unknown as { _parts?: Array<[string, unknown]> })._parts ?? [];
+  return parts.find(([key]) => key === name)?.[1];
+}
+
+describe('submissionsService', () => {
+  beforeEach(() => {
+    resetApiTransport();
+  });
+
+  afterEach(() => {
+    resetApiTransport();
+  });
+
+  it('creates a story with contributor visibility and uploads image, audio, and video files', async () => {
+    const requests: Array<{ method: string; url?: string; data?: unknown }> = [];
+
+    setApiTransport(async (method: any, config: any) => {
+      requests.push({ method, url: config.url, data: config.data });
+
+      if (method === 'POST' && config.url === '/stories/') {
+        return {
+          status: 201,
+          data: { id: 12 } as never,
+          config,
+        };
+      }
+
+      if (method === 'POST' && config.url === '/stories/12/images/') {
+        return { status: 201, data: {} as never, config };
+      }
+
+      if (method === 'POST' && config.url === '/stories/12/media/') {
+        expect(config.data).toBeInstanceOf(FormData);
+        return { status: 201, data: {} as never, config };
+      }
+
+      throw new Error(`Unexpected request: ${method} ${config.url}`);
+    });
+
+    await submissionsService.createStory({
+      title: 'Mixed Media',
+      narrative: 'A story with several files.',
+      location: { latitude: 41.0082, longitude: 28.9784 },
+      placeName: 'Old City',
+      timeType: 'exact_year',
+      year: 1453,
+      tags: [],
+      contributorVisible: false,
+      image: { uri: 'file:///story.jpg', name: 'story.jpg', type: 'image/jpeg' },
+      audio: { uri: 'file:///story.mp3', name: 'story.mp3', type: 'audio/mpeg', mediaType: 'audio' },
+      video: { uri: 'file:///story.mp4', name: 'story.mp4', type: 'video/mp4', mediaType: 'video' },
+    });
+
+    expect(requests.map((request) => `${request.method} ${request.url}`)).toEqual([
+      'POST /stories/',
+      'POST /stories/12/images/',
+      'POST /stories/12/media/',
+      'POST /stories/12/media/',
+    ]);
+
+    expect(requests[0].data).toBeInstanceOf(FormData);
+    expect(getFormField(requests[0].data as FormData, 'contributor_visible')).toBe('false');
+    expect(requests[1].data).toBeInstanceOf(FormData);
+    expect(getFormField(requests[1].data as FormData, 'file')).toBeTruthy();
+
+    const mediaFiles = requests
+      .slice(2)
+      .map((request) => getFormField(request.data as FormData, 'file'));
+
+    expect(mediaFiles).toEqual([expect.anything(), expect.anything()]);
+  });
+});

--- a/mobile/src/features/submissions/application/services/index.ts
+++ b/mobile/src/features/submissions/application/services/index.ts
@@ -14,6 +14,15 @@ export interface SubmissionImageInput {
   type: string;
 }
 
+export type SubmissionMediaType = 'audio' | 'video';
+
+export interface SubmissionMediaInput {
+  uri: string;
+  name: string;
+  type: string;
+  mediaType: SubmissionMediaType;
+}
+
 export interface CreateStoryInput {
   title: string;
   narrative: string;
@@ -25,6 +34,9 @@ export interface CreateStoryInput {
   yearEnd?: number;
   tags: string[];
   image?: SubmissionImageInput | null;
+  audio?: SubmissionMediaInput | null;
+  video?: SubmissionMediaInput | null;
+  contributorVisible: boolean;
 }
 
 interface StoryCreateResponse {
@@ -40,7 +52,7 @@ function buildStoryFormData(input: CreateStoryInput) {
   formData.append('location_lng', input.location.longitude.toFixed(6));
   formData.append('location_name', input.placeName.trim());
   formData.append('time_type', input.timeType);
-  formData.append('contributor_visible', 'true');
+  formData.append('contributor_visible', input.contributorVisible ? 'true' : 'false');
 
   if (input.timeType === 'year_range') {
     if (typeof input.yearStart === 'number') {
@@ -56,12 +68,12 @@ function buildStoryFormData(input: CreateStoryInput) {
   return formData;
 }
 
-function buildImageFormData(image: SubmissionImageInput) {
+function buildUploadFormData(file: SubmissionImageInput | SubmissionMediaInput) {
   const formData = new FormData();
   formData.append('file', {
-    uri: image.uri,
-    name: image.name,
-    type: image.type,
+    uri: file.uri,
+    name: file.name,
+    type: file.type,
   } as unknown as Blob);
   return formData;
 }
@@ -80,7 +92,18 @@ export const submissionsService = {
     if (input.image) {
       await apiClient.post(
         `${endpoints.stories}/${story.id}/images/`,
-        buildImageFormData(input.image),
+        buildUploadFormData(input.image),
+      );
+    }
+
+    const mediaUploads = [input.audio, input.video].filter(
+      (media): media is SubmissionMediaInput => Boolean(media),
+    );
+
+    for (const media of mediaUploads) {
+      await apiClient.post(
+        `${endpoints.stories}/${story.id}/media/`,
+        buildUploadFormData(media),
       );
     }
 

--- a/mobile/src/features/submissions/presentation/screens/SubmissionScreen.tsx
+++ b/mobile/src/features/submissions/presentation/screens/SubmissionScreen.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useRef, useState } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 import {
   Image,
   LayoutChangeEvent,
@@ -8,7 +8,12 @@ import {
   TextInput,
   View,
 } from 'react-native';
+import Slider from '@react-native-community/slider';
+import { useAudioPlayer, useAudioPlayerStatus } from 'expo-audio';
+import * as DocumentPicker from 'expo-document-picker';
 import * as ImagePicker from 'expo-image-picker';
+import { VideoView, useVideoPlayer } from 'expo-video';
+import { Pause, Play, Volume2 } from 'lucide-react-native';
 import { ROUTES } from '../../../../app/navigation/routes';
 import { navigationRef } from '../../../../app/navigation/navigationRef';
 import { limits } from '../../../../core/constants/limits';
@@ -19,6 +24,7 @@ import {
   CreateStoryInput,
   StoryTimeType,
   SubmissionImageInput,
+  SubmissionMediaInput,
   submissionsService,
 } from '../../application/services';
 import { StoryLocationPicker } from '../components/StoryLocationPicker';
@@ -50,7 +56,9 @@ type FieldName =
   | 'yearStart'
   | 'yearEnd'
   | 'tags'
-  | 'image';
+  | 'image'
+  | 'audio'
+  | 'video';
 
 type LayoutTargetName = FieldName | 'time';
 
@@ -64,6 +72,8 @@ const FIELD_SCROLL_ORDER: FieldName[] = [
   'yearEnd',
   'tags',
   'image',
+  'audio',
+  'video',
 ];
 
 interface SubmissionFormState {
@@ -80,6 +90,9 @@ interface SubmissionFormState {
   customTag: string;
   image: (SubmissionImageInput & { fileSize?: number | null }) | null;
   imagePreviewUri: string | null;
+  audio: (SubmissionMediaInput & { fileSize?: number | null }) | null;
+  video: (SubmissionMediaInput & { fileSize?: number | null }) | null;
+  contributorVisible: boolean;
   isSubmitting: boolean;
   apiError?: string;
 }
@@ -98,6 +111,9 @@ const initialState: SubmissionFormState = {
   customTag: '',
   image: null,
   imagePreviewUri: null,
+  audio: null,
+  video: null,
+  contributorVisible: true,
   isSubmitting: false,
 };
 
@@ -113,8 +129,41 @@ function inferMimeType(uri: string) {
   return 'image/jpeg';
 }
 
+function inferAudioMimeType(nameOrUri: string) {
+  const normalized = nameOrUri.toLowerCase();
+  if (normalized.endsWith('.wav')) {
+    return 'audio/wav';
+  }
+  if (normalized.endsWith('.ogg')) {
+    return 'audio/ogg';
+  }
+  return 'audio/mpeg';
+}
+
+function inferVideoMimeType(nameOrUri: string) {
+  const normalized = nameOrUri.toLowerCase();
+  if (normalized.endsWith('.webm')) {
+    return 'video/webm';
+  }
+  return 'video/mp4';
+}
+
 function isValidImageType(mimeType: string) {
   return mimeType === 'image/jpeg' || mimeType === 'image/png';
+}
+
+function isValidAudioType(mimeType: string) {
+  return (
+    mimeType === 'audio/mpeg' ||
+    mimeType === 'audio/mp3' ||
+    mimeType === 'audio/wav' ||
+    mimeType === 'audio/x-wav' ||
+    mimeType === 'audio/ogg'
+  );
+}
+
+function isValidVideoType(mimeType: string) {
+  return mimeType === 'video/mp4' || mimeType === 'video/webm';
 }
 
 function buildFieldLabel(tag: string) {
@@ -123,6 +172,172 @@ function buildFieldLabel(tag: string) {
     .filter(Boolean)
     .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
     .join(' ');
+}
+
+function formatPlaybackTime(seconds: number) {
+  if (!Number.isFinite(seconds) || seconds <= 0) {
+    return '0:00';
+  }
+
+  const totalSeconds = Math.floor(seconds);
+  const minutes = Math.floor(totalSeconds / 60);
+  const remainingSeconds = totalSeconds % 60;
+  return `${minutes}:${String(remainingSeconds).padStart(2, '0')}`;
+}
+
+function AudioPlaybackPreview({ uri, label, title }: { uri: string; label: string; title: string }) {
+  const { colors, spacing, typography } = useAppTheme();
+  const player = useAudioPlayer({ uri }, { updateInterval: 250 });
+  const status = useAudioPlayerStatus(player);
+  const [scrubTime, setScrubTime] = useState(0);
+  const [isScrubbing, setIsScrubbing] = useState(false);
+  const [pendingSeekTime, setPendingSeekTime] = useState<number | null>(null);
+  const shouldResumeAfterScrubRef = useRef(false);
+  const duration = status.duration || 0;
+  const displayedTime = isScrubbing ? scrubTime : pendingSeekTime ?? status.currentTime;
+
+  useEffect(() => {
+    if (pendingSeekTime == null) {
+      return;
+    }
+
+    if (Math.abs(status.currentTime - pendingSeekTime) < 0.35) {
+      setPendingSeekTime(null);
+    }
+  }, [pendingSeekTime, status.currentTime]);
+
+  const togglePlayback = () => {
+    if (status.playing) {
+      player.pause();
+      return;
+    }
+
+    if (status.didJustFinish) {
+      void player.seekTo(0);
+    }
+    player.play();
+  };
+
+  return (
+    <View
+      accessibilityLabel={label}
+      style={{
+        minHeight: 150,
+        borderRadius: 18,
+        backgroundColor: '#111827',
+        padding: spacing.md,
+        justifyContent: 'space-between',
+        gap: spacing.md,
+      }}
+    >
+      <View style={{ flexDirection: 'row', alignItems: 'center', gap: spacing.md }}>
+        <Pressable
+          accessibilityRole="button"
+          accessibilityLabel={status.playing ? 'Pause audio preview' : 'Play audio preview'}
+          onPress={togglePlayback}
+          style={({ pressed }) => ({
+            width: 58,
+            height: 58,
+            borderRadius: 999,
+            alignItems: 'center',
+            justifyContent: 'center',
+            backgroundColor: colors.background,
+            opacity: pressed ? 0.85 : 1,
+          })}
+        >
+          {status.playing ? (
+            <Pause size={26} color="#111827" fill="#111827" />
+          ) : (
+            <Play size={26} color="#111827" fill="#111827" style={{ marginLeft: 2 }} />
+          )}
+        </Pressable>
+        <View style={{ flex: 1, gap: spacing.xs }}>
+          <Text numberOfLines={1} style={{ color: colors.background, fontSize: typography.body, fontWeight: '800' }}>
+            {title}
+          </Text>
+          <View style={{ flexDirection: 'row', alignItems: 'center', gap: spacing.xs }}>
+            <Volume2 size={16} color="#cbd5e1" />
+            <Text style={{ color: '#cbd5e1', fontSize: typography.caption, fontWeight: '600' }}>
+              Audio preview
+            </Text>
+          </View>
+        </View>
+      </View>
+      <View style={{ gap: spacing.xs }}>
+        <Slider
+          accessibilityLabel="Seek audio preview"
+          disabled={duration <= 0}
+          minimumValue={0}
+          maximumValue={Math.max(duration, 0)}
+          value={Math.min(displayedTime, duration || displayedTime)}
+          minimumTrackTintColor={colors.primary}
+          maximumTrackTintColor="#334155"
+          thumbTintColor={colors.background}
+          tapToSeek
+          onSlidingStart={(value) => {
+            setPendingSeekTime(null);
+            shouldResumeAfterScrubRef.current = status.playing;
+            if (status.playing) {
+              player.pause();
+            }
+            setIsScrubbing(true);
+            setScrubTime(value);
+          }}
+          onValueChange={(value) => {
+            setScrubTime(value);
+          }}
+          onSlidingComplete={(value) => {
+            setScrubTime(value);
+            setIsScrubbing(false);
+            if (duration > 0) {
+              setPendingSeekTime(value);
+              void player.seekTo(value).then(() => {
+                if (shouldResumeAfterScrubRef.current) {
+                  player.play();
+                }
+                shouldResumeAfterScrubRef.current = false;
+              });
+              return;
+            }
+            setPendingSeekTime(null);
+            shouldResumeAfterScrubRef.current = false;
+          }}
+          style={{
+            width: '100%',
+            height: 36,
+          }}
+        />
+        <View style={{ flexDirection: 'row', justifyContent: 'space-between' }}>
+          <Text style={{ color: '#cbd5e1', fontSize: typography.caption, fontWeight: '700' }}>
+            {formatPlaybackTime(displayedTime)}
+          </Text>
+          <Text style={{ color: '#cbd5e1', fontSize: typography.caption, fontWeight: '700' }}>
+            {status.isLoaded && duration > 0 ? formatPlaybackTime(duration) : '--:--'}
+          </Text>
+        </View>
+      </View>
+    </View>
+  );
+}
+
+function VideoPlaybackPreview({ uri, label }: { uri: string; label: string }) {
+  const player = useVideoPlayer({ uri });
+
+  return (
+    <VideoView
+      accessibilityLabel={label}
+      player={player}
+      nativeControls
+      contentFit="contain"
+      allowsFullscreen
+      style={{
+        height: 280,
+        width: '100%',
+        borderRadius: 16,
+        backgroundColor: '#111827',
+      }}
+    />
+  );
 }
 
 export function SubmissionScreen() {
@@ -236,6 +451,22 @@ export function SubmissionScreen() {
         nextErrors.image = 'Only JPG and PNG images are allowed.';
       } else if ((state.image.fileSize ?? 0) > limits.maxStoryImageBytes) {
         nextErrors.image = 'Image must be smaller than 2MB.';
+      }
+    }
+
+    if (state.audio) {
+      if (!isValidAudioType(state.audio.type)) {
+        nextErrors.audio = 'Only MP3, WAV, and OGG audio files are allowed.';
+      } else if ((state.audio.fileSize ?? 0) > limits.maxStoryAudioBytes) {
+        nextErrors.audio = 'Audio must be smaller than 10MB.';
+      }
+    }
+
+    if (state.video) {
+      if (!isValidVideoType(state.video.type)) {
+        nextErrors.video = 'Only MP4 and WEBM videos are allowed.';
+      } else if ((state.video.fileSize ?? 0) > limits.maxStoryVideoBytes) {
+        nextErrors.video = 'Video must be smaller than 50MB.';
       }
     }
 
@@ -364,6 +595,99 @@ export function SubmissionScreen() {
     clearFieldError('image');
   };
 
+  const applyPickedAudio = (asset: DocumentPicker.DocumentPickerAsset) => {
+    const mimeType = asset.mimeType ?? inferAudioMimeType(asset.name || asset.uri);
+    const audio = {
+      uri: asset.uri,
+      name: asset.name || 'story-audio.mp3',
+      type: mimeType,
+      mediaType: 'audio' as const,
+      fileSize: asset.size,
+    };
+
+    updateField('audio', audio);
+
+    if (!isValidAudioType(mimeType)) {
+      setFieldErrors((current) => ({ ...current, audio: 'Only MP3, WAV, and OGG audio files are allowed.' }));
+      return false;
+    }
+
+    if ((asset.size ?? 0) > limits.maxStoryAudioBytes) {
+      setFieldErrors((current) => ({ ...current, audio: 'Audio must be smaller than 10MB.' }));
+      return false;
+    }
+
+    clearFieldError('audio');
+    return true;
+  };
+
+  const handlePickAudio = async () => {
+    const result = await DocumentPicker.getDocumentAsync({
+      type: ['audio/mpeg', 'audio/wav', 'audio/x-wav', 'audio/ogg'],
+      copyToCacheDirectory: true,
+      multiple: false,
+    });
+
+    if (!result.canceled) {
+      applyPickedAudio(result.assets[0]);
+    }
+  };
+
+  const removeAudio = () => {
+    updateField('audio', null);
+    clearFieldError('audio');
+  };
+
+  const applyPickedVideo = (asset: ImagePicker.ImagePickerAsset) => {
+    const mimeType = asset.mimeType ?? inferVideoMimeType(asset.fileName ?? asset.uri);
+    const video = {
+      uri: asset.uri,
+      name: asset.fileName ?? `story-video.${mimeType === 'video/webm' ? 'webm' : 'mp4'}`,
+      type: mimeType,
+      mediaType: 'video' as const,
+      fileSize: asset.fileSize,
+    };
+
+    updateField('video', video);
+
+    if (!isValidVideoType(mimeType)) {
+      setFieldErrors((current) => ({ ...current, video: 'Only MP4 and WEBM videos are allowed.' }));
+      return false;
+    }
+
+    if ((asset.fileSize ?? 0) > limits.maxStoryVideoBytes) {
+      setFieldErrors((current) => ({ ...current, video: 'Video must be smaller than 50MB.' }));
+      return false;
+    }
+
+    clearFieldError('video');
+    return true;
+  };
+
+  const handlePickVideo = async () => {
+    const permission = await ImagePicker.requestMediaLibraryPermissionsAsync();
+
+    if (!permission.granted) {
+      setFieldErrors((current) => ({ ...current, video: 'Photo library permission is required.' }));
+      return;
+    }
+
+    const result = await ImagePicker.launchImageLibraryAsync({
+      mediaTypes: ['videos'],
+      allowsEditing: true,
+      quality: 0.85,
+    });
+
+    if (!result.canceled) {
+      applyPickedVideo(result.assets[0]);
+    }
+  };
+
+  const removeVideo = () => {
+    updateField('video', null);
+    clearFieldError('video');
+  };
+
   const submit = async () => {
     if (state.isSubmitting) {
       return;
@@ -386,6 +710,9 @@ export function SubmissionScreen() {
       timeType: state.timeType,
       tags: state.selectedTags,
       image: state.image,
+      audio: state.audio,
+      video: state.video,
+      contributorVisible: state.contributorVisible,
     };
 
     if (state.timeType === 'year_range') {
@@ -437,7 +764,7 @@ export function SubmissionScreen() {
           </Text>
           <Text style={{ color: colors.muted }}>
             Match the web flow: add the title, narrative, map pin, place name, time details, tags,
-            and an optional image before publishing.
+            optional media, and visibility before publishing.
           </Text>
         </View>
 
@@ -720,6 +1047,137 @@ export function SubmissionScreen() {
           ) : null}
           {fieldErrors.image ? <Text style={{ color: colors.danger }}>{fieldErrors.image}</Text> : null}
         </View>
+
+        <View testID="submission-field-audio" onLayout={registerFieldLayout('audio')} style={{ gap: spacing.sm }}>
+          <Text style={{ color: colors.text, fontWeight: '700' }}>Audio upload</Text>
+          <Button onPress={handlePickAudio} disabled={state.isSubmitting}>
+            Choose audio
+          </Button>
+          <Text style={{ color: colors.muted }}>
+            MP3, WAV, or OGG only, maximum 10MB.
+          </Text>
+          {state.audio ? (
+            <View
+              style={{
+                padding: spacing.sm,
+                borderRadius: 16,
+                borderWidth: 1,
+                borderColor: colors.border,
+                backgroundColor: colors.surface,
+                shadowColor: '#000000',
+                shadowOpacity: 0.08,
+                shadowRadius: 12,
+                shadowOffset: { width: 0, height: 6 },
+                elevation: 2,
+                gap: spacing.sm,
+              }}
+            >
+              <AudioPlaybackPreview
+                uri={state.audio.uri}
+                label="Selected story audio preview"
+                title={state.audio.name}
+              />
+              <View style={{ flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center', gap: spacing.sm }}>
+                <Text numberOfLines={2} style={{ color: colors.text, flex: 1 }}>
+                  Selected audio
+                </Text>
+                <Pressable onPress={removeAudio} accessibilityLabel="Remove audio">
+                  <Text style={{ color: colors.danger, fontWeight: '700' }}>Remove</Text>
+                </Pressable>
+              </View>
+            </View>
+          ) : null}
+          {fieldErrors.audio ? <Text style={{ color: colors.danger }}>{fieldErrors.audio}</Text> : null}
+        </View>
+
+        <View testID="submission-field-video" onLayout={registerFieldLayout('video')} style={{ gap: spacing.sm }}>
+          <Text style={{ color: colors.text, fontWeight: '700' }}>Video upload</Text>
+          <Button onPress={handlePickVideo} disabled={state.isSubmitting}>
+            Choose video
+          </Button>
+          <Text style={{ color: colors.muted }}>
+            MP4 or WEBM only, maximum 50MB.
+          </Text>
+          {state.video ? (
+            <View
+              style={{
+                padding: spacing.sm,
+                borderRadius: 16,
+                borderWidth: 1,
+                borderColor: colors.border,
+                backgroundColor: colors.surface,
+                shadowColor: '#000000',
+                shadowOpacity: 0.08,
+                shadowRadius: 12,
+                shadowOffset: { width: 0, height: 6 },
+                elevation: 2,
+                gap: spacing.sm,
+              }}
+            >
+              <VideoPlaybackPreview
+                uri={state.video.uri}
+                label="Selected story video preview"
+              />
+              <View style={{ flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center', gap: spacing.sm }}>
+                <Text numberOfLines={2} style={{ color: colors.text, flex: 1 }}>
+                  {state.video.name}
+                </Text>
+                <Pressable onPress={removeVideo} accessibilityLabel="Remove video">
+                  <Text style={{ color: colors.danger, fontWeight: '700' }}>Remove</Text>
+                </Pressable>
+              </View>
+            </View>
+          ) : null}
+          {fieldErrors.video ? <Text style={{ color: colors.danger }}>{fieldErrors.video}</Text> : null}
+        </View>
+
+        <Pressable
+          accessibilityRole="checkbox"
+          accessibilityState={{ checked: state.contributorVisible, disabled: state.isSubmitting }}
+          accessibilityLabel="Show my name on this story"
+          disabled={state.isSubmitting}
+          onPress={() => updateField('contributorVisible', !state.contributorVisible)}
+          style={{
+            flexDirection: 'row',
+            alignItems: 'center',
+            gap: spacing.sm,
+            padding: spacing.md,
+            borderRadius: 16,
+            borderWidth: 1,
+            borderColor: colors.border,
+            backgroundColor: colors.surface,
+          }}
+        >
+          <View
+            style={{
+              width: 24,
+              height: 24,
+              borderRadius: 6,
+              borderWidth: 2,
+              borderColor: state.contributorVisible ? colors.primary : colors.border,
+              backgroundColor: state.contributorVisible ? colors.primary : colors.surface,
+              alignItems: 'center',
+              justifyContent: 'center',
+            }}
+          >
+            {state.contributorVisible ? (
+              <View
+                style={{
+                  width: 10,
+                  height: 10,
+                  borderRadius: 3,
+                  backgroundColor: colors.background,
+                }}
+              />
+            ) : null}
+          </View>
+          <View style={{ flex: 1, gap: spacing.xs }}>
+            <Text style={{ color: colors.text, fontWeight: '700' }}>Show my name on this story</Text>
+            <Text style={{ color: colors.muted }}>
+              Turn this off to submit anonymously and hide profile access from this story.
+            </Text>
+          </View>
+        </Pressable>
 
         <Button onPress={submit} disabled={state.isSubmitting} fullWidth>
           {state.isSubmitting ? 'Submitting story...' : 'Submit story'}

--- a/mobile/src/features/submissions/presentation/screens/__tests__/SubmissionScreen.test.tsx
+++ b/mobile/src/features/submissions/presentation/screens/__tests__/SubmissionScreen.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react-native';
+import * as DocumentPicker from 'expo-document-picker';
 import * as ImagePicker from 'expo-image-picker';
 import { ScrollView, StyleSheet, ViewStyle } from 'react-native';
 import { lightColors } from '../../../../../app/theme/colors';
@@ -202,6 +203,7 @@ describe('SubmissionScreen', () => {
           year: 1453,
           tags: ['architecture'],
           location: { latitude: 41.0082, longitude: 28.9784 },
+          contributorVisible: true,
         }),
       );
     });
@@ -395,5 +397,135 @@ describe('SubmissionScreen', () => {
     fireEvent.press(screen.getByText('Choose image'));
 
     expect(await screen.findByText('Image must be smaller than 2MB.')).toBeTruthy();
+  });
+
+  it('accepts audio and video files with previews and submits them together', async () => {
+    (DocumentPicker.getDocumentAsync as jest.Mock).mockResolvedValue({
+      canceled: false,
+      assets: [
+        {
+          uri: 'file:///story.mp3',
+          name: 'story.mp3',
+          size: 4 * 1024 * 1024,
+          mimeType: 'audio/mpeg',
+        },
+      ],
+    });
+    jest.spyOn(ImagePicker, 'launchImageLibraryAsync').mockResolvedValue({
+      canceled: false,
+      assets: [
+        {
+          uri: 'file:///story.mp4',
+          fileName: 'story.mp4',
+          fileSize: 12 * 1024 * 1024,
+          mimeType: 'video/mp4',
+          width: 100,
+          height: 100,
+          type: 'video',
+          assetId: 'asset-video',
+          duration: 30,
+          base64: null,
+          exif: null,
+          file: undefined,
+          pairedVideoAsset: undefined,
+        },
+      ],
+    } as ImagePicker.ImagePickerSuccessResult);
+    (submissionsService.createStory as jest.Mock).mockResolvedValue({ id: 12 });
+
+    renderSubmissionScreen();
+
+    fireEvent.press(screen.getByText('Choose audio'));
+    expect(await screen.findByText('story.mp3')).toBeTruthy();
+    expect(screen.getByLabelText('Selected story audio preview')).toBeTruthy();
+
+    fireEvent.press(screen.getByText('Choose video'));
+    expect(await screen.findByText('story.mp4')).toBeTruthy();
+    expect(screen.getByLabelText('Selected story video preview')).toBeTruthy();
+
+    fireEvent.changeText(screen.getByLabelText('Story title'), 'Mixed Media');
+    fireEvent.changeText(screen.getByLabelText('Story narrative'), 'A story with oral history and video.');
+    fireEvent(screen.getByTestId('story-location-map'), 'press', {
+      nativeEvent: { coordinate: { latitude: 41.0082, longitude: 28.9784 } },
+    });
+    fireEvent.changeText(screen.getByLabelText('Place name'), 'Old City');
+    fireEvent.changeText(screen.getByLabelText('Year'), '1453');
+    fireEvent.press(screen.getByText('Submit story'));
+
+    await waitFor(() => {
+      expect(submissionsService.createStory).toHaveBeenCalledWith(
+        expect.objectContaining({
+          audio: expect.objectContaining({ name: 'story.mp3', type: 'audio/mpeg', mediaType: 'audio' }),
+          video: expect.objectContaining({ name: 'story.mp4', type: 'video/mp4', mediaType: 'video' }),
+        }),
+      );
+    });
+  });
+
+  it('shows inline validation errors for invalid audio and oversized video files', async () => {
+    (DocumentPicker.getDocumentAsync as jest.Mock).mockResolvedValue({
+      canceled: false,
+      assets: [
+        {
+          uri: 'file:///notes.txt',
+          name: 'notes.txt',
+          size: 100,
+          mimeType: 'text/plain',
+        },
+      ],
+    });
+    jest.spyOn(ImagePicker, 'launchImageLibraryAsync').mockResolvedValue({
+      canceled: false,
+      assets: [
+        {
+          uri: 'file:///large.mp4',
+          fileName: 'large.mp4',
+          fileSize: 60 * 1024 * 1024,
+          mimeType: 'video/mp4',
+          width: 100,
+          height: 100,
+          type: 'video',
+          assetId: 'asset-video',
+          duration: 30,
+          base64: null,
+          exif: null,
+          file: undefined,
+          pairedVideoAsset: undefined,
+        },
+      ],
+    } as ImagePicker.ImagePickerSuccessResult);
+
+    renderSubmissionScreen();
+    fireEvent.press(screen.getByText('Choose audio'));
+    expect(await screen.findByText('Only MP3, WAV, and OGG audio files are allowed.')).toBeTruthy();
+
+    fireEvent.press(screen.getByText('Choose video'));
+    expect(await screen.findByText('Video must be smaller than 50MB.')).toBeTruthy();
+  });
+
+  it('lets the contributor visibility toggle submit anonymous stories', async () => {
+    (submissionsService.createStory as jest.Mock).mockResolvedValue({ id: 12 });
+    renderSubmissionScreen();
+
+    expect(screen.getByLabelText('Show my name on this story').props.accessibilityState.checked).toBe(true);
+    fireEvent.press(screen.getByLabelText('Show my name on this story'));
+    expect(screen.getByLabelText('Show my name on this story').props.accessibilityState.checked).toBe(false);
+
+    fireEvent.changeText(screen.getByLabelText('Story title'), 'Anonymous Memory');
+    fireEvent.changeText(screen.getByLabelText('Story narrative'), 'A story that should not link to a profile.');
+    fireEvent(screen.getByTestId('story-location-map'), 'press', {
+      nativeEvent: { coordinate: { latitude: 41.0082, longitude: 28.9784 } },
+    });
+    fireEvent.changeText(screen.getByLabelText('Place name'), 'Old City');
+    fireEvent.changeText(screen.getByLabelText('Year'), '1453');
+    fireEvent.press(screen.getByText('Submit story'));
+
+    await waitFor(() => {
+      expect(submissionsService.createStory).toHaveBeenCalledWith(
+        expect.objectContaining({
+          contributorVisible: false,
+        }),
+      );
+    });
   });
 });


### PR DESCRIPTION
# 📝 Description
Fixes #197

Adds mixed-media story submission and playback support for mobile. The story submission flow now supports image, audio, and video attachments with client-side validation, contributor visibility, and multipart uploads. Story detail now renders mixed media with native video playback and a draggable native audio scrubber.

# 📊 Type of Change
- [ ]  Bug fix
- [x]  New feature
- [ ]  Refactoring
- [ ]  Documentation
 
# ✅ Acceptance Criteria / Checklist
- [x] Project builds successfully
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, especially in hard-to-understand parts
- [x] I have performed a self-review of my code
- [x] I have added/updated tests
- [x] New and existing unit tests pass locally with my changes

# 📸 Screenshots / Recordings
Not attached. Please verify media picker/player UX on a device or simulator because this PR adds native Expo media modules.

# ⏱️ Estimated Review Time
- [ ] < 5 min
- [ ] 5-15 min
- [x] > 15 min

Validation run locally:
- npm run typecheck
- npm test -- --runTestsByPath src/features/submissions/presentation/screens/__tests__/SubmissionScreen.test.tsx src/features/stories/presentation/screens/__tests__/StoryScreen.test.tsx --runInBand
- npm test -- --runTestsByPath src/features/stories/presentation/screens/__tests__/StoryScreen.test.tsx src/features/stories/data/mappers/__tests__/storyMappers.test.ts src/features/submissions/presentation/screens/__tests__/SubmissionScreen.test.tsx src/features/submissions/application/services/__tests__/submissionsService.test.ts --runInBand
