### PR TITLE
Feat/mobile edtf submission

### DIFF
--- a/mobile/src/features/feed/data/mappers/__tests__/feedMappers.test.ts
+++ b/mobile/src/features/feed/data/mappers/__tests__/feedMappers.test.ts
@@ -49,6 +49,19 @@ describe('feed mappers', () => {
     expect(page.items[0].likeCount).toBe(3);
   });
 
+  it('maps exact date feed card time periods without changing year-based formatting', () => {
+    expect(
+      mapFeedItem({
+        id: 44,
+        title: 'Republic Day',
+        location_name: 'Ankara',
+        time_type: 'exact_date',
+        date_value: '1923-10-29',
+        time_value: '09:30:00',
+      }).timePeriod,
+    ).toBe('1923-10-29 09:30');
+  });
+
   it('maps legacy like count aliases from feed payloads', () => {
     expect(
       mapFeedItem({

--- a/mobile/src/features/feed/data/mappers/index.ts
+++ b/mobile/src/features/feed/data/mappers/index.ts
@@ -8,6 +8,8 @@ interface FeedApiRecord {
   year?: unknown;
   year_start?: unknown;
   year_end?: unknown;
+  date_value?: unknown;
+  time_value?: unknown;
   preview_text?: unknown;
   narrative?: unknown;
   submitted_at?: unknown;
@@ -80,6 +82,8 @@ function formatTimePeriod(record: FeedApiRecord) {
   const year = asInteger(record.year, NaN);
   const yearStart = asInteger(record.year_start, NaN);
   const yearEnd = asInteger(record.year_end, NaN);
+  const dateValue = asString(record.date_value);
+  const timeValue = asString(record.time_value);
 
   switch (record.time_type) {
     case 'exact_year':
@@ -90,6 +94,8 @@ function formatTimePeriod(record: FeedApiRecord) {
       return Number.isFinite(year) ? `${Math.floor(year / 10) * 10}s` : '';
     case 'year_range':
       return Number.isFinite(yearStart) && Number.isFinite(yearEnd) ? `${yearStart}-${yearEnd}` : '';
+    case 'exact_date':
+      return dateValue ? `${dateValue}${timeValue ? ` ${timeValue.slice(0, 5)}` : ''}` : '';
     default:
       return '';
   }

--- a/mobile/src/features/stories/data/mappers/__tests__/storyMappers.test.ts
+++ b/mobile/src/features/stories/data/mappers/__tests__/storyMappers.test.ts
@@ -115,6 +115,26 @@ describe('story mappers', () => {
     expect(result.mediaUrl).toBe('https://example.com/story.jpg');
   });
 
+  it('maps exact date stories to a readable time period', () => {
+    const result = mapStory({
+      id: 56,
+      user: 7,
+      title: 'Republic Day',
+      narrative: 'A precise date memory.',
+      status: 'published',
+      location_name: 'Ankara',
+      location_lat: '39.9334',
+      location_lng: '32.8597',
+      time_type: 'exact_date',
+      date_value: '1923-10-29',
+      time_value: '09:30:00',
+      contributor_name: 'Aylin',
+      submitted_at: '2026-03-18T10:00:00Z',
+    });
+
+    expect(result.timePeriod).toBe('1923-10-29 09:30');
+  });
+
   it('maps normalized anonymous stories with the anonymous contributor label', () => {
     const result = mapStory({
       id: 53,

--- a/mobile/src/features/stories/data/mappers/index.ts
+++ b/mobile/src/features/stories/data/mappers/index.ts
@@ -165,6 +165,8 @@ function formatTimePeriod(story: Record<string, unknown>) {
   const year = asNumericValue(story.year);
   const yearStart = asNumericValue(story.year_start) ?? asNumericValue(story.yearStart);
   const yearEnd = asNumericValue(story.year_end) ?? asNumericValue(story.yearEnd);
+  const dateValue = asString(story.date_value) || asString(story.dateValue);
+  const timeValue = asString(story.time_value) || asString(story.timeValue);
 
   if (timeType === 'year_range' && yearStart !== undefined && yearEnd !== undefined) {
     return `${yearStart}-${yearEnd}`;
@@ -172,6 +174,10 @@ function formatTimePeriod(story: Record<string, unknown>) {
 
   if (timeType === 'decade' && year !== undefined) {
     return `${year}s`;
+  }
+
+  if (timeType === 'exact_date' && dateValue) {
+    return `${dateValue}${timeValue ? ` ${timeValue.slice(0, 5)}` : ''}`;
   }
 
   if (year !== undefined) {
@@ -205,6 +211,8 @@ function formatTimePeriodFromRecord(story: StoryRecord | Record<string, unknown>
   const year = asNumber(story.year);
   const yearStart = asNumber(story.year_start);
   const yearEnd = asNumber(story.year_end);
+  const dateValue = asString((story as Record<string, unknown>).date_value) || asString((story as Record<string, unknown>).dateValue);
+  const timeValue = asString((story as Record<string, unknown>).time_value) || asString((story as Record<string, unknown>).timeValue);
   const explicit = asString((story as Record<string, unknown>).timePeriod) || asString((story as Record<string, unknown>).time_period);
 
   if (explicit) {
@@ -220,6 +228,8 @@ function formatTimePeriodFromRecord(story: StoryRecord | Record<string, unknown>
       return year !== undefined ? `${Math.floor(year / 10) * 10}s` : '';
     case 'year_range':
       return yearStart !== undefined && yearEnd !== undefined ? `${yearStart}-${yearEnd}` : '';
+    case 'exact_date':
+      return dateValue ? `${dateValue}${timeValue ? ` ${timeValue.slice(0, 5)}` : ''}` : '';
     default:
       return '';
   }

--- a/mobile/src/features/submissions/application/services/__tests__/submissionsService.test.ts
+++ b/mobile/src/features/submissions/application/services/__tests__/submissionsService.test.ts
@@ -103,8 +103,7 @@ describe('submissionsService', () => {
       placeName: 'Ankara',
       timeType: 'exact_date',
       dateValue: '1923-10-29',
-      timeValue: '09:30',
-      temporalCoverage: '1923-10-29T09:30',
+      timeValue: '9:30',
       tags: [],
       contributorVisible: true,
     });

--- a/mobile/src/features/submissions/application/services/__tests__/submissionsService.test.ts
+++ b/mobile/src/features/submissions/application/services/__tests__/submissionsService.test.ts
@@ -68,6 +68,7 @@ describe('submissionsService', () => {
 
     expect(requests[0].data).toBeInstanceOf(FormData);
     expect(getFormField(requests[0].data as FormData, 'contributor_visible')).toBe('false');
+    expect(getFormField(requests[0].data as FormData, 'temporal_coverage')).toBe('1453');
     expect(requests[1].data).toBeInstanceOf(FormData);
     expect(getFormField(requests[1].data as FormData, 'file')).toBeTruthy();
 
@@ -76,5 +77,43 @@ describe('submissionsService', () => {
       .map((request) => getFormField(request.data as FormData, 'file'));
 
     expect(mediaFiles).toEqual([expect.anything(), expect.anything()]);
+  });
+
+  it('creates exact date stories with date, optional time, and EDTF temporal coverage fields', async () => {
+    const requests: Array<{ method: string; url?: string; data?: unknown }> = [];
+
+    setApiTransport(async (method: any, config: any) => {
+      requests.push({ method, url: config.url, data: config.data });
+
+      if (method === 'POST' && config.url === '/stories/') {
+        return {
+          status: 201,
+          data: { id: 13 } as never,
+          config,
+        };
+      }
+
+      throw new Error(`Unexpected request: ${method} ${config.url}`);
+    });
+
+    await submissionsService.createStory({
+      title: 'Republic Day',
+      narrative: 'A memory tied to a specific date and time.',
+      location: { latitude: 39.9334, longitude: 32.8597 },
+      placeName: 'Ankara',
+      timeType: 'exact_date',
+      dateValue: '1923-10-29',
+      timeValue: '09:30',
+      temporalCoverage: '1923-10-29T09:30',
+      tags: [],
+      contributorVisible: true,
+    });
+
+    expect(requests).toHaveLength(1);
+    expect(getFormField(requests[0].data as FormData, 'time_type')).toBe('exact_date');
+    expect(getFormField(requests[0].data as FormData, 'date_value')).toBe('1923-10-29');
+    expect(getFormField(requests[0].data as FormData, 'time_value')).toBe('09:30');
+    expect(getFormField(requests[0].data as FormData, 'temporal_coverage')).toBe('1923-10-29T09:30');
+    expect(getFormField(requests[0].data as FormData, 'year')).toBeNull();
   });
 });

--- a/mobile/src/features/submissions/application/services/__tests__/temporal.test.ts
+++ b/mobile/src/features/submissions/application/services/__tests__/temporal.test.ts
@@ -1,0 +1,36 @@
+import {
+  buildDateValueFromParts,
+  buildEdtfTemporalCoverage,
+  isValidDateValue,
+  isValidTimeValue,
+  normalizeTimeValue,
+} from '../temporal';
+
+describe('submission temporal EDTF helpers', () => {
+  it('formats supported year-based time types as EDTF strings', () => {
+    expect(buildEdtfTemporalCoverage({ timeType: 'exact_year', year: 1965 })).toBe('1965');
+    expect(buildEdtfTemporalCoverage({ timeType: 'approximate_year', year: 1965 })).toBe('~1965');
+    expect(buildEdtfTemporalCoverage({ timeType: 'decade', year: 1960 })).toBe('196X');
+    expect(buildEdtfTemporalCoverage({ timeType: 'year_range', yearStart: 1950, yearEnd: 1975 })).toBe('1950/1975');
+  });
+
+  it('formats specific dates and optional times as EDTF strings', () => {
+    expect(buildDateValueFromParts('29', '10', '1923')).toBe('1923-10-29');
+    expect(buildEdtfTemporalCoverage({ timeType: 'exact_date', dateValue: '1923-10-29' })).toBe('1923-10-29');
+    expect(
+      buildEdtfTemporalCoverage({
+        timeType: 'exact_date',
+        dateValue: '1923-10-29',
+        timeValue: '09:30',
+      }),
+    ).toBe('1923-10-29T09:30');
+  });
+
+  it('rejects invalid calendar dates and malformed times', () => {
+    expect(buildDateValueFromParts('31', '02', '1923')).toBeUndefined();
+    expect(isValidDateValue('1923-02-31')).toBe(false);
+    expect(isValidTimeValue('24:00')).toBe(false);
+    expect(normalizeTimeValue('')).toBeUndefined();
+    expect(normalizeTimeValue('09:30')).toBe('09:30');
+  });
+});

--- a/mobile/src/features/submissions/application/services/__tests__/temporal.test.ts
+++ b/mobile/src/features/submissions/application/services/__tests__/temporal.test.ts
@@ -9,7 +9,7 @@ import {
 describe('submission temporal EDTF helpers', () => {
   it('formats supported year-based time types as EDTF strings', () => {
     expect(buildEdtfTemporalCoverage({ timeType: 'exact_year', year: 1965 })).toBe('1965');
-    expect(buildEdtfTemporalCoverage({ timeType: 'approximate_year', year: 1965 })).toBe('~1965');
+    expect(buildEdtfTemporalCoverage({ timeType: 'approximate_year', year: 1965 })).toBe('1965~');
     expect(buildEdtfTemporalCoverage({ timeType: 'decade', year: 1960 })).toBe('196X');
     expect(buildEdtfTemporalCoverage({ timeType: 'year_range', yearStart: 1950, yearEnd: 1975 })).toBe('1950/1975');
   });
@@ -21,7 +21,7 @@ describe('submission temporal EDTF helpers', () => {
       buildEdtfTemporalCoverage({
         timeType: 'exact_date',
         dateValue: '1923-10-29',
-        timeValue: '09:30',
+        timeValue: '9:30',
       }),
     ).toBe('1923-10-29T09:30');
   });
@@ -29,8 +29,11 @@ describe('submission temporal EDTF helpers', () => {
   it('rejects invalid calendar dates and malformed times', () => {
     expect(buildDateValueFromParts('31', '02', '1923')).toBeUndefined();
     expect(isValidDateValue('1923-02-31')).toBe(false);
+    expect(isValidDateValue('0000-01-01')).toBe(false);
+    expect(isValidDateValue('0001-01-01')).toBe(true);
     expect(isValidTimeValue('24:00')).toBe(false);
     expect(normalizeTimeValue('')).toBeUndefined();
     expect(normalizeTimeValue('09:30')).toBe('09:30');
+    expect(normalizeTimeValue('9:30')).toBe('09:30');
   });
 });

--- a/mobile/src/features/submissions/application/services/index.ts
+++ b/mobile/src/features/submissions/application/services/index.ts
@@ -1,7 +1,9 @@
 import { apiClient } from '../../../../core/api/client';
 import { endpoints } from '../../../../core/api/endpoints';
+import { buildEdtfTemporalCoverage, type StoryTimeType } from './temporal';
 
-export type StoryTimeType = 'exact_year' | 'approximate_year' | 'decade' | 'year_range';
+export type { StoryTimeType } from './temporal';
+export { buildDateValueFromParts, buildEdtfTemporalCoverage, normalizeTimeValue } from './temporal';
 
 export interface SubmissionLocationInput {
   latitude: number;
@@ -32,6 +34,9 @@ export interface CreateStoryInput {
   year?: number;
   yearStart?: number;
   yearEnd?: number;
+  dateValue?: string;
+  timeValue?: string;
+  temporalCoverage?: string;
   tags: string[];
   image?: SubmissionImageInput | null;
   audio?: SubmissionMediaInput | null;
@@ -52,9 +57,28 @@ function buildStoryFormData(input: CreateStoryInput) {
   formData.append('location_lng', input.location.longitude.toFixed(6));
   formData.append('location_name', input.placeName.trim());
   formData.append('time_type', input.timeType);
+  formData.append(
+    'temporal_coverage',
+    input.temporalCoverage ??
+      buildEdtfTemporalCoverage({
+        timeType: input.timeType,
+        year: input.year,
+        yearStart: input.yearStart,
+        yearEnd: input.yearEnd,
+        dateValue: input.dateValue,
+        timeValue: input.timeValue,
+      }),
+  );
   formData.append('contributor_visible', input.contributorVisible ? 'true' : 'false');
 
-  if (input.timeType === 'year_range') {
+  if (input.timeType === 'exact_date') {
+    if (input.dateValue) {
+      formData.append('date_value', input.dateValue);
+    }
+    if (input.timeValue) {
+      formData.append('time_value', input.timeValue);
+    }
+  } else if (input.timeType === 'year_range') {
     if (typeof input.yearStart === 'number') {
       formData.append('year_start', String(input.yearStart));
     }

--- a/mobile/src/features/submissions/application/services/index.ts
+++ b/mobile/src/features/submissions/application/services/index.ts
@@ -1,6 +1,6 @@
 import { apiClient } from '../../../../core/api/client';
 import { endpoints } from '../../../../core/api/endpoints';
-import { buildEdtfTemporalCoverage, type StoryTimeType } from './temporal';
+import { buildEdtfTemporalCoverage, normalizeTimeValue, type StoryTimeType } from './temporal';
 
 export type { StoryTimeType } from './temporal';
 export { buildDateValueFromParts, buildEdtfTemporalCoverage, normalizeTimeValue } from './temporal';
@@ -50,6 +50,14 @@ interface StoryCreateResponse {
 
 function buildStoryFormData(input: CreateStoryInput) {
   const formData = new FormData();
+  const hasExactDateTimeValue = input.timeType === 'exact_date' && Boolean(input.timeValue?.trim());
+  const normalizedExactDateTimeValue = hasExactDateTimeValue
+    ? normalizeTimeValue(input.timeValue ?? '')
+    : undefined;
+
+  if (hasExactDateTimeValue && !normalizedExactDateTimeValue) {
+    throw new Error('timeValue must use HH:MM format.');
+  }
 
   formData.append('title', input.title.trim());
   formData.append('narrative', input.narrative.trim());
@@ -66,7 +74,7 @@ function buildStoryFormData(input: CreateStoryInput) {
         yearStart: input.yearStart,
         yearEnd: input.yearEnd,
         dateValue: input.dateValue,
-        timeValue: input.timeValue,
+        timeValue: normalizedExactDateTimeValue ?? input.timeValue,
       }),
   );
   formData.append('contributor_visible', input.contributorVisible ? 'true' : 'false');
@@ -75,8 +83,8 @@ function buildStoryFormData(input: CreateStoryInput) {
     if (input.dateValue) {
       formData.append('date_value', input.dateValue);
     }
-    if (input.timeValue) {
-      formData.append('time_value', input.timeValue);
+    if (normalizedExactDateTimeValue) {
+      formData.append('time_value', normalizedExactDateTimeValue);
     }
   } else if (input.timeType === 'year_range') {
     if (typeof input.yearStart === 'number') {

--- a/mobile/src/features/submissions/application/services/temporal.ts
+++ b/mobile/src/features/submissions/application/services/temporal.ts
@@ -17,13 +17,37 @@ function padTwoDigits(value: string) {
   return value.trim().padStart(2, '0');
 }
 
+function parseTimeValue(value: string) {
+  const match = /^(\d{1,2}):([0-5]\d)$/.exec(value.trim());
+
+  if (!match) {
+    return undefined;
+  }
+
+  const hour = Number(match[1]);
+
+  if (!Number.isInteger(hour) || hour < 0 || hour > 23) {
+    return undefined;
+  }
+
+  return {
+    hour: String(hour).padStart(2, '0'),
+    minute: match[2],
+  };
+}
+
 export function isValidDateValue(value: string) {
   if (!/^\d{4}-\d{2}-\d{2}$/.test(value)) {
     return false;
   }
 
   const [year, month, day] = value.split('-').map((part) => Number(part));
+  if (year < 1) {
+    return false;
+  }
+
   const parsedDate = new Date(Date.UTC(year, month - 1, day, 12));
+  parsedDate.setUTCFullYear(year);
 
   return (
     Number.isFinite(parsedDate.getTime()) &&
@@ -34,7 +58,7 @@ export function isValidDateValue(value: string) {
 }
 
 export function isValidTimeValue(value: string) {
-  return /^([01]\d|2[0-3]):[0-5]\d$/.test(value);
+  return parseTimeValue(value) !== undefined;
 }
 
 export function buildDateValueFromParts(day: string, month: string, year: string) {
@@ -45,13 +69,13 @@ export function buildDateValueFromParts(day: string, month: string, year: string
 }
 
 export function normalizeTimeValue(value: string) {
-  const trimmedValue = value.trim();
+  const parsedTime = parseTimeValue(value);
 
-  if (!trimmedValue) {
+  if (!parsedTime) {
     return undefined;
   }
 
-  return isValidTimeValue(trimmedValue) ? trimmedValue : undefined;
+  return `${parsedTime.hour}:${parsedTime.minute}`;
 }
 
 export function buildEdtfTemporalCoverage(input: StoryTemporalCoverageInput) {
@@ -65,7 +89,7 @@ export function buildEdtfTemporalCoverage(input: StoryTemporalCoverageInput) {
       if (!isFiniteNumber(input.year)) {
         throw new Error('year is required for approximate_year.');
       }
-      return `~${input.year}`;
+      return `${input.year}~`;
     case 'decade':
       if (!isFiniteNumber(input.year)) {
         throw new Error('year is required for decade.');
@@ -81,10 +105,11 @@ export function buildEdtfTemporalCoverage(input: StoryTemporalCoverageInput) {
         throw new Error('dateValue is required for exact_date.');
       }
       if (input.timeValue) {
-        if (!isValidTimeValue(input.timeValue)) {
+        const normalizedTimeValue = normalizeTimeValue(input.timeValue);
+        if (!normalizedTimeValue) {
           throw new Error('timeValue must use HH:MM format.');
         }
-        return `${input.dateValue}T${input.timeValue}`;
+        return `${input.dateValue}T${normalizedTimeValue}`;
       }
       return input.dateValue;
     default:

--- a/mobile/src/features/submissions/application/services/temporal.ts
+++ b/mobile/src/features/submissions/application/services/temporal.ts
@@ -1,0 +1,93 @@
+export type StoryTimeType = 'exact_year' | 'approximate_year' | 'decade' | 'year_range' | 'exact_date';
+
+export interface StoryTemporalCoverageInput {
+  timeType: StoryTimeType;
+  year?: number;
+  yearStart?: number;
+  yearEnd?: number;
+  dateValue?: string;
+  timeValue?: string;
+}
+
+function isFiniteNumber(value: unknown): value is number {
+  return typeof value === 'number' && Number.isFinite(value);
+}
+
+function padTwoDigits(value: string) {
+  return value.trim().padStart(2, '0');
+}
+
+export function isValidDateValue(value: string) {
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(value)) {
+    return false;
+  }
+
+  const [year, month, day] = value.split('-').map((part) => Number(part));
+  const parsedDate = new Date(Date.UTC(year, month - 1, day, 12));
+
+  return (
+    Number.isFinite(parsedDate.getTime()) &&
+    parsedDate.getUTCFullYear() === year &&
+    parsedDate.getUTCMonth() === month - 1 &&
+    parsedDate.getUTCDate() === day
+  );
+}
+
+export function isValidTimeValue(value: string) {
+  return /^([01]\d|2[0-3]):[0-5]\d$/.test(value);
+}
+
+export function buildDateValueFromParts(day: string, month: string, year: string) {
+  const trimmedYear = year.trim();
+  const dateValue = `${trimmedYear}-${padTwoDigits(month)}-${padTwoDigits(day)}`;
+
+  return isValidDateValue(dateValue) ? dateValue : undefined;
+}
+
+export function normalizeTimeValue(value: string) {
+  const trimmedValue = value.trim();
+
+  if (!trimmedValue) {
+    return undefined;
+  }
+
+  return isValidTimeValue(trimmedValue) ? trimmedValue : undefined;
+}
+
+export function buildEdtfTemporalCoverage(input: StoryTemporalCoverageInput) {
+  switch (input.timeType) {
+    case 'exact_year':
+      if (!isFiniteNumber(input.year)) {
+        throw new Error('year is required for exact_year.');
+      }
+      return String(input.year);
+    case 'approximate_year':
+      if (!isFiniteNumber(input.year)) {
+        throw new Error('year is required for approximate_year.');
+      }
+      return `~${input.year}`;
+    case 'decade':
+      if (!isFiniteNumber(input.year)) {
+        throw new Error('year is required for decade.');
+      }
+      return `${Math.floor(input.year / 10)}X`;
+    case 'year_range':
+      if (!isFiniteNumber(input.yearStart) || !isFiniteNumber(input.yearEnd)) {
+        throw new Error('yearStart and yearEnd are required for year_range.');
+      }
+      return `${input.yearStart}/${input.yearEnd}`;
+    case 'exact_date':
+      if (!input.dateValue || !isValidDateValue(input.dateValue)) {
+        throw new Error('dateValue is required for exact_date.');
+      }
+      if (input.timeValue) {
+        if (!isValidTimeValue(input.timeValue)) {
+          throw new Error('timeValue must use HH:MM format.');
+        }
+        return `${input.dateValue}T${input.timeValue}`;
+      }
+      return input.dateValue;
+    default:
+      throw new Error(`Unsupported time type: ${String(input.timeType)}`);
+  }
+}

--- a/mobile/src/features/submissions/presentation/screens/SubmissionScreen.tsx
+++ b/mobile/src/features/submissions/presentation/screens/SubmissionScreen.tsx
@@ -389,6 +389,8 @@ export function SubmissionScreen() {
     () => TIME_TYPES.find((timeType) => timeType.value === state.timeType) ?? TIME_TYPES[0],
     [state.timeType],
   );
+  const sharedDateError = fieldErrors.dateDay || fieldErrors.dateMonth || fieldErrors.dateYear;
+  const sharedYearRangeError = fieldErrors.yearStart || fieldErrors.yearEnd;
 
   const updateField = <K extends keyof SubmissionFormState>(field: K, value: SubmissionFormState[K]) => {
     setState((current) => ({ ...current, [field]: value, apiError: undefined }));
@@ -488,6 +490,8 @@ export function SubmissionScreen() {
         !buildDateValueFromParts(state.dateDay, state.dateMonth, state.dateYear)
       ) {
         nextErrors.dateDay = 'Enter a valid calendar date.';
+        nextErrors.dateMonth = 'Enter a valid calendar date.';
+        nextErrors.dateYear = 'Enter a valid calendar date.';
       }
 
       if (state.timeValue.trim() && !normalizeTimeValue(state.timeValue)) {
@@ -512,6 +516,7 @@ export function SubmissionScreen() {
 
       if (!nextErrors.yearStart && !nextErrors.yearEnd && Number(state.yearStart) >= Number(state.yearEnd)) {
         nextErrors.yearStart = 'Start year must be earlier than end year.';
+        nextErrors.yearEnd = 'End year must be later than start year.';
       }
     } else if (!state.year.trim()) {
       nextErrors.year = 'Year is required.';
@@ -1017,7 +1022,6 @@ export function SubmissionScreen() {
                     accessibilityLabel="Specific date day"
                     style={getInputShellStyle('dateDay')}
                   />
-                  {fieldErrors.dateDay ? <Text style={{ color: colors.danger }}>{fieldErrors.dateDay}</Text> : null}
                 </View>
                 <View
                   testID="submission-field-date-month"
@@ -1036,7 +1040,6 @@ export function SubmissionScreen() {
                     accessibilityLabel="Specific date month"
                     style={getInputShellStyle('dateMonth')}
                   />
-                  {fieldErrors.dateMonth ? <Text style={{ color: colors.danger }}>{fieldErrors.dateMonth}</Text> : null}
                 </View>
                 <View
                   testID="submission-field-date-year"
@@ -1055,9 +1058,9 @@ export function SubmissionScreen() {
                     accessibilityLabel="Specific date year"
                     style={getInputShellStyle('dateYear')}
                   />
-                  {fieldErrors.dateYear ? <Text style={{ color: colors.danger }}>{fieldErrors.dateYear}</Text> : null}
                 </View>
               </View>
+              {sharedDateError ? <Text style={{ color: colors.danger }}>{sharedDateError}</Text> : null}
               <View
                 testID="submission-field-time-value"
                 onLayout={registerFieldLayout('timeValue', 'time')}
@@ -1078,45 +1081,46 @@ export function SubmissionScreen() {
               </View>
             </View>
           ) : state.timeType === 'year_range' ? (
-            <View style={{ flexDirection: 'row', gap: spacing.sm }}>
-              <View
-                testID="submission-field-year-start"
-                onLayout={registerFieldLayout('yearStart', 'time')}
-                style={{ flex: 1, gap: spacing.sm }}
-              >
-                <Input
-                  value={state.yearStart}
-                  onChangeText={(value) => {
-                    updateField('yearStart', normalizeYearInput(value));
-                    clearFieldError('yearStart');
-                  }}
-                  placeholder="Start year"
-                  keyboardType="numeric"
-                  editable={!state.isSubmitting}
-                  accessibilityLabel="Start year"
-                  style={getInputShellStyle('yearStart')}
-                />
-                {fieldErrors.yearStart ? <Text style={{ color: colors.danger }}>{fieldErrors.yearStart}</Text> : null}
+            <View style={{ gap: spacing.sm }}>
+              <View style={{ flexDirection: 'row', gap: spacing.sm }}>
+                <View
+                  testID="submission-field-year-start"
+                  onLayout={registerFieldLayout('yearStart', 'time')}
+                  style={{ flex: 1, gap: spacing.sm }}
+                >
+                  <Input
+                    value={state.yearStart}
+                    onChangeText={(value) => {
+                      updateField('yearStart', normalizeYearInput(value));
+                      clearFieldError('yearStart');
+                    }}
+                    placeholder="Start year"
+                    keyboardType="numeric"
+                    editable={!state.isSubmitting}
+                    accessibilityLabel="Start year"
+                    style={getInputShellStyle('yearStart')}
+                  />
+                </View>
+                <View
+                  testID="submission-field-year-end"
+                  onLayout={registerFieldLayout('yearEnd', 'time')}
+                  style={{ flex: 1, gap: spacing.sm }}
+                >
+                  <Input
+                    value={state.yearEnd}
+                    onChangeText={(value) => {
+                      updateField('yearEnd', normalizeYearInput(value));
+                      clearFieldError('yearEnd');
+                    }}
+                    placeholder="End year"
+                    keyboardType="numeric"
+                    editable={!state.isSubmitting}
+                    accessibilityLabel="End year"
+                    style={getInputShellStyle('yearEnd')}
+                  />
+                </View>
               </View>
-              <View
-                testID="submission-field-year-end"
-                onLayout={registerFieldLayout('yearEnd', 'time')}
-                style={{ flex: 1, gap: spacing.sm }}
-              >
-                <Input
-                  value={state.yearEnd}
-                  onChangeText={(value) => {
-                    updateField('yearEnd', normalizeYearInput(value));
-                    clearFieldError('yearEnd');
-                  }}
-                  placeholder="End year"
-                  keyboardType="numeric"
-                  editable={!state.isSubmitting}
-                  accessibilityLabel="End year"
-                  style={getInputShellStyle('yearEnd')}
-                />
-                {fieldErrors.yearEnd ? <Text style={{ color: colors.danger }}>{fieldErrors.yearEnd}</Text> : null}
-              </View>
+              {sharedYearRangeError ? <Text style={{ color: colors.danger }}>{sharedYearRangeError}</Text> : null}
             </View>
           ) : (
             <View testID="submission-field-year" onLayout={registerFieldLayout('year', 'time')} style={{ gap: spacing.sm }}>

--- a/mobile/src/features/submissions/presentation/screens/SubmissionScreen.tsx
+++ b/mobile/src/features/submissions/presentation/screens/SubmissionScreen.tsx
@@ -41,12 +41,14 @@ const TAG_OPTIONS = [
   { label: 'Politics', value: 'politics' },
 ] as const;
 
-const TIME_TYPES: Array<{ value: StoryTimeType; label: string; helper: string }> = [
-  { value: 'exact_year', label: 'Exact Year', helper: 'Use a specific known year.' },
-  { value: 'approximate_year', label: 'Approximate', helper: 'For estimated years like circa 1450.' },
-  { value: 'decade', label: 'Decade', helper: 'Enter the decade base year like 1980.' },
-  { value: 'year_range', label: 'Year Range', helper: 'Capture stories that span multiple years.' },
-  { value: 'exact_date', label: 'Specific Date', helper: 'Use a day, month, and year. Time is optional.' },
+const MAX_STORY_YEAR = 2026;
+
+const TIME_TYPES: Array<{ value: StoryTimeType; label: string; accessibilityLabel: string; helper: string }> = [
+  { value: 'exact_year', label: 'Exact', accessibilityLabel: 'Exact Year', helper: 'Use a specific known year.' },
+  { value: 'approximate_year', label: 'Approx', accessibilityLabel: 'Approximate Year', helper: 'For estimated years like circa 1450.' },
+  { value: 'decade', label: 'Decade', accessibilityLabel: 'Decade', helper: 'Enter the decade base year like 1980.' },
+  { value: 'year_range', label: 'Range', accessibilityLabel: 'Year Range', helper: 'Capture stories that span multiple years.' },
+  { value: 'exact_date', label: 'Date', accessibilityLabel: 'Specific Date', helper: 'Use a day, month, and year. Time is optional.' },
 ];
 
 type FieldName =
@@ -137,6 +139,23 @@ const initialState: SubmissionFormState = {
 
 function normalizeTagName(tag: string) {
   return tag.trim().toLowerCase().replace(/[^a-z0-9\s-]/g, '').replace(/\s+/g, '-').replace(/-+/g, '-');
+}
+
+function normalizeYearInput(value: string, allowNegative = true) {
+  const trimmedValue = value.trim();
+  const isNegative = allowNegative && trimmedValue.startsWith('-');
+  const digitsOnly = trimmedValue.replace(/[^0-9]/g, '').slice(0, 4);
+  const numericValue = Number(digitsOnly);
+
+  if (digitsOnly.length === 4 && Number.isFinite(numericValue) && numericValue > MAX_STORY_YEAR) {
+    return isNegative ? `-${digitsOnly}` : String(MAX_STORY_YEAR);
+  }
+
+  return `${isNegative ? '-' : ''}${digitsOnly}`;
+}
+
+function isYearAfterLimit(value: string) {
+  return Number(value) > MAX_STORY_YEAR;
 }
 
 function inferMimeType(uri: string) {
@@ -455,9 +474,19 @@ export function SubmissionScreen() {
       }
       if (!hasYear) {
         nextErrors.dateYear = 'Year is required.';
+      } else if (Number.isNaN(Number(state.dateYear))) {
+        nextErrors.dateYear = 'Year must be a number.';
+      } else if (isYearAfterLimit(state.dateYear)) {
+        nextErrors.dateYear = `Year cannot be later than ${MAX_STORY_YEAR}.`;
       }
 
-      if (hasDay && hasMonth && hasYear && !buildDateValueFromParts(state.dateDay, state.dateMonth, state.dateYear)) {
+      if (
+        hasDay &&
+        hasMonth &&
+        hasYear &&
+        !nextErrors.dateYear &&
+        !buildDateValueFromParts(state.dateDay, state.dateMonth, state.dateYear)
+      ) {
         nextErrors.dateDay = 'Enter a valid calendar date.';
       }
 
@@ -469,12 +498,16 @@ export function SubmissionScreen() {
         nextErrors.yearStart = 'Start year is required.';
       } else if (Number.isNaN(Number(state.yearStart))) {
         nextErrors.yearStart = 'Start year must be a number.';
+      } else if (isYearAfterLimit(state.yearStart)) {
+        nextErrors.yearStart = `Start year cannot be later than ${MAX_STORY_YEAR}.`;
       }
 
       if (!state.yearEnd.trim()) {
         nextErrors.yearEnd = 'End year is required.';
       } else if (Number.isNaN(Number(state.yearEnd))) {
         nextErrors.yearEnd = 'End year must be a number.';
+      } else if (isYearAfterLimit(state.yearEnd)) {
+        nextErrors.yearEnd = `End year cannot be later than ${MAX_STORY_YEAR}.`;
       }
 
       if (!nextErrors.yearStart && !nextErrors.yearEnd && Number(state.yearStart) >= Number(state.yearEnd)) {
@@ -484,6 +517,8 @@ export function SubmissionScreen() {
       nextErrors.year = 'Year is required.';
     } else if (Number.isNaN(Number(state.year))) {
       nextErrors.year = 'Year must be a number.';
+    } else if (isYearAfterLimit(state.year)) {
+      nextErrors.year = `Year cannot be later than ${MAX_STORY_YEAR}.`;
     }
 
     if (state.image) {
@@ -912,12 +947,18 @@ export function SubmissionScreen() {
 
         <View testID="submission-field-time" onLayout={registerFieldLayout('time')} style={{ gap: spacing.sm }}>
           <Text style={{ color: colors.text, fontWeight: '700' }}>Time information</Text>
-          <ScrollView horizontal showsHorizontalScrollIndicator={false} contentContainerStyle={{ gap: spacing.sm }}>
+          <View
+            testID="submission-time-type-options"
+            style={{ flexDirection: 'row', flexWrap: 'wrap', gap: spacing.xs }}
+          >
             {TIME_TYPES.map((timeType) => {
               const active = timeType.value === state.timeType;
               return (
                 <Pressable
                   key={timeType.value}
+                  accessibilityRole="button"
+                  accessibilityLabel={timeType.accessibilityLabel}
+                  accessibilityState={{ selected: active }}
                   onPress={() => {
                     updateField('timeType', timeType.value);
                     clearFieldError('year');
@@ -929,21 +970,31 @@ export function SubmissionScreen() {
                     clearFieldError('timeValue');
                   }}
                   style={{
-                    paddingHorizontal: spacing.md,
-                    paddingVertical: spacing.sm + 2,
+                    flexBasis: 88,
+                    flexGrow: 1,
+                    minHeight: 38,
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                    paddingHorizontal: spacing.sm,
+                    paddingVertical: spacing.xs + 2,
                     borderRadius: 999,
                     borderWidth: 1,
                     borderColor: active ? colors.primary : colors.border,
-                    backgroundColor: active ? colors.primary : colors.surface,
+                    backgroundColor: active ? colors.primary : colors.infoSurface,
                   }}
                 >
-                  <Text style={{ color: active ? colors.background : colors.text, fontWeight: '700' }}>
+                  <Text
+                    numberOfLines={1}
+                    adjustsFontSizeToFit
+                    minimumFontScale={0.85}
+                    style={{ color: active ? colors.background : colors.text, fontWeight: '800', fontSize: 13 }}
+                  >
                     {timeType.label}
                   </Text>
                 </Pressable>
               );
             })}
-          </ScrollView>
+          </View>
           <Text style={{ color: colors.muted }}>{selectedTimeType.helper}</Text>
 
           {state.timeType === 'exact_date' ? (
@@ -995,7 +1046,7 @@ export function SubmissionScreen() {
                   <Input
                     value={state.dateYear}
                     onChangeText={(value) => {
-                      updateField('dateYear', value.replace(/[^0-9]/g, '').slice(0, 4));
+                      updateField('dateYear', normalizeYearInput(value, false));
                       clearFieldError('dateYear');
                     }}
                     placeholder="YYYY"
@@ -1036,7 +1087,7 @@ export function SubmissionScreen() {
                 <Input
                   value={state.yearStart}
                   onChangeText={(value) => {
-                    updateField('yearStart', value);
+                    updateField('yearStart', normalizeYearInput(value));
                     clearFieldError('yearStart');
                   }}
                   placeholder="Start year"
@@ -1055,7 +1106,7 @@ export function SubmissionScreen() {
                 <Input
                   value={state.yearEnd}
                   onChangeText={(value) => {
-                    updateField('yearEnd', value);
+                    updateField('yearEnd', normalizeYearInput(value));
                     clearFieldError('yearEnd');
                   }}
                   placeholder="End year"
@@ -1072,7 +1123,7 @@ export function SubmissionScreen() {
               <Input
                 value={state.year}
                 onChangeText={(value) => {
-                  updateField('year', value);
+                  updateField('year', normalizeYearInput(value));
                   clearFieldError('year');
                 }}
                 placeholder={state.timeType === 'decade' ? 'e.g. 1980' : 'e.g. 1453'}

--- a/mobile/src/features/submissions/presentation/screens/SubmissionScreen.tsx
+++ b/mobile/src/features/submissions/presentation/screens/SubmissionScreen.tsx
@@ -27,6 +27,7 @@ import {
   SubmissionMediaInput,
   submissionsService,
 } from '../../application/services';
+import { buildDateValueFromParts, buildEdtfTemporalCoverage, normalizeTimeValue } from '../../application/services/temporal';
 import { StoryLocationPicker } from '../components/StoryLocationPicker';
 
 const TAG_OPTIONS = [
@@ -45,6 +46,7 @@ const TIME_TYPES: Array<{ value: StoryTimeType; label: string; helper: string }>
   { value: 'approximate_year', label: 'Approximate', helper: 'For estimated years like circa 1450.' },
   { value: 'decade', label: 'Decade', helper: 'Enter the decade base year like 1980.' },
   { value: 'year_range', label: 'Year Range', helper: 'Capture stories that span multiple years.' },
+  { value: 'exact_date', label: 'Specific Date', helper: 'Use a day, month, and year. Time is optional.' },
 ];
 
 type FieldName =
@@ -55,6 +57,10 @@ type FieldName =
   | 'year'
   | 'yearStart'
   | 'yearEnd'
+  | 'dateDay'
+  | 'dateMonth'
+  | 'dateYear'
+  | 'timeValue'
   | 'tags'
   | 'image'
   | 'audio'
@@ -70,6 +76,10 @@ const FIELD_SCROLL_ORDER: FieldName[] = [
   'year',
   'yearStart',
   'yearEnd',
+  'dateDay',
+  'dateMonth',
+  'dateYear',
+  'timeValue',
   'tags',
   'image',
   'audio',
@@ -86,6 +96,10 @@ interface SubmissionFormState {
   year: string;
   yearStart: string;
   yearEnd: string;
+  dateDay: string;
+  dateMonth: string;
+  dateYear: string;
+  timeValue: string;
   selectedTags: string[];
   customTag: string;
   image: (SubmissionImageInput & { fileSize?: number | null }) | null;
@@ -107,6 +121,10 @@ const initialState: SubmissionFormState = {
   year: '',
   yearStart: '',
   yearEnd: '',
+  dateDay: '',
+  dateMonth: '',
+  dateYear: '',
+  timeValue: '',
   selectedTags: [],
   customTag: '',
   image: null,
@@ -424,7 +442,29 @@ export function SubmissionScreen() {
       nextErrors.tags = `Choose up to ${limits.maxTagsPerStory} tags.`;
     }
 
-    if (state.timeType === 'year_range') {
+    if (state.timeType === 'exact_date') {
+      const hasDay = Boolean(state.dateDay.trim());
+      const hasMonth = Boolean(state.dateMonth.trim());
+      const hasYear = Boolean(state.dateYear.trim());
+
+      if (!hasDay) {
+        nextErrors.dateDay = 'Day is required.';
+      }
+      if (!hasMonth) {
+        nextErrors.dateMonth = 'Month is required.';
+      }
+      if (!hasYear) {
+        nextErrors.dateYear = 'Year is required.';
+      }
+
+      if (hasDay && hasMonth && hasYear && !buildDateValueFromParts(state.dateDay, state.dateMonth, state.dateYear)) {
+        nextErrors.dateDay = 'Enter a valid calendar date.';
+      }
+
+      if (state.timeValue.trim() && !normalizeTimeValue(state.timeValue)) {
+        nextErrors.timeValue = 'Time must use 24-hour HH:MM format.';
+      }
+    } else if (state.timeType === 'year_range') {
       if (!state.yearStart.trim()) {
         nextErrors.yearStart = 'Start year is required.';
       } else if (Number.isNaN(Number(state.yearStart))) {
@@ -715,7 +755,18 @@ export function SubmissionScreen() {
       contributorVisible: state.contributorVisible,
     };
 
-    if (state.timeType === 'year_range') {
+    if (state.timeType === 'exact_date') {
+      const dateValue = buildDateValueFromParts(state.dateDay, state.dateMonth, state.dateYear);
+      const timeValue = normalizeTimeValue(state.timeValue);
+
+      payload.dateValue = dateValue;
+      payload.timeValue = timeValue;
+      payload.temporalCoverage = buildEdtfTemporalCoverage({
+        timeType: state.timeType,
+        dateValue,
+        timeValue,
+      });
+    } else if (state.timeType === 'year_range') {
       payload.yearStart = Number(state.yearStart);
       payload.yearEnd = Number(state.yearEnd);
     } else {
@@ -872,6 +923,10 @@ export function SubmissionScreen() {
                     clearFieldError('year');
                     clearFieldError('yearStart');
                     clearFieldError('yearEnd');
+                    clearFieldError('dateDay');
+                    clearFieldError('dateMonth');
+                    clearFieldError('dateYear');
+                    clearFieldError('timeValue');
                   }}
                   style={{
                     paddingHorizontal: spacing.md,
@@ -891,7 +946,87 @@ export function SubmissionScreen() {
           </ScrollView>
           <Text style={{ color: colors.muted }}>{selectedTimeType.helper}</Text>
 
-          {state.timeType === 'year_range' ? (
+          {state.timeType === 'exact_date' ? (
+            <View style={{ gap: spacing.sm }}>
+              <View style={{ flexDirection: 'row', gap: spacing.sm }}>
+                <View
+                  testID="submission-field-date-day"
+                  onLayout={registerFieldLayout('dateDay', 'time')}
+                  style={{ flex: 1, gap: spacing.sm }}
+                >
+                  <Input
+                    value={state.dateDay}
+                    onChangeText={(value) => {
+                      updateField('dateDay', value.replace(/[^0-9]/g, '').slice(0, 2));
+                      clearFieldError('dateDay');
+                    }}
+                    placeholder="DD"
+                    keyboardType="numeric"
+                    editable={!state.isSubmitting}
+                    accessibilityLabel="Specific date day"
+                    style={getInputShellStyle('dateDay')}
+                  />
+                  {fieldErrors.dateDay ? <Text style={{ color: colors.danger }}>{fieldErrors.dateDay}</Text> : null}
+                </View>
+                <View
+                  testID="submission-field-date-month"
+                  onLayout={registerFieldLayout('dateMonth', 'time')}
+                  style={{ flex: 1, gap: spacing.sm }}
+                >
+                  <Input
+                    value={state.dateMonth}
+                    onChangeText={(value) => {
+                      updateField('dateMonth', value.replace(/[^0-9]/g, '').slice(0, 2));
+                      clearFieldError('dateMonth');
+                    }}
+                    placeholder="MM"
+                    keyboardType="numeric"
+                    editable={!state.isSubmitting}
+                    accessibilityLabel="Specific date month"
+                    style={getInputShellStyle('dateMonth')}
+                  />
+                  {fieldErrors.dateMonth ? <Text style={{ color: colors.danger }}>{fieldErrors.dateMonth}</Text> : null}
+                </View>
+                <View
+                  testID="submission-field-date-year"
+                  onLayout={registerFieldLayout('dateYear', 'time')}
+                  style={{ flex: 1.4, gap: spacing.sm }}
+                >
+                  <Input
+                    value={state.dateYear}
+                    onChangeText={(value) => {
+                      updateField('dateYear', value.replace(/[^0-9]/g, '').slice(0, 4));
+                      clearFieldError('dateYear');
+                    }}
+                    placeholder="YYYY"
+                    keyboardType="numeric"
+                    editable={!state.isSubmitting}
+                    accessibilityLabel="Specific date year"
+                    style={getInputShellStyle('dateYear')}
+                  />
+                  {fieldErrors.dateYear ? <Text style={{ color: colors.danger }}>{fieldErrors.dateYear}</Text> : null}
+                </View>
+              </View>
+              <View
+                testID="submission-field-time-value"
+                onLayout={registerFieldLayout('timeValue', 'time')}
+                style={{ gap: spacing.sm }}
+              >
+                <Input
+                  value={state.timeValue}
+                  onChangeText={(value) => {
+                    updateField('timeValue', value.replace(/[^0-9:]/g, '').slice(0, 5));
+                    clearFieldError('timeValue');
+                  }}
+                  placeholder="Optional time, e.g. 09:30"
+                  editable={!state.isSubmitting}
+                  accessibilityLabel="Optional specific time"
+                  style={getInputShellStyle('timeValue')}
+                />
+                {fieldErrors.timeValue ? <Text style={{ color: colors.danger }}>{fieldErrors.timeValue}</Text> : null}
+              </View>
+            </View>
+          ) : state.timeType === 'year_range' ? (
             <View style={{ flexDirection: 'row', gap: spacing.sm }}>
               <View
                 testID="submission-field-year-start"

--- a/mobile/src/features/submissions/presentation/screens/__tests__/SubmissionScreen.test.tsx
+++ b/mobile/src/features/submissions/presentation/screens/__tests__/SubmissionScreen.test.tsx
@@ -225,7 +225,7 @@ describe('SubmissionScreen', () => {
     fireEvent.changeText(screen.getByLabelText('Specific date day'), '29');
     fireEvent.changeText(screen.getByLabelText('Specific date month'), '10');
     fireEvent.changeText(screen.getByLabelText('Specific date year'), '1923');
-    fireEvent.changeText(screen.getByLabelText('Optional specific time'), '09:30');
+    fireEvent.changeText(screen.getByLabelText('Optional specific time'), '9:30');
 
     fireEvent.press(screen.getByText('Submit story'));
 

--- a/mobile/src/features/submissions/presentation/screens/__tests__/SubmissionScreen.test.tsx
+++ b/mobile/src/features/submissions/presentation/screens/__tests__/SubmissionScreen.test.tsx
@@ -112,6 +112,17 @@ describe('SubmissionScreen', () => {
     expect(submissionsService.createStory).not.toHaveBeenCalled();
   });
 
+  it('renders compact time type options without horizontal scrolling', () => {
+    renderSubmissionScreen();
+
+    expect(screen.getByTestId('submission-time-type-options')).toBeTruthy();
+    expect(screen.getByText('Exact')).toBeTruthy();
+    expect(screen.getByText('Approx')).toBeTruthy();
+    expect(screen.getByText('Decade')).toBeTruthy();
+    expect(screen.getByText('Range')).toBeTruthy();
+    expect(screen.getByText('Date')).toBeTruthy();
+  });
+
   it('marks blank required inputs with red outer borders', async () => {
     renderSubmissionScreen();
 
@@ -178,6 +189,23 @@ describe('SubmissionScreen', () => {
     }
   });
 
+  it('caps future year input values at 2026', () => {
+    renderSubmissionScreen();
+
+    fireEvent.changeText(screen.getByLabelText('Year'), '8888');
+    expect(screen.getByLabelText('Year').props.value).toBe('2026');
+
+    fireEvent.press(screen.getByLabelText('Year Range'));
+    fireEvent.changeText(screen.getByLabelText('Start year'), '8888');
+    fireEvent.changeText(screen.getByLabelText('End year'), '8888');
+    expect(screen.getByLabelText('Start year').props.value).toBe('2026');
+    expect(screen.getByLabelText('End year').props.value).toBe('2026');
+
+    fireEvent.press(screen.getByLabelText('Specific Date'));
+    fireEvent.changeText(screen.getByLabelText('Specific date year'), '8888');
+    expect(screen.getByLabelText('Specific date year').props.value).toBe('2026');
+  });
+
   it('submits the story payload and returns the user to the feed on success', async () => {
     (submissionsService.createStory as jest.Mock).mockResolvedValue({ id: 12 });
     renderSubmissionScreen();
@@ -221,7 +249,7 @@ describe('SubmissionScreen', () => {
       nativeEvent: { coordinate: { latitude: 39.9334, longitude: 32.8597 } },
     });
     fireEvent.changeText(screen.getByLabelText('Place name'), 'Ankara');
-    fireEvent.press(screen.getByText('Specific Date'));
+    fireEvent.press(screen.getByLabelText('Specific Date'));
     fireEvent.changeText(screen.getByLabelText('Specific date day'), '29');
     fireEvent.changeText(screen.getByLabelText('Specific date month'), '10');
     fireEvent.changeText(screen.getByLabelText('Specific date year'), '1923');
@@ -250,7 +278,7 @@ describe('SubmissionScreen', () => {
       nativeEvent: { coordinate: { latitude: 39.9334, longitude: 32.8597 } },
     });
     fireEvent.changeText(screen.getByLabelText('Place name'), 'Ankara');
-    fireEvent.press(screen.getByText('Specific Date'));
+    fireEvent.press(screen.getByLabelText('Specific Date'));
     fireEvent.changeText(screen.getByLabelText('Specific date day'), '31');
     fireEvent.changeText(screen.getByLabelText('Specific date month'), '02');
     fireEvent.changeText(screen.getByLabelText('Specific date year'), '1923');

--- a/mobile/src/features/submissions/presentation/screens/__tests__/SubmissionScreen.test.tsx
+++ b/mobile/src/features/submissions/presentation/screens/__tests__/SubmissionScreen.test.tsx
@@ -288,6 +288,30 @@ describe('SubmissionScreen', () => {
 
     expect(await screen.findByText('Enter a valid calendar date.')).toBeTruthy();
     expect(screen.getByText('Time must use 24-hour HH:MM format.')).toBeTruthy();
+    expect(getInputShellStyle('Specific date day').borderColor).toBe(lightColors.danger);
+    expect(getInputShellStyle('Specific date month').borderColor).toBe(lightColors.danger);
+    expect(getInputShellStyle('Specific date year').borderColor).toBe(lightColors.danger);
+    expect(submissionsService.createStory).not.toHaveBeenCalled();
+  });
+
+  it('marks both year range inputs when start year is not earlier than end year', async () => {
+    renderSubmissionScreen();
+
+    fireEvent.changeText(screen.getByLabelText('Story title'), 'Range Error');
+    fireEvent.changeText(screen.getByLabelText('Story narrative'), 'A story with an invalid range.');
+    fireEvent(screen.getByTestId('story-location-map'), 'press', {
+      nativeEvent: { coordinate: { latitude: 39.9334, longitude: 32.8597 } },
+    });
+    fireEvent.changeText(screen.getByLabelText('Place name'), 'Ankara');
+    fireEvent.press(screen.getByLabelText('Year Range'));
+    fireEvent.changeText(screen.getByLabelText('Start year'), '1923');
+    fireEvent.changeText(screen.getByLabelText('End year'), '1923');
+
+    fireEvent.press(screen.getByText('Submit story'));
+
+    expect(await screen.findByText('Start year must be earlier than end year.')).toBeTruthy();
+    expect(getInputShellStyle('Start year').borderColor).toBe(lightColors.danger);
+    expect(getInputShellStyle('End year').borderColor).toBe(lightColors.danger);
     expect(submissionsService.createStory).not.toHaveBeenCalled();
   });
 

--- a/mobile/src/features/submissions/presentation/screens/__tests__/SubmissionScreen.test.tsx
+++ b/mobile/src/features/submissions/presentation/screens/__tests__/SubmissionScreen.test.tsx
@@ -211,6 +211,58 @@ describe('SubmissionScreen', () => {
     expect(navigationRef.navigate).toHaveBeenCalledWith(ROUTES.FEED);
   });
 
+  it('submits specific date stories with optional time and EDTF temporal coverage', async () => {
+    (submissionsService.createStory as jest.Mock).mockResolvedValue({ id: 12 });
+    renderSubmissionScreen();
+
+    fireEvent.changeText(screen.getByLabelText('Story title'), 'Republic Day');
+    fireEvent.changeText(screen.getByLabelText('Story narrative'), 'A story tied to a specific day.');
+    fireEvent(screen.getByTestId('story-location-map'), 'press', {
+      nativeEvent: { coordinate: { latitude: 39.9334, longitude: 32.8597 } },
+    });
+    fireEvent.changeText(screen.getByLabelText('Place name'), 'Ankara');
+    fireEvent.press(screen.getByText('Specific Date'));
+    fireEvent.changeText(screen.getByLabelText('Specific date day'), '29');
+    fireEvent.changeText(screen.getByLabelText('Specific date month'), '10');
+    fireEvent.changeText(screen.getByLabelText('Specific date year'), '1923');
+    fireEvent.changeText(screen.getByLabelText('Optional specific time'), '09:30');
+
+    fireEvent.press(screen.getByText('Submit story'));
+
+    await waitFor(() => {
+      expect(submissionsService.createStory).toHaveBeenCalledWith(
+        expect.objectContaining({
+          timeType: 'exact_date',
+          dateValue: '1923-10-29',
+          timeValue: '09:30',
+          temporalCoverage: '1923-10-29T09:30',
+        }),
+      );
+    });
+  });
+
+  it('validates specific date and optional time inputs', async () => {
+    renderSubmissionScreen();
+
+    fireEvent.changeText(screen.getByLabelText('Story title'), 'Invalid Date');
+    fireEvent.changeText(screen.getByLabelText('Story narrative'), 'A story with invalid temporal input.');
+    fireEvent(screen.getByTestId('story-location-map'), 'press', {
+      nativeEvent: { coordinate: { latitude: 39.9334, longitude: 32.8597 } },
+    });
+    fireEvent.changeText(screen.getByLabelText('Place name'), 'Ankara');
+    fireEvent.press(screen.getByText('Specific Date'));
+    fireEvent.changeText(screen.getByLabelText('Specific date day'), '31');
+    fireEvent.changeText(screen.getByLabelText('Specific date month'), '02');
+    fireEvent.changeText(screen.getByLabelText('Specific date year'), '1923');
+    fireEvent.changeText(screen.getByLabelText('Optional specific time'), '25:00');
+
+    fireEvent.press(screen.getByText('Submit story'));
+
+    expect(await screen.findByText('Enter a valid calendar date.')).toBeTruthy();
+    expect(screen.getByText('Time must use 24-hour HH:MM format.')).toBeTruthy();
+    expect(submissionsService.createStory).not.toHaveBeenCalled();
+  });
+
   it('debounces story location search API calls by 300ms', async () => {
     jest.useFakeTimers();
     renderSubmissionScreen();


### PR DESCRIPTION
# 📝 Description
Fixes #493

This PR enhances the mobile story submission flow with EDTF-compatible temporal resolution support.

Changes include:
- Added a new Specific Date time option to the mobile submission form
- Added day, month, year, and optional time inputs for specific date submissions
- Generated EDTF temporal values for supported mobile time types
- Sent exact date submissions using `date_value` and optional `time_value`
- Preserved existing user-facing rendering for exact year, approximate year, decade, and year range
- Added exact date rendering fallback in feed and story detail mappers
- Made the mobile time type selector more compact so all options are visible without horizontal scrolling
- Prevented future year values above `2026` in year-based inputs
- Added/updated unit tests for temporal formatting, submission payloads, validation, and rendering

# 📊 Type of Change
- [ ]  Bug fix
- [x]  New feature
- [ ]  Refactoring
- [ ]  Documentation
 
# ✅ Acceptance Criteria / Checklist
- [x] Project builds successfully
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, especially in hard-to-understand parts
- [x] I have performed a self-review of my code
- [x] I have added/updated tests
- [x] New and existing unit tests pass locally with my changes

# 📸 Screenshots / Recordings
Mobile UI changes are in the story submission time information section.

# ⏱️ Estimated Review Time
- [ ] < 5 min
- [ ] 5-15 min
- [ ] > 15 min
