### PR TITLE
feat: forgot-password and reset-password flow

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -30,7 +30,7 @@ function App() {
               <Route path="/login" element={<LoginPage />} />
               <Route path="/register" element={<RegisterPage />} />
               <Route path="/forgot-password" element={<ForgotPasswordPage />} />
-              <Route path="/reset-password" element={<ResetPasswordPage />} />
+              <Route path="/reset-password/:token" element={<ResetPasswordPage />} />
               <Route
                 path="/complete-profile"
                 element={(

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -7,6 +7,8 @@ import { ToastProvider } from "@/context/ToastContext";
 import { Toaster } from "@/components/ui/toaster";
 import LoginPage from "@/pages/LoginPage";
 import RegisterPage from "@/pages/RegisterPage";
+import ForgotPasswordPage from "@/pages/ForgotPasswordPage";
+import ResetPasswordPage from "@/pages/ResetPasswordPage";
 import ProfileCompletionPage from "@/pages/ProfileCompletionPage";
 import NotFoundPage from "@/pages/NotFoundPage";
 import FeedPage from "@/pages/FeedPage";
@@ -27,6 +29,8 @@ function App() {
               <Route path="/map" element={<MapPage />} />
               <Route path="/login" element={<LoginPage />} />
               <Route path="/register" element={<RegisterPage />} />
+              <Route path="/forgot-password" element={<ForgotPasswordPage />} />
+              <Route path="/reset-password" element={<ResetPasswordPage />} />
               <Route
                 path="/complete-profile"
                 element={(

--- a/frontend/src/pages/ForgotPasswordPage.jsx
+++ b/frontend/src/pages/ForgotPasswordPage.jsx
@@ -1,0 +1,164 @@
+import { useState } from "react";
+import { Link } from "react-router-dom";
+import { Mail, Loader2, MapPin, MailCheck } from "lucide-react";
+
+import {
+  Button,
+  Input,
+  Label,
+  Card,
+  CardHeader,
+  CardTitle,
+  CardDescription,
+  CardContent,
+  CardFooter,
+} from "@/components/ui";
+import { forgotPassword } from "@/services/authService";
+
+function validateEmail(email) {
+  return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email);
+}
+
+function ForgotPasswordPage() {
+  const [email, setEmail] = useState("");
+  const [emailError, setEmailError] = useState("");
+  const [apiError, setApiError] = useState("");
+  const [isLoading, setIsLoading] = useState(false);
+  const [submitted, setSubmitted] = useState(false);
+
+  function validate() {
+    if (!email.trim()) {
+      setEmailError("Email is required.");
+      return false;
+    }
+    if (!validateEmail(email)) {
+      setEmailError("Enter a valid email address.");
+      return false;
+    }
+    setEmailError("");
+    return true;
+  }
+
+  async function handleSubmit(e) {
+    e.preventDefault();
+    setApiError("");
+    if (!validate()) return;
+    setIsLoading(true);
+    try {
+      await forgotPassword(email);
+      setSubmitted(true);
+    } catch (error) {
+      const data = error.response?.data;
+      const fieldEmail = data?.errors?.email;
+      if (fieldEmail) {
+        setEmailError(Array.isArray(fieldEmail) ? fieldEmail[0] : fieldEmail);
+      } else {
+        setApiError(
+          data?.message || data?.detail || "Could not submit request. Please try again."
+        );
+      }
+    } finally {
+      setIsLoading(false);
+    }
+  }
+
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-background px-4 py-12">
+      <Card className="w-full max-w-md">
+        <CardHeader className="space-y-3 text-center">
+          <div className="flex items-center justify-center gap-2">
+            <MapPin className="h-6 w-6 text-primary" />
+            <CardTitle className="text-2xl font-bold">
+              Local History Story Map
+            </CardTitle>
+          </div>
+          <CardDescription>
+            {submitted
+              ? "Check your inbox"
+              : "Enter your email and we'll send you a reset link"}
+          </CardDescription>
+        </CardHeader>
+
+        <CardContent>
+          {submitted ? (
+            <div
+              role="status"
+              className="flex flex-col items-center gap-3 rounded-md border border-input bg-muted/40 px-4 py-6 text-center"
+            >
+              <MailCheck className="h-10 w-10 text-primary" aria-hidden="true" />
+              <p className="text-sm text-muted-foreground">
+                If an account exists with this email, we&apos;ve sent a password
+                reset link. Check your inbox.
+              </p>
+            </div>
+          ) : (
+            <>
+              {apiError && (
+                <div
+                  role="alert"
+                  className="mb-4 rounded-md border border-destructive/50 bg-destructive/10 px-4 py-3 text-sm text-destructive"
+                >
+                  {apiError}
+                </div>
+              )}
+
+              <form onSubmit={handleSubmit} className="space-y-4" noValidate>
+                <div className="space-y-2">
+                  <Label htmlFor="email">Email</Label>
+                  <div className="relative">
+                    <Mail className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+                    <Input
+                      id="email"
+                      type="email"
+                      placeholder="you@example.com"
+                      className="pl-9"
+                      autoComplete="email"
+                      aria-invalid={!!emailError}
+                      aria-describedby={emailError ? "email-error" : undefined}
+                      value={email}
+                      onChange={(e) => {
+                        setEmail(e.target.value);
+                        if (emailError) setEmailError("");
+                      }}
+                      disabled={isLoading}
+                    />
+                  </div>
+                  {emailError && (
+                    <p id="email-error" className="text-sm text-destructive">
+                      {emailError}
+                    </p>
+                  )}
+                </div>
+
+                <Button type="submit" className="w-full" disabled={isLoading}>
+                  {isLoading ? (
+                    <>
+                      <Loader2 className="h-4 w-4 animate-spin" />
+                      Sending...
+                    </>
+                  ) : (
+                    "Send reset link"
+                  )}
+                </Button>
+              </form>
+            </>
+          )}
+        </CardContent>
+
+        <CardFooter className="justify-center">
+          <p className="text-sm text-muted-foreground">
+            Remembered your password?{" "}
+            <Link
+              to="/login"
+              className="font-medium text-primary underline-offset-4 hover:underline"
+            >
+              Sign in
+            </Link>
+          </p>
+        </CardFooter>
+      </Card>
+    </div>
+  );
+}
+
+export default ForgotPasswordPage;

--- a/frontend/src/pages/LoginPage.jsx
+++ b/frontend/src/pages/LoginPage.jsx
@@ -163,6 +163,14 @@ function LoginPage() {
                   {fieldErrors.password}
                 </p>
               )}
+              <div className="text-right">
+                <Link
+                  to="/forgot-password"
+                  className="text-sm font-medium text-primary underline-offset-4 hover:underline"
+                >
+                  Forgot your password?
+                </Link>
+              </div>
             </div>
 
             <Button type="submit" className="w-full" disabled={isLoading}>

--- a/frontend/src/pages/ResetPasswordPage.jsx
+++ b/frontend/src/pages/ResetPasswordPage.jsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { useNavigate, useSearchParams, Link } from "react-router-dom";
+import { useNavigate, useParams, Link } from "react-router-dom";
 import { Lock, Eye, EyeOff, Loader2, MapPin, AlertCircle, Check, X } from "lucide-react";
 
 import {
@@ -43,9 +43,9 @@ function isInvalidTokenError(error) {
 
 function ResetPasswordPage() {
   const navigate = useNavigate();
-  const [searchParams] = useSearchParams();
+  const { token: tokenParam } = useParams();
   const { toast } = useToast();
-  const token = searchParams.get("token") || "";
+  const token = tokenParam || "";
 
   const [password, setPassword] = useState("");
   const [confirmPassword, setConfirmPassword] = useState("");
@@ -206,7 +206,7 @@ function ResetPasswordPage() {
                   className="pl-9 pr-9"
                   autoComplete="new-password"
                   aria-invalid={!!fieldErrors.password}
-                  aria-describedby="password-error"
+                  aria-describedby={fieldErrors.password ? "password-error" : undefined}
                   value={password}
                   onChange={(e) => {
                     setPassword(e.target.value);

--- a/frontend/src/pages/ResetPasswordPage.jsx
+++ b/frontend/src/pages/ResetPasswordPage.jsx
@@ -1,0 +1,333 @@
+import { useState } from "react";
+import { useNavigate, useSearchParams, Link } from "react-router-dom";
+import { Lock, Eye, EyeOff, Loader2, MapPin, AlertCircle, Check, X } from "lucide-react";
+
+import {
+  Button,
+  Input,
+  Label,
+  Card,
+  CardHeader,
+  CardTitle,
+  CardDescription,
+  CardContent,
+  CardFooter,
+} from "@/components/ui";
+import { resetPassword } from "@/services/authService";
+import { useToast } from "@/hooks/useToast";
+
+const PASSWORD_RULES = [
+  { id: "length",    label: "At least 8 characters",     test: (p) => p.length >= 8 },
+  { id: "uppercase", label: "One uppercase letter (A–Z)", test: (p) => /[A-Z]/.test(p) },
+  { id: "lowercase", label: "One lowercase letter (a–z)", test: (p) => /[a-z]/.test(p) },
+  { id: "number",    label: "One number (0–9)",           test: (p) => /[0-9]/.test(p) },
+];
+
+function validatePasswordStrength(password) {
+  if (password.length < 8) return "Password must be at least 8 characters.";
+  if (!/[A-Z]/.test(password)) return "Password must contain an uppercase letter.";
+  if (!/[a-z]/.test(password)) return "Password must contain a lowercase letter.";
+  if (!/[0-9]/.test(password)) return "Password must contain a number.";
+  return "";
+}
+
+function isInvalidTokenError(error) {
+  if (!error.response) return false;
+  const data = error.response.data || {};
+  const tokenErr = data.errors?.token;
+  const detail = (data.detail || data.message || "").toString().toLowerCase();
+  if (tokenErr) return true;
+  if (error.response.status === 410) return true;
+  return detail.includes("token") && (detail.includes("invalid") || detail.includes("expired"));
+}
+
+function ResetPasswordPage() {
+  const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
+  const { toast } = useToast();
+  const token = searchParams.get("token") || "";
+
+  const [password, setPassword] = useState("");
+  const [confirmPassword, setConfirmPassword] = useState("");
+  const [showPassword, setShowPassword] = useState(false);
+  const [showConfirmPassword, setShowConfirmPassword] = useState(false);
+  const [fieldErrors, setFieldErrors] = useState({ password: "", confirmPassword: "" });
+  const [apiError, setApiError] = useState("");
+  const [tokenInvalid, setTokenInvalid] = useState(false);
+  const [isLoading, setIsLoading] = useState(false);
+
+  if (!token) {
+    return (
+      <div className="flex min-h-screen items-center justify-center bg-background px-4 py-12">
+        <Card className="w-full max-w-md">
+          <CardHeader className="space-y-3 text-center">
+            <div className="flex items-center justify-center gap-2">
+              <AlertCircle className="h-6 w-6 text-destructive" />
+              <CardTitle className="text-2xl font-bold">Invalid reset link</CardTitle>
+            </div>
+            <CardDescription>
+              This password reset link is missing a token.
+            </CardDescription>
+          </CardHeader>
+          <CardFooter className="justify-center">
+            <Link
+              to="/forgot-password"
+              className="text-sm font-medium text-primary underline-offset-4 hover:underline"
+            >
+              Request a new reset link
+            </Link>
+          </CardFooter>
+        </Card>
+      </div>
+    );
+  }
+
+  function validate() {
+    const errors = { password: "", confirmPassword: "" };
+    let valid = true;
+    if (!password) {
+      errors.password = "Password is required.";
+      valid = false;
+    } else {
+      const msg = validatePasswordStrength(password);
+      if (msg) {
+        errors.password = msg;
+        valid = false;
+      }
+    }
+    if (!confirmPassword) {
+      errors.confirmPassword = "Please confirm your password.";
+      valid = false;
+    } else if (password !== confirmPassword) {
+      errors.confirmPassword = "Passwords do not match.";
+      valid = false;
+    }
+    setFieldErrors(errors);
+    return valid;
+  }
+
+  async function handleSubmit(e) {
+    e.preventDefault();
+    setApiError("");
+    if (!validate()) return;
+    setIsLoading(true);
+    try {
+      await resetPassword(token, password, confirmPassword);
+      toast.success("Password reset successfully. Please log in with your new password.");
+      navigate("/login", { replace: true });
+    } catch (error) {
+      if (isInvalidTokenError(error)) {
+        setTokenInvalid(true);
+      } else {
+        const data = error.response?.data;
+        const fieldErrs = data?.errors || {};
+        const next = { password: "", confirmPassword: "" };
+        if (fieldErrs.new_password) {
+          next.password = Array.isArray(fieldErrs.new_password)
+            ? fieldErrs.new_password[0]
+            : fieldErrs.new_password;
+        }
+        if (fieldErrs.new_password_confirmation) {
+          next.confirmPassword = Array.isArray(fieldErrs.new_password_confirmation)
+            ? fieldErrs.new_password_confirmation[0]
+            : fieldErrs.new_password_confirmation;
+        }
+        if (next.password || next.confirmPassword) {
+          setFieldErrors(next);
+        } else {
+          setApiError(
+            data?.message || data?.detail || "Could not reset password. Please try again."
+          );
+        }
+      }
+    } finally {
+      setIsLoading(false);
+    }
+  }
+
+  if (tokenInvalid) {
+    return (
+      <div className="flex min-h-screen items-center justify-center bg-background px-4 py-12">
+        <Card className="w-full max-w-md">
+          <CardHeader className="space-y-3 text-center">
+            <div className="flex items-center justify-center gap-2">
+              <AlertCircle className="h-6 w-6 text-destructive" />
+              <CardTitle className="text-2xl font-bold">Reset link expired</CardTitle>
+            </div>
+            <CardDescription>
+              This password reset link is invalid or has expired.
+            </CardDescription>
+          </CardHeader>
+          <CardFooter className="justify-center">
+            <Link
+              to="/forgot-password"
+              className="text-sm font-medium text-primary underline-offset-4 hover:underline"
+            >
+              Request a new reset link
+            </Link>
+          </CardFooter>
+        </Card>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-background px-4 py-12">
+      <Card className="w-full max-w-md">
+        <CardHeader className="space-y-3 text-center">
+          <div className="flex items-center justify-center gap-2">
+            <MapPin className="h-6 w-6 text-primary" />
+            <CardTitle className="text-2xl font-bold">
+              Local History Story Map
+            </CardTitle>
+          </div>
+          <CardDescription>Choose a new password</CardDescription>
+        </CardHeader>
+
+        <CardContent>
+          {apiError && (
+            <div
+              role="alert"
+              className="mb-4 rounded-md border border-destructive/50 bg-destructive/10 px-4 py-3 text-sm text-destructive"
+            >
+              {apiError}
+            </div>
+          )}
+
+          <form onSubmit={handleSubmit} className="space-y-4" noValidate>
+            <div className="space-y-2">
+              <Label htmlFor="password">New password</Label>
+              <div className="relative">
+                <Lock className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+                <Input
+                  id="password"
+                  type={showPassword ? "text" : "password"}
+                  placeholder="New password"
+                  className="pl-9 pr-9"
+                  autoComplete="new-password"
+                  aria-invalid={!!fieldErrors.password}
+                  aria-describedby="password-error"
+                  value={password}
+                  onChange={(e) => {
+                    setPassword(e.target.value);
+                    if (fieldErrors.password) {
+                      setFieldErrors((p) => ({ ...p, password: "" }));
+                    }
+                  }}
+                  disabled={isLoading}
+                />
+                <button
+                  type="button"
+                  className="absolute right-3 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
+                  onClick={() => setShowPassword(!showPassword)}
+                  tabIndex={-1}
+                  aria-label={showPassword ? "Hide password" : "Show password"}
+                >
+                  {showPassword ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
+                </button>
+              </div>
+              {fieldErrors.password && (
+                <p id="password-error" className="text-sm text-destructive">
+                  {fieldErrors.password}
+                </p>
+              )}
+              <ul className="mt-2 space-y-1">
+                {PASSWORD_RULES.map((rule) => {
+                  const passed = rule.test(password);
+                  const showRed = !!fieldErrors.password && !passed;
+                  return (
+                    <li
+                      key={rule.id}
+                      className={`flex items-center gap-1.5 text-xs ${
+                        showRed
+                          ? "text-destructive"
+                          : passed
+                            ? "text-green-600 dark:text-green-400"
+                            : "text-muted-foreground"
+                      }`}
+                    >
+                      {passed
+                        ? <Check className="h-3 w-3 shrink-0" />
+                        : <X className="h-3 w-3 shrink-0" />}
+                      {rule.label}
+                    </li>
+                  );
+                })}
+              </ul>
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="confirmPassword">Confirm password</Label>
+              <div className="relative">
+                <Lock className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+                <Input
+                  id="confirmPassword"
+                  type={showConfirmPassword ? "text" : "password"}
+                  placeholder="Repeat your password"
+                  className="pl-9 pr-9"
+                  autoComplete="new-password"
+                  aria-invalid={!!fieldErrors.confirmPassword}
+                  aria-describedby={
+                    fieldErrors.confirmPassword ? "confirmPassword-error" : undefined
+                  }
+                  value={confirmPassword}
+                  onChange={(e) => {
+                    setConfirmPassword(e.target.value);
+                    if (fieldErrors.confirmPassword) {
+                      setFieldErrors((p) => ({ ...p, confirmPassword: "" }));
+                    }
+                  }}
+                  disabled={isLoading}
+                />
+                <button
+                  type="button"
+                  className="absolute right-3 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
+                  onClick={() => setShowConfirmPassword(!showConfirmPassword)}
+                  tabIndex={-1}
+                  aria-label={
+                    showConfirmPassword ? "Hide confirm password" : "Show confirm password"
+                  }
+                >
+                  {showConfirmPassword ? (
+                    <EyeOff className="h-4 w-4" />
+                  ) : (
+                    <Eye className="h-4 w-4" />
+                  )}
+                </button>
+              </div>
+              {fieldErrors.confirmPassword && (
+                <p id="confirmPassword-error" className="text-sm text-destructive">
+                  {fieldErrors.confirmPassword}
+                </p>
+              )}
+            </div>
+
+            <Button type="submit" className="w-full" disabled={isLoading}>
+              {isLoading ? (
+                <>
+                  <Loader2 className="h-4 w-4 animate-spin" />
+                  Resetting...
+                </>
+              ) : (
+                "Reset password"
+              )}
+            </Button>
+          </form>
+        </CardContent>
+
+        <CardFooter className="justify-center">
+          <p className="text-sm text-muted-foreground">
+            <Link
+              to="/login"
+              className="font-medium text-primary underline-offset-4 hover:underline"
+            >
+              Back to sign in
+            </Link>
+          </p>
+        </CardFooter>
+      </Card>
+    </div>
+  );
+}
+
+export default ResetPasswordPage;

--- a/frontend/src/pages/__tests__/ForgotPasswordPage.test.jsx
+++ b/frontend/src/pages/__tests__/ForgotPasswordPage.test.jsx
@@ -1,0 +1,106 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { BrowserRouter } from "react-router-dom";
+
+import ForgotPasswordPage from "../ForgotPasswordPage";
+
+vi.mock("@/services/authService", () => ({
+  forgotPassword: vi.fn(),
+}));
+
+import { forgotPassword } from "@/services/authService";
+
+function renderPage() {
+  return render(
+    <BrowserRouter>
+      <ForgotPasswordPage />
+    </BrowserRouter>
+  );
+}
+
+describe("ForgotPasswordPage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders form fields", () => {
+    renderPage();
+    expect(screen.getByLabelText("Email")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /send reset link/i })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /sign in/i })).toBeInTheDocument();
+  });
+
+  it("shows error when email is empty", async () => {
+    const user = userEvent.setup();
+    renderPage();
+    await user.click(screen.getByRole("button", { name: /send reset link/i }));
+    expect(await screen.findByText(/email is required/i)).toBeInTheDocument();
+    expect(forgotPassword).not.toHaveBeenCalled();
+  });
+
+  it("shows error for invalid email format", async () => {
+    const user = userEvent.setup();
+    renderPage();
+    await user.type(screen.getByLabelText("Email"), "notanemail");
+    await user.click(screen.getByRole("button", { name: /send reset link/i }));
+    expect(await screen.findByText(/valid email/i)).toBeInTheDocument();
+    expect(forgotPassword).not.toHaveBeenCalled();
+  });
+
+  it("calls forgotPassword with email on valid submit", async () => {
+    const user = userEvent.setup();
+    forgotPassword.mockResolvedValue({ message: "ok" });
+    renderPage();
+    await user.type(screen.getByLabelText("Email"), "test@example.com");
+    await user.click(screen.getByRole("button", { name: /send reset link/i }));
+    await waitFor(() => {
+      expect(forgotPassword).toHaveBeenCalledWith("test@example.com");
+    });
+  });
+
+  it("shows generic confirmation that does not reveal account existence", async () => {
+    const user = userEvent.setup();
+    forgotPassword.mockResolvedValue({ message: "ok" });
+    renderPage();
+    await user.type(screen.getByLabelText("Email"), "test@example.com");
+    await user.click(screen.getByRole("button", { name: /send reset link/i }));
+    expect(
+      await screen.findByText(/if an account exists with this email/i)
+    ).toBeInTheDocument();
+    expect(screen.queryByLabelText("Email")).not.toBeInTheDocument();
+  });
+
+  it("shows loading state during submission", async () => {
+    const user = userEvent.setup();
+    forgotPassword.mockReturnValue(new Promise(() => {}));
+    renderPage();
+    await user.type(screen.getByLabelText("Email"), "test@example.com");
+    await user.click(screen.getByRole("button", { name: /send reset link/i }));
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: /sending/i })).toBeDisabled();
+    });
+  });
+
+  it("shows API error from response", async () => {
+    const user = userEvent.setup();
+    const error = new Error("server");
+    error.response = { data: { detail: "Service unavailable." } };
+    forgotPassword.mockRejectedValue(error);
+    renderPage();
+    await user.type(screen.getByLabelText("Email"), "test@example.com");
+    await user.click(screen.getByRole("button", { name: /send reset link/i }));
+    expect(await screen.findByText(/service unavailable/i)).toBeInTheDocument();
+  });
+
+  it("shows backend field error for email", async () => {
+    const user = userEvent.setup();
+    const error = new Error("bad request");
+    error.response = { data: { errors: { email: ["Enter a valid email."] } } };
+    forgotPassword.mockRejectedValue(error);
+    renderPage();
+    await user.type(screen.getByLabelText("Email"), "test@example.com");
+    await user.click(screen.getByRole("button", { name: /send reset link/i }));
+    expect(await screen.findByText(/enter a valid email/i)).toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/__tests__/LoginPage.test.jsx
+++ b/frontend/src/pages/__tests__/LoginPage.test.jsx
@@ -215,6 +215,13 @@ describe("LoginPage", () => {
     expect(signUpLink).toBeInTheDocument();
   });
 
+  it("has link to forgot password page", () => {
+    renderLoginPage();
+
+    const forgotLink = screen.getByRole("link", { name: /forgot your password/i });
+    expect(forgotLink).toHaveAttribute("href", "/forgot-password");
+  });
+
   it("shows contextual message when redirected from submit-story", () => {
     render(
       <ToastProvider>

--- a/frontend/src/pages/__tests__/ResetPasswordPage.test.jsx
+++ b/frontend/src/pages/__tests__/ResetPasswordPage.test.jsx
@@ -23,12 +23,13 @@ const TOKEN = "abc123-token";
 const VALID_PASSWORD = "Password1";
 
 function renderPage({ token = TOKEN } = {}) {
-  const path = token ? `/reset-password?token=${token}` : "/reset-password";
+  const path = token ? `/reset-password/${token}` : "/reset-password";
   return render(
     <ToastProvider>
       <MemoryRouter initialEntries={[path]}>
         <Routes>
           <Route path="/reset-password" element={<ResetPasswordPage />} />
+          <Route path="/reset-password/:token" element={<ResetPasswordPage />} />
         </Routes>
       </MemoryRouter>
       <Toaster />
@@ -41,7 +42,7 @@ describe("ResetPasswordPage", () => {
     vi.clearAllMocks();
   });
 
-  it("shows missing-token state when token query param is absent", () => {
+  it("shows missing-token state when token path param is absent", () => {
     renderPage({ token: "" });
     expect(screen.getByText(/invalid reset link/i)).toBeInTheDocument();
     expect(

--- a/frontend/src/pages/__tests__/ResetPasswordPage.test.jsx
+++ b/frontend/src/pages/__tests__/ResetPasswordPage.test.jsx
@@ -1,0 +1,161 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter, Routes, Route } from "react-router-dom";
+
+import ResetPasswordPage from "../ResetPasswordPage";
+import { ToastProvider } from "@/context/ToastContext";
+import { Toaster } from "@/components/ui/toaster";
+
+vi.mock("@/services/authService", () => ({
+  resetPassword: vi.fn(),
+}));
+
+const mockNavigate = vi.fn();
+vi.mock("react-router-dom", async () => {
+  const actual = await vi.importActual("react-router-dom");
+  return { ...actual, useNavigate: () => mockNavigate };
+});
+
+import { resetPassword } from "@/services/authService";
+
+const TOKEN = "abc123-token";
+const VALID_PASSWORD = "Password1";
+
+function renderPage({ token = TOKEN } = {}) {
+  const path = token ? `/reset-password?token=${token}` : "/reset-password";
+  return render(
+    <ToastProvider>
+      <MemoryRouter initialEntries={[path]}>
+        <Routes>
+          <Route path="/reset-password" element={<ResetPasswordPage />} />
+        </Routes>
+      </MemoryRouter>
+      <Toaster />
+    </ToastProvider>
+  );
+}
+
+describe("ResetPasswordPage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("shows missing-token state when token query param is absent", () => {
+    renderPage({ token: "" });
+    expect(screen.getByText(/invalid reset link/i)).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: /request a new reset link/i })
+    ).toBeInTheDocument();
+  });
+
+  it("renders form when token is present", () => {
+    renderPage();
+    expect(screen.getByLabelText("New password")).toBeInTheDocument();
+    expect(screen.getByLabelText("Confirm password")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /reset password/i })).toBeInTheDocument();
+  });
+
+  it("shows error when password is empty", async () => {
+    const user = userEvent.setup();
+    renderPage();
+    await user.click(screen.getByRole("button", { name: /reset password/i }));
+    expect(await screen.findByText(/password is required/i)).toBeInTheDocument();
+    expect(resetPassword).not.toHaveBeenCalled();
+  });
+
+  it("validates password strength rules", async () => {
+    const user = userEvent.setup();
+    renderPage();
+    await user.type(screen.getByLabelText("New password"), "weak");
+    await user.type(screen.getByLabelText("Confirm password"), "weak");
+    await user.click(screen.getByRole("button", { name: /reset password/i }));
+    expect(
+      await screen.findByText(/password must be at least 8 characters/i)
+    ).toBeInTheDocument();
+    expect(resetPassword).not.toHaveBeenCalled();
+  });
+
+  it("shows error when passwords do not match", async () => {
+    const user = userEvent.setup();
+    renderPage();
+    await user.type(screen.getByLabelText("New password"), VALID_PASSWORD);
+    await user.type(screen.getByLabelText("Confirm password"), "DifferentPwd1");
+    await user.click(screen.getByRole("button", { name: /reset password/i }));
+    expect(
+      await screen.findByText(/passwords do not match/i)
+    ).toBeInTheDocument();
+    expect(resetPassword).not.toHaveBeenCalled();
+  });
+
+  it("calls resetPassword with token, password, confirmation on valid submit", async () => {
+    const user = userEvent.setup();
+    resetPassword.mockResolvedValue({ message: "ok" });
+    renderPage();
+    await user.type(screen.getByLabelText("New password"), VALID_PASSWORD);
+    await user.type(screen.getByLabelText("Confirm password"), VALID_PASSWORD);
+    await user.click(screen.getByRole("button", { name: /reset password/i }));
+    await waitFor(() => {
+      expect(resetPassword).toHaveBeenCalledWith(TOKEN, VALID_PASSWORD, VALID_PASSWORD);
+    });
+  });
+
+  it("navigates to /login and shows success toast on success", async () => {
+    const user = userEvent.setup();
+    resetPassword.mockResolvedValue({ message: "ok" });
+    renderPage();
+    await user.type(screen.getByLabelText("New password"), VALID_PASSWORD);
+    await user.type(screen.getByLabelText("Confirm password"), VALID_PASSWORD);
+    await user.click(screen.getByRole("button", { name: /reset password/i }));
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith("/login", { replace: true });
+    });
+    expect(
+      await screen.findByText(/password reset successfully/i)
+    ).toBeInTheDocument();
+  });
+
+  it("shows expired-token state with link to forgot-password on token error", async () => {
+    const user = userEvent.setup();
+    const error = new Error("bad token");
+    error.response = { status: 400, data: { errors: { token: ["Invalid or expired token."] } } };
+    resetPassword.mockRejectedValue(error);
+    renderPage();
+    await user.type(screen.getByLabelText("New password"), VALID_PASSWORD);
+    await user.type(screen.getByLabelText("Confirm password"), VALID_PASSWORD);
+    await user.click(screen.getByRole("button", { name: /reset password/i }));
+    expect(await screen.findByText(/reset link expired/i)).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: /request a new reset link/i })
+    ).toBeInTheDocument();
+  });
+
+  it("shows backend new_password field error", async () => {
+    const user = userEvent.setup();
+    const error = new Error("bad");
+    error.response = {
+      status: 400,
+      data: { errors: { new_password: ["This password is too common."] } },
+    };
+    resetPassword.mockRejectedValue(error);
+    renderPage();
+    await user.type(screen.getByLabelText("New password"), VALID_PASSWORD);
+    await user.type(screen.getByLabelText("Confirm password"), VALID_PASSWORD);
+    await user.click(screen.getByRole("button", { name: /reset password/i }));
+    expect(
+      await screen.findByText(/this password is too common/i)
+    ).toBeInTheDocument();
+  });
+
+  it("shows loading state during submission", async () => {
+    const user = userEvent.setup();
+    resetPassword.mockReturnValue(new Promise(() => {}));
+    renderPage();
+    await user.type(screen.getByLabelText("New password"), VALID_PASSWORD);
+    await user.type(screen.getByLabelText("Confirm password"), VALID_PASSWORD);
+    await user.click(screen.getByRole("button", { name: /reset password/i }));
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: /resetting/i })).toBeDisabled();
+    });
+  });
+});

--- a/frontend/src/services/__tests__/authService.test.js
+++ b/frontend/src/services/__tests__/authService.test.js
@@ -10,7 +10,7 @@ vi.mock("../tokenStore", () => ({
   clear: vi.fn(),
 }));
 
-import { login, register, logout } from "../authService";
+import { login, register, logout, forgotPassword, resetPassword } from "../authService";
 import { setAccessToken, setRefreshToken, getRefreshToken, clear } from "../tokenStore";
 
 describe("authService", () => {
@@ -96,6 +96,38 @@ describe("authService", () => {
       await logout();
 
       expect(clear).toHaveBeenCalled();
+    });
+  });
+
+  describe("forgotPassword", () => {
+    it("posts email to /auth/password-reset/", async () => {
+      axios.post.mockResolvedValue({ data: { message: "ok" } });
+
+      const result = await forgotPassword("test@example.com");
+
+      expect(axios.post).toHaveBeenCalledWith(
+        expect.stringContaining("/auth/password-reset/"),
+        { email: "test@example.com" }
+      );
+      expect(result).toEqual({ message: "ok" });
+    });
+  });
+
+  describe("resetPassword", () => {
+    it("posts token and new_password fields to /auth/password-reset/confirm/", async () => {
+      axios.post.mockResolvedValue({ data: { message: "ok" } });
+
+      const result = await resetPassword("token-uuid", "Password1", "Password1");
+
+      expect(axios.post).toHaveBeenCalledWith(
+        expect.stringContaining("/auth/password-reset/confirm/"),
+        {
+          token: "token-uuid",
+          new_password: "Password1",
+          new_password_confirmation: "Password1",
+        }
+      );
+      expect(result).toEqual({ message: "ok" });
     });
   });
 });

--- a/frontend/src/services/authService.js
+++ b/frontend/src/services/authService.js
@@ -31,3 +31,17 @@ export async function logout() {
     clear();
   }
 }
+
+export async function forgotPassword(email) {
+  const response = await axios.post(`${API_URL}/auth/password-reset/`, { email });
+  return response.data;
+}
+
+export async function resetPassword(token, newPassword, newPasswordConfirmation) {
+  const response = await axios.post(`${API_URL}/auth/password-reset/confirm/`, {
+    token,
+    new_password: newPassword,
+    new_password_confirmation: newPasswordConfirmation,
+  });
+  return response.data;
+}


### PR DESCRIPTION
# Description
Fixes #180

Adds the complete account-recovery flow for users who forget their password.

## What's added
- **`pages/ForgotPasswordPage.jsx`** at `/forgot-password` — email input that calls `POST /auth/password-reset/`. After submit, replaces the form with a generic confirmation ("If an account exists with this email…") that does not reveal whether the email is registered.
- **`pages/ResetPasswordPage.jsx`** at `/reset-password` — reads the token from the URL query string, shows new/confirm password fields with the same strength rules as registration (8+ chars, upper, lower, number), and submits to `POST /auth/password-reset/confirm/`. Has dedicated states for missing token and invalid/expired token, both linking back to `/forgot-password`. On success it shows a success toast and redirects to `/login`.
- **`services/authService.js`** — `forgotPassword(email)` and `resetPassword(token, newPassword, newPasswordConfirmation)` aligned with the actual backend serializer (`new_password` + `new_password_confirmation`).
- **`pages/LoginPage.jsx`** — new "Forgot your password?" link below the password field.
- **Routes** wired into `App.jsx`.
- **Unit tests** for both pages, the new service methods, and the new login link.

## Backend Context (informational, not a change request)
- Backend already exposes both endpoints: `POST /auth/password-reset/` and `POST /auth/password-reset/confirm/` (`apps/users/views.py:208-239`, `apps/users/urls.py`).
- The frontend uses these actual paths rather than the `/auth/forgot-password` and `/auth/reset-password` names mentioned in the issue body, so no backend changes are needed.
- `PasswordResetConfirmSerializer` requires both `new_password` and `new_password_confirmation`; the frontend service sends both.

# Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Refactoring
- [ ] Documentation

# Acceptance Criteria / Checklist
- [x] Project builds successfully
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, especially in hard-to-understand parts
- [x] I have performed a self-review of my code
- [x] I have added/updated tests
- [x] New and existing unit tests pass locally with my changes

# Screenshots / Recordings
<!-- N/A — flow validated via unit tests. -->

# Estimated Review Time
- [ ] < 5 min
- [x] 5-15 min
- [ ] > 15 min