### PR TITLE
fix: include tags in story feed API response

### DIFF
--- a/backend/apps/stories/serializers.py
+++ b/backend/apps/stories/serializers.py
@@ -236,6 +236,7 @@ class StoryFeedSerializer(serializers.ModelSerializer):
 
     user_has_liked = serializers.SerializerMethodField()
     user_has_saved = serializers.SerializerMethodField()
+    tags = TagSerializer(many=True, read_only=True)
 
     class Meta:
         model = Story
@@ -259,6 +260,7 @@ class StoryFeedSerializer(serializers.ModelSerializer):
             'user_has_liked',
             'user_has_saved',
             'submitted_at',
+            'tags',
         ]
         read_only_fields = fields
 

--- a/backend/apps/stories/services.py
+++ b/backend/apps/stories/services.py
@@ -85,7 +85,7 @@ def get_story_feed(
 
     sort_by — 'recent' (default) orders by submission date; 'popular' orders by like_count
     """
-    qs = Story.objects.filter(status=Story.STATUS_PUBLISHED)
+    qs = Story.objects.filter(status=Story.STATUS_PUBLISHED).prefetch_related('tags')
 
     if year_from is not None:
         qs = qs.filter(
@@ -235,6 +235,7 @@ def get_story_search(
     qs = (
         Story.objects
         .filter(status=Story.STATUS_PUBLISHED)
+        .prefetch_related('tags')
         .filter(Q(title__icontains=q) | Q(location_name__icontains=q))
     )
 

--- a/backend/apps/stories/tests/test_serializers.py
+++ b/backend/apps/stories/tests/test_serializers.py
@@ -58,7 +58,7 @@ class TestStoryFeedSerializer:
             'time_type', 'year', 'year_start', 'year_end', 'date_value', 'time_value',
             'status', 'contributor_name', 'preview_text',
             'like_count', 'save_count',
-            'user_has_liked', 'user_has_saved', 'submitted_at',
+            'user_has_liked', 'user_has_saved', 'submitted_at', 'tags',
         }
         assert expected_fields == set(data.keys())
 

--- a/backend/apps/stories/tests/test_views.py
+++ b/backend/apps/stories/tests/test_views.py
@@ -176,9 +176,26 @@ class TestStoryFeedView:
             'time_type', 'year', 'year_start', 'year_end', 'date_value', 'time_value',
             'status', 'contributor_name', 'preview_text',
             'like_count', 'save_count',
-            'user_has_liked', 'user_has_saved', 'submitted_at',
+            'user_has_liked', 'user_has_saved', 'submitted_at', 'tags',
         }
         assert expected_fields == set(card.keys())
+
+    def test_feed_story_card_includes_tags(self, client):
+        story = make_story()
+        tag = Tag.objects.create(name='folklore')
+        StoryTag.objects.create(story=story, tag=tag)
+        response = client.get(FEED_URL)
+        card = response.data['results'][0]
+        assert 'tags' in card
+        assert len(card['tags']) == 1
+        assert card['tags'][0]['name'] == 'folklore'
+        assert 'id' in card['tags'][0]
+
+    def test_feed_story_card_tags_empty_when_no_tags(self, client):
+        make_story()
+        response = client.get(FEED_URL)
+        card = response.data['results'][0]
+        assert card['tags'] == []
 
     def test_feed_result_contains_interaction_counts(self, client):
         make_story(like_count=6, save_count=2)


### PR DESCRIPTION
 # 📝 Description 
Fixes #470

This PR updates the story feed/search response so that each story card includes its associated tags.

This change was added based on a frontend-side need: the frontend requested tag data directly in the story card response in order to display selected/story-related tags without making an additional request.

Main changes include:

- Added `tags` to `StoryFeedSerializer` using `TagSerializer`.
- Included `tags` in the serialized story card fields.
- Added `prefetch_related('tags')` to feed and search querysets to avoid inefficient per-story tag queries.
- Added tests to verify:
  - feed response includes the `tags` field,
  - tagged stories return their tag data,
  - stories without tags return an empty `tags` list,
  - the expected feed card fields include `tags`.

# 📊 Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactoring
- [ ] Documentation

# ✅ Acceptance Criteria / Checklist

- [x] The project builds successfully.
- [x] Code follows the project style guidelines.
- [x] I have performed a self-review of my code.
- [x] Story feed response includes a `tags` field for each story card.
- [x] Story search response can also serialize tags through the shared feed serializer.
- [x] Tagged stories return their associated tag data.
- [x] Untagged stories return an empty `tags` list.
- [x] Tag serialization uses the existing `TagSerializer`.
- [x] Feed/search querysets prefetch tags to avoid N+1 queries.
- [x] Tests were added/updated for the feed response behavior.



# ⏱️ Estimated Review Time

- [x] <5 min
- [ ] 5–15 min
- [ ] >15 min