### PR TITLE
Feat/ support multiple tag filtering 

### DIFF
--- a/backend/apps/stories/serializers.py
+++ b/backend/apps/stories/serializers.py
@@ -322,8 +322,12 @@ class FeedQuerySerializer(serializers.Serializer):
     year_to = serializers.IntegerField(required=False)
     # Substring match against location_name — partial values like "galata" are valid
     location = serializers.CharField(required=False, allow_blank=False)
-    # Exact (case-insensitive) match against tag name — use the tag slug, e.g. "ottoman-era"
-    tag = serializers.CharField(required=False, allow_blank=False)
+    # AND filter — each tag name must match exactly (case-insensitive); all must be present on the story
+    tags = serializers.ListField(
+        child=serializers.CharField(allow_blank=False),
+        required=False,
+        allow_empty=False,
+    )
     latitude = serializers.FloatField(required=False, min_value=-90.0, max_value=90.0)
     longitude = serializers.FloatField(required=False, min_value=-180.0, max_value=180.0)
     # Minimum of 0.001 km — a zero radius would always return empty results.
@@ -406,7 +410,7 @@ class SearchQuerySerializer(FeedQuerySerializer):
     Validates query parameters for the story search endpoint.
 
     q is required. All filter params from FeedQuerySerializer (sort_by, year_from,
-    year_to, location, tag, latitude, longitude, radius_km) are inherited so search
+    year_to, location, tags, latitude, longitude, radius_km) are inherited so search
     results can be narrowed with the same filters as the feed.
     """
 

--- a/backend/apps/stories/services.py
+++ b/backend/apps/stories/services.py
@@ -61,7 +61,7 @@ def get_story_feed(
     year_from=None,
     year_to=None,
     location=None,
-    tag=None,
+    tags=None,
     latitude=None,
     longitude=None,
     radius_km=None,
@@ -102,8 +102,11 @@ def get_story_feed(
     if location:
         qs = qs.filter(location_name__icontains=location)
 
-    if tag:
-        qs = qs.filter(story_tags__tag__name__iexact=tag).distinct()
+    for tag in (tags or []):
+        # Each chained filter is a separate JOIN — AND semantics: story must have ALL tags
+        qs = qs.filter(story_tags__tag__name__iexact=tag)
+    if tags:
+        qs = qs.distinct()
 
     if latitude is not None and longitude is not None and radius_km is not None:
         qs = _apply_radius_filter(qs, latitude, longitude, radius_km)
@@ -215,7 +218,7 @@ def get_story_search(
     year_from=None,
     year_to=None,
     location=None,
-    tag=None,
+    tags=None,
     latitude=None,
     longitude=None,
     radius_km=None,
@@ -253,8 +256,11 @@ def get_story_search(
     if location:
         qs = qs.filter(location_name__icontains=location)
 
-    if tag:
-        qs = qs.filter(story_tags__tag__name__iexact=tag).distinct()
+    for tag in (tags or []):
+        # Each chained filter is a separate JOIN — AND semantics: story must have ALL tags
+        qs = qs.filter(story_tags__tag__name__iexact=tag)
+    if tags:
+        qs = qs.distinct()
 
     if latitude is not None and longitude is not None and radius_km is not None:
         qs = _apply_radius_filter(qs, latitude, longitude, radius_km)

--- a/backend/apps/stories/tests/test_serializers.py
+++ b/backend/apps/stories/tests/test_serializers.py
@@ -701,7 +701,14 @@ class TestFeedQuerySerializerGeoValidation:
         })
 
     def test_geo_params_combined_with_tag_filter_is_valid(self):
-        self._valid({'latitude': 41.0, 'longitude': 29.0, 'radius_km': 1.0, 'tag': 'ottoman'})
+        self._valid({'latitude': 41.0, 'longitude': 29.0, 'radius_km': 1.0, 'tags': ['ottoman']})
+
+    def test_multi_tags_list_is_valid(self):
+        self._valid({'tags': ['ottoman-era', 'folklore']})
+
+    def test_empty_tags_list_is_invalid(self):
+        errors = self._invalid({'tags': []})
+        assert 'tags' in errors
 
     # ── Partial geo param sets rejected ──────────────────────────────────────
 

--- a/backend/apps/stories/tests/test_services.py
+++ b/backend/apps/stories/tests/test_services.py
@@ -315,7 +315,7 @@ class TestGetStoryFeedTagFilter:
         make_story(title='Untagged Story')
         tag = Tag.objects.create(name='folklore')
         StoryTag.objects.create(story=tagged, tag=tag)
-        qs = get_story_feed(tag='folklore')
+        qs = get_story_feed(tags=['folklore'])
         assert qs.count() == 1
         assert qs.first().title == 'Tagged Story'
 
@@ -323,14 +323,14 @@ class TestGetStoryFeedTagFilter:
         story = make_story()
         tag = Tag.objects.create(name='ottoman-era')
         StoryTag.objects.create(story=story, tag=tag)
-        assert get_story_feed(tag='folklore').count() == 0
+        assert get_story_feed(tags=['folklore']).count() == 0
 
     def test_feed_tag_filter_is_case_insensitive(self):
         story = make_story()
         tag = Tag.objects.create(name='ottoman-era')
         StoryTag.objects.create(story=story, tag=tag)
-        assert get_story_feed(tag='Ottoman-Era').count() == 1
-        assert get_story_feed(tag='OTTOMAN-ERA').count() == 1
+        assert get_story_feed(tags=['Ottoman-Era']).count() == 1
+        assert get_story_feed(tags=['OTTOMAN-ERA']).count() == 1
 
     def test_feed_tag_filter_combined_with_year_filter(self):
         match = make_story(title='Match', year=1950)
@@ -338,7 +338,7 @@ class TestGetStoryFeedTagFilter:
         tag = Tag.objects.create(name='folklore')
         StoryTag.objects.create(story=match, tag=tag)
         StoryTag.objects.create(story=no_match, tag=tag)
-        qs = get_story_feed(tag='folklore', year_from=1900)
+        qs = get_story_feed(tags=['folklore'], year_from=1900)
         assert qs.count() == 1
         assert qs.first().title == 'Match'
 
@@ -348,7 +348,7 @@ class TestGetStoryFeedTagFilter:
         tag = Tag.objects.create(name='folklore')
         StoryTag.objects.create(story=match, tag=tag)
         StoryTag.objects.create(story=no_match, tag=tag)
-        qs = get_story_feed(tag='folklore', location='Istanbul')
+        qs = get_story_feed(tags=['folklore'], location='Istanbul')
         assert qs.count() == 1
         assert qs.first().title == 'Match'
 
@@ -359,7 +359,32 @@ class TestGetStoryFeedTagFilter:
         StoryTag.objects.create(story=story, tag=tag1)
         StoryTag.objects.create(story=story, tag=tag2)
         # Filtering by one tag on a story that has multiple tags must not produce duplicates
-        assert get_story_feed(tag='folklore').count() == 1
+        assert get_story_feed(tags=['folklore']).count() == 1
+
+    def test_feed_multi_tag_and_returns_only_stories_with_all_tags(self):
+        tag1 = Tag.objects.create(name='folklore')
+        tag2 = Tag.objects.create(name='ottoman-era')
+        both = make_story(title='Both Tags')
+        only_first = make_story(title='Only Folklore')
+        StoryTag.objects.create(story=both, tag=tag1)
+        StoryTag.objects.create(story=both, tag=tag2)
+        StoryTag.objects.create(story=only_first, tag=tag1)
+        qs = get_story_feed(tags=['folklore', 'ottoman-era'])
+        assert qs.count() == 1
+        assert qs.first().title == 'Both Tags'
+
+    def test_feed_multi_tag_and_empty_when_no_story_has_all_tags(self):
+        tag1 = Tag.objects.create(name='folklore')
+        tag2 = Tag.objects.create(name='ottoman-era')
+        story = make_story()
+        StoryTag.objects.create(story=story, tag=tag1)
+        # story only has tag1, not tag2
+        assert get_story_feed(tags=['folklore', 'ottoman-era']).count() == 0
+
+    def test_feed_no_tags_param_returns_all_stories(self):
+        make_story(title='Story A')
+        make_story(title='Story B')
+        assert get_story_feed(tags=None).count() == 2
 
 
 # ── get_story_search — tag filter ────────────────────────────────────────────
@@ -371,20 +396,32 @@ class TestGetStorySearchTagFilter:
         make_story(title='Istanbul Lore')
         tag = Tag.objects.create(name='folklore')
         StoryTag.objects.create(story=tagged, tag=tag)
-        qs = get_story_search('Istanbul', tag='folklore')
+        qs = get_story_search('Istanbul', tags=['folklore'])
         assert qs.count() == 1
         assert qs.first().title == 'Istanbul Tale'
 
     def test_search_tag_param_excludes_untagged(self):
         make_story(title='Istanbul Tale')
-        assert get_story_search('Istanbul', tag='folklore').count() == 0
+        assert get_story_search('Istanbul', tags=['folklore']).count() == 0
 
     def test_search_tag_and_q_both_must_match(self):
         # Story matches tag but neither title nor location_name matches q — should not appear
         tagged = make_story(title='Ankara Chronicle', location_name='Ankara')
         tag = Tag.objects.create(name='folklore')
         StoryTag.objects.create(story=tagged, tag=tag)
-        assert get_story_search('Istanbul', tag='folklore').count() == 0
+        assert get_story_search('Istanbul', tags=['folklore']).count() == 0
+
+    def test_search_multi_tag_and_returns_only_stories_with_all_tags(self):
+        tag1 = Tag.objects.create(name='folklore')
+        tag2 = Tag.objects.create(name='ottoman-era')
+        both = make_story(title='Istanbul Both')
+        only_first = make_story(title='Istanbul Folklore Only')
+        StoryTag.objects.create(story=both, tag=tag1)
+        StoryTag.objects.create(story=both, tag=tag2)
+        StoryTag.objects.create(story=only_first, tag=tag1)
+        qs = get_story_search('Istanbul', tags=['folklore', 'ottoman-era'])
+        assert qs.count() == 1
+        assert qs.first().title == 'Istanbul Both'
 
 
 # ── delete_story ──────────────────────────────────────────────────────────────
@@ -531,7 +568,7 @@ class TestGetStoryFeedGeoFilter:
         near_tagged = make_geo_story(NEAR_LAT, NEAR_LNG, title='NearTagged')
         StoryTag.objects.create(story=near_tagged, tag=tag)
         near_untagged = make_geo_story(NEAR_LAT, NEAR_LNG, title='NearUntagged')
-        qs = get_story_feed(latitude=CENTER_LAT, longitude=CENTER_LNG, radius_km=1.0, tag='geo-svc-tag')
+        qs = get_story_feed(latitude=CENTER_LAT, longitude=CENTER_LNG, radius_km=1.0, tags=['geo-svc-tag'])
         assert near_tagged in qs
         assert near_untagged not in qs
 

--- a/backend/apps/stories/tests/test_views.py
+++ b/backend/apps/stories/tests/test_views.py
@@ -204,14 +204,14 @@ class TestStoryFeedView:
         make_story(title='Untagged')
         tag = Tag.objects.create(name='folklore')
         StoryTag.objects.create(story=tagged, tag=tag)
-        response = client.get(FEED_URL + '?tag=folklore')
+        response = client.get(FEED_URL + '?tags=folklore')
         assert response.data['count'] == 1
         assert response.data['results'][0]['title'] == 'Tagged'
 
     def test_feed_tag_filter_returns_empty_when_no_match(self, client):
         make_story(title='Untagged')
         Tag.objects.create(name='folklore')
-        response = client.get(FEED_URL + '?tag=folklore')
+        response = client.get(FEED_URL + '?tags=folklore')
         assert response.data['count'] == 0
 
     def test_feed_tag_and_location_filter_combined(self, client):
@@ -220,9 +220,29 @@ class TestStoryFeedView:
         tag = Tag.objects.create(name='folklore')
         StoryTag.objects.create(story=match, tag=tag)
         StoryTag.objects.create(story=no_match, tag=tag)
-        response = client.get(FEED_URL + '?tag=folklore&location=Istanbul')
+        response = client.get(FEED_URL + '?tags=folklore&location=Istanbul')
         assert response.data['count'] == 1
         assert response.data['results'][0]['title'] == 'Match'
+
+    def test_feed_multi_tag_and_returns_only_stories_with_all_tags(self, client):
+        tag1 = Tag.objects.create(name='folklore')
+        tag2 = Tag.objects.create(name='ottoman-era')
+        both = make_story(title='Both Tags')
+        only_first = make_story(title='Only Folklore')
+        StoryTag.objects.create(story=both, tag=tag1)
+        StoryTag.objects.create(story=both, tag=tag2)
+        StoryTag.objects.create(story=only_first, tag=tag1)
+        response = client.get(FEED_URL + '?tags=folklore&tags=ottoman-era')
+        assert response.data['count'] == 1
+        assert response.data['results'][0]['title'] == 'Both Tags'
+
+    def test_feed_multi_tag_and_empty_when_no_story_has_all_tags(self, client):
+        tag1 = Tag.objects.create(name='folklore')
+        tag2 = Tag.objects.create(name='ottoman-era')
+        story = make_story()
+        StoryTag.objects.create(story=story, tag=tag1)
+        response = client.get(FEED_URL + '?tags=folklore&tags=ottoman-era')
+        assert response.data['count'] == 0
     
     def test_feed_bbox_filtering(self, client):
         make_story(title='Istanbul Story', location_lat=41.0, location_lng=28.9)
@@ -469,13 +489,13 @@ class TestStorySearchView:
         make_story(title='Istanbul Lore')
         tag = Tag.objects.create(name='folklore')
         StoryTag.objects.create(story=tagged, tag=tag)
-        response = client.get(SEARCH_URL + '?q=Istanbul&tag=folklore')
+        response = client.get(SEARCH_URL + '?q=Istanbul&tags=folklore')
         assert response.data['count'] == 1
         assert response.data['results'][0]['title'] == 'Istanbul Tale'
 
     def test_search_tag_filter_returns_empty_when_tag_missing(self, client):
         make_story(title='Istanbul Tale')
-        response = client.get(SEARCH_URL + '?q=Istanbul&tag=folklore')
+        response = client.get(SEARCH_URL + '?q=Istanbul&tags=folklore')
         assert response.data['count'] == 0
 
     def test_search_tag_and_q_both_must_match(self, client):
@@ -483,8 +503,20 @@ class TestStorySearchView:
         story = make_story(title='Ankara Chronicle', location_name='Ankara')
         tag = Tag.objects.create(name='folklore')
         StoryTag.objects.create(story=story, tag=tag)
-        response = client.get(SEARCH_URL + '?q=Istanbul&tag=folklore')
+        response = client.get(SEARCH_URL + '?q=Istanbul&tags=folklore')
         assert response.data['count'] == 0
+
+    def test_search_multi_tag_and_returns_only_stories_with_all_tags(self, client):
+        tag1 = Tag.objects.create(name='folklore')
+        tag2 = Tag.objects.create(name='ottoman-era')
+        both = make_story(title='Istanbul Both')
+        only_first = make_story(title='Istanbul Folklore Only')
+        StoryTag.objects.create(story=both, tag=tag1)
+        StoryTag.objects.create(story=both, tag=tag2)
+        StoryTag.objects.create(story=only_first, tag=tag1)
+        response = client.get(SEARCH_URL + '?q=Istanbul&tags=folklore&tags=ottoman-era')
+        assert response.data['count'] == 1
+        assert response.data['results'][0]['title'] == 'Istanbul Both'
 
     def test_search_bbox_filtering(self, client):
         make_story(title='Istanbul Story', location_lat=41.0, location_lng=28.9)
@@ -605,15 +637,27 @@ class TestStoryMapView:
         make_story(title='Untagged')
         tag = Tag.objects.create(name='ottoman-era')
         StoryTag.objects.create(story=tagged, tag=tag)
-        response = client.get(MAP_URL + '?tag=ottoman-era')
+        response = client.get(MAP_URL + '?tags=ottoman-era')
         assert len(response.data['features']) == 1
         assert response.data['features'][0]['properties']['title'] == 'Tagged'
 
     def test_map_tag_filter_returns_empty_when_no_match(self, client):
         make_story(title='Untagged')
-        response = client.get(MAP_URL + '?tag=ottoman-era')
+        response = client.get(MAP_URL + '?tags=ottoman-era')
         assert len(response.data['features']) == 0
-        
+
+    def test_map_multi_tag_and_returns_only_stories_with_all_tags(self, client):
+        tag1 = Tag.objects.create(name='folklore')
+        tag2 = Tag.objects.create(name='ottoman-era')
+        both = make_story(title='Both Tags')
+        only_first = make_story(title='Only Folklore')
+        StoryTag.objects.create(story=both, tag=tag1)
+        StoryTag.objects.create(story=both, tag=tag2)
+        StoryTag.objects.create(story=only_first, tag=tag1)
+        response = client.get(MAP_URL + '?tags=folklore&tags=ottoman-era')
+        assert len(response.data['features']) == 1
+        assert response.data['features'][0]['properties']['title'] == 'Both Tags'
+
     def test_map_bbox_filtering(self, client):
         make_story(title='Istanbul Story', location_lat=41.0, location_lng=28.9)
         make_story(title='Ankara Story', location_lat=39.9, location_lng=32.9)
@@ -970,7 +1014,7 @@ class TestStoryFeedViewGeoFilter:
         near_tagged = make_geo_story(_GEO_NEAR_LAT, _GEO_NEAR_LNG, title='TaggedNear')
         StoryTag.objects.create(story=near_tagged, tag=tag)
         make_geo_story(_GEO_NEAR_LAT, _GEO_NEAR_LNG, title='UntaggedNear')
-        response = client.get(f'{FEED_URL}?{self._geo_params()}&tag=view-geo-tag')
+        response = client.get(f'{FEED_URL}?{self._geo_params()}&tags=view-geo-tag')
         assert response.status_code == status.HTTP_200_OK
         titles = [s['title'] for s in response.data['results']]
         assert 'TaggedNear' in titles

--- a/backend/apps/stories/views.py
+++ b/backend/apps/stories/views.py
@@ -35,7 +35,7 @@ class StoryFeedView(APIView):
       year_from  — include stories from this year onwards
       year_to    — include stories up to and including this year
       location   — case-insensitive substring match against location_name
-      tag        — exact tag name filter (case-insensitive), e.g. "ottoman-era"
+      tags       — AND filter: repeat for each tag, e.g. "?tags=ottoman-era&tags=folklore"
       latitude   — WGS-84 latitude of user's position (-90 to 90)
       longitude  — WGS-84 longitude of user's position (-180 to 180)
       radius_km  — filter radius in kilometres (must be provided with latitude + longitude)
@@ -63,14 +63,14 @@ class StoryFeedView(APIView):
             year_from=params.get('year_from'),
             year_to=params.get('year_to'),
             location=params.get('location'),
-            tag=params.get('tag'),
+            tags=params.get('tags'),
             latitude=params.get('latitude'),
             longitude=params.get('longitude'),
             radius_km=params.get('radius_km'),
         )
-        
+
         qs = apply_bbox_filters(qs, params)
-        
+
         if request.user.is_authenticated:
             qs = annotate_user_interactions(qs, request.user)
 
@@ -94,7 +94,7 @@ class StoryMapView(APIView):
       year_from  — include stories from this year onwards
       year_to    — include stories up to and including this year
       location   — case-insensitive substring match against location_name
-      tag        — exact tag name filter (case-insensitive), e.g. "ottoman-era"
+      tags       — AND filter: repeat for each tag, e.g. "?tags=ottoman-era&tags=folklore"
       latitude   — WGS-84 latitude of user's position (-90 to 90)
       longitude  — WGS-84 longitude of user's position (-180 to 180)
       radius_km  — filter radius in kilometres (must be provided with latitude + longitude)
@@ -115,7 +115,7 @@ class StoryMapView(APIView):
             year_from=params.get('year_from'),
             year_to=params.get('year_to'),
             location=params.get('location'),
-            tag=params.get('tag'),
+            tags=params.get('tags'),
             latitude=params.get('latitude'),
             longitude=params.get('longitude'),
             radius_km=params.get('radius_km'),
@@ -139,7 +139,7 @@ class StorySearchView(APIView):
 
     Query params:
       q        — required, min 1 character after stripping whitespace
-      tag      — optional exact tag name filter (case-insensitive), e.g. "ottoman-era"
+      tags     — AND filter: repeat for each tag, e.g. "?tags=ottoman-era&tags=folklore"
       lat_min   — minimum latitude of bounding box (optional)
       lat_max   — maximum latitude of bounding box (optional)
       lng_min   — minimum longitude of bounding box (optional)
@@ -159,7 +159,7 @@ class StorySearchView(APIView):
             year_from=params.get('year_from'),
             year_to=params.get('year_to'),
             location=params.get('location'),
-            tag=params.get('tag'),
+            tags=params.get('tags'),
             latitude=params.get('latitude'),
             longitude=params.get('longitude'),
             radius_km=params.get('radius_km'),


### PR DESCRIPTION
# 📝 Description 

Fixes #506 

This change was added based on an additional request from the frontend side, since the frontend needed to send multiple selected tags as repeated `tags` query parameters and receive results matching all selected tags.

This PR updates story filtering to support **multiple tag filters with AND logic** across the feed, map, and search endpoints.

Previously, story filtering supported a single `tag` query parameter. With this change, clients can pass repeated `tags` query parameters, such as:

`?tags=folklore&tags=ottoman-era`

The returned stories must contain **all** provided tags, not just one of them. This makes tag-based filtering more useful for discovery flows where users want to narrow results by combining multiple categories.

Main changes include:

- Replaced the single `tag` query parameter with a `tags` list parameter.
- Added AND-based tag filtering in `get_story_feed` and `get_story_search`.
- Updated feed, map, and search views to pass `tags` into the service layer.
- Updated serializer validation to reject empty tag lists.
- Added and updated tests for:
  - single tag filtering through `tags`
  - multiple tag filtering with AND semantics
  - case-insensitive tag matching
  - combination with year, location, geo, search, and map filters
  - duplicate prevention when stories have multiple tags

# 📊 Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactoring
- [ ] Documentation

# ✅ Acceptance Criteria / Checklist

- [x] The project builds successfully.
- [x] Code follows the project style guidelines.
- [x] I have performed a self-review of my code.
- [x] Existing single-tag filtering behavior is preserved through the new `tags` parameter.
- [x] Feed endpoint supports repeated `tags` query parameters.
- [x] Map endpoint supports repeated `tags` query parameters.
- [x] Search endpoint supports repeated `tags` query parameters.
- [x] Multiple tag filters use AND logic, so returned stories must contain all selected tags.
- [x] Tag filtering remains case-insensitive.
- [x] Empty `tags` lists are rejected by serializer validation.
- [x] Filtering does not return duplicate stories when a story has multiple tags.
- [x] Tests were added/updated for serializers, services, and views.



# ⏱️ Estimated Review Time

- [ ] <5 min
- [x] 5–15 min
- [ ] >15 min