### PR TITLE
Implement mobile saved stories section

### DIFF
--- a/mobile/src/app/navigation/RootNavigator.tsx
+++ b/mobile/src/app/navigation/RootNavigator.tsx
@@ -489,13 +489,13 @@ export function RootNavigator() {
   };
 
   const handleStoryInteractionUpdated = useCallback(
-    (update: { storyId: string; likeCount: number; savedByViewer: boolean }) => {
+    (update: { storyId: string } & FeedStoryInteractionUpdate) => {
       setStoryInteractionUpdates((current) => ({
         ...current,
         [update.storyId]: {
           ...current[update.storyId],
-          likeCount: update.likeCount,
-          savedByViewer: update.savedByViewer,
+          likeCount: update.likeCount ?? current[update.storyId]?.likeCount,
+          savedByViewer: update.savedByViewer ?? current[update.storyId]?.savedByViewer,
         },
       }));
     },
@@ -546,7 +546,11 @@ export function RootNavigator() {
           framed={false}
           fillContent
         >
-          <ProfileScreen mode="self" />
+          <ProfileScreen
+            mode="self"
+            onOpenStory={handleOpenStoryDetail}
+            onStoryInteractionUpdated={handleStoryInteractionUpdated}
+          />
         </ScreenShell>
       </ProtectedScreen>
     );
@@ -654,6 +658,9 @@ export function RootNavigator() {
                 showSearchControls={false}
                 searchScope="main"
                 storyInteractionUpdates={storyInteractionUpdates}
+                onStoryInteractionUpdated={handleStoryInteractionUpdated}
+                isAuthenticated={Boolean(isAuthenticated)}
+                onRequestLogin={() => showAuthRequiredMessage('Please sign in to bookmark stories.')}
               />
             </ScreenShell>
           </View>

--- a/mobile/src/features/feed/presentation/components/FeedCard.tsx
+++ b/mobile/src/features/feed/presentation/components/FeedCard.tsx
@@ -7,6 +7,9 @@ import { FeedEntity } from '../../domain/entities';
 interface FeedCardProps {
   story: FeedEntity;
   onPress?: (storyId: string) => void;
+  onBookmarkPress?: (storyId: string) => void;
+  isBookmarkPending?: boolean;
+  bookmarkAccessibilityLabel?: string;
 }
 
 function formatSubmittedAt(value: string) {
@@ -27,8 +30,32 @@ function formatSubmittedAt(value: string) {
   });
 }
 
-export function FeedCard({ story, onPress }: FeedCardProps) {
+export function FeedCard({
+  story,
+  onPress,
+  onBookmarkPress,
+  isBookmarkPending = false,
+  bookmarkAccessibilityLabel,
+}: FeedCardProps) {
   const { colors, spacing, typography } = useAppTheme();
+  const bookmarkIndicatorStyle = {
+    width: 30,
+    height: 30,
+    borderRadius: 999,
+    borderWidth: 1,
+    borderColor: story.savedByViewer ? colors.primary : colors.border,
+    backgroundColor: story.savedByViewer ? colors.primary : colors.background,
+    alignItems: 'center' as const,
+    justifyContent: 'center' as const,
+  };
+  const bookmarkIcon = (
+    <Bookmark
+      size={16}
+      color={story.savedByViewer ? colors.background : colors.muted}
+      fill={story.savedByViewer ? colors.background : 'transparent'}
+      strokeWidth={2.2}
+    />
+  );
 
   return (
     <Pressable
@@ -56,26 +83,33 @@ export function FeedCard({ story, onPress }: FeedCardProps) {
           {story.title}
         </Text>
         <View style={{ flexDirection: 'row', alignItems: 'center', gap: spacing.xs }}>
-          <View
-            accessibilityLabel={story.savedByViewer ? 'Bookmarked story' : 'Not bookmarked story'}
-            style={{
-              width: 30,
-              height: 30,
-              borderRadius: 999,
-              borderWidth: 1,
-              borderColor: story.savedByViewer ? colors.primary : colors.border,
-              backgroundColor: story.savedByViewer ? colors.primary : colors.background,
-              alignItems: 'center',
-              justifyContent: 'center',
-            }}
-          >
-            <Bookmark
-              size={16}
-              color={story.savedByViewer ? colors.background : colors.muted}
-              fill={story.savedByViewer ? colors.background : 'transparent'}
-              strokeWidth={2.2}
-            />
-          </View>
+          {onBookmarkPress ? (
+            <Pressable
+              accessibilityRole="button"
+              accessibilityLabel={
+                bookmarkAccessibilityLabel ?? (story.savedByViewer ? 'Bookmarked story' : 'Not bookmarked story')
+              }
+              accessibilityState={{ disabled: isBookmarkPending, selected: story.savedByViewer }}
+              disabled={isBookmarkPending}
+              onPress={(event) => {
+                event?.stopPropagation?.();
+                onBookmarkPress(story.id);
+              }}
+              style={({ pressed }) => ({
+                ...bookmarkIndicatorStyle,
+                opacity: isBookmarkPending ? 0.62 : pressed ? 0.78 : 1,
+              })}
+            >
+              {bookmarkIcon}
+            </Pressable>
+          ) : (
+            <View
+              accessibilityLabel={story.savedByViewer ? 'Bookmarked story' : 'Not bookmarked story'}
+              style={bookmarkIndicatorStyle}
+            >
+              {bookmarkIcon}
+            </View>
+          )}
           {story.hasMedia ? (
             <View
               accessibilityLabel="Has media"

--- a/mobile/src/features/feed/presentation/components/__tests__/FeedCard.test.tsx
+++ b/mobile/src/features/feed/presentation/components/__tests__/FeedCard.test.tsx
@@ -50,4 +50,16 @@ describe('FeedCard', () => {
     expect(screen.getByLabelText('Bookmarked story')).toBeTruthy();
     expect(screen.queryByLabelText('Not bookmarked story')).toBeNull();
   });
+
+  it('calls the bookmark handler from the card bookmark button', () => {
+    const onPress = jest.fn();
+    const onBookmarkPress = jest.fn();
+
+    render(<FeedCard story={story} onPress={onPress} onBookmarkPress={onBookmarkPress} />);
+
+    fireEvent.press(screen.getByLabelText('Not bookmarked story'));
+
+    expect(onBookmarkPress).toHaveBeenCalledWith('story-101');
+    expect(onPress).not.toHaveBeenCalled();
+  });
 });

--- a/mobile/src/features/feed/presentation/screens/FeedScreen.tsx
+++ b/mobile/src/features/feed/presentation/screens/FeedScreen.tsx
@@ -3,6 +3,7 @@ import { FlatList, Pressable, Text, View } from 'react-native';
 import { useAppTheme } from '../../../../core/hooks/useAppTheme';
 import { EmptyState, ErrorState, Loader, SkeletonCard } from '../../../../shared';
 import { useDebounce } from '../../../../shared/hooks/useDebounce';
+import { interactionService } from '../../../interactions/application/services';
 import { storyService } from '../../../stories/application/services';
 import { StoryFilters } from '../../../stories/domain/repositories';
 import { StorySearchControls } from '../../../search/presentation/components/StorySearchControls';
@@ -22,9 +23,14 @@ interface FeedScreenProps {
   onSortChange?: (sort: FeedSortOption) => void;
   onOpenStory?: (storyId: string) => void;
   getFeed?: typeof storyService.getFeed;
+  bookmarkStory?: typeof interactionService.bookmarkStory;
+  unbookmarkStory?: typeof interactionService.unbookmarkStory;
   showSearchControls?: boolean;
   searchScope?: SearchFilterScope;
   storyInteractionUpdates?: Record<string, FeedStoryInteractionUpdate>;
+  onStoryInteractionUpdated?: (update: { storyId: string } & FeedStoryInteractionUpdate) => void;
+  isAuthenticated?: boolean;
+  onRequestLogin?: () => void;
 }
 
 const EMPTY_FILTERS: StoryFilters = {};
@@ -45,15 +51,21 @@ export function FeedScreen({
   onSortChange,
   onOpenStory,
   getFeed = storyService.getFeed,
+  bookmarkStory = interactionService.bookmarkStory,
+  unbookmarkStory = interactionService.unbookmarkStory,
   showSearchControls = true,
   searchScope = 'feed',
   storyInteractionUpdates = EMPTY_STORY_INTERACTION_UPDATES,
+  onStoryInteractionUpdated,
+  isAuthenticated = true,
+  onRequestLogin,
 }: FeedScreenProps) {
   const { colors, spacing, typography } = useAppTheme();
   const { filters, refreshToken, isHydrated, setFilters } = useSearchFilters(searchScope);
   const debouncedQuery = useDebounce(filters.query, 350);
   const [useImmediateQuery, setUseImmediateQuery] = useState(false);
   const [state, setState] = useState(() => createInitialFeedUiState(initialFilters, initialSort));
+  const [pendingBookmarkIds, setPendingBookmarkIds] = useState<Record<string, boolean>>({});
   const stateRef = useRef(state);
   const storyInteractionUpdatesRef = useRef(storyInteractionUpdates);
   const hasRequestedNextPage = useRef(false);
@@ -190,6 +202,58 @@ export function FeedScreen({
     loadPage(1, 'initial', { filters: activeFilters, sort });
   };
 
+  const handleBookmarkPress = useCallback(
+    async (storyId: string) => {
+      if (!isAuthenticated) {
+        onRequestLogin?.();
+        return;
+      }
+
+      if (pendingBookmarkIds[storyId]) {
+        return;
+      }
+
+      const previousStory = stateRef.current.items.find((item) => item.id === storyId);
+
+      if (!previousStory) {
+        return;
+      }
+
+      const savedByViewer = !previousStory.savedByViewer;
+
+      setPendingBookmarkIds((current) => ({ ...current, [storyId]: true }));
+      setState((current) => applyStoryInteractionUpdates(current, { [storyId]: { savedByViewer } }));
+      onStoryInteractionUpdated?.({ storyId, savedByViewer });
+
+      try {
+        if (savedByViewer) {
+          await bookmarkStory(storyId);
+        } else {
+          await unbookmarkStory(storyId);
+        }
+      } catch {
+        setState((current) =>
+          applyStoryInteractionUpdates(current, { [storyId]: { savedByViewer: previousStory.savedByViewer } }),
+        );
+        onStoryInteractionUpdated?.({ storyId, savedByViewer: previousStory.savedByViewer });
+      } finally {
+        setPendingBookmarkIds((current) => {
+          const next = { ...current };
+          delete next[storyId];
+          return next;
+        });
+      }
+    },
+    [
+      bookmarkStory,
+      isAuthenticated,
+      onRequestLogin,
+      onStoryInteractionUpdated,
+      pendingBookmarkIds,
+      unbookmarkStory,
+    ],
+  );
+
   const renderControls = () => {
     return (
       <View style={{ paddingHorizontal: spacing.lg, paddingTop: spacing.sm, paddingBottom: spacing.xs, gap: spacing.sm }}>
@@ -307,7 +371,16 @@ export function FeedScreen({
         testID="feed-list"
         data={state.items}
         keyExtractor={(item) => item.id}
-        renderItem={({ item }) => <FeedCard story={item} onPress={onOpenStory} />}
+        renderItem={({ item }) => (
+          <FeedCard
+            story={item}
+            onPress={onOpenStory}
+            onBookmarkPress={(storyId) => {
+              void handleBookmarkPress(storyId);
+            }}
+            isBookmarkPending={Boolean(pendingBookmarkIds[item.id])}
+          />
+        )}
         contentContainerStyle={{
           paddingHorizontal: spacing.lg,
           paddingBottom: spacing.xl,

--- a/mobile/src/features/feed/presentation/screens/__tests__/FeedScreen.test.tsx
+++ b/mobile/src/features/feed/presentation/screens/__tests__/FeedScreen.test.tsx
@@ -6,9 +6,17 @@ import { FeedPageEntity } from '../../../domain/entities';
 import { SearchFiltersProvider } from '../../../../search/presentation/context/SearchFiltersContext';
 import { storage } from '../../../../../core/storage/storage';
 import { geocodeLocationQuery } from '../../../../search/application/services';
+import { interactionService } from '../../../../interactions/application/services';
 
 jest.mock('../../../../search/application/services', () => ({
   geocodeLocationQuery: jest.fn(),
+}));
+
+jest.mock('../../../../interactions/application/services', () => ({
+  interactionService: {
+    bookmarkStory: jest.fn(async () => undefined),
+    unbookmarkStory: jest.fn(async () => undefined),
+  },
 }));
 
 function makeStory(id: string, overrides: Partial<FeedPageEntity['items'][number]> = {}) {
@@ -39,6 +47,7 @@ function makeFeedPage(overrides: Partial<FeedPageEntity> = {}): FeedPageEntity {
 
 describe('FeedScreen', () => {
   beforeEach(async () => {
+    jest.clearAllMocks();
     (geocodeLocationQuery as jest.Mock).mockResolvedValue(null);
     jest.mocked(Location.requestForegroundPermissionsAsync).mockResolvedValue({ granted: true } as never);
     jest.mocked(Location.hasServicesEnabledAsync).mockResolvedValue(true);
@@ -49,6 +58,8 @@ describe('FeedScreen', () => {
         longitude: 28.9784,
       },
     } as never);
+    jest.mocked(interactionService.bookmarkStory).mockResolvedValue(undefined);
+    jest.mocked(interactionService.unbookmarkStory).mockResolvedValue(undefined);
     await storage.clear();
   });
 
@@ -221,6 +232,112 @@ describe('FeedScreen', () => {
       expect(screen.getByText('♥ 1')).toBeTruthy();
       expect(screen.getByLabelText('Bookmarked story')).toBeTruthy();
     });
+  });
+
+  it('bookmarks stories from the feed with an optimistic update', async () => {
+    const onStoryInteractionUpdated = jest.fn();
+    const getFeed = jest.fn<Promise<FeedPageEntity>, [any]>().mockResolvedValue(
+      makeFeedPage({
+        items: [makeStory('1', { savedByViewer: false })],
+        totalCount: 1,
+      }),
+    );
+
+    renderScreen(
+      <FeedScreen
+        getFeed={getFeed}
+        onStoryInteractionUpdated={onStoryInteractionUpdated}
+        isAuthenticated
+      />,
+    );
+
+    expect(await screen.findByText('Story 1')).toBeTruthy();
+    fireEvent.press(screen.getByLabelText('Not bookmarked story'));
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('Bookmarked story')).toBeTruthy();
+      expect(interactionService.bookmarkStory).toHaveBeenCalledWith('1');
+      expect(onStoryInteractionUpdated).toHaveBeenCalledWith({ storyId: '1', savedByViewer: true });
+    });
+  });
+
+  it('removes feed bookmarks with an optimistic update', async () => {
+    const onStoryInteractionUpdated = jest.fn();
+    const getFeed = jest.fn<Promise<FeedPageEntity>, [any]>().mockResolvedValue(
+      makeFeedPage({
+        items: [makeStory('1', { savedByViewer: true })],
+        totalCount: 1,
+      }),
+    );
+
+    renderScreen(
+      <FeedScreen
+        getFeed={getFeed}
+        onStoryInteractionUpdated={onStoryInteractionUpdated}
+        isAuthenticated
+      />,
+    );
+
+    expect(await screen.findByLabelText('Bookmarked story')).toBeTruthy();
+    fireEvent.press(screen.getByLabelText('Bookmarked story'));
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('Not bookmarked story')).toBeTruthy();
+      expect(interactionService.unbookmarkStory).toHaveBeenCalledWith('1');
+      expect(onStoryInteractionUpdated).toHaveBeenCalledWith({ storyId: '1', savedByViewer: false });
+    });
+  });
+
+  it('reverts feed bookmark updates when the request fails', async () => {
+    jest.mocked(interactionService.bookmarkStory).mockRejectedValueOnce(new Error('Network error'));
+    const onStoryInteractionUpdated = jest.fn();
+    const getFeed = jest.fn<Promise<FeedPageEntity>, [any]>().mockResolvedValue(
+      makeFeedPage({
+        items: [makeStory('1', { savedByViewer: false })],
+        totalCount: 1,
+      }),
+    );
+
+    renderScreen(
+      <FeedScreen
+        getFeed={getFeed}
+        onStoryInteractionUpdated={onStoryInteractionUpdated}
+        isAuthenticated
+      />,
+    );
+
+    expect(await screen.findByText('Story 1')).toBeTruthy();
+    fireEvent.press(screen.getByLabelText('Not bookmarked story'));
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('Not bookmarked story')).toBeTruthy();
+      expect(onStoryInteractionUpdated).toHaveBeenLastCalledWith({ storyId: '1', savedByViewer: false });
+    });
+  });
+
+  it('prompts guests before bookmarking from the feed', async () => {
+    const onRequestLogin = jest.fn();
+    const getFeed = jest.fn<Promise<FeedPageEntity>, [any]>().mockResolvedValue(
+      makeFeedPage({
+        items: [makeStory('1', { savedByViewer: false })],
+        totalCount: 1,
+      }),
+    );
+
+    renderScreen(
+      <FeedScreen
+        getFeed={getFeed}
+        isAuthenticated={false}
+        onRequestLogin={onRequestLogin}
+      />,
+    );
+
+    expect(await screen.findByText('Story 1')).toBeTruthy();
+    fireEvent.press(screen.getByLabelText('Not bookmarked story'));
+
+    expect(onRequestLogin).toHaveBeenCalledTimes(1);
+    expect(interactionService.bookmarkStory).not.toHaveBeenCalled();
+    expect(screen.getByLabelText('Not bookmarked story')).toBeTruthy();
   });
 
   it('updates search query filters after debounce', async () => {

--- a/mobile/src/features/profile/application/services/__tests__/userService.test.ts
+++ b/mobile/src/features/profile/application/services/__tests__/userService.test.ts
@@ -197,6 +197,52 @@ describe('userService', () => {
     });
   });
 
+  it('loads saved stories from the profile bookmarks endpoint', async () => {
+    setApiTransport(async (method: any, config: any) => {
+      if (method === 'GET' && config.url === '/users/7/bookmarks/?page=2&page_size=10') {
+        return {
+          status: 200,
+          data: {
+            count: 1,
+            next: null,
+            previous: 'previous-page',
+            results: [
+              {
+                id: 'story-1',
+                title: 'Saved Harbor',
+                location_name: 'Golden Horn',
+                time_type: 'exact_year',
+                year: 1978,
+                preview_text: 'A saved story.',
+                submitted_at: '2026-03-18T10:00:00Z',
+                like_count: 4,
+                user_has_saved: true,
+              },
+            ],
+          } as never,
+          config,
+        };
+      }
+
+      throw new Error(`Unexpected request: ${method} ${config.url}`);
+    });
+
+    await expect(userService.getSavedStories('7', 2)).resolves.toMatchObject({
+      page: 2,
+      totalCount: 1,
+      items: [
+        {
+          id: 'story-1',
+          title: 'Saved Harbor',
+          locationName: 'Golden Horn',
+          timePeriod: '1978',
+          likeCount: 4,
+          savedByViewer: true,
+        },
+      ],
+    });
+  });
+
   it('updates the authenticated profile via PATCH /users/me/', async () => {
     setApiTransport(async (method: any, config: any) => {
       if (method === 'PATCH' && config.url === '/users/me/') {

--- a/mobile/src/features/profile/application/services/index.ts
+++ b/mobile/src/features/profile/application/services/index.ts
@@ -1,5 +1,6 @@
 import { ProfileRepositoryImpl } from '../../data/repositories';
 import { FollowListResult, ProfileEntity, ProfilePhotoUploadInput, UpdateProfileInput } from '../../domain/entities';
+import { FeedPageEntity } from '../../../feed/domain/entities';
 
 const repository = new ProfileRepositoryImpl();
 
@@ -36,5 +37,8 @@ export const userService = {
   },
   async getFollowing(userId: string, page = 1): Promise<FollowListResult> {
     return repository.getFollowing(userId, page);
+  },
+  async getSavedStories(userId: string, page = 1): Promise<FeedPageEntity> {
+    return repository.getSavedStories(userId, page);
   },
 };

--- a/mobile/src/features/profile/data/repositories/index.ts
+++ b/mobile/src/features/profile/data/repositories/index.ts
@@ -7,6 +7,7 @@ import {
 import { ProfileRepository } from '../../domain/repositories';
 import { mapCurrentProfile, mapFollowList, mapPublicProfile, mergePublicProfileSummary } from '../mappers';
 import { profileRemoteSource } from '../sources';
+import { mapFeedPage } from '../../../feed/data/mappers';
 
 export class ProfileRepositoryImpl implements ProfileRepository {
   async getCurrentProfile(): Promise<ProfileEntity> {
@@ -68,5 +69,10 @@ export class ProfileRepositoryImpl implements ProfileRepository {
   async getFollowing(userId: string, page = 1): Promise<FollowListResult> {
     const payload = await profileRemoteSource.getFollowing(userId, page);
     return mapFollowList(payload);
+  }
+
+  async getSavedStories(userId: string, page = 1) {
+    const payload = await profileRemoteSource.getSavedStories(userId, page);
+    return mapFeedPage(payload, page, 10);
   }
 }

--- a/mobile/src/features/profile/data/sources/index.ts
+++ b/mobile/src/features/profile/data/sources/index.ts
@@ -154,6 +154,17 @@ export const profileRemoteSource = {
       results: [],
     };
   },
+
+  async getSavedStories(userId: string, page = 1) {
+    return (await apiClient.get<Record<string, unknown>>(
+      `/users/${userId}/bookmarks/${buildQueryString({ page, page_size: 10 })}`,
+    )) ?? {
+      count: 0,
+      next: null,
+      previous: null,
+      results: [],
+    };
+  },
 };
 
 export const profileLocalSource = {};

--- a/mobile/src/features/profile/domain/repositories/index.ts
+++ b/mobile/src/features/profile/domain/repositories/index.ts
@@ -1,4 +1,5 @@
 import { FollowListResult, ProfileEntity, ProfilePhotoUploadInput, UpdateProfileInput } from '../entities';
+import { FeedPageEntity } from '../../../feed/domain/entities';
 
 export interface ProfileRepository {
   getCurrentProfile(): Promise<ProfileEntity>;
@@ -11,4 +12,5 @@ export interface ProfileRepository {
   unfollowUser(userId: string): Promise<void>;
   getFollowers(userId: string, page?: number): Promise<FollowListResult>;
   getFollowing(userId: string, page?: number): Promise<FollowListResult>;
+  getSavedStories(userId: string, page?: number): Promise<FeedPageEntity>;
 }

--- a/mobile/src/features/profile/presentation/screens/ProfileScreen.tsx
+++ b/mobile/src/features/profile/presentation/screens/ProfileScreen.tsx
@@ -3,12 +3,16 @@ import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { Image, Modal, Pressable, ScrollView, Text, View } from 'react-native';
 import { GestureResponderEvent } from 'react-native';
 import { navigationRef } from '../../../../app/navigation/navigationRef';
+import { ROUTES } from '../../../../app/navigation/routes';
 import { limits } from '../../../../core/constants/limits';
 import { useAppTheme } from '../../../../core/hooks/useAppTheme';
-import { Button, ErrorState, Input, Loader, Skeleton } from '../../../../shared';
+import { Button, EmptyState, ErrorState, Input, Loader, Skeleton } from '../../../../shared';
 import { useToast } from '../../../../shared/hooks/useToast';
 import { authService } from '../../../auth/application/services';
 import { useAuth } from '../../../auth';
+import { interactionService } from '../../../interactions/application/services';
+import { FeedCard } from '../../../feed/presentation/components/FeedCard';
+import { FeedEntity, FeedPageEntity } from '../../../feed/domain/entities';
 import { userService } from '../../application/services';
 import { FollowListResult, FollowUserEntity, ProfileEntity, ProfilePhotoUploadInput, UpdateProfileInput } from '../../domain/entities';
 import { AuthUser } from '../../../../core/auth/session';
@@ -48,6 +52,8 @@ interface ProfileScreenProps {
   unfollowUser?: typeof userService.unfollowUser;
   getFollowers?: typeof userService.getFollowers;
   getFollowing?: typeof userService.getFollowing;
+  getSavedStories?: typeof userService.getSavedStories;
+  unbookmarkStory?: typeof interactionService.unbookmarkStory;
   onOpenUserProfile?: (userId: string) => void;
 }
 
@@ -792,6 +798,155 @@ function FieldCard({
   );
 }
 
+function SavedStoriesSection({
+  userId,
+  getSavedStories,
+  unbookmarkStory,
+}: {
+  userId: string;
+  getSavedStories: (userId: string, page?: number) => Promise<FeedPageEntity>;
+  unbookmarkStory: (storyId: string) => Promise<void>;
+}) {
+  const { colors, spacing, typography } = useAppTheme();
+  const { toast } = useToast();
+  const [stories, setStories] = useState<FeedEntity[]>([]);
+  const [page, setPage] = useState(1);
+  const [hasMore, setHasMore] = useState(false);
+  const [isLoading, setIsLoading] = useState(true);
+  const [isLoadingMore, setIsLoadingMore] = useState(false);
+  const [error, setError] = useState<string>();
+  const [pendingStoryId, setPendingStoryId] = useState<string | null>(null);
+
+  const loadPage = useCallback(
+    async (nextPage: number, append: boolean) => {
+      if (append) {
+        setIsLoadingMore(true);
+      } else {
+        setIsLoading(true);
+      }
+
+      setError(undefined);
+
+      try {
+        const result = await getSavedStories(userId, nextPage);
+        setStories((current) => (append ? [...current, ...result.items] : result.items));
+        setPage(nextPage);
+        setHasMore(result.hasNextPage);
+      } catch (loadError) {
+        setError(loadError instanceof Error ? loadError.message : 'Unable to load saved stories.');
+      } finally {
+        setIsLoading(false);
+        setIsLoadingMore(false);
+      }
+    },
+    [getSavedStories, userId],
+  );
+
+  useEffect(() => {
+    setStories([]);
+    setPage(1);
+    setHasMore(false);
+    void loadPage(1, false);
+  }, [loadPage]);
+
+  const handleRemoveBookmark = useCallback(
+    async (storyId: string) => {
+      if (pendingStoryId) {
+        return;
+      }
+
+      const previousStories = stories;
+      const nextStories = stories.filter((story) => story.id !== storyId);
+
+      setPendingStoryId(storyId);
+      setStories(nextStories);
+
+      try {
+        await unbookmarkStory(storyId);
+        toast.success('Removed from saved stories.');
+      } catch {
+        setStories(previousStories);
+        toast.error('Failed to remove saved story. Please try again.');
+      } finally {
+        setPendingStoryId(null);
+      }
+    },
+    [pendingStoryId, stories, toast, unbookmarkStory],
+  );
+
+  return (
+    <View
+      accessibilityLabel="Saved stories section"
+      style={{
+        padding: spacing.lg,
+        borderRadius: 20,
+        borderWidth: 1,
+        borderColor: colors.border,
+        backgroundColor: colors.surface,
+        gap: spacing.md,
+      }}
+    >
+      <View style={{ gap: spacing.xs }}>
+        <Text style={{ color: colors.text, fontSize: typography.subtitle, fontWeight: '800' }}>
+          Saved Stories
+        </Text>
+        <Text style={{ color: colors.muted }}>
+          Stories you bookmarked, ordered by most recently saved.
+        </Text>
+      </View>
+
+      {isLoading && stories.length === 0 ? <Loader message="Loading saved stories..." /> : null}
+
+      {error && stories.length === 0 ? (
+        <ErrorState
+          title="Saved stories unavailable"
+          message={error}
+          retryLabel="Try again"
+          onRetry={() => {
+            void loadPage(1, false);
+          }}
+        />
+      ) : null}
+
+      {!isLoading && !error && stories.length === 0 ? (
+        <EmptyState
+          title="No saved stories yet"
+          message="Bookmark stories to find them here later."
+          actionLabel="Browse stories"
+          onAction={() => navigationRef.navigate?.(ROUTES.FEED)}
+        />
+      ) : null}
+
+      {stories.length > 0 ? (
+        <View style={{ gap: spacing.md }}>
+          {stories.map((story) => (
+            <FeedCard
+              key={story.id}
+              story={{ ...story, savedByViewer: true }}
+              bookmarkAccessibilityLabel={`Remove ${story.title} from saved stories`}
+              isBookmarkPending={pendingStoryId === story.id}
+              onBookmarkPress={(storyId) => {
+                void handleRemoveBookmark(storyId);
+              }}
+            />
+          ))}
+          {hasMore ? (
+            <Button
+              variant="outline"
+              onPress={() => {
+                void loadPage(page + 1, true);
+              }}
+              disabled={isLoadingMore}
+            >
+              {isLoadingMore ? 'Loading...' : 'Load more saved stories'}
+            </Button>
+          ) : null}
+        </View>
+      ) : null}
+    </View>
+  );
+}
+
 export function ProfileScreen({
   mode = 'self',
   userId,
@@ -805,6 +960,8 @@ export function ProfileScreen({
   unfollowUser = userService.unfollowUser,
   getFollowers = userService.getFollowers,
   getFollowing = userService.getFollowing,
+  getSavedStories = userService.getSavedStories,
+  unbookmarkStory = interactionService.unbookmarkStory,
   onOpenUserProfile,
 }: ProfileScreenProps) {
   const { user, isAuthenticated, updateUser, logout } = useAuth();
@@ -1276,6 +1433,14 @@ export function ProfileScreen({
             </FieldCard>
           ) : null}
         </View>
+
+        {isSelfMode ? (
+          <SavedStoriesSection
+            userId={profile.id}
+            getSavedStories={getSavedStories}
+            unbookmarkStory={unbookmarkStory}
+          />
+        ) : null}
 
         {isSelfMode ? (
           <View

--- a/mobile/src/features/profile/presentation/screens/ProfileScreen.tsx
+++ b/mobile/src/features/profile/presentation/screens/ProfileScreen.tsx
@@ -456,33 +456,38 @@ function StatButton({
   label,
   value,
   onPress,
+  accessibilityLabel,
+  selected = false,
 }: {
   label: string;
   value: string;
   onPress: () => void;
+  accessibilityLabel?: string;
+  selected?: boolean;
 }) {
   const { colors, spacing, typography } = useAppTheme();
 
   return (
     <Pressable
       accessibilityRole="button"
-      accessibilityLabel={`${value} ${label}`}
+      accessibilityLabel={accessibilityLabel ?? `${value} ${label}`}
+      accessibilityState={{ selected }}
       onPress={onPress}
       style={({ pressed }) => ({
         minWidth: 120,
         padding: spacing.md,
         borderRadius: 16,
         borderWidth: 1,
-        borderColor: colors.border,
-        backgroundColor: colors.background,
+        borderColor: selected ? colors.primary : colors.border,
+        backgroundColor: selected ? colors.infoSurface : colors.background,
         gap: spacing.xs,
         opacity: pressed ? 0.82 : 1,
       })}
     >
-      <Text style={{ color: colors.muted, fontSize: typography.caption, textTransform: 'uppercase' }}>
+      <Text style={{ color: selected ? colors.primary : colors.muted, fontSize: typography.caption, textTransform: 'uppercase' }}>
         {label}
       </Text>
-      <Text style={{ color: colors.text, fontSize: typography.subtitle, fontWeight: '800' }}>{value}</Text>
+      <Text style={{ color: selected ? colors.primary : colors.text, fontSize: typography.subtitle, fontWeight: '800' }}>{value}</Text>
     </Pressable>
   );
 }
@@ -517,69 +522,6 @@ function FollowActionButton({
     >
       {isLoading ? 'Updating...' : isFollowing ? 'Following' : 'Follow'}
     </Button>
-  );
-}
-
-function SelfProfileTabs({
-  activeTab,
-  onChange,
-}: {
-  activeTab: SelfProfileTab;
-  onChange: (tab: SelfProfileTab) => void;
-}) {
-  const { colors, spacing, typography } = useAppTheme();
-  const tabs: Array<{ key: SelfProfileTab; label: string; accessibilityLabel: string }> = [
-    { key: 'profile', label: 'Profile', accessibilityLabel: 'Show profile info' },
-    { key: 'saved', label: 'Saved', accessibilityLabel: 'Show saved stories' },
-  ];
-
-  return (
-    <View
-      accessibilityLabel="Profile content tabs"
-      style={{
-        flexDirection: 'row',
-        alignSelf: 'flex-start',
-        gap: spacing.xs,
-        padding: spacing.xs,
-        borderRadius: 999,
-        borderWidth: 1,
-        borderColor: colors.border,
-        backgroundColor: colors.surface,
-      }}
-    >
-      {tabs.map((tab) => {
-        const isActive = activeTab === tab.key;
-
-        return (
-          <Pressable
-            key={tab.key}
-            accessibilityRole="tab"
-            accessibilityLabel={tab.accessibilityLabel}
-            accessibilityState={{ selected: isActive }}
-            onPress={() => onChange(tab.key)}
-            style={({ pressed }) => ({
-              minWidth: 92,
-              alignItems: 'center',
-              paddingHorizontal: spacing.md,
-              paddingVertical: spacing.sm,
-              borderRadius: 999,
-              backgroundColor: isActive ? colors.primary : colors.surface,
-              opacity: pressed ? 0.78 : 1,
-            })}
-          >
-            <Text
-              style={{
-                color: isActive ? colors.background : colors.text,
-                fontSize: typography.caption,
-                fontWeight: '800',
-              }}
-            >
-              {tab.label}
-            </Text>
-          </Pressable>
-        );
-      })}
-    </View>
   );
 }
 
@@ -1477,6 +1419,17 @@ export function ProfileScreen({
               value={String(followingCount)}
               onPress={() => openFollowList('following')}
             />
+            {isSelfMode ? (
+              <StatButton
+                label="Saved"
+                value="Stories"
+                accessibilityLabel="Show saved stories"
+                selected={activeSelfTab === 'saved'}
+                onPress={() => {
+                  setActiveSelfTab((current) => (current === 'saved' ? 'profile' : 'saved'));
+                }}
+              />
+            ) : null}
             {profile.location ? <StatChip label="Location" value={profile.location} /> : null}
             {birthDateDisplay ? <StatChip label="Birth date" value={birthDateDisplay} /> : null}
             {profile.birthYear ? <StatChip label="Birth year" value={String(profile.birthYear)} /> : null}
@@ -1498,10 +1451,6 @@ export function ProfileScreen({
             </FieldCard>
           ) : null}
         </View>
-
-        {isSelfMode ? (
-          <SelfProfileTabs activeTab={activeSelfTab} onChange={setActiveSelfTab} />
-        ) : null}
 
         {isSelfMode && activeSelfTab === 'saved' ? (
           <SavedStoriesSection

--- a/mobile/src/features/profile/presentation/screens/ProfileScreen.tsx
+++ b/mobile/src/features/profile/presentation/screens/ProfileScreen.tsx
@@ -808,10 +808,12 @@ function SavedStoriesSection({
   userId,
   getSavedStories,
   unbookmarkStory,
+  onTotalCountChange,
 }: {
   userId: string;
   getSavedStories: (userId: string, page?: number) => Promise<FeedPageEntity>;
   unbookmarkStory: (storyId: string) => Promise<void>;
+  onTotalCountChange?: (count: number) => void;
 }) {
   const { colors, spacing, typography } = useAppTheme();
   const { toast } = useToast();
@@ -822,6 +824,7 @@ function SavedStoriesSection({
   const [isLoadingMore, setIsLoadingMore] = useState(false);
   const [error, setError] = useState<string>();
   const [pendingStoryId, setPendingStoryId] = useState<string | null>(null);
+  const [totalCount, setTotalCount] = useState(0);
 
   const loadPage = useCallback(
     async (nextPage: number, append: boolean) => {
@@ -838,6 +841,8 @@ function SavedStoriesSection({
         setStories((current) => (append ? [...current, ...result.items] : result.items));
         setPage(nextPage);
         setHasMore(result.hasNextPage);
+        setTotalCount(result.totalCount);
+        onTotalCountChange?.(result.totalCount);
       } catch (loadError) {
         setError(loadError instanceof Error ? loadError.message : 'Unable to load saved stories.');
       } finally {
@@ -845,7 +850,7 @@ function SavedStoriesSection({
         setIsLoadingMore(false);
       }
     },
-    [getSavedStories, userId],
+    [getSavedStories, onTotalCountChange, userId],
   );
 
   useEffect(() => {
@@ -862,22 +867,28 @@ function SavedStoriesSection({
       }
 
       const previousStories = stories;
+      const previousTotalCount = totalCount;
       const nextStories = stories.filter((story) => story.id !== storyId);
+      const nextTotalCount = Math.max(0, totalCount - 1);
 
       setPendingStoryId(storyId);
       setStories(nextStories);
+      setTotalCount(nextTotalCount);
+      onTotalCountChange?.(nextTotalCount);
 
       try {
         await unbookmarkStory(storyId);
         toast.success('Removed from saved stories.');
       } catch {
         setStories(previousStories);
+        setTotalCount(previousTotalCount);
+        onTotalCountChange?.(previousTotalCount);
         toast.error('Failed to remove saved story. Please try again.');
       } finally {
         setPendingStoryId(null);
       }
     },
-    [pendingStoryId, stories, toast, unbookmarkStory],
+    [onTotalCountChange, pendingStoryId, stories, toast, totalCount, unbookmarkStory],
   );
 
   return (
@@ -1000,6 +1011,7 @@ export function ProfileScreen({
   const [followListMode, setFollowListMode] = useState<'followers' | 'following'>('followers');
   const [isFollowListVisible, setIsFollowListVisible] = useState(false);
   const [activeSelfTab, setActiveSelfTab] = useState<SelfProfileTab>('profile');
+  const [savedStoriesCount, setSavedStoriesCount] = useState<number | null>(null);
 
   const resetPhotoDraft = useCallback(() => {
     setPendingPhoto(null);
@@ -1057,6 +1069,32 @@ export function ProfileScreen({
 
     void loadProfile();
   }, [isSelfMode, loadProfile, userId]);
+
+  useEffect(() => {
+    if (!isSelfMode || !profile?.id) {
+      setSavedStoriesCount(null);
+      return;
+    }
+
+    let isActive = true;
+
+    setSavedStoriesCount(null);
+    void getSavedStories(profile.id, 1)
+      .then((result) => {
+        if (isActive) {
+          setSavedStoriesCount(result.totalCount);
+        }
+      })
+      .catch(() => {
+        if (isActive) {
+          setSavedStoriesCount(0);
+        }
+      });
+
+    return () => {
+      isActive = false;
+    };
+  }, [getSavedStories, isSelfMode, profile?.id]);
 
   const validateForm = useCallback(() => {
     const nextErrors: FormErrors = {};
@@ -1422,7 +1460,7 @@ export function ProfileScreen({
             {isSelfMode ? (
               <StatButton
                 label="Saved"
-                value="Stories"
+                value={savedStoriesCount === null ? '...' : String(savedStoriesCount)}
                 accessibilityLabel="Show saved stories"
                 selected={activeSelfTab === 'saved'}
                 onPress={() => {
@@ -1457,6 +1495,7 @@ export function ProfileScreen({
             userId={profile.id}
             getSavedStories={getSavedStories}
             unbookmarkStory={unbookmarkStory}
+            onTotalCountChange={setSavedStoriesCount}
           />
         ) : null}
 

--- a/mobile/src/features/profile/presentation/screens/ProfileScreen.tsx
+++ b/mobile/src/features/profile/presentation/screens/ProfileScreen.tsx
@@ -56,6 +56,8 @@ interface ProfileScreenProps {
   getSavedStories?: typeof userService.getSavedStories;
   unbookmarkStory?: typeof interactionService.unbookmarkStory;
   onOpenUserProfile?: (userId: string) => void;
+  onOpenStory?: (storyId: string) => void;
+  onStoryInteractionUpdated?: (update: { storyId: string; savedByViewer?: boolean; likeCount?: number }) => void;
 }
 
 interface ProfileFormState {
@@ -809,11 +811,15 @@ function SavedStoriesSection({
   getSavedStories,
   unbookmarkStory,
   onTotalCountChange,
+  onOpenStory,
+  onStoryInteractionUpdated,
 }: {
   userId: string;
   getSavedStories: (userId: string, page?: number) => Promise<FeedPageEntity>;
   unbookmarkStory: (storyId: string) => Promise<void>;
   onTotalCountChange?: (count: number) => void;
+  onOpenStory?: (storyId: string) => void;
+  onStoryInteractionUpdated?: (update: { storyId: string; savedByViewer?: boolean; likeCount?: number }) => void;
 }) {
   const { colors, spacing, typography } = useAppTheme();
   const { toast } = useToast();
@@ -875,6 +881,7 @@ function SavedStoriesSection({
       setStories(nextStories);
       setTotalCount(nextTotalCount);
       onTotalCountChange?.(nextTotalCount);
+      onStoryInteractionUpdated?.({ storyId, savedByViewer: false });
 
       try {
         await unbookmarkStory(storyId);
@@ -883,12 +890,13 @@ function SavedStoriesSection({
         setStories(previousStories);
         setTotalCount(previousTotalCount);
         onTotalCountChange?.(previousTotalCount);
+        onStoryInteractionUpdated?.({ storyId, savedByViewer: true });
         toast.error('Failed to remove saved story. Please try again.');
       } finally {
         setPendingStoryId(null);
       }
     },
-    [onTotalCountChange, pendingStoryId, stories, toast, totalCount, unbookmarkStory],
+    [onStoryInteractionUpdated, onTotalCountChange, pendingStoryId, stories, toast, totalCount, unbookmarkStory],
   );
 
   return (
@@ -942,6 +950,7 @@ function SavedStoriesSection({
               story={{ ...story, savedByViewer: true }}
               bookmarkAccessibilityLabel={`Remove ${story.title} from saved stories`}
               isBookmarkPending={pendingStoryId === story.id}
+              onPress={onOpenStory}
               onBookmarkPress={(storyId) => {
                 void handleRemoveBookmark(storyId);
               }}
@@ -980,6 +989,8 @@ export function ProfileScreen({
   getSavedStories = userService.getSavedStories,
   unbookmarkStory = interactionService.unbookmarkStory,
   onOpenUserProfile,
+  onOpenStory,
+  onStoryInteractionUpdated,
 }: ProfileScreenProps) {
   const { user, isAuthenticated, updateUser, logout } = useAuth();
   const { toast } = useToast();
@@ -1012,6 +1023,9 @@ export function ProfileScreen({
   const [isFollowListVisible, setIsFollowListVisible] = useState(false);
   const [activeSelfTab, setActiveSelfTab] = useState<SelfProfileTab>('profile');
   const [savedStoriesCount, setSavedStoriesCount] = useState<number | null>(null);
+  const scrollViewRef = useRef<ScrollView>(null);
+  const savedStoriesSectionYRef = useRef(0);
+  const shouldScrollToSavedStoriesRef = useRef(false);
 
   const resetPhotoDraft = useCallback(() => {
     setPendingPhoto(null);
@@ -1359,6 +1373,33 @@ export function ProfileScreen({
     );
   }, [formState, isPhotoRemoved, pendingPhoto, profile]);
   const profilePhotoUri = pendingPhoto?.previewUri ?? (isPhotoRemoved ? null : profile?.profilePhoto ?? null);
+  const scrollToSavedStories = useCallback(() => {
+    const y = savedStoriesSectionYRef.current;
+
+    if (y <= 0) {
+      return false;
+    }
+
+    scrollViewRef.current?.scrollTo({
+      y: Math.max(y - spacing.md, 0),
+      animated: true,
+    });
+    return true;
+  }, [spacing.md]);
+
+  useEffect(() => {
+    if (activeSelfTab !== 'saved' || !shouldScrollToSavedStoriesRef.current) {
+      return;
+    }
+
+    const timer = setTimeout(() => {
+      if (scrollToSavedStories()) {
+        shouldScrollToSavedStoriesRef.current = false;
+      }
+    }, 0);
+
+    return () => clearTimeout(timer);
+  }, [activeSelfTab, scrollToSavedStories]);
 
   if (isLoading) {
     return <LoadingState />;
@@ -1384,6 +1425,8 @@ export function ProfileScreen({
   return (
     <>
       <ScrollView
+        ref={scrollViewRef}
+        testID="profile-scroll-view"
         contentContainerStyle={{
           paddingBottom: spacing.xl,
           gap: spacing.lg,
@@ -1464,7 +1507,11 @@ export function ProfileScreen({
                 accessibilityLabel="Show saved stories"
                 selected={activeSelfTab === 'saved'}
                 onPress={() => {
-                  setActiveSelfTab((current) => (current === 'saved' ? 'profile' : 'saved'));
+                  setActiveSelfTab((current) => {
+                    const nextTab = current === 'saved' ? 'profile' : 'saved';
+                    shouldScrollToSavedStoriesRef.current = nextTab === 'saved';
+                    return nextTab;
+                  });
                 }}
               />
             ) : null}
@@ -1491,12 +1538,24 @@ export function ProfileScreen({
         </View>
 
         {isSelfMode && activeSelfTab === 'saved' ? (
-          <SavedStoriesSection
-            userId={profile.id}
-            getSavedStories={getSavedStories}
-            unbookmarkStory={unbookmarkStory}
-            onTotalCountChange={setSavedStoriesCount}
-          />
+          <View
+            testID="profile-saved-stories-wrapper"
+            onLayout={(event) => {
+              savedStoriesSectionYRef.current = event.nativeEvent.layout.y;
+              if (shouldScrollToSavedStoriesRef.current && scrollToSavedStories()) {
+                shouldScrollToSavedStoriesRef.current = false;
+              }
+            }}
+          >
+            <SavedStoriesSection
+              userId={profile.id}
+              getSavedStories={getSavedStories}
+              unbookmarkStory={unbookmarkStory}
+              onTotalCountChange={setSavedStoriesCount}
+              onOpenStory={onOpenStory}
+              onStoryInteractionUpdated={onStoryInteractionUpdated}
+            />
+          </View>
         ) : null}
 
         {isSelfMode && activeSelfTab === 'profile' ? (

--- a/mobile/src/features/profile/presentation/screens/ProfileScreen.tsx
+++ b/mobile/src/features/profile/presentation/screens/ProfileScreen.tsx
@@ -18,6 +18,7 @@ import { FollowListResult, FollowUserEntity, ProfileEntity, ProfilePhotoUploadIn
 import { AuthUser } from '../../../../core/auth/session';
 
 type ProfileMode = 'self' | 'public';
+type SelfProfileTab = 'profile' | 'saved';
 
 const BIO_MAX_LENGTH = 280;
 const MIN_BIRTH_YEAR = 1900;
@@ -519,6 +520,69 @@ function FollowActionButton({
   );
 }
 
+function SelfProfileTabs({
+  activeTab,
+  onChange,
+}: {
+  activeTab: SelfProfileTab;
+  onChange: (tab: SelfProfileTab) => void;
+}) {
+  const { colors, spacing, typography } = useAppTheme();
+  const tabs: Array<{ key: SelfProfileTab; label: string; accessibilityLabel: string }> = [
+    { key: 'profile', label: 'Profile', accessibilityLabel: 'Show profile info' },
+    { key: 'saved', label: 'Saved', accessibilityLabel: 'Show saved stories' },
+  ];
+
+  return (
+    <View
+      accessibilityLabel="Profile content tabs"
+      style={{
+        flexDirection: 'row',
+        alignSelf: 'flex-start',
+        gap: spacing.xs,
+        padding: spacing.xs,
+        borderRadius: 999,
+        borderWidth: 1,
+        borderColor: colors.border,
+        backgroundColor: colors.surface,
+      }}
+    >
+      {tabs.map((tab) => {
+        const isActive = activeTab === tab.key;
+
+        return (
+          <Pressable
+            key={tab.key}
+            accessibilityRole="tab"
+            accessibilityLabel={tab.accessibilityLabel}
+            accessibilityState={{ selected: isActive }}
+            onPress={() => onChange(tab.key)}
+            style={({ pressed }) => ({
+              minWidth: 92,
+              alignItems: 'center',
+              paddingHorizontal: spacing.md,
+              paddingVertical: spacing.sm,
+              borderRadius: 999,
+              backgroundColor: isActive ? colors.primary : colors.surface,
+              opacity: pressed ? 0.78 : 1,
+            })}
+          >
+            <Text
+              style={{
+                color: isActive ? colors.background : colors.text,
+                fontSize: typography.caption,
+                fontWeight: '800',
+              }}
+            >
+              {tab.label}
+            </Text>
+          </Pressable>
+        );
+      })}
+    </View>
+  );
+}
+
 function FollowListModal({
   visible,
   mode,
@@ -993,6 +1057,7 @@ export function ProfileScreen({
   const [isFollowLoading, setIsFollowLoading] = useState(false);
   const [followListMode, setFollowListMode] = useState<'followers' | 'following'>('followers');
   const [isFollowListVisible, setIsFollowListVisible] = useState(false);
+  const [activeSelfTab, setActiveSelfTab] = useState<SelfProfileTab>('profile');
 
   const resetPhotoDraft = useCallback(() => {
     setPendingPhoto(null);
@@ -1435,6 +1500,10 @@ export function ProfileScreen({
         </View>
 
         {isSelfMode ? (
+          <SelfProfileTabs activeTab={activeSelfTab} onChange={setActiveSelfTab} />
+        ) : null}
+
+        {isSelfMode && activeSelfTab === 'saved' ? (
           <SavedStoriesSection
             userId={profile.id}
             getSavedStories={getSavedStories}
@@ -1442,7 +1511,7 @@ export function ProfileScreen({
           />
         ) : null}
 
-        {isSelfMode ? (
+        {isSelfMode && activeSelfTab === 'profile' ? (
           <View
             style={{
               padding: spacing.lg,
@@ -1695,7 +1764,9 @@ export function ProfileScreen({
               </>
             )}
           </View>
-        ) : (
+        ) : null}
+
+        {!isSelfMode ? (
           <View
             style={{
               padding: spacing.lg,
@@ -1713,7 +1784,7 @@ export function ProfileScreen({
               Stories are intentionally out of scope for this profile version and will be added later.
             </Text>
           </View>
-        )}
+        ) : null}
       </ScrollView>
 
       <FollowListModal

--- a/mobile/src/features/profile/presentation/screens/__tests__/ProfileScreen.test.tsx
+++ b/mobile/src/features/profile/presentation/screens/__tests__/ProfileScreen.test.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react-native';
 import * as ImagePicker from 'expo-image-picker';
+import { ScrollView } from 'react-native';
 import { ProfileScreen } from '../ProfileScreen';
 import { navigationRef } from '../../../../../app/navigation/navigationRef';
 import { userService } from '../../../application/services';
@@ -222,8 +223,58 @@ describe('ProfileScreen', () => {
     expect(getSavedStories).toHaveBeenCalledTimes(2);
   });
 
+  it('scrolls to the saved stories section when the saved stat is pressed', async () => {
+    const scrollToSpy = jest.spyOn(ScrollView.prototype, 'scrollTo').mockImplementation(jest.fn());
+
+    try {
+      render(
+        <ProfileScreen
+          mode="self"
+          getCurrentProfile={async () => selfProfile}
+          getSavedStories={async () => makeSavedStoriesPage()}
+        />,
+      );
+
+      expect(await screen.findByText('Traveler')).toBeTruthy();
+      fireEvent.press(screen.getByLabelText('Show saved stories'));
+      expect(await screen.findByText('Saved Stories')).toBeTruthy();
+
+      fireEvent(screen.getByTestId('profile-saved-stories-wrapper'), 'layout', {
+        nativeEvent: { layout: { y: 640 } },
+      });
+
+      await waitFor(() => {
+        expect(scrollToSpy).toHaveBeenCalledWith({ y: 624, animated: true });
+      });
+    } finally {
+      scrollToSpy.mockRestore();
+    }
+  });
+
+  it('opens a saved story from the profile saved list', async () => {
+    const onOpenStory = jest.fn();
+
+    render(
+      <ProfileScreen
+        mode="self"
+        getCurrentProfile={async () => selfProfile}
+        getSavedStories={async () => makeSavedStoriesPage()}
+        onOpenStory={onOpenStory}
+      />,
+    );
+
+    expect(await screen.findByText('Traveler')).toBeTruthy();
+    fireEvent.press(screen.getByLabelText('Show saved stories'));
+    expect(await screen.findByText('Saved Harbor')).toBeTruthy();
+
+    fireEvent.press(screen.getByLabelText('Read story: Saved Harbor'));
+
+    expect(onOpenStory).toHaveBeenCalledWith('saved-1');
+  });
+
   it('removes a saved story with an optimistic update and confirmation toast', async () => {
     const unbookmarkStory = jest.fn(async () => undefined);
+    const onStoryInteractionUpdated = jest.fn();
 
     render(
       <ProfileScreen
@@ -231,6 +282,7 @@ describe('ProfileScreen', () => {
         getCurrentProfile={async () => selfProfile}
         getSavedStories={async () => makeSavedStoriesPage()}
         unbookmarkStory={unbookmarkStory}
+        onStoryInteractionUpdated={onStoryInteractionUpdated}
       />,
     );
 
@@ -244,10 +296,12 @@ describe('ProfileScreen', () => {
       expect(unbookmarkStory).toHaveBeenCalledWith('saved-1');
       expect(screen.queryByText('Saved Harbor')).toBeNull();
       expect(mockToastSuccess).toHaveBeenCalledWith('Removed from saved stories.');
+      expect(onStoryInteractionUpdated).toHaveBeenCalledWith({ storyId: 'saved-1', savedByViewer: false });
     });
   });
 
   it('restores a saved story when removing the bookmark fails', async () => {
+    const onStoryInteractionUpdated = jest.fn();
     const unbookmarkStory = jest.fn(async () => {
       throw new Error('Network error');
     });
@@ -258,6 +312,7 @@ describe('ProfileScreen', () => {
         getCurrentProfile={async () => selfProfile}
         getSavedStories={async () => makeSavedStoriesPage()}
         unbookmarkStory={unbookmarkStory}
+        onStoryInteractionUpdated={onStoryInteractionUpdated}
       />,
     );
 
@@ -271,6 +326,7 @@ describe('ProfileScreen', () => {
       expect(unbookmarkStory).toHaveBeenCalledWith('saved-1');
       expect(mockToastError).toHaveBeenCalledWith('Failed to remove saved story. Please try again.');
       expect(screen.getByText('Saved Harbor')).toBeTruthy();
+      expect(onStoryInteractionUpdated).toHaveBeenLastCalledWith({ storyId: 'saved-1', savedByViewer: true });
     });
   });
 

--- a/mobile/src/features/profile/presentation/screens/__tests__/ProfileScreen.test.tsx
+++ b/mobile/src/features/profile/presentation/screens/__tests__/ProfileScreen.test.tsx
@@ -203,8 +203,9 @@ describe('ProfileScreen', () => {
     );
 
     expect(await screen.findByText('Traveler')).toBeTruthy();
-    expect(screen.getByText('Profile')).toBeTruthy();
     expect(screen.getByText('Saved')).toBeTruthy();
+    expect(screen.getByLabelText('Show saved stories')).toBeTruthy();
+    expect(screen.queryByLabelText('Profile content tabs')).toBeNull();
     expect(screen.queryByText('Saved Stories')).toBeNull();
     expect(getSavedStories).not.toHaveBeenCalled();
 

--- a/mobile/src/features/profile/presentation/screens/__tests__/ProfileScreen.test.tsx
+++ b/mobile/src/features/profile/presentation/screens/__tests__/ProfileScreen.test.tsx
@@ -3,6 +3,8 @@ import { fireEvent, render, screen, waitFor } from '@testing-library/react-nativ
 import * as ImagePicker from 'expo-image-picker';
 import { ProfileScreen } from '../ProfileScreen';
 import { navigationRef } from '../../../../../app/navigation/navigationRef';
+import { userService } from '../../../application/services';
+import { FeedEntity, FeedPageEntity } from '../../../../feed/domain/entities';
 
 const mockToastSuccess = jest.fn();
 const mockToastError = jest.fn();
@@ -89,9 +91,38 @@ const publicProfile = {
   isFollowedByMe: false,
 };
 
+function makeSavedStory(id: string, title = `Saved Story ${id}`): FeedEntity {
+  return {
+    id,
+    title,
+    locationName: 'Golden Horn',
+    timePeriod: '1978',
+    previewText: 'A saved story about local history.',
+    submittedAt: '2026-03-18T10:00:00Z',
+    hasMedia: false,
+    likeCount: 4,
+    savedByViewer: true,
+  };
+}
+
+function makeSavedStoriesPage(overrides: Partial<FeedPageEntity> = {}): FeedPageEntity {
+  return {
+    items: [makeSavedStory('saved-1', 'Saved Harbor')],
+    page: 1,
+    pageSize: 10,
+    totalCount: 1,
+    hasNextPage: false,
+    ...overrides,
+  };
+}
+
 describe('ProfileScreen', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    jest.spyOn(userService, 'getSavedStories').mockResolvedValue(makeSavedStoriesPage({
+      items: [],
+      totalCount: 0,
+    }));
     mockAuthUser = {
       id: 7,
       email: 'traveler@example.com',
@@ -158,6 +189,125 @@ describe('ProfileScreen', () => {
 
     expect(await screen.findByText('Traveler')).toBeTruthy();
     expect(screen.getByText('May 20, 1995')).toBeTruthy();
+  });
+
+  it('renders saved stories on the signed-in user profile', async () => {
+    const getSavedStories = jest.fn(async () => makeSavedStoriesPage());
+
+    render(
+      <ProfileScreen
+        mode="self"
+        getCurrentProfile={async () => selfProfile}
+        getSavedStories={getSavedStories}
+      />,
+    );
+
+    expect(await screen.findByText('Saved Stories')).toBeTruthy();
+    expect(await screen.findByText('Saved Harbor')).toBeTruthy();
+    expect(screen.getByText('Golden Horn')).toBeTruthy();
+    expect(screen.getByLabelText('Remove Saved Harbor from saved stories')).toBeTruthy();
+    expect(getSavedStories).toHaveBeenCalledWith('7', 1);
+  });
+
+  it('removes a saved story with an optimistic update and confirmation toast', async () => {
+    const unbookmarkStory = jest.fn(async () => undefined);
+
+    render(
+      <ProfileScreen
+        mode="self"
+        getCurrentProfile={async () => selfProfile}
+        getSavedStories={async () => makeSavedStoriesPage()}
+        unbookmarkStory={unbookmarkStory}
+      />,
+    );
+
+    expect(await screen.findByText('Saved Harbor')).toBeTruthy();
+
+    fireEvent.press(screen.getByLabelText('Remove Saved Harbor from saved stories'));
+
+    await waitFor(() => {
+      expect(unbookmarkStory).toHaveBeenCalledWith('saved-1');
+      expect(screen.queryByText('Saved Harbor')).toBeNull();
+      expect(mockToastSuccess).toHaveBeenCalledWith('Removed from saved stories.');
+    });
+  });
+
+  it('restores a saved story when removing the bookmark fails', async () => {
+    const unbookmarkStory = jest.fn(async () => {
+      throw new Error('Network error');
+    });
+
+    render(
+      <ProfileScreen
+        mode="self"
+        getCurrentProfile={async () => selfProfile}
+        getSavedStories={async () => makeSavedStoriesPage()}
+        unbookmarkStory={unbookmarkStory}
+      />,
+    );
+
+    expect(await screen.findByText('Saved Harbor')).toBeTruthy();
+
+    fireEvent.press(screen.getByLabelText('Remove Saved Harbor from saved stories'));
+
+    await waitFor(() => {
+      expect(unbookmarkStory).toHaveBeenCalledWith('saved-1');
+      expect(mockToastError).toHaveBeenCalledWith('Failed to remove saved story. Please try again.');
+      expect(screen.getByText('Saved Harbor')).toBeTruthy();
+    });
+  });
+
+  it('shows the saved stories empty state and browse action', async () => {
+    navigationRef.navigate = jest.fn();
+
+    render(
+      <ProfileScreen
+        mode="self"
+        getCurrentProfile={async () => selfProfile}
+        getSavedStories={async () => makeSavedStoriesPage({
+          items: [],
+          totalCount: 0,
+        })}
+      />,
+    );
+
+    expect(await screen.findByText('No saved stories yet')).toBeTruthy();
+    expect(screen.getByText('Bookmark stories to find them here later.')).toBeTruthy();
+
+    fireEvent.press(screen.getByText('Browse stories'));
+
+    expect(navigationRef.navigate).toHaveBeenCalledWith('Feed');
+  });
+
+  it('loads more saved stories when more bookmark pages exist', async () => {
+    const getSavedStories = jest
+      .fn()
+      .mockResolvedValueOnce(makeSavedStoriesPage({
+        items: [makeSavedStory('saved-1', 'First Saved Story')],
+        totalCount: 2,
+        hasNextPage: true,
+      }))
+      .mockResolvedValueOnce(makeSavedStoriesPage({
+        items: [makeSavedStory('saved-2', 'Second Saved Story')],
+        page: 2,
+        totalCount: 2,
+        hasNextPage: false,
+      }));
+
+    render(
+      <ProfileScreen
+        mode="self"
+        getCurrentProfile={async () => selfProfile}
+        getSavedStories={getSavedStories}
+      />,
+    );
+
+    expect(await screen.findByText('First Saved Story')).toBeTruthy();
+
+    fireEvent.press(screen.getByText('Load more saved stories'));
+
+    expect(await screen.findByText('Second Saved Story')).toBeTruthy();
+    expect(getSavedStories).toHaveBeenCalledWith('7', 2);
   });
 
   it('falls back to the public birth year on the signed-in user profile when the full date is unavailable', async () => {
@@ -398,6 +548,7 @@ describe('ProfileScreen', () => {
     expect(screen.queryByText('May 20, 1995')).toBeNull();
     expect(screen.getByText('I write about harbor neighborhoods.')).toBeTruthy();
     expect(screen.queryByText('Edit Profile')).toBeNull();
+    expect(screen.queryByText('Saved Stories')).toBeNull();
     expect(screen.getByText('12')).toBeTruthy();
     expect(screen.getByText('5')).toBeTruthy();
 

--- a/mobile/src/features/profile/presentation/screens/__tests__/ProfileScreen.test.tsx
+++ b/mobile/src/features/profile/presentation/screens/__tests__/ProfileScreen.test.tsx
@@ -207,7 +207,11 @@ describe('ProfileScreen', () => {
     expect(screen.getByLabelText('Show saved stories')).toBeTruthy();
     expect(screen.queryByLabelText('Profile content tabs')).toBeNull();
     expect(screen.queryByText('Saved Stories')).toBeNull();
-    expect(getSavedStories).not.toHaveBeenCalled();
+
+    await waitFor(() => {
+      expect(getSavedStories).toHaveBeenCalledWith('7', 1);
+      expect(screen.getByText('1')).toBeTruthy();
+    });
 
     fireEvent.press(screen.getByLabelText('Show saved stories'));
 
@@ -215,7 +219,7 @@ describe('ProfileScreen', () => {
     expect(await screen.findByText('Saved Harbor')).toBeTruthy();
     expect(screen.getByText('Golden Horn')).toBeTruthy();
     expect(screen.getByLabelText('Remove Saved Harbor from saved stories')).toBeTruthy();
-    expect(getSavedStories).toHaveBeenCalledWith('7', 1);
+    expect(getSavedStories).toHaveBeenCalledTimes(2);
   });
 
   it('removes a saved story with an optimistic update and confirmation toast', async () => {
@@ -298,6 +302,11 @@ describe('ProfileScreen', () => {
   it('loads more saved stories when more bookmark pages exist', async () => {
     const getSavedStories = jest
       .fn()
+      .mockResolvedValueOnce(makeSavedStoriesPage({
+        items: [makeSavedStory('saved-1', 'First Saved Story')],
+        totalCount: 2,
+        hasNextPage: true,
+      }))
       .mockResolvedValueOnce(makeSavedStoriesPage({
         items: [makeSavedStory('saved-1', 'First Saved Story')],
         totalCount: 2,

--- a/mobile/src/features/profile/presentation/screens/__tests__/ProfileScreen.test.tsx
+++ b/mobile/src/features/profile/presentation/screens/__tests__/ProfileScreen.test.tsx
@@ -202,6 +202,14 @@ describe('ProfileScreen', () => {
       />,
     );
 
+    expect(await screen.findByText('Traveler')).toBeTruthy();
+    expect(screen.getByText('Profile')).toBeTruthy();
+    expect(screen.getByText('Saved')).toBeTruthy();
+    expect(screen.queryByText('Saved Stories')).toBeNull();
+    expect(getSavedStories).not.toHaveBeenCalled();
+
+    fireEvent.press(screen.getByLabelText('Show saved stories'));
+
     expect(await screen.findByText('Saved Stories')).toBeTruthy();
     expect(await screen.findByText('Saved Harbor')).toBeTruthy();
     expect(screen.getByText('Golden Horn')).toBeTruthy();
@@ -221,6 +229,8 @@ describe('ProfileScreen', () => {
       />,
     );
 
+    expect(await screen.findByText('Traveler')).toBeTruthy();
+    fireEvent.press(screen.getByLabelText('Show saved stories'));
     expect(await screen.findByText('Saved Harbor')).toBeTruthy();
 
     fireEvent.press(screen.getByLabelText('Remove Saved Harbor from saved stories'));
@@ -246,6 +256,8 @@ describe('ProfileScreen', () => {
       />,
     );
 
+    expect(await screen.findByText('Traveler')).toBeTruthy();
+    fireEvent.press(screen.getByLabelText('Show saved stories'));
     expect(await screen.findByText('Saved Harbor')).toBeTruthy();
 
     fireEvent.press(screen.getByLabelText('Remove Saved Harbor from saved stories'));
@@ -270,6 +282,9 @@ describe('ProfileScreen', () => {
         })}
       />,
     );
+
+    expect(await screen.findByText('Traveler')).toBeTruthy();
+    fireEvent.press(screen.getByLabelText('Show saved stories'));
 
     expect(await screen.findByText('No saved stories yet')).toBeTruthy();
     expect(screen.getByText('Bookmark stories to find them here later.')).toBeTruthy();
@@ -302,6 +317,8 @@ describe('ProfileScreen', () => {
       />,
     );
 
+    expect(await screen.findByText('Traveler')).toBeTruthy();
+    fireEvent.press(screen.getByLabelText('Show saved stories'));
     expect(await screen.findByText('First Saved Story')).toBeTruthy();
 
     fireEvent.press(screen.getByText('Load more saved stories'));


### PR DESCRIPTION
Fixes #217
### Description

This PR implements the mobile Saved Stories flow for authenticated users.

Users can now see their saved story count from their own profile stats area and open the Saved Stories section from there. Saved stories are fetched from the bookmarks API, displayed with the existing mobile feed card layout, and ordered by the backend bookmark ordering. Users can remove a saved story directly from the list with optimistic UI feedback.

The Saved Stories entry is visible only on the signed-in user's own profile and remains hidden on public profiles.

### Changes

- Added `userService.getSavedStories()`
- Added mobile profile Saved Stories section
- Added saved story count in the profile stats row
- Reused existing `FeedCard` layout for saved stories
- Added bookmark removal from saved stories list
- Added optimistic unbookmark behavior with rollback on API failure
- Added loading, empty, error, and pagination states
- Kept Saved Stories hidden on public profiles
- Added/updated unit tests for saved stories behavior

### Tests

- `npm run typecheck`
- `npm test -- --runTestsByPath src/features/profile/presentation/screens/__tests__/ProfileScreen.test.tsx src/features/profile/application/services/__tests__/userService.test.ts src/features/feed/presentation/components/__tests__/FeedCard.test.tsx --runInBand --watchAll=false`
- `npm test -- --watchAll=false --runInBand`


# 📊 Type of Change
- [ ]  Bug fix
- [ ]  New feature
- [ ]  Refactoring
- [ ]  Documentation
 
# ✅ Acceptance Criteria / Checklist
- [ ] Project builds successfully
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, especially in hard-to-understand parts
- [ ] I have performed a self-review of my code
- [ ] I have added/updated tests
- [ ] New and existing unit tests pass locally with my changes

# ⏱️ Estimated Review Time
- [ ] < 5 min
- [ ] 5-15 min
- [ ] > 15 min
