### PR TITLE
fix:filter-location-mobile

### DIFF
--- a/mobile/src/app/navigation/__tests__/RootNavigator.test.tsx
+++ b/mobile/src/app/navigation/__tests__/RootNavigator.test.tsx
@@ -6,10 +6,11 @@ import { storageKeys } from '../../../core/storage/keys';
 import { interceptors } from '../../../core/api/interceptors';
 import { resetApiTransport, setApiTransport } from '../../../core/api/client';
 import { AppProviders } from '../../providers/AppProviders';
-import { geocodeLocationQuery } from '../../../features/search/application/services';
+import { geocodeLocationQuery, searchLocationSuggestions } from '../../../features/search/application/services';
 
 jest.mock('../../../features/search/application/services', () => ({
   geocodeLocationQuery: jest.fn(),
+  searchLocationSuggestions: jest.fn(),
 }));
 
 function renderNavigator() {
@@ -38,6 +39,8 @@ const feedResults = [
     user_has_liked: false,
   },
 ];
+
+const goldenHornBounds = { latMin: 41, latMax: 41.05, lngMin: 28.94, lngMax: 28.99 };
 
 const storyDetail = {
   id: 'story-001',
@@ -268,6 +271,7 @@ function installAuthTransport() {
 describe('RootNavigator auth flow', () => {
   beforeEach(async () => {
     (geocodeLocationQuery as jest.Mock).mockResolvedValue(null);
+    (searchLocationSuggestions as jest.Mock).mockResolvedValue([]);
     await storage.clear();
     interceptors.clear();
     resetApiTransport();
@@ -538,6 +542,8 @@ describe('RootNavigator auth flow', () => {
   });
 
   it('persists search and filter state between feed and map views', async () => {
+    (geocodeLocationQuery as jest.Mock).mockResolvedValueOnce(goldenHornBounds);
+
     renderNavigator();
 
     await screen.findByLabelText('Search stories');
@@ -547,7 +553,7 @@ describe('RootNavigator auth flow', () => {
     fireEvent.changeText(screen.getByLabelText('Location filter'), 'Golden Horn');
     fireEvent.changeText(screen.getByLabelText('Start year'), '1990');
     fireEvent.changeText(screen.getByLabelText('End year'), '2000');
-    expect(await screen.findByText('No map match found. Apply will search story place names instead.')).toBeTruthy();
+    expect(await screen.findByText('Filtering by map area.')).toBeTruthy();
     fireEvent.press(screen.getByLabelText('Apply filters'));
 
     await waitFor(() => {

--- a/mobile/src/features/feed/presentation/screens/__tests__/FeedScreen.test.tsx
+++ b/mobile/src/features/feed/presentation/screens/__tests__/FeedScreen.test.tsx
@@ -5,11 +5,14 @@ import { FeedScreen } from '../FeedScreen';
 import { FeedPageEntity } from '../../../domain/entities';
 import { SearchFiltersProvider } from '../../../../search/presentation/context/SearchFiltersContext';
 import { storage } from '../../../../../core/storage/storage';
-import { geocodeLocationQuery } from '../../../../search/application/services';
+import { geocodeLocationQuery, searchLocationSuggestions } from '../../../../search/application/services';
 
 jest.mock('../../../../search/application/services', () => ({
   geocodeLocationQuery: jest.fn(),
+  searchLocationSuggestions: jest.fn(),
 }));
+
+const istanbulBounds = { latMin: 40.8, latMax: 41.2, lngMin: 28.7, lngMax: 29.2 };
 
 function makeStory(id: string, overrides: Partial<FeedPageEntity['items'][number]> = {}) {
   return {
@@ -40,6 +43,7 @@ function makeFeedPage(overrides: Partial<FeedPageEntity> = {}): FeedPageEntity {
 describe('FeedScreen', () => {
   beforeEach(async () => {
     (geocodeLocationQuery as jest.Mock).mockResolvedValue(null);
+    (searchLocationSuggestions as jest.Mock).mockResolvedValue([]);
     jest.mocked(Location.requestForegroundPermissionsAsync).mockResolvedValue({ granted: true } as never);
     jest.mocked(Location.hasServicesEnabledAsync).mockResolvedValue(true);
     jest.mocked(Location.getLastKnownPositionAsync).mockResolvedValue(null);
@@ -270,6 +274,10 @@ describe('FeedScreen', () => {
 
   it('updates advanced filters in feed requests', async () => {
     const getFeed = jest.fn<Promise<FeedPageEntity>, [any]>().mockResolvedValue(makeFeedPage());
+    (geocodeLocationQuery as jest.Mock).mockResolvedValueOnce(istanbulBounds);
+    (searchLocationSuggestions as jest.Mock).mockResolvedValueOnce([
+      { id: 'istanbul', title: 'Istanbul', subtitle: 'Turkiye', latitude: 41.0082, longitude: 28.9784, bounds: istanbulBounds },
+    ]);
 
     renderScreen(<FeedScreen getFeed={getFeed} />);
 
@@ -278,7 +286,7 @@ describe('FeedScreen', () => {
     fireEvent.changeText(screen.getByLabelText('Location filter'), 'Istanbul');
     fireEvent.changeText(screen.getByLabelText('Start year'), '1900');
     fireEvent.changeText(screen.getByLabelText('End year'), '1950');
-    expect(await screen.findByText('No map match found. Apply will search story place names instead.')).toBeTruthy();
+    expect(await screen.findByText('Filtering by map area.')).toBeTruthy();
     fireEvent.press(screen.getByLabelText('Apply filters'));
 
     await waitFor(() => {
@@ -288,7 +296,7 @@ describe('FeedScreen', () => {
         filters: {
           q: undefined,
           location: 'Istanbul',
-          locationBounds: undefined,
+          locationBounds: istanbulBounds,
           yearFrom: 1900,
           yearTo: 1950,
         },
@@ -298,6 +306,48 @@ describe('FeedScreen', () => {
     expect(screen.getByLabelText('Remove Location: Istanbul')).toBeTruthy();
     expect(screen.getByLabelText('Remove From: 1900')).toBeTruthy();
     expect(screen.getByLabelText('Remove To: 1950')).toBeTruthy();
+  });
+
+  it('shows location suggestions and applies the selected place', async () => {
+    const getFeed = jest.fn<Promise<FeedPageEntity>, [any]>().mockResolvedValue(makeFeedPage());
+    const galataBounds = { latMin: 41.02, latMax: 41.04, lngMin: 28.96, lngMax: 28.99 };
+    (geocodeLocationQuery as jest.Mock).mockResolvedValueOnce(null);
+    (searchLocationSuggestions as jest.Mock).mockResolvedValueOnce([
+      {
+        id: 'galata',
+        title: 'Galata',
+        subtitle: 'Beyoglu, Istanbul',
+        latitude: 41.0256,
+        longitude: 28.9742,
+        bounds: galataBounds,
+      },
+    ]);
+
+    renderScreen(<FeedScreen getFeed={getFeed} />);
+
+    await screen.findByText('Story 1');
+    fireEvent.press(screen.getByText('Show filters'));
+    fireEvent.changeText(screen.getByLabelText('Location filter'), 'Galat');
+
+    expect(await screen.findByTestId('location-filter-suggestions')).toBeTruthy();
+    expect(screen.getByText('Galata')).toBeTruthy();
+    expect(screen.getByText('Beyoglu, Istanbul')).toBeTruthy();
+    fireEvent.press(screen.getByLabelText('Select location Galata'));
+    fireEvent.press(screen.getByLabelText('Apply filters'));
+
+    await waitFor(() => {
+      expect(getFeed).toHaveBeenLastCalledWith({
+        page: 1,
+        sort: 'recent',
+        filters: {
+          q: undefined,
+          location: 'Galata',
+          locationBounds: galataBounds,
+          yearFrom: undefined,
+          yearTo: undefined,
+        },
+      });
+    });
   });
 
   it('does not apply placeholder year filters when submitted unchanged', async () => {
@@ -431,6 +481,7 @@ describe('FeedScreen', () => {
 
   it('resets only filter fields and preserves the search query', async () => {
     const getFeed = jest.fn<Promise<FeedPageEntity>, [any]>().mockResolvedValue(makeFeedPage());
+    (geocodeLocationQuery as jest.Mock).mockResolvedValueOnce(istanbulBounds);
 
     renderScreen(<FeedScreen getFeed={getFeed} />);
 
@@ -440,7 +491,7 @@ describe('FeedScreen', () => {
     fireEvent.changeText(screen.getByLabelText('Location filter'), 'Istanbul');
     fireEvent.changeText(screen.getByLabelText('Start year'), '1900');
     fireEvent.changeText(screen.getByLabelText('End year'), '1950');
-    expect(await screen.findByText('No map match found. Apply will search story place names instead.')).toBeTruthy();
+    expect(await screen.findByText('Filtering by map area.')).toBeTruthy();
     fireEvent.press(screen.getByText('Reset filter form'));
     fireEvent.press(screen.getByLabelText('Apply filters'));
 

--- a/mobile/src/features/map/presentation/screens/MapScreen.tsx
+++ b/mobile/src/features/map/presentation/screens/MapScreen.tsx
@@ -205,7 +205,7 @@ export function MapScreen({
     }
 
     return 'No stories found with this criteria';
-  }, [activeFilters.location, state.error, state.isLoading, statusIndicatorMode, statusStoryCount]);
+  }, [activeFilters.location, activeFilters.locationBounds, state.error, state.isLoading, statusIndicatorMode, statusStoryCount]);
 
   function handlePreviewLayout(event: LayoutChangeEvent) {
     previewOffsetRef.current = event.nativeEvent.layout.y;

--- a/mobile/src/features/map/presentation/screens/__tests__/MapScreen.test.tsx
+++ b/mobile/src/features/map/presentation/screens/__tests__/MapScreen.test.tsx
@@ -4,11 +4,14 @@ import { MapScreen } from '../MapScreen';
 import { MapMarkerGroup } from '../../../domain/entities';
 import { SearchFiltersProvider } from '../../../../search/presentation/context/SearchFiltersContext';
 import { storage } from '../../../../../core/storage/storage';
-import { geocodeLocationQuery } from '../../../../search/application/services';
+import { geocodeLocationQuery, searchLocationSuggestions } from '../../../../search/application/services';
 
 jest.mock('../../../../search/application/services', () => ({
   geocodeLocationQuery: jest.fn(),
+  searchLocationSuggestions: jest.fn(),
 }));
+
+const goldenHornBounds = { latMin: 41, latMax: 41.05, lngMin: 28.94, lngMax: 28.99 };
 
 jest.mock('../../../../../shared/components/WebMapView', () => {
   const React = require('react');
@@ -122,6 +125,7 @@ const markerGroups: MapMarkerGroup[] = [
 describe('MapScreen', () => {
   beforeEach(async () => {
     (geocodeLocationQuery as jest.Mock).mockResolvedValue(null);
+    (searchLocationSuggestions as jest.Mock).mockResolvedValue([]);
     await storage.clear();
   });
 
@@ -237,16 +241,21 @@ describe('MapScreen', () => {
     });
   });
 
-  it('shows a no-results badge for a location search', async () => {
-    renderScreen(<MapScreen getMarkerGroups={async () => []} />);
+  it('keeps unapplied location filters disabled when the place cannot be found', async () => {
+    const getMarkerGroups = jest.fn<Promise<MapMarkerGroup[]>, [any]>().mockResolvedValue([]);
+
+    renderScreen(<MapScreen getMarkerGroups={getMarkerGroups} />);
 
     await screen.findByText('No stories match the current filters.');
     fireEvent.press(screen.getByText('Show filters'));
     fireEvent.changeText(screen.getByLabelText('Location filter'), 'Beykoz');
-    expect(await screen.findByText('No map match found. Apply will search story place names instead.')).toBeTruthy();
+    expect(await screen.findByText('Location not found. Choose a listed place before applying.')).toBeTruthy();
+    expect(screen.getByLabelText('Apply filters').props.accessibilityState.disabled).toBe(true);
     fireEvent.press(screen.getByLabelText('Apply filters'));
 
-    expect(await screen.findByText('Place could not be found')).toBeTruthy();
+    await waitFor(() => {
+      expect(getMarkerGroups).toHaveBeenLastCalledWith({});
+    });
   });
 
   it('does not apply placeholder year filters when submitted unchanged', async () => {
@@ -303,19 +312,21 @@ describe('MapScreen', () => {
 
   it('refetches all markers when a chip filter is removed', async () => {
     const getMarkerGroups = jest.fn<Promise<MapMarkerGroup[]>, [any]>().mockResolvedValue(markerGroups);
+    (geocodeLocationQuery as jest.Mock).mockResolvedValueOnce(goldenHornBounds);
 
     renderScreen(<MapScreen getMarkerGroups={getMarkerGroups} />);
 
     await screen.findByText('Select a story marker to preview.');
     fireEvent.press(screen.getByText('Show filters'));
     fireEvent.changeText(screen.getByLabelText('Location filter'), 'Golden Horn');
-    expect(await screen.findByText('No map match found. Apply will search story place names instead.')).toBeTruthy();
+    expect(await screen.findByText('Filtering by map area.')).toBeTruthy();
     fireEvent.press(screen.getByLabelText('Apply filters'));
 
     await waitFor(() => {
       expect(getMarkerGroups).toHaveBeenLastCalledWith({
         q: undefined,
         location: 'Golden Horn',
+        locationBounds: goldenHornBounds,
         yearFrom: undefined,
         yearTo: undefined,
       });
@@ -335,19 +346,21 @@ describe('MapScreen', () => {
 
   it('refetches all markers when clear all filters is pressed', async () => {
     const getMarkerGroups = jest.fn<Promise<MapMarkerGroup[]>, [any]>().mockResolvedValue(markerGroups);
+    (geocodeLocationQuery as jest.Mock).mockResolvedValueOnce(goldenHornBounds);
 
     renderScreen(<MapScreen getMarkerGroups={getMarkerGroups} />);
 
     await screen.findByText('Select a story marker to preview.');
     fireEvent.press(screen.getByText('Show filters'));
     fireEvent.changeText(screen.getByLabelText('Location filter'), 'Golden Horn');
-    expect(await screen.findByText('No map match found. Apply will search story place names instead.')).toBeTruthy();
+    expect(await screen.findByText('Filtering by map area.')).toBeTruthy();
     fireEvent.press(screen.getByLabelText('Apply filters'));
 
     await waitFor(() => {
       expect(getMarkerGroups).toHaveBeenLastCalledWith({
         q: undefined,
         location: 'Golden Horn',
+        locationBounds: goldenHornBounds,
         yearFrom: undefined,
         yearTo: undefined,
       });

--- a/mobile/src/features/search/application/services/geocodingService.ts
+++ b/mobile/src/features/search/application/services/geocodingService.ts
@@ -11,6 +11,7 @@ export interface LocationSuggestion {
   subtitle?: string;
   latitude: number;
   longitude: number;
+  bounds?: LocationBounds;
 }
 
 interface NominatimSearchResult {
@@ -130,5 +131,6 @@ function parseNominatimSuggestion(result: NominatimSearchResult): LocationSugges
     subtitle: fallbackRest.join(', ') || undefined,
     latitude,
     longitude,
+    bounds: parseNominatimBounds(result.boundingbox) ?? undefined,
   };
 }

--- a/mobile/src/features/search/presentation/components/StorySearchControls.tsx
+++ b/mobile/src/features/search/presentation/components/StorySearchControls.tsx
@@ -9,7 +9,7 @@ import {
 } from '../../../../shared/components/FilterPanel';
 import { FilterChipItem, FilterChips } from '../../../../shared/components/FilterChips';
 import { SearchInput } from '../../../../shared/components/SearchInput';
-import { geocodeLocationQuery, LocationBounds } from '../../application/services';
+import { geocodeLocationQuery, LocationBounds, LocationSuggestion, searchLocationSuggestions } from '../../application/services';
 import { SearchFilterScope, useSearchFilters } from '../context/SearchFiltersContext';
 
 function buildChips(
@@ -52,8 +52,10 @@ export function StorySearchControls({ helperText, hideHeading = false, scope }: 
   const [showFilters, setShowFilters] = useState(false);
   const [draftLocation, setDraftLocation] = useState('');
   const [draftLocationBounds, setDraftLocationBounds] = useState<LocationBounds | undefined>();
+  const [locationSuggestions, setLocationSuggestions] = useState<LocationSuggestion[]>([]);
   const [isLocationResolving, setIsLocationResolving] = useState(false);
   const [locationStatusText, setLocationStatusText] = useState<string | undefined>();
+  const [isLocationError, setIsLocationError] = useState(false);
   const [draftProximityRadiusKm, setDraftProximityRadiusKm] = useState<ProximityRadiusOption | undefined>();
   const [draftProximityCoordinates, setDraftProximityCoordinates] = useState<DeviceCoordinates | undefined>();
   const [isProximityResolving, setIsProximityResolving] = useState(false);
@@ -63,6 +65,7 @@ export function StorySearchControls({ helperText, hideHeading = false, scope }: 
   const [draftTimeTo, setDraftTimeTo] = useState('');
   const debouncedDraftLocation = useDebounce(draftLocation, 500);
   const locationRequestIdRef = useRef(0);
+  const selectedLocationQueryRef = useRef<string | undefined>(undefined);
   const proximityRequestIdRef = useRef(0);
 
   const chips = useMemo(() => buildChips(filters), [filters]);
@@ -70,7 +73,9 @@ export function StorySearchControls({ helperText, hideHeading = false, scope }: 
   const openFilters = () => {
     setDraftLocation(filters.location);
     setDraftLocationBounds(filters.locationBounds);
+    setLocationSuggestions([]);
     setLocationStatusText(undefined);
+    setIsLocationError(false);
     setIsLocationResolving(false);
     setDraftProximityRadiusKm(filters.proximityRadiusKm);
     setDraftProximityCoordinates(filters.proximityCoordinates);
@@ -87,8 +92,21 @@ export function StorySearchControls({ helperText, hideHeading = false, scope }: 
   const handleDraftLocationChange = (location: string) => {
     setDraftLocation(location);
     setDraftLocationBounds(undefined);
+    setLocationSuggestions([]);
     setLocationStatusText(undefined);
+    setIsLocationError(false);
+    selectedLocationQueryRef.current = undefined;
     setIsLocationResolving(location.trim().length > 0);
+  };
+
+  const handleLocationSuggestionPress = (suggestion: LocationSuggestion) => {
+    selectedLocationQueryRef.current = suggestion.title;
+    setDraftLocation(suggestion.title);
+    setDraftLocationBounds(suggestion.bounds ?? buildFallbackBounds(suggestion.latitude, suggestion.longitude));
+    setLocationSuggestions([]);
+    setIsLocationResolving(false);
+    setIsLocationError(false);
+    setLocationStatusText('Filtering by map area.');
   };
 
   const handleProximityRadiusChange = async (radiusKm?: ProximityRadiusOption) => {
@@ -143,24 +161,33 @@ export function StorySearchControls({ helperText, hideHeading = false, scope }: 
 
     if (!location) {
       setDraftLocationBounds(undefined);
+      setLocationSuggestions([]);
       setIsLocationResolving(false);
       setLocationStatusText(undefined);
+      setIsLocationError(false);
+      return;
+    }
+
+    if (selectedLocationQueryRef.current === location && draftLocationBounds) {
+      selectedLocationQueryRef.current = undefined;
+      setIsLocationResolving(false);
       return;
     }
 
     setIsLocationResolving(true);
     setLocationStatusText('Looking up this place...');
+    setIsLocationError(false);
 
-    geocodeLocationQuery(location)
-      .then((bounds) => {
+    Promise.all([geocodeLocationQuery(location), searchLocationSuggestions(location)])
+      .then(([bounds, suggestions]) => {
         if (locationRequestIdRef.current !== requestId) {
           return;
         }
 
         setDraftLocationBounds(bounds ?? undefined);
-        setLocationStatusText(
-          bounds ? 'Filtering by map area.' : 'No map match found. Apply will search story place names instead.',
-        );
+        setLocationSuggestions(suggestions);
+        setIsLocationError(!bounds);
+        setLocationStatusText(bounds ? 'Filtering by map area.' : 'Location not found. Choose a listed place before applying.');
       })
       .catch(() => {
         if (locationRequestIdRef.current !== requestId) {
@@ -168,7 +195,9 @@ export function StorySearchControls({ helperText, hideHeading = false, scope }: 
         }
 
         setDraftLocationBounds(undefined);
-        setLocationStatusText('Location lookup failed. Apply will search story place names instead.');
+        setLocationSuggestions([]);
+        setIsLocationError(true);
+        setLocationStatusText('Location lookup failed. Try again before applying.');
       })
       .finally(() => {
         if (locationRequestIdRef.current === requestId) {
@@ -228,9 +257,11 @@ export function StorySearchControls({ helperText, hideHeading = false, scope }: 
           <Pressable onPress={(event) => event?.stopPropagation?.()} style={{ width: '100%' }}>
             <FilterPanel
               location={draftLocation}
+              locationSuggestions={locationSuggestions}
               timeFrom={draftTimeFrom}
               timeTo={draftTimeTo}
               onLocationChange={handleDraftLocationChange}
+              onLocationSuggestionPress={handleLocationSuggestionPress}
               onTimeFromChange={setDraftTimeFrom}
               onTimeToChange={setDraftTimeTo}
               proximityRadiusKm={draftProximityRadiusKm}
@@ -240,11 +271,19 @@ export function StorySearchControls({ helperText, hideHeading = false, scope }: 
               isProximityError={isProximityError}
               isLocationResolving={isLocationResolving}
               locationStatusText={locationStatusText}
-              isApplyDisabled={isLocationResolving || isProximityResolving || Boolean(draftProximityRadiusKm && !draftProximityCoordinates)}
+              isApplyDisabled={
+                isLocationResolving ||
+                isLocationError ||
+                Boolean(draftLocation.trim() && !draftLocationBounds) ||
+                isProximityResolving ||
+                Boolean(draftProximityRadiusKm && !draftProximityCoordinates)
+              }
               onClearAll={() => {
                 setDraftLocation('');
                 setDraftLocationBounds(undefined);
+                setLocationSuggestions([]);
                 setLocationStatusText(undefined);
+                setIsLocationError(false);
                 setDraftProximityRadiusKm(undefined);
                 setDraftProximityCoordinates(undefined);
                 setProximityStatusText(undefined);
@@ -277,4 +316,15 @@ export function StorySearchControls({ helperText, hideHeading = false, scope }: 
       />
     </View>
   );
+}
+
+function buildFallbackBounds(latitude: number, longitude: number): LocationBounds {
+  const delta = 0.01;
+
+  return {
+    latMin: latitude - delta,
+    latMax: latitude + delta,
+    lngMin: longitude - delta,
+    lngMax: longitude + delta,
+  };
 }

--- a/mobile/src/shared/components/FilterPanel.tsx
+++ b/mobile/src/shared/components/FilterPanel.tsx
@@ -8,6 +8,19 @@ export const DEFAULT_TO_YEAR = '2026';
 export const MIN_YEAR = 1000;
 export const MAX_YEAR = 2030;
 export type ProximityRadiusOption = 1 | 10 | 100;
+export interface LocationFilterSuggestion {
+  id: string;
+  title: string;
+  subtitle?: string;
+  latitude: number;
+  longitude: number;
+  bounds?: {
+    latMin: number;
+    latMax: number;
+    lngMin: number;
+    lngMax: number;
+  };
+}
 
 const PROXIMITY_OPTIONS: Array<{ label: string; value?: ProximityRadiusOption }> = [
   { label: 'Anywhere' },
@@ -51,6 +64,8 @@ interface FilterPanelProps {
   timeFrom: string;
   timeTo: string;
   onLocationChange: (value: string) => void;
+  locationSuggestions?: LocationFilterSuggestion[];
+  onLocationSuggestionPress?: (suggestion: LocationFilterSuggestion) => void;
   onTimeFromChange: (value: string) => void;
   onTimeToChange: (value: string) => void;
   onClearAll: () => void;
@@ -70,6 +85,8 @@ export function FilterPanel({
   timeFrom,
   timeTo,
   onLocationChange,
+  locationSuggestions = [],
+  onLocationSuggestionPress,
   onTimeFromChange,
   onTimeToChange,
   onClearAll,
@@ -162,9 +179,50 @@ export function FilterPanel({
           }
         />
         {locationStatusText ? (
-          <Text style={{ color: colors.muted, fontSize: typography.caption + 1 }}>
+          <Text
+            accessibilityRole={locationStatusText.startsWith('Location not found') ? 'alert' : undefined}
+            style={{
+              color: locationStatusText.startsWith('Location not found') ? colors.danger : colors.muted,
+              fontSize: typography.caption + 1,
+            }}
+          >
             {locationStatusText}
           </Text>
+        ) : null}
+        {locationSuggestions.length ? (
+          <View
+            testID="location-filter-suggestions"
+            style={{
+              borderRadius: 16,
+              borderWidth: 1,
+              borderColor: colors.border,
+              backgroundColor: colors.background,
+              overflow: 'hidden',
+            }}
+          >
+            {locationSuggestions.map((suggestion, index) => (
+              <Pressable
+                key={suggestion.id}
+                accessibilityRole="button"
+                accessibilityLabel={`Select location ${suggestion.title}`}
+                onPress={() => onLocationSuggestionPress?.(suggestion)}
+                style={({ pressed }) => ({
+                  paddingHorizontal: spacing.md,
+                  paddingVertical: spacing.sm + 2,
+                  borderTopWidth: index === 0 ? 0 : 1,
+                  borderTopColor: colors.border,
+                  backgroundColor: pressed ? colors.infoSurface : colors.background,
+                })}
+              >
+                <Text style={{ color: colors.text, fontWeight: '700' }}>{suggestion.title}</Text>
+                {suggestion.subtitle ? (
+                  <Text numberOfLines={2} style={{ marginTop: 2, color: colors.muted, fontSize: typography.caption }}>
+                    {suggestion.subtitle}
+                  </Text>
+                ) : null}
+              </Pressable>
+            ))}
+          </View>
         ) : null}
       </View>
 


### PR DESCRIPTION
# 📝 Description
Fixes #501 501

Improves the mobile location filter UX by preventing unresolved locations from being applied and showing selectable location suggestions below the location input, matching the submission location picker behavior.

# 📊 Type of Change
- [ ]  Bug fix
- [x]  New feature
- [ ]  Refactoring
- [ ]  Documentation
 
# ✅ Acceptance Criteria / Checklist
- [x] Project builds successfully
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, especially in hard-to-understand parts
- [x] I have performed a self-review of my code
- [x] I have added/updated tests
- [x] New and existing unit tests pass locally with my changes

# 📸 Screenshots / Recordings
<!-- If applicable !-->

# ⏱️ Estimated Review Time
- [ ] < 5 min
- [x] 5-15 min
- [ ] > 15 min
