### PR TITLE
feat: show active proximity location on map

### DIFF
--- a/mobile/src/features/map/presentation/components/MapCard.tsx
+++ b/mobile/src/features/map/presentation/components/MapCard.tsx
@@ -14,6 +14,7 @@ interface MapCardProps {
   error?: string;
   statusBadgeText?: string;
   fitToMarkers?: boolean;
+  userLocation?: { latitude: number; longitude: number };
   onSelectMarker: (markerId: string) => void;
   onOpenStory: (storyId: string) => void;
   onMarkerPress?: () => void;
@@ -30,6 +31,7 @@ export function MapCard({
   error,
   statusBadgeText,
   fitToMarkers = false,
+  userLocation,
   onSelectMarker,
   onOpenStory,
   onMarkerPress,
@@ -46,12 +48,12 @@ export function MapCard({
 
   useEffect(() => {
     if (fitToMarkers) {
-      setCurrentRegion(region);
+      setCurrentRegion((current) => (regionsEqual(current, region) ? current : region));
       return;
     }
 
     if (!selectedMarker) {
-      setCurrentRegion(region);
+      setCurrentRegion((current) => (regionsEqual(current, region) ? current : region));
       return;
     }
 
@@ -77,6 +79,7 @@ export function MapCard({
         <WebMapView
           key={mapContentKey}
           region={currentRegion}
+          userLocation={userLocation}
           markers={markers.map((marker) => ({
             id: marker.id,
             latitude: marker.latitude,
@@ -226,4 +229,13 @@ function truncatePreview(value: string) {
   }
 
   return `${value.slice(0, PREVIEW_MAX_LENGTH - 1).trim()}...`;
+}
+
+function regionsEqual(left: Region, right: Region) {
+  return (
+    left.latitude === right.latitude &&
+    left.longitude === right.longitude &&
+    left.latitudeDelta === right.latitudeDelta &&
+    left.longitudeDelta === right.longitudeDelta
+  );
 }

--- a/mobile/src/features/map/presentation/screens/MapScreen.tsx
+++ b/mobile/src/features/map/presentation/screens/MapScreen.tsx
@@ -173,6 +173,7 @@ export function MapScreen({
     () => getRegionForMarkers(state.markers, ISTANBUL_REGION),
     [state.markers],
   );
+  const userLocation = filters.proximityRadiusKm && filters.proximityCoordinates ? filters.proximityCoordinates : undefined;
   const fitToMarkers = state.markers.length > 0 && (!state.selectedMarkerId || hasActiveFilters);
 
   const statusStoryCount = useMemo(() => {
@@ -239,6 +240,7 @@ export function MapScreen({
           error={state.error}
           statusBadgeText={statusBadgeText}
           fitToMarkers={fitToMarkers}
+          userLocation={userLocation}
           onSelectMarker={(markerId) => setState((current) => ({ ...current, selectedMarkerId: markerId }))}
           onOpenStory={(storyId) => onOpenStory?.(storyId)}
           onMarkerPress={handleMarkerPreviewRequest}

--- a/mobile/src/features/map/presentation/screens/__tests__/MapScreen.test.tsx
+++ b/mobile/src/features/map/presentation/screens/__tests__/MapScreen.test.tsx
@@ -3,6 +3,7 @@ import { fireEvent, render, screen, waitFor } from '@testing-library/react-nativ
 import { MapScreen } from '../MapScreen';
 import { MapMarkerGroup } from '../../../domain/entities';
 import { SearchFiltersProvider } from '../../../../search/presentation/context/SearchFiltersContext';
+import { storageKeys } from '../../../../../core/storage/keys';
 import { storage } from '../../../../../core/storage/storage';
 import { geocodeLocationQuery, searchLocationSuggestions } from '../../../../search/application/services';
 
@@ -21,6 +22,7 @@ jest.mock('../../../../../shared/components/WebMapView', () => {
     WebMapView: ({
       region,
       markers = [],
+      userLocation,
       onMarkerPress,
       onRegionChangeComplete,
     }: {
@@ -31,6 +33,10 @@ jest.mock('../../../../../shared/components/WebMapView', () => {
         longitudeDelta: number;
       };
       markers?: Array<{ id: string }>;
+      userLocation?: {
+        latitude: number;
+        longitude: number;
+      };
       onMarkerPress?: (markerId: string) => void;
       onRegionChangeComplete?: (region: {
         latitude: number;
@@ -44,6 +50,12 @@ jest.mock('../../../../../shared/components/WebMapView', () => {
           testID="map-region-props"
           accessibilityLabel={`region:${region?.latitude}:${region?.longitude}:${region?.latitudeDelta}:${region?.longitudeDelta}`}
         />
+        {userLocation ? (
+          <View
+            testID="user-location-marker"
+            accessibilityLabel={`user-location:${userLocation.latitude}:${userLocation.longitude}`}
+          />
+        ) : null}
         <Pressable
           testID="map-region-change"
           onPress={() =>
@@ -308,6 +320,50 @@ describe('MapScreen', () => {
     fireEvent.press(screen.getByTestId('map-region-change'));
 
     expect(await screen.findByText('1 story found in this area')).toBeTruthy();
+  });
+
+  it('shows the user location marker when proximity filters are active', async () => {
+    await storage.set(storageKeys.mapSearchFilters, {
+      query: '',
+      location: '',
+      proximityRadiusKm: 10,
+      proximityCoordinates: {
+        latitude: 41.0082,
+        longitude: 28.9784,
+      },
+      timeFrom: '',
+      timeTo: '',
+    });
+
+    renderScreen(<MapScreen getMarkerGroups={async () => markerGroups} />);
+
+    await screen.findByText('Select a story marker to preview.');
+
+    await waitFor(() => {
+      expect(screen.getByTestId('user-location-marker').props.accessibilityLabel).toBe('user-location:41.0082:28.9784');
+    });
+  });
+
+  it('hides the user location marker when proximity filter is anywhere even if old coordinates remain', async () => {
+    await storage.set(storageKeys.mapSearchFilters, {
+      query: '',
+      location: '',
+      proximityRadiusKm: undefined,
+      proximityCoordinates: {
+        latitude: 41.0082,
+        longitude: 28.9784,
+      },
+      timeFrom: '',
+      timeTo: '',
+    });
+
+    renderScreen(<MapScreen getMarkerGroups={async () => markerGroups} />);
+
+    await screen.findByText('Select a story marker to preview.');
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('user-location-marker')).toBeNull();
+    });
   });
 
   it('refetches all markers when a chip filter is removed', async () => {

--- a/mobile/src/shared/components/WebMapView.tsx
+++ b/mobile/src/shared/components/WebMapView.tsx
@@ -10,6 +10,11 @@ type MarkerItem = {
   label?: string;
 };
 
+interface UserLocationLike {
+  latitude: number;
+  longitude: number;
+}
+
 interface RegionLike {
   latitude: number;
   longitude: number;
@@ -20,6 +25,7 @@ interface RegionLike {
 interface WebMapViewProps {
   region: RegionLike;
   markers?: MarkerItem[];
+  userLocation?: UserLocationLike;
   interactive?: boolean;
   onMarkerPress?: (markerId: string) => void;
   onMapPress?: (coords: { latitude: number; longitude: number }) => void;
@@ -29,10 +35,12 @@ interface WebMapViewProps {
 const mapHtml = ({
   region,
   markers,
+  userLocation,
   interactive,
 }: {
   region: RegionLike;
   markers: MarkerItem[];
+  userLocation?: UserLocationLike;
   interactive: boolean;
 }) => `<!DOCTYPE html>
 <html>
@@ -85,6 +93,15 @@ const mapHtml = ({
         text-shadow: 0 1px 2px rgba(0, 0, 0, 0.35);
         pointer-events: none;
       }
+
+      .user-location-marker {
+        width: 18px;
+        height: 18px;
+        border-radius: 9999px;
+        background: #1d4ed8;
+        border: 3px solid #ffffff;
+        box-shadow: 0 0 0 6px rgba(29, 78, 216, 0.18);
+      }
     </style>
   </head>
   <body>
@@ -93,6 +110,7 @@ const mapHtml = ({
     <script>
       const region = ${JSON.stringify(region)};
       const markers = ${JSON.stringify(markers)};
+      const userLocation = ${JSON.stringify(userLocation ?? null)};
       const interactive = ${interactive ? 'true' : 'false'};
       let hasCompletedInitialMove = false;
 
@@ -157,6 +175,15 @@ const mapHtml = ({
           .addTo(map);
       });
 
+      if (userLocation) {
+        const element = document.createElement('div');
+        element.className = 'user-location-marker';
+
+        new maplibregl.Marker({ element, anchor: 'center' })
+          .setLngLat([userLocation.longitude, userLocation.latitude])
+          .addTo(map);
+      }
+
       if (!interactive) {
         map.boxZoom.disable();
       }
@@ -194,6 +221,7 @@ const mapHtml = ({
 export function WebMapView({
   region,
   markers = [],
+  userLocation,
   interactive = true,
   onMarkerPress,
   onMapPress,
@@ -201,9 +229,9 @@ export function WebMapView({
 }: WebMapViewProps) {
   const source = useMemo(
     () => ({
-      html: mapHtml({ region, markers, interactive }),
+      html: mapHtml({ region, markers, userLocation, interactive }),
     }),
-    [interactive, markers, region],
+    [interactive, markers, region, userLocation],
   );
 
   return (


### PR DESCRIPTION
# 📝 Description
Fixes #513

This PR improves the mobile map proximity experience by visualizing the active proximity-filter location directly on the map.

It passes active proximity coordinates into the shared map view, renders a distinct blue marker only when a non-Anywhere distance filter is selected, and adds regression coverage so stale saved coordinates do not keep the marker visible after the filter is reset.

# 📊 Type of Change
- [ ]  Bug fix
- [x]  New feature
- [ ]  Refactoring
- [ ]  Documentation
 
# ✅ Acceptance Criteria / Checklist
- [x] Project builds successfully
- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, especially in hard-to-understand parts
- [x] I have performed a self-review of my code
- [x] I have added/updated tests
- [x] New and existing unit tests pass locally with my changes

# 📸 Screenshots / Recordings
<!-- If applicable !-->
Not included.

# ⏱️ Estimated Review Time
- [ ] < 5 min
- [x] 5-15 min
- [ ] > 15 min

## Validation
- `npm run typecheck`
- `npm test -- --runTestsByPath src/features/map/presentation/screens/__tests__/MapScreen.test.tsx --watch=false`
