### PR TITLE
Feat/mobile auto zoom

### DIFF
--- a/mobile/jest.setup.ts
+++ b/mobile/jest.setup.ts
@@ -89,8 +89,13 @@ jest.mock('react-native-webview', () => {
   const React = require('react');
   const { View } = require('react-native');
 
-  const MockWebView = ({ children, ...props }: { children?: React.ReactNode }) =>
-    React.createElement(View, props, children);
+  const MockWebView = React.forwardRef(({ children, ...props }: { children?: React.ReactNode }, ref: React.Ref<unknown>) => {
+    React.useImperativeHandle(ref, () => ({
+      injectJavaScript: jest.fn(),
+    }));
+
+    return React.createElement(View, props, children);
+  });
 
   return {
     __esModule: true,

--- a/mobile/src/app/navigation/RootNavigator.tsx
+++ b/mobile/src/app/navigation/RootNavigator.tsx
@@ -193,6 +193,8 @@ function ScreenShell({
   fillContent = false,
   hideHeader = false,
   active = false,
+  scrollEnabled = true,
+  testID,
   preservedScrollY = 0,
   onScrollOffsetChange,
 }: {
@@ -209,6 +211,8 @@ function ScreenShell({
   fillContent?: boolean;
   hideHeader?: boolean;
   active?: boolean;
+  scrollEnabled?: boolean;
+  testID?: string;
   preservedScrollY?: number;
   onScrollOffsetChange?: (y: number) => void;
 }) {
@@ -292,9 +296,11 @@ function ScreenShell({
     return (
       <ScrollView
         ref={scrollViewRef}
+        testID={testID}
         style={{ flex: 1, backgroundColor: colors.background }}
         contentContainerStyle={{ padding: spacing.lg, paddingBottom: spacing.xl }}
         showsVerticalScrollIndicator={false}
+        scrollEnabled={scrollEnabled}
         scrollEventThrottle={16}
         refreshControl={
           refreshHandler ? (
@@ -328,6 +334,7 @@ export function RootNavigator() {
   const [feedSort, setFeedSort] = useState<FeedSortOption>('recent');
   const [storyInteractionUpdates, setStoryInteractionUpdates] = useState<Record<string, FeedStoryInteractionUpdate>>({});
   const [unreadNotificationCount, setUnreadNotificationCount] = useState(0);
+  const [isMapGestureActive, setIsMapGestureActive] = useState(false);
   const [hasResolvedInitialSession, setHasResolvedInitialSession] = useState(false);
   const [backStack, setBackStack] = useState<RouteSnapshot[]>([]);
   const pagerRef = useRef<ScrollView>(null);
@@ -718,6 +725,7 @@ export function RootNavigator() {
           testID="main-route-pager"
           horizontal
           pagingEnabled
+          scrollEnabled={!isMapGestureActive}
           contentOffset={{ x: currentRoute === ROUTES.MAP ? 0 : width, y: 0 }}
           showsHorizontalScrollIndicator={false}
           scrollEventThrottle={16}
@@ -738,6 +746,8 @@ export function RootNavigator() {
               scrollable
               hideHeader
               active={currentRoute === ROUTES.MAP}
+              scrollEnabled={!isMapGestureActive}
+              testID="map-route-scroll"
               preservedScrollY={mapScrollOffsetRef.current}
               onScrollOffsetChange={(y) => {
                 mapScrollOffsetRef.current = y;
@@ -747,6 +757,7 @@ export function RootNavigator() {
                 <MapScreen
                   onOpenStory={handleOpenStoryDetail}
                   onMarkerPreviewRequested={(targetY) => scrollTo(targetY)}
+                  onMapGestureActiveChange={setIsMapGestureActive}
                   showSearchControls={false}
                   onRegisterRefresh={registerRefreshHandler}
                   searchScope="main"

--- a/mobile/src/app/navigation/RootNavigator.tsx
+++ b/mobile/src/app/navigation/RootNavigator.tsx
@@ -768,7 +768,6 @@ export function RootNavigator() {
           horizontal
           pagingEnabled
           canCancelContentTouches={currentRoute !== ROUTES.MAP}
-          contentOffset={{ x: currentRoute === ROUTES.MAP ? 0 : width, y: 0 }}
           directionalLockEnabled
           keyboardDismissMode="on-drag"
           keyboardShouldPersistTaps="handled"

--- a/mobile/src/app/navigation/RootNavigator.tsx
+++ b/mobile/src/app/navigation/RootNavigator.tsx
@@ -195,6 +195,7 @@ function ScreenShell({
   active = false,
   disableScrollViewPanResponder = false,
   scrollEnabled = true,
+  externalScrollViewRef,
   testID,
   preservedScrollY = 0,
   onScrollOffsetChange,
@@ -214,12 +215,14 @@ function ScreenShell({
   active?: boolean;
   disableScrollViewPanResponder?: boolean;
   scrollEnabled?: boolean;
+  externalScrollViewRef?: React.MutableRefObject<ScrollView | null>;
   testID?: string;
   preservedScrollY?: number;
   onScrollOffsetChange?: (y: number) => void;
 }) {
   const { colors, spacing, typography } = useAppTheme();
-  const scrollViewRef = useRef<ScrollView>(null);
+  const internalScrollViewRef = useRef<ScrollView | null>(null);
+  const scrollViewRef = externalScrollViewRef ?? internalScrollViewRef;
   const [refreshHandler, setRefreshHandler] = useState<(() => Promise<void>) | null>(null);
   const [isRefreshing, setIsRefreshing] = useState(false);
   const scrollTo = useCallback(
@@ -337,9 +340,11 @@ export function RootNavigator() {
   const [feedSort, setFeedSort] = useState<FeedSortOption>('recent');
   const [storyInteractionUpdates, setStoryInteractionUpdates] = useState<Record<string, FeedStoryInteractionUpdate>>({});
   const [unreadNotificationCount, setUnreadNotificationCount] = useState(0);
+  const [isMapGestureActive, setIsMapGestureActive] = useState(false);
   const [hasResolvedInitialSession, setHasResolvedInitialSession] = useState(false);
   const [backStack, setBackStack] = useState<RouteSnapshot[]>([]);
-  const pagerRef = useRef<ScrollView>(null);
+  const pagerRef = useRef<ScrollView | null>(null);
+  const mapRouteScrollRef = useRef<ScrollView>(null);
   const mapScrollOffsetRef = useRef(0);
 
   const currentSnapshot = useMemo<RouteSnapshot>(
@@ -414,6 +419,25 @@ export function RootNavigator() {
     },
     [currentSnapshot, restoreSnapshot],
   );
+
+  const setMapParentScrollEnabled = useCallback((enabled: boolean) => {
+    pagerRef.current?.setNativeProps({ scrollEnabled: enabled });
+    mapRouteScrollRef.current?.setNativeProps({ scrollEnabled: enabled });
+  }, []);
+
+  const handleMapGestureActiveChange = useCallback(
+    (active: boolean) => {
+      setMapParentScrollEnabled(!active);
+      setIsMapGestureActive(active);
+    },
+    [setMapParentScrollEnabled],
+  );
+
+  useEffect(() => {
+    if (currentRoute !== ROUTES.MAP) {
+      handleMapGestureActiveChange(false);
+    }
+  }, [currentRoute, handleMapGestureActiveChange]);
 
   const handleBack = useCallback(() => {
     setBackStack((current) => {
@@ -727,8 +751,8 @@ export function RootNavigator() {
           testID="main-route-pager"
           horizontal
           pagingEnabled
-          disableScrollViewPanResponder={currentRoute === ROUTES.MAP}
-          scrollEnabled={currentRoute !== ROUTES.MAP}
+          disableScrollViewPanResponder={isMapGestureActive}
+          scrollEnabled={!isMapGestureActive}
           contentOffset={{ x: currentRoute === ROUTES.MAP ? 0 : width, y: 0 }}
           showsHorizontalScrollIndicator={false}
           scrollEventThrottle={16}
@@ -749,8 +773,9 @@ export function RootNavigator() {
               scrollable
               hideHeader
               active={currentRoute === ROUTES.MAP}
-              disableScrollViewPanResponder={currentRoute === ROUTES.MAP}
-              scrollEnabled={currentRoute !== ROUTES.MAP}
+              disableScrollViewPanResponder={isMapGestureActive}
+              scrollEnabled={!isMapGestureActive}
+              externalScrollViewRef={mapRouteScrollRef}
               testID="map-route-scroll"
               preservedScrollY={mapScrollOffsetRef.current}
               onScrollOffsetChange={(y) => {
@@ -761,6 +786,7 @@ export function RootNavigator() {
                 <MapScreen
                   onOpenStory={handleOpenStoryDetail}
                   onMarkerPreviewRequested={(targetY) => scrollTo(targetY)}
+                  onMapGestureActiveChange={handleMapGestureActiveChange}
                   showSearchControls={false}
                   onRegisterRefresh={registerRefreshHandler}
                   searchScope="main"

--- a/mobile/src/app/navigation/RootNavigator.tsx
+++ b/mobile/src/app/navigation/RootNavigator.tsx
@@ -725,7 +725,7 @@ export function RootNavigator() {
           testID="main-route-pager"
           horizontal
           pagingEnabled
-          scrollEnabled={!isMapGestureActive}
+          scrollEnabled={currentRoute !== ROUTES.MAP && !isMapGestureActive}
           contentOffset={{ x: currentRoute === ROUTES.MAP ? 0 : width, y: 0 }}
           showsHorizontalScrollIndicator={false}
           scrollEventThrottle={16}
@@ -746,7 +746,7 @@ export function RootNavigator() {
               scrollable
               hideHeader
               active={currentRoute === ROUTES.MAP}
-              scrollEnabled={!isMapGestureActive}
+              scrollEnabled={false}
               testID="map-route-scroll"
               preservedScrollY={mapScrollOffsetRef.current}
               onScrollOffsetChange={(y) => {

--- a/mobile/src/app/navigation/RootNavigator.tsx
+++ b/mobile/src/app/navigation/RootNavigator.tsx
@@ -195,7 +195,7 @@ function ScreenShell({
   active = false,
   disableScrollViewPanResponder = false,
   scrollEnabled = true,
-  externalScrollViewRef,
+  canCancelContentTouches = true,
   testID,
   preservedScrollY = 0,
   onScrollOffsetChange,
@@ -215,14 +215,13 @@ function ScreenShell({
   active?: boolean;
   disableScrollViewPanResponder?: boolean;
   scrollEnabled?: boolean;
-  externalScrollViewRef?: React.MutableRefObject<ScrollView | null>;
+  canCancelContentTouches?: boolean;
   testID?: string;
   preservedScrollY?: number;
   onScrollOffsetChange?: (y: number) => void;
 }) {
   const { colors, spacing, typography } = useAppTheme();
-  const internalScrollViewRef = useRef<ScrollView | null>(null);
-  const scrollViewRef = externalScrollViewRef ?? internalScrollViewRef;
+  const scrollViewRef = useRef<ScrollView>(null);
   const [refreshHandler, setRefreshHandler] = useState<(() => Promise<void>) | null>(null);
   const [isRefreshing, setIsRefreshing] = useState(false);
   const scrollTo = useCallback(
@@ -307,6 +306,7 @@ function ScreenShell({
         showsVerticalScrollIndicator={false}
         disableScrollViewPanResponder={disableScrollViewPanResponder}
         scrollEnabled={scrollEnabled}
+        canCancelContentTouches={canCancelContentTouches}
         scrollEventThrottle={16}
         refreshControl={
           refreshHandler ? (
@@ -340,11 +340,9 @@ export function RootNavigator() {
   const [feedSort, setFeedSort] = useState<FeedSortOption>('recent');
   const [storyInteractionUpdates, setStoryInteractionUpdates] = useState<Record<string, FeedStoryInteractionUpdate>>({});
   const [unreadNotificationCount, setUnreadNotificationCount] = useState(0);
-  const [isMapGestureActive, setIsMapGestureActive] = useState(false);
   const [hasResolvedInitialSession, setHasResolvedInitialSession] = useState(false);
   const [backStack, setBackStack] = useState<RouteSnapshot[]>([]);
-  const pagerRef = useRef<ScrollView | null>(null);
-  const mapRouteScrollRef = useRef<ScrollView>(null);
+  const pagerRef = useRef<ScrollView>(null);
   const mapScrollOffsetRef = useRef(0);
 
   const currentSnapshot = useMemo<RouteSnapshot>(
@@ -419,25 +417,6 @@ export function RootNavigator() {
     },
     [currentSnapshot, restoreSnapshot],
   );
-
-  const setMapParentScrollEnabled = useCallback((enabled: boolean) => {
-    pagerRef.current?.setNativeProps({ scrollEnabled: enabled });
-    mapRouteScrollRef.current?.setNativeProps({ scrollEnabled: enabled });
-  }, []);
-
-  const handleMapGestureActiveChange = useCallback(
-    (active: boolean) => {
-      setMapParentScrollEnabled(!active);
-      setIsMapGestureActive(active);
-    },
-    [setMapParentScrollEnabled],
-  );
-
-  useEffect(() => {
-    if (currentRoute !== ROUTES.MAP) {
-      handleMapGestureActiveChange(false);
-    }
-  }, [currentRoute, handleMapGestureActiveChange]);
 
   const handleBack = useCallback(() => {
     setBackStack((current) => {
@@ -751,8 +730,7 @@ export function RootNavigator() {
           testID="main-route-pager"
           horizontal
           pagingEnabled
-          disableScrollViewPanResponder={isMapGestureActive}
-          scrollEnabled={!isMapGestureActive}
+          canCancelContentTouches={currentRoute !== ROUTES.MAP}
           contentOffset={{ x: currentRoute === ROUTES.MAP ? 0 : width, y: 0 }}
           showsHorizontalScrollIndicator={false}
           scrollEventThrottle={16}
@@ -773,9 +751,7 @@ export function RootNavigator() {
               scrollable
               hideHeader
               active={currentRoute === ROUTES.MAP}
-              disableScrollViewPanResponder={isMapGestureActive}
-              scrollEnabled={!isMapGestureActive}
-              externalScrollViewRef={mapRouteScrollRef}
+              canCancelContentTouches={false}
               testID="map-route-scroll"
               preservedScrollY={mapScrollOffsetRef.current}
               onScrollOffsetChange={(y) => {
@@ -786,7 +762,6 @@ export function RootNavigator() {
                 <MapScreen
                   onOpenStory={handleOpenStoryDetail}
                   onMarkerPreviewRequested={(targetY) => scrollTo(targetY)}
-                  onMapGestureActiveChange={handleMapGestureActiveChange}
                   showSearchControls={false}
                   onRegisterRefresh={registerRefreshHandler}
                   searchScope="main"

--- a/mobile/src/app/navigation/RootNavigator.tsx
+++ b/mobile/src/app/navigation/RootNavigator.tsx
@@ -193,6 +193,7 @@ function ScreenShell({
   fillContent = false,
   hideHeader = false,
   active = false,
+  disableScrollViewPanResponder = false,
   scrollEnabled = true,
   testID,
   preservedScrollY = 0,
@@ -211,6 +212,7 @@ function ScreenShell({
   fillContent?: boolean;
   hideHeader?: boolean;
   active?: boolean;
+  disableScrollViewPanResponder?: boolean;
   scrollEnabled?: boolean;
   testID?: string;
   preservedScrollY?: number;
@@ -300,6 +302,7 @@ function ScreenShell({
         style={{ flex: 1, backgroundColor: colors.background }}
         contentContainerStyle={{ padding: spacing.lg, paddingBottom: spacing.xl }}
         showsVerticalScrollIndicator={false}
+        disableScrollViewPanResponder={disableScrollViewPanResponder}
         scrollEnabled={scrollEnabled}
         scrollEventThrottle={16}
         refreshControl={
@@ -334,7 +337,6 @@ export function RootNavigator() {
   const [feedSort, setFeedSort] = useState<FeedSortOption>('recent');
   const [storyInteractionUpdates, setStoryInteractionUpdates] = useState<Record<string, FeedStoryInteractionUpdate>>({});
   const [unreadNotificationCount, setUnreadNotificationCount] = useState(0);
-  const [isMapGestureActive, setIsMapGestureActive] = useState(false);
   const [hasResolvedInitialSession, setHasResolvedInitialSession] = useState(false);
   const [backStack, setBackStack] = useState<RouteSnapshot[]>([]);
   const pagerRef = useRef<ScrollView>(null);
@@ -725,7 +727,7 @@ export function RootNavigator() {
           testID="main-route-pager"
           horizontal
           pagingEnabled
-          scrollEnabled={!isMapGestureActive}
+          disableScrollViewPanResponder={currentRoute === ROUTES.MAP}
           contentOffset={{ x: currentRoute === ROUTES.MAP ? 0 : width, y: 0 }}
           showsHorizontalScrollIndicator={false}
           scrollEventThrottle={16}
@@ -746,7 +748,7 @@ export function RootNavigator() {
               scrollable
               hideHeader
               active={currentRoute === ROUTES.MAP}
-              scrollEnabled={!isMapGestureActive}
+              disableScrollViewPanResponder={currentRoute === ROUTES.MAP}
               testID="map-route-scroll"
               preservedScrollY={mapScrollOffsetRef.current}
               onScrollOffsetChange={(y) => {
@@ -757,7 +759,6 @@ export function RootNavigator() {
                 <MapScreen
                   onOpenStory={handleOpenStoryDetail}
                   onMarkerPreviewRequested={(targetY) => scrollTo(targetY)}
-                  onMapGestureActiveChange={setIsMapGestureActive}
                   showSearchControls={false}
                   onRegisterRefresh={registerRefreshHandler}
                   searchScope="main"

--- a/mobile/src/app/navigation/RootNavigator.tsx
+++ b/mobile/src/app/navigation/RootNavigator.tsx
@@ -728,6 +728,7 @@ export function RootNavigator() {
           horizontal
           pagingEnabled
           disableScrollViewPanResponder={currentRoute === ROUTES.MAP}
+          scrollEnabled={currentRoute !== ROUTES.MAP}
           contentOffset={{ x: currentRoute === ROUTES.MAP ? 0 : width, y: 0 }}
           showsHorizontalScrollIndicator={false}
           scrollEventThrottle={16}
@@ -749,6 +750,7 @@ export function RootNavigator() {
               hideHeader
               active={currentRoute === ROUTES.MAP}
               disableScrollViewPanResponder={currentRoute === ROUTES.MAP}
+              scrollEnabled={currentRoute !== ROUTES.MAP}
               testID="map-route-scroll"
               preservedScrollY={mapScrollOffsetRef.current}
               onScrollOffsetChange={(y) => {

--- a/mobile/src/app/navigation/RootNavigator.tsx
+++ b/mobile/src/app/navigation/RootNavigator.tsx
@@ -725,7 +725,7 @@ export function RootNavigator() {
           testID="main-route-pager"
           horizontal
           pagingEnabled
-          scrollEnabled={currentRoute !== ROUTES.MAP && !isMapGestureActive}
+          scrollEnabled={!isMapGestureActive}
           contentOffset={{ x: currentRoute === ROUTES.MAP ? 0 : width, y: 0 }}
           showsHorizontalScrollIndicator={false}
           scrollEventThrottle={16}
@@ -746,7 +746,7 @@ export function RootNavigator() {
               scrollable
               hideHeader
               active={currentRoute === ROUTES.MAP}
-              scrollEnabled={false}
+              scrollEnabled={!isMapGestureActive}
               testID="map-route-scroll"
               preservedScrollY={mapScrollOffsetRef.current}
               onScrollOffsetChange={(y) => {

--- a/mobile/src/app/navigation/__tests__/RootNavigator.test.tsx
+++ b/mobile/src/app/navigation/__tests__/RootNavigator.test.tsx
@@ -367,22 +367,19 @@ describe('RootNavigator auth flow', () => {
     });
   });
 
-  it('disables parent scrolling while the map is being touched', async () => {
+  it('lets the map own pan gestures without disabling scroll APIs', async () => {
     renderNavigator();
 
     await screen.findByLabelText('Map');
     fireEvent.press(screen.getByLabelText('Map'));
 
     const mapView = await screen.findByTestId('web-map-view');
-    fireEvent(mapView, 'touchStart');
+    expect(mapView.props.onTouchStart).toBeUndefined();
 
-    expect(screen.getByTestId('main-route-pager').props.scrollEnabled).toBe(false);
-    expect(screen.getByTestId('map-route-scroll').props.scrollEnabled).toBe(false);
-
-    fireEvent(mapView, 'touchEnd');
-
-    expect(screen.getByTestId('main-route-pager').props.scrollEnabled).toBe(true);
+    expect(screen.getByTestId('main-route-pager').props.scrollEnabled).not.toBe(false);
+    expect(screen.getByTestId('main-route-pager').props.disableScrollViewPanResponder).toBe(true);
     expect(screen.getByTestId('map-route-scroll').props.scrollEnabled).toBe(true);
+    expect(screen.getByTestId('map-route-scroll').props.disableScrollViewPanResponder).toBe(true);
   });
 
   it('shows only the StoryMap brand in the main header', async () => {

--- a/mobile/src/app/navigation/__tests__/RootNavigator.test.tsx
+++ b/mobile/src/app/navigation/__tests__/RootNavigator.test.tsx
@@ -367,6 +367,24 @@ describe('RootNavigator auth flow', () => {
     });
   });
 
+  it('disables parent scrolling while the map is being touched', async () => {
+    renderNavigator();
+
+    await screen.findByLabelText('Map');
+    fireEvent.press(screen.getByLabelText('Map'));
+
+    const mapView = await screen.findByTestId('web-map-view');
+    fireEvent(mapView, 'touchStart');
+
+    expect(screen.getByTestId('main-route-pager').props.scrollEnabled).toBe(false);
+    expect(screen.getByTestId('map-route-scroll').props.scrollEnabled).toBe(false);
+
+    fireEvent(mapView, 'touchEnd');
+
+    expect(screen.getByTestId('main-route-pager').props.scrollEnabled).toBe(true);
+    expect(screen.getByTestId('map-route-scroll').props.scrollEnabled).toBe(true);
+  });
+
   it('shows only the StoryMap brand in the main header', async () => {
     renderNavigator();
 

--- a/mobile/src/app/navigation/__tests__/RootNavigator.test.tsx
+++ b/mobile/src/app/navigation/__tests__/RootNavigator.test.tsx
@@ -367,7 +367,7 @@ describe('RootNavigator auth flow', () => {
     });
   });
 
-  it('prevents parent scroll views from stealing map gestures', async () => {
+  it('prevents parent scroll views from stealing touches only while the map is touched', async () => {
     renderNavigator();
 
     await screen.findByLabelText('Map');
@@ -376,10 +376,28 @@ describe('RootNavigator auth flow', () => {
     const mapView = await screen.findByTestId('web-map-view');
     expect(mapView.props.onTouchStart).toBeUndefined();
 
-    expect(screen.getByTestId('main-route-pager').props.scrollEnabled).toBe(false);
-    expect(screen.getByTestId('main-route-pager').props.disableScrollViewPanResponder).toBe(true);
-    expect(screen.getByTestId('map-route-scroll').props.scrollEnabled).toBe(false);
-    expect(screen.getByTestId('map-route-scroll').props.disableScrollViewPanResponder).toBe(true);
+    expect(screen.getByTestId('main-route-pager').props.scrollEnabled).toBe(true);
+    expect(screen.getByTestId('map-route-scroll').props.scrollEnabled).toBe(true);
+
+    fireEvent(screen.getByTestId('interactive-map-touch-area'), 'touchStart', {
+      nativeEvent: { touches: [{}] },
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('main-route-pager').props.scrollEnabled).toBe(false);
+      expect(screen.getByTestId('main-route-pager').props.disableScrollViewPanResponder).toBe(true);
+      expect(screen.getByTestId('map-route-scroll').props.scrollEnabled).toBe(false);
+      expect(screen.getByTestId('map-route-scroll').props.disableScrollViewPanResponder).toBe(true);
+    });
+
+    fireEvent(screen.getByTestId('interactive-map-touch-area'), 'touchEnd', {
+      nativeEvent: { touches: [] },
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('main-route-pager').props.scrollEnabled).toBe(true);
+      expect(screen.getByTestId('map-route-scroll').props.scrollEnabled).toBe(true);
+    });
   });
 
   it('shows only the StoryMap brand in the main header', async () => {

--- a/mobile/src/app/navigation/__tests__/RootNavigator.test.tsx
+++ b/mobile/src/app/navigation/__tests__/RootNavigator.test.tsx
@@ -367,11 +367,14 @@ describe('RootNavigator auth flow', () => {
     });
   });
 
-  it('disables parent scrolling while the map is being touched', async () => {
+  it('keeps parent scrolling disabled on the map tab', async () => {
     renderNavigator();
 
     await screen.findByLabelText('Map');
     fireEvent.press(screen.getByLabelText('Map'));
+
+    expect(screen.getByTestId('main-route-pager').props.scrollEnabled).toBe(false);
+    expect(screen.getByTestId('map-route-scroll').props.scrollEnabled).toBe(false);
 
     const mapView = await screen.findByTestId('web-map-view');
     fireEvent(mapView, 'touchStart');
@@ -381,8 +384,8 @@ describe('RootNavigator auth flow', () => {
 
     fireEvent(mapView, 'touchEnd');
 
-    expect(screen.getByTestId('main-route-pager').props.scrollEnabled).toBe(true);
-    expect(screen.getByTestId('map-route-scroll').props.scrollEnabled).toBe(true);
+    expect(screen.getByTestId('main-route-pager').props.scrollEnabled).toBe(false);
+    expect(screen.getByTestId('map-route-scroll').props.scrollEnabled).toBe(false);
   });
 
   it('shows only the StoryMap brand in the main header', async () => {

--- a/mobile/src/app/navigation/__tests__/RootNavigator.test.tsx
+++ b/mobile/src/app/navigation/__tests__/RootNavigator.test.tsx
@@ -367,7 +367,7 @@ describe('RootNavigator auth flow', () => {
     });
   });
 
-  it('lets the map own pan gestures without disabling scroll APIs', async () => {
+  it('prevents parent scroll views from stealing map gestures', async () => {
     renderNavigator();
 
     await screen.findByLabelText('Map');
@@ -376,9 +376,9 @@ describe('RootNavigator auth flow', () => {
     const mapView = await screen.findByTestId('web-map-view');
     expect(mapView.props.onTouchStart).toBeUndefined();
 
-    expect(screen.getByTestId('main-route-pager').props.scrollEnabled).not.toBe(false);
+    expect(screen.getByTestId('main-route-pager').props.scrollEnabled).toBe(false);
     expect(screen.getByTestId('main-route-pager').props.disableScrollViewPanResponder).toBe(true);
-    expect(screen.getByTestId('map-route-scroll').props.scrollEnabled).toBe(true);
+    expect(screen.getByTestId('map-route-scroll').props.scrollEnabled).toBe(false);
     expect(screen.getByTestId('map-route-scroll').props.disableScrollViewPanResponder).toBe(true);
   });
 

--- a/mobile/src/app/navigation/__tests__/RootNavigator.test.tsx
+++ b/mobile/src/app/navigation/__tests__/RootNavigator.test.tsx
@@ -367,14 +367,11 @@ describe('RootNavigator auth flow', () => {
     });
   });
 
-  it('keeps parent scrolling disabled on the map tab', async () => {
+  it('disables parent scrolling while the map is being touched', async () => {
     renderNavigator();
 
     await screen.findByLabelText('Map');
     fireEvent.press(screen.getByLabelText('Map'));
-
-    expect(screen.getByTestId('main-route-pager').props.scrollEnabled).toBe(false);
-    expect(screen.getByTestId('map-route-scroll').props.scrollEnabled).toBe(false);
 
     const mapView = await screen.findByTestId('web-map-view');
     fireEvent(mapView, 'touchStart');
@@ -384,8 +381,8 @@ describe('RootNavigator auth flow', () => {
 
     fireEvent(mapView, 'touchEnd');
 
-    expect(screen.getByTestId('main-route-pager').props.scrollEnabled).toBe(false);
-    expect(screen.getByTestId('map-route-scroll').props.scrollEnabled).toBe(false);
+    expect(screen.getByTestId('main-route-pager').props.scrollEnabled).toBe(true);
+    expect(screen.getByTestId('map-route-scroll').props.scrollEnabled).toBe(true);
   });
 
   it('shows only the StoryMap brand in the main header', async () => {

--- a/mobile/src/app/navigation/__tests__/RootNavigator.test.tsx
+++ b/mobile/src/app/navigation/__tests__/RootNavigator.test.tsx
@@ -367,7 +367,7 @@ describe('RootNavigator auth flow', () => {
     });
   });
 
-  it('prevents parent scroll views from stealing touches only while the map is touched', async () => {
+  it('keeps parent scrolling available while preserving map child touches', async () => {
     renderNavigator();
 
     await screen.findByLabelText('Map');
@@ -376,28 +376,11 @@ describe('RootNavigator auth flow', () => {
     const mapView = await screen.findByTestId('web-map-view');
     expect(mapView.props.onTouchStart).toBeUndefined();
 
-    expect(screen.getByTestId('main-route-pager').props.scrollEnabled).toBe(true);
+    expect(screen.getByTestId('interactive-map-touch-area').props.onTouchStart).toBeUndefined();
+    expect(screen.getByTestId('main-route-pager').props.scrollEnabled).not.toBe(false);
+    expect(screen.getByTestId('main-route-pager').props.canCancelContentTouches).toBe(false);
     expect(screen.getByTestId('map-route-scroll').props.scrollEnabled).toBe(true);
-
-    fireEvent(screen.getByTestId('interactive-map-touch-area'), 'touchStart', {
-      nativeEvent: { touches: [{}] },
-    });
-
-    await waitFor(() => {
-      expect(screen.getByTestId('main-route-pager').props.scrollEnabled).toBe(false);
-      expect(screen.getByTestId('main-route-pager').props.disableScrollViewPanResponder).toBe(true);
-      expect(screen.getByTestId('map-route-scroll').props.scrollEnabled).toBe(false);
-      expect(screen.getByTestId('map-route-scroll').props.disableScrollViewPanResponder).toBe(true);
-    });
-
-    fireEvent(screen.getByTestId('interactive-map-touch-area'), 'touchEnd', {
-      nativeEvent: { touches: [] },
-    });
-
-    await waitFor(() => {
-      expect(screen.getByTestId('main-route-pager').props.scrollEnabled).toBe(true);
-      expect(screen.getByTestId('map-route-scroll').props.scrollEnabled).toBe(true);
-    });
+    expect(screen.getByTestId('map-route-scroll').props.canCancelContentTouches).toBe(false);
   });
 
   it('shows only the StoryMap brand in the main header', async () => {

--- a/mobile/src/features/map/presentation/components/MapCard.tsx
+++ b/mobile/src/features/map/presentation/components/MapCard.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useMemo } from 'react';
 import { ActivityIndicator, LayoutChangeEvent, Pressable, ScrollView, Text, View } from 'react-native';
 import { Region } from 'react-native-maps';
 import { useAppTheme } from '../../../../core/hooks/useAppTheme';
@@ -37,11 +37,17 @@ export function MapCard({
 }: MapCardProps) {
   const { colors, spacing, typography } = useAppTheme();
   const selectedMarker = selectedMarkerId ? markers.find((marker) => marker.id === selectedMarkerId) : undefined;
-  const [currentRegion, setCurrentRegion] = useState(region);
-
-  useEffect(() => {
-    setCurrentRegion((current) => (regionsEqual(current, region) ? current : region));
-  }, [region]);
+  const mapMarkers = useMemo(
+    () =>
+      markers.map((marker) => ({
+        id: marker.id,
+        latitude: marker.latitude,
+        longitude: marker.longitude,
+        selected: marker.id === selectedMarkerId,
+        label: marker.isCluster ? String(marker.count) : undefined,
+      })),
+    [markers, selectedMarkerId],
+  );
 
   return (
     <View
@@ -58,16 +64,10 @@ export function MapCard({
         style={{ height: 420 }}
       >
         <WebMapView
-          region={currentRegion}
+          region={region}
           userLocation={userLocation}
           transitionDurationMs={450}
-          markers={markers.map((marker) => ({
-            id: marker.id,
-            latitude: marker.latitude,
-            longitude: marker.longitude,
-            selected: marker.id === selectedMarkerId,
-            label: marker.isCluster ? String(marker.count) : undefined,
-          }))}
+          markers={mapMarkers}
           onMarkerPress={(markerId) => {
             onSelectMarker(markerId);
           }}
@@ -209,13 +209,4 @@ function truncatePreview(value: string) {
   }
 
   return `${value.slice(0, PREVIEW_MAX_LENGTH - 1).trim()}...`;
-}
-
-function regionsEqual(left: Region, right: Region) {
-  return (
-    left.latitude === right.latitude &&
-    left.longitude === right.longitude &&
-    left.latitudeDelta === right.latitudeDelta &&
-    left.longitudeDelta === right.longitudeDelta
-  );
 }

--- a/mobile/src/features/map/presentation/components/MapCard.tsx
+++ b/mobile/src/features/map/presentation/components/MapCard.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { ActivityIndicator, GestureResponderEvent, LayoutChangeEvent, Pressable, ScrollView, Text, View } from 'react-native';
+import { ActivityIndicator, LayoutChangeEvent, Pressable, ScrollView, Text, View } from 'react-native';
 import { Region } from 'react-native-maps';
 import { useAppTheme } from '../../../../core/hooks/useAppTheme';
 import { Button } from '../../../../shared/ui/Button';
@@ -16,7 +16,6 @@ interface MapCardProps {
   userLocation?: { latitude: number; longitude: number };
   onSelectMarker: (markerId: string) => void;
   onOpenStory: (storyId: string) => void;
-  onMapGestureActiveChange?: (active: boolean) => void;
   onRegionChangeComplete?: (region: Region) => void;
   onPreviewLayout?: (event: LayoutChangeEvent) => void;
 }
@@ -32,7 +31,6 @@ export function MapCard({
   userLocation,
   onSelectMarker,
   onOpenStory,
-  onMapGestureActiveChange,
   onRegionChangeComplete,
   onPreviewLayout,
 }: MapCardProps) {
@@ -43,23 +41,6 @@ export function MapCard({
   useEffect(() => {
     setCurrentRegion((current) => (regionsEqual(current, region) ? current : region));
   }, [region]);
-
-  function handleMapTouchStart() {
-    onMapGestureActiveChange?.(true);
-  }
-
-  function handleMapTouchEnd(event?: GestureResponderEvent) {
-    const remainingTouches = event?.nativeEvent.touches?.length ?? 0;
-
-    if (remainingTouches === 0) {
-      onMapGestureActiveChange?.(false);
-    }
-  }
-
-  function handleMapResponderCapture() {
-    handleMapTouchStart();
-    return false;
-  }
 
   return (
     <View
@@ -74,11 +55,6 @@ export function MapCard({
       <View
         testID="interactive-map-touch-area"
         style={{ height: 420 }}
-        onStartShouldSetResponderCapture={handleMapResponderCapture}
-        onMoveShouldSetResponderCapture={handleMapResponderCapture}
-        onTouchStart={handleMapTouchStart}
-        onTouchEnd={handleMapTouchEnd}
-        onTouchCancel={() => handleMapTouchEnd()}
       >
         <WebMapView
           region={currentRegion}

--- a/mobile/src/features/map/presentation/components/MapCard.tsx
+++ b/mobile/src/features/map/presentation/components/MapCard.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { ActivityIndicator, LayoutChangeEvent, Pressable, ScrollView, Text, View } from 'react-native';
+import { ActivityIndicator, GestureResponderEvent, LayoutChangeEvent, Pressable, ScrollView, Text, View } from 'react-native';
 import { Region } from 'react-native-maps';
 import { useAppTheme } from '../../../../core/hooks/useAppTheme';
 import { Button } from '../../../../shared/ui/Button';
@@ -16,7 +16,7 @@ interface MapCardProps {
   userLocation?: { latitude: number; longitude: number };
   onSelectMarker: (markerId: string) => void;
   onOpenStory: (storyId: string) => void;
-  onMarkerPress?: () => void;
+  onMapGestureActiveChange?: (active: boolean) => void;
   onRegionChangeComplete?: (region: Region) => void;
   onPreviewLayout?: (event: LayoutChangeEvent) => void;
 }
@@ -32,7 +32,7 @@ export function MapCard({
   userLocation,
   onSelectMarker,
   onOpenStory,
-  onMarkerPress,
+  onMapGestureActiveChange,
   onRegionChangeComplete,
   onPreviewLayout,
 }: MapCardProps) {
@@ -44,6 +44,23 @@ export function MapCard({
     setCurrentRegion((current) => (regionsEqual(current, region) ? current : region));
   }, [region]);
 
+  function handleMapTouchStart() {
+    onMapGestureActiveChange?.(true);
+  }
+
+  function handleMapTouchEnd(event?: GestureResponderEvent) {
+    const remainingTouches = event?.nativeEvent.touches?.length ?? 0;
+
+    if (remainingTouches === 0) {
+      onMapGestureActiveChange?.(false);
+    }
+  }
+
+  function handleMapResponderCapture() {
+    handleMapTouchStart();
+    return false;
+  }
+
   return (
     <View
       style={{
@@ -54,7 +71,15 @@ export function MapCard({
         backgroundColor: colors.surface,
       }}
     >
-      <View style={{ height: 420 }}>
+      <View
+        testID="interactive-map-touch-area"
+        style={{ height: 420 }}
+        onStartShouldSetResponderCapture={handleMapResponderCapture}
+        onMoveShouldSetResponderCapture={handleMapResponderCapture}
+        onTouchStart={handleMapTouchStart}
+        onTouchEnd={handleMapTouchEnd}
+        onTouchCancel={() => handleMapTouchEnd()}
+      >
         <WebMapView
           region={currentRegion}
           userLocation={userLocation}
@@ -68,7 +93,6 @@ export function MapCard({
           }))}
           onMarkerPress={(markerId) => {
             onSelectMarker(markerId);
-            onMarkerPress?.();
           }}
           onRegionChangeComplete={onRegionChangeComplete}
         />

--- a/mobile/src/features/map/presentation/components/MapCard.tsx
+++ b/mobile/src/features/map/presentation/components/MapCard.tsx
@@ -13,12 +13,10 @@ interface MapCardProps {
   isLoading?: boolean;
   error?: string;
   statusBadgeText?: string;
-  fitToMarkers?: boolean;
   userLocation?: { latitude: number; longitude: number };
   onSelectMarker: (markerId: string) => void;
   onOpenStory: (storyId: string) => void;
   onMarkerPress?: () => void;
-  onMapGestureActiveChange?: (active: boolean) => void;
   onRegionChangeComplete?: (region: Region) => void;
   onPreviewLayout?: (event: LayoutChangeEvent) => void;
 }
@@ -31,12 +29,10 @@ export function MapCard({
   isLoading = false,
   error,
   statusBadgeText,
-  fitToMarkers = false,
   userLocation,
   onSelectMarker,
   onOpenStory,
   onMarkerPress,
-  onMapGestureActiveChange,
   onRegionChangeComplete,
   onPreviewLayout,
 }: MapCardProps) {
@@ -45,23 +41,8 @@ export function MapCard({
   const [currentRegion, setCurrentRegion] = useState(region);
 
   useEffect(() => {
-    if (fitToMarkers) {
-      setCurrentRegion((current) => (regionsEqual(current, region) ? current : region));
-      return;
-    }
-
-    if (!selectedMarker) {
-      setCurrentRegion((current) => (regionsEqual(current, region) ? current : region));
-      return;
-    }
-
-    setCurrentRegion((current) => ({
-      latitude: selectedMarker.latitude,
-      longitude: selectedMarker.longitude,
-      latitudeDelta: current.latitudeDelta,
-      longitudeDelta: current.longitudeDelta,
-    }));
-  }, [fitToMarkers, region, selectedMarker]);
+    setCurrentRegion((current) => (regionsEqual(current, region) ? current : region));
+  }, [region]);
 
   return (
     <View
@@ -73,12 +54,7 @@ export function MapCard({
         backgroundColor: colors.surface,
       }}
     >
-      <View
-        style={{ height: 420 }}
-        onTouchStart={() => onMapGestureActiveChange?.(true)}
-        onTouchEnd={() => onMapGestureActiveChange?.(false)}
-        onTouchCancel={() => onMapGestureActiveChange?.(false)}
-      >
+      <View style={{ height: 420 }}>
         <WebMapView
           region={currentRegion}
           userLocation={userLocation}
@@ -94,7 +70,6 @@ export function MapCard({
             onSelectMarker(markerId);
             onMarkerPress?.();
           }}
-          onGestureActiveChange={onMapGestureActiveChange}
           onRegionChangeComplete={onRegionChangeComplete}
         />
 

--- a/mobile/src/features/map/presentation/components/MapCard.tsx
+++ b/mobile/src/features/map/presentation/components/MapCard.tsx
@@ -21,6 +21,7 @@ interface MapCardProps {
 }
 
 const PREVIEW_MAX_LENGTH = 140;
+const passivePreviewTextProps = { pointerEvents: 'none' as const };
 export function MapCard({
   region,
   markers,
@@ -151,12 +152,12 @@ export function MapCard({
       </View>
 
       <View testID="story-preview-panel" style={{ padding: spacing.lg, gap: spacing.md }} onLayout={onPreviewLayout}>
-        <Text style={{ color: colors.text, fontSize: typography.subtitle, fontWeight: '800' }}>
+        <Text {...passivePreviewTextProps} style={{ color: colors.text, fontSize: typography.subtitle, fontWeight: '800' }}>
           {selectedMarker?.isCluster ? `${selectedMarker.count} nearby stories` : 'Story preview'}
         </Text>
 
         {!selectedMarker ? (
-          <Text style={{ color: colors.muted }}>
+          <Text {...passivePreviewTextProps} style={{ color: colors.muted }}>
             {markers.length ? 'Select a story marker to preview.' : 'No stories match the current filters.'}
           </Text>
         ) : selectedMarker.isCluster ? (
@@ -179,21 +180,21 @@ export function MapCard({
                   borderColor: colors.border,
                 }}
               >
-                <Text style={{ color: colors.text, fontWeight: '700' }}>{story.title}</Text>
-                <Text style={{ marginTop: spacing.xs, color: colors.muted }}>{story.placeName}</Text>
-                <Text style={{ marginTop: spacing.xs, color: colors.muted }}>{story.timePeriod}</Text>
-                <Text style={{ marginTop: spacing.sm, color: colors.text }}>{truncatePreview(story.previewText)}</Text>
+                <Text {...passivePreviewTextProps} style={{ color: colors.text, fontWeight: '700' }}>{story.title}</Text>
+                <Text {...passivePreviewTextProps} style={{ marginTop: spacing.xs, color: colors.muted }}>{story.placeName}</Text>
+                <Text {...passivePreviewTextProps} style={{ marginTop: spacing.xs, color: colors.muted }}>{story.timePeriod}</Text>
+                <Text {...passivePreviewTextProps} style={{ marginTop: spacing.sm, color: colors.text }}>{truncatePreview(story.previewText)}</Text>
               </Pressable>
             ))}
           </ScrollView>
         ) : (
           <>
-            <Text style={{ color: colors.text, fontSize: typography.subtitle, fontWeight: '700' }}>
+            <Text {...passivePreviewTextProps} style={{ color: colors.text, fontSize: typography.subtitle, fontWeight: '700' }}>
               {selectedMarker.stories[0].title}
             </Text>
-            <Text style={{ color: colors.muted }}>{selectedMarker.stories[0].placeName}</Text>
-            <Text style={{ color: colors.muted }}>{selectedMarker.stories[0].timePeriod}</Text>
-            <Text style={{ color: colors.text }}>{truncatePreview(selectedMarker.stories[0].previewText)}</Text>
+            <Text {...passivePreviewTextProps} style={{ color: colors.muted }}>{selectedMarker.stories[0].placeName}</Text>
+            <Text {...passivePreviewTextProps} style={{ color: colors.muted }}>{selectedMarker.stories[0].timePeriod}</Text>
+            <Text {...passivePreviewTextProps} style={{ color: colors.text }}>{truncatePreview(selectedMarker.stories[0].previewText)}</Text>
             <Button onPress={() => onOpenStory(selectedMarker.stories[0].id)}>Read full story</Button>
           </>
         )}

--- a/mobile/src/features/map/presentation/components/MapCard.tsx
+++ b/mobile/src/features/map/presentation/components/MapCard.tsx
@@ -18,6 +18,7 @@ interface MapCardProps {
   onSelectMarker: (markerId: string) => void;
   onOpenStory: (storyId: string) => void;
   onMarkerPress?: () => void;
+  onMapGestureActiveChange?: (active: boolean) => void;
   onRegionChangeComplete?: (region: Region) => void;
   onPreviewLayout?: (event: LayoutChangeEvent) => void;
 }
@@ -35,6 +36,7 @@ export function MapCard({
   onSelectMarker,
   onOpenStory,
   onMarkerPress,
+  onMapGestureActiveChange,
   onRegionChangeComplete,
   onPreviewLayout,
 }: MapCardProps) {
@@ -71,7 +73,12 @@ export function MapCard({
         backgroundColor: colors.surface,
       }}
     >
-      <View style={{ height: 420 }}>
+      <View
+        style={{ height: 420 }}
+        onTouchStart={() => onMapGestureActiveChange?.(true)}
+        onTouchEnd={() => onMapGestureActiveChange?.(false)}
+        onTouchCancel={() => onMapGestureActiveChange?.(false)}
+      >
         <WebMapView
           region={currentRegion}
           userLocation={userLocation}
@@ -87,6 +94,7 @@ export function MapCard({
             onSelectMarker(markerId);
             onMarkerPress?.();
           }}
+          onGestureActiveChange={onMapGestureActiveChange}
           onRegionChangeComplete={onRegionChangeComplete}
         />
 

--- a/mobile/src/features/map/presentation/components/MapCard.tsx
+++ b/mobile/src/features/map/presentation/components/MapCard.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { ActivityIndicator, LayoutChangeEvent, Pressable, ScrollView, Text, View } from 'react-native';
 import { Region } from 'react-native-maps';
 import { useAppTheme } from '../../../../core/hooks/useAppTheme';
@@ -41,10 +41,6 @@ export function MapCard({
   const { colors, spacing, typography } = useAppTheme();
   const selectedMarker = selectedMarkerId ? markers.find((marker) => marker.id === selectedMarkerId) : undefined;
   const [currentRegion, setCurrentRegion] = useState(region);
-  const mapContentKey = useMemo(
-    () => (markers.length ? markers.map((marker) => `${marker.id}:${marker.latitude}:${marker.longitude}`).join('|') : 'empty'),
-    [markers],
-  );
 
   useEffect(() => {
     if (fitToMarkers) {
@@ -77,9 +73,9 @@ export function MapCard({
     >
       <View style={{ height: 420 }}>
         <WebMapView
-          key={mapContentKey}
           region={currentRegion}
           userLocation={userLocation}
+          transitionDurationMs={450}
           markers={markers.map((marker) => ({
             id: marker.id,
             latitude: marker.latitude,

--- a/mobile/src/features/map/presentation/screens/MapScreen.tsx
+++ b/mobile/src/features/map/presentation/screens/MapScreen.tsx
@@ -16,7 +16,6 @@ interface MapScreenProps {
   onOpenStory?: (storyId: string) => void;
   getMarkerGroups?: (filters?: StoryFilters) => Promise<MapMarkerGroup[]>;
   onMarkerPreviewRequested?: (targetY: number) => void;
-  onMapGestureActiveChange?: (active: boolean) => void;
   showSearchControls?: boolean;
   onRegisterRefresh?: (handler: (() => Promise<void>) | null) => void;
   searchScope?: SearchFilterScope;
@@ -45,7 +44,6 @@ export function MapScreen({
   onOpenStory,
   getMarkerGroups = mapService.getMarkerGroups,
   onMarkerPreviewRequested,
-  onMapGestureActiveChange,
   showSearchControls = true,
   onRegisterRefresh,
   searchScope = 'map',
@@ -278,7 +276,6 @@ export function MapScreen({
             }
           }}
           onOpenStory={(storyId) => onOpenStory?.(storyId)}
-          onMapGestureActiveChange={onMapGestureActiveChange}
           onRegionChangeComplete={(region) => {
             setMapRegion(region);
             setVisibleRegion(region);

--- a/mobile/src/features/map/presentation/screens/MapScreen.tsx
+++ b/mobile/src/features/map/presentation/screens/MapScreen.tsx
@@ -59,6 +59,7 @@ export function MapScreen({
   const [hasInteractedWithArea, setHasInteractedWithArea] = useState(false);
   const [statusIndicatorMode, setStatusIndicatorMode] = useState<StatusIndicatorMode>('hidden');
   const lastAutoZoomContextKeyRef = useRef<string | null>(null);
+  const loadRequestIdRef = useRef(0);
   const previewOffsetRef = useRef<number | null>(null);
 
   useEffect(() => {
@@ -91,6 +92,9 @@ export function MapScreen({
   const autoZoomContextKey = useMemo(() => buildAutoZoomContextKey(activeFilters), [activeFilters]);
 
   const loadMarkers = React.useCallback(async () => {
+    const requestId = loadRequestIdRef.current + 1;
+    loadRequestIdRef.current = requestId;
+
     setState((current) => ({
       ...current,
       isLoading: true,
@@ -102,6 +106,10 @@ export function MapScreen({
       const markers = await getMarkerGroups(activeFilters);
       const selectedMarkerId = getPreferredMarkerId(markers, activeFilters);
       const nextAutoRegion = getAutoZoomRegion(markers, activeFilters);
+
+      if (requestId !== loadRequestIdRef.current) {
+        return;
+      }
 
       setState({
         isLoading: false,
@@ -116,6 +124,10 @@ export function MapScreen({
         setMapRegion(nextAutoRegion);
       }
     } catch (error) {
+      if (requestId !== loadRequestIdRef.current) {
+        return;
+      }
+
       setState({
         isLoading: false,
         error: error instanceof Error ? error.message || 'Unable to load stories' : 'Unable to load stories',

--- a/mobile/src/features/map/presentation/screens/MapScreen.tsx
+++ b/mobile/src/features/map/presentation/screens/MapScreen.tsx
@@ -16,6 +16,7 @@ interface MapScreenProps {
   onOpenStory?: (storyId: string) => void;
   getMarkerGroups?: (filters?: StoryFilters) => Promise<MapMarkerGroup[]>;
   onMarkerPreviewRequested?: (targetY: number) => void;
+  onMapGestureActiveChange?: (active: boolean) => void;
   showSearchControls?: boolean;
   onRegisterRefresh?: (handler: (() => Promise<void>) | null) => void;
   searchScope?: SearchFilterScope;
@@ -44,6 +45,7 @@ export function MapScreen({
   onOpenStory,
   getMarkerGroups = mapService.getMarkerGroups,
   onMarkerPreviewRequested,
+  onMapGestureActiveChange,
   showSearchControls = true,
   onRegisterRefresh,
   searchScope = 'map',
@@ -89,7 +91,10 @@ export function MapScreen({
       activeFilters.yearTo ||
       activeFilters.radiusKm,
   );
-  const autoZoomContextKey = useMemo(() => buildAutoZoomContextKey(activeFilters), [activeFilters]);
+  const autoZoomContextKey = useMemo(
+    () => `${buildAutoZoomContextKey(activeFilters)}:${refreshToken}`,
+    [activeFilters, refreshToken],
+  );
 
   const loadMarkers = React.useCallback(async () => {
     const requestId = loadRequestIdRef.current + 1;
@@ -266,6 +271,7 @@ export function MapScreen({
           onSelectMarker={(markerId) => setState((current) => ({ ...current, selectedMarkerId: markerId }))}
           onOpenStory={(storyId) => onOpenStory?.(storyId)}
           onMarkerPress={handleMarkerPreviewRequest}
+          onMapGestureActiveChange={onMapGestureActiveChange}
           onRegionChangeComplete={(region) => {
             setMapRegion(region);
             setVisibleRegion(region);

--- a/mobile/src/features/map/presentation/screens/MapScreen.tsx
+++ b/mobile/src/features/map/presentation/screens/MapScreen.tsx
@@ -380,16 +380,16 @@ function buildAutoZoomContextKey(filters: StoryFilters) {
 }
 
 function getAutoZoomRegion(markers: MapMarkerGroup[], filters: StoryFilters): Region | undefined {
-  if (!markers.length) {
-    return undefined;
-  }
-
   if (filters.locationBounds) {
     return getRegionForLocationBounds(filters.locationBounds);
   }
 
   if (filters.latitude !== undefined && filters.longitude !== undefined && filters.radiusKm !== undefined) {
     return getRegionForProximityFilter(filters.latitude, filters.longitude, filters.radiusKm);
+  }
+
+  if (!markers.length) {
+    return undefined;
   }
 
   return getRegionForMarkers(markers);

--- a/mobile/src/features/map/presentation/screens/MapScreen.tsx
+++ b/mobile/src/features/map/presentation/screens/MapScreen.tsx
@@ -32,6 +32,11 @@ const ISTANBUL_REGION: Region = {
 
 const MIN_FIT_DELTA = 0.06;
 const FIT_PADDING_FACTOR = 2.6;
+const MIN_LOCATION_DELTA = 0.02;
+const LOCATION_BOUNDS_PADDING_FACTOR = 1.15;
+const PROXIMITY_PADDING_FACTOR = 2.4;
+const KILOMETERS_PER_LATITUDE_DEGREE = 111;
+const MAX_AUTO_REGION_DELTA = 20;
 type StatusIndicatorMode = 'hidden' | 'filters' | 'area';
 
 export function MapScreen({
@@ -48,10 +53,12 @@ export function MapScreen({
   const debouncedQuery = useDebounce(filters.query, 350);
   const [useImmediateQuery, setUseImmediateQuery] = useState(false);
   const [state, setState] = useState<MapUiState>(() => createInitialMapUiState(initialFilters));
+  const [mapRegion, setMapRegion] = useState<Region>(ISTANBUL_REGION);
   const [mapCardTop, setMapCardTop] = useState(0);
   const [visibleRegion, setVisibleRegion] = useState<Region | undefined>();
   const [hasInteractedWithArea, setHasInteractedWithArea] = useState(false);
   const [statusIndicatorMode, setStatusIndicatorMode] = useState<StatusIndicatorMode>('hidden');
+  const lastAutoZoomContextKeyRef = useRef<string | null>(null);
   const previewOffsetRef = useRef<number | null>(null);
 
   useEffect(() => {
@@ -81,6 +88,7 @@ export function MapScreen({
       activeFilters.yearTo ||
       activeFilters.radiusKm,
   );
+  const autoZoomContextKey = useMemo(() => buildAutoZoomContextKey(activeFilters), [activeFilters]);
 
   const loadMarkers = React.useCallback(async () => {
     setState((current) => ({
@@ -93,6 +101,7 @@ export function MapScreen({
     try {
       const markers = await getMarkerGroups(activeFilters);
       const selectedMarkerId = getPreferredMarkerId(markers, activeFilters);
+      const nextAutoRegion = getAutoZoomRegion(markers, activeFilters);
 
       setState({
         isLoading: false,
@@ -101,6 +110,11 @@ export function MapScreen({
         markers,
         selectedMarkerId,
       });
+
+      if (nextAutoRegion && lastAutoZoomContextKeyRef.current !== autoZoomContextKey) {
+        lastAutoZoomContextKeyRef.current = autoZoomContextKey;
+        setMapRegion(nextAutoRegion);
+      }
     } catch (error) {
       setState({
         isLoading: false,
@@ -110,7 +124,7 @@ export function MapScreen({
         selectedMarkerId: undefined,
       });
     }
-  }, [activeFilters, getMarkerGroups]);
+  }, [activeFilters, autoZoomContextKey, getMarkerGroups]);
 
   useEffect(() => {
     if (!isHydrated) {
@@ -169,10 +183,6 @@ export function MapScreen({
     [state.markers],
   );
 
-  const mapRegion = useMemo(
-    () => getRegionForMarkers(state.markers, ISTANBUL_REGION),
-    [state.markers],
-  );
   const userLocation = filters.proximityRadiusKm && filters.proximityCoordinates ? filters.proximityCoordinates : undefined;
   const fitToMarkers = state.markers.length > 0 && (!state.selectedMarkerId || hasActiveFilters);
 
@@ -245,6 +255,7 @@ export function MapScreen({
           onOpenStory={(storyId) => onOpenStory?.(storyId)}
           onMarkerPress={handleMarkerPreviewRequest}
           onRegionChangeComplete={(region) => {
+            setMapRegion(region);
             setVisibleRegion(region);
             setHasInteractedWithArea(true);
             setStatusIndicatorMode('area');
@@ -336,11 +347,43 @@ function formatStoryCount(count: number) {
   return `${count} ${count === 1 ? 'story' : 'stories'}`;
 }
 
-function getRegionForMarkers(markers: MapMarkerGroup[], fallbackRegion: Region): Region {
+function buildAutoZoomContextKey(filters: StoryFilters) {
+  return JSON.stringify({
+    q: filters.q ?? '',
+    location: filters.location ?? '',
+    locationBounds: filters.locationBounds
+      ? [
+          filters.locationBounds.latMin,
+          filters.locationBounds.latMax,
+          filters.locationBounds.lngMin,
+          filters.locationBounds.lngMax,
+        ]
+      : null,
+    yearFrom: filters.yearFrom ?? null,
+    yearTo: filters.yearTo ?? null,
+    latitude: filters.latitude ?? null,
+    longitude: filters.longitude ?? null,
+    radiusKm: filters.radiusKm ?? null,
+  });
+}
+
+function getAutoZoomRegion(markers: MapMarkerGroup[], filters: StoryFilters): Region | undefined {
   if (!markers.length) {
-    return fallbackRegion;
+    return undefined;
   }
 
+  if (filters.locationBounds) {
+    return getRegionForLocationBounds(filters.locationBounds);
+  }
+
+  if (filters.latitude !== undefined && filters.longitude !== undefined && filters.radiusKm !== undefined) {
+    return getRegionForProximityFilter(filters.latitude, filters.longitude, filters.radiusKm);
+  }
+
+  return getRegionForMarkers(markers);
+}
+
+function getRegionForMarkers(markers: MapMarkerGroup[]): Region {
   const latitudes = markers.map((marker) => marker.latitude);
   const longitudes = markers.map((marker) => marker.longitude);
   const minLatitude = Math.min(...latitudes);
@@ -354,4 +397,35 @@ function getRegionForMarkers(markers: MapMarkerGroup[], fallbackRegion: Region):
     latitudeDelta: Math.max((maxLatitude - minLatitude) * FIT_PADDING_FACTOR, MIN_FIT_DELTA),
     longitudeDelta: Math.max((maxLongitude - minLongitude) * FIT_PADDING_FACTOR, MIN_FIT_DELTA),
   };
+}
+
+function getRegionForLocationBounds(bounds: NonNullable<StoryFilters['locationBounds']>): Region {
+  const minLatitude = Math.min(bounds.latMin, bounds.latMax);
+  const maxLatitude = Math.max(bounds.latMin, bounds.latMax);
+  const minLongitude = Math.min(bounds.lngMin, bounds.lngMax);
+  const maxLongitude = Math.max(bounds.lngMin, bounds.lngMax);
+
+  return {
+    latitude: (minLatitude + maxLatitude) / 2,
+    longitude: (minLongitude + maxLongitude) / 2,
+    latitudeDelta: clampRegionDelta((maxLatitude - minLatitude) * LOCATION_BOUNDS_PADDING_FACTOR, MIN_LOCATION_DELTA),
+    longitudeDelta: clampRegionDelta((maxLongitude - minLongitude) * LOCATION_BOUNDS_PADDING_FACTOR, MIN_LOCATION_DELTA),
+  };
+}
+
+function getRegionForProximityFilter(latitude: number, longitude: number, radiusKm: number): Region {
+  const latitudeDelta = (radiusKm / KILOMETERS_PER_LATITUDE_DEGREE) * PROXIMITY_PADDING_FACTOR;
+  const longitudeDegreesPerKm = KILOMETERS_PER_LATITUDE_DEGREE * Math.max(Math.cos((latitude * Math.PI) / 180), 0.2);
+  const longitudeDelta = (radiusKm / longitudeDegreesPerKm) * PROXIMITY_PADDING_FACTOR;
+
+  return {
+    latitude,
+    longitude,
+    latitudeDelta: clampRegionDelta(latitudeDelta, MIN_LOCATION_DELTA),
+    longitudeDelta: clampRegionDelta(longitudeDelta, MIN_LOCATION_DELTA),
+  };
+}
+
+function clampRegionDelta(value: number, minimum: number) {
+  return Math.min(Math.max(value, minimum), MAX_AUTO_REGION_DELTA);
 }

--- a/mobile/src/features/map/presentation/screens/MapScreen.tsx
+++ b/mobile/src/features/map/presentation/screens/MapScreen.tsx
@@ -16,6 +16,7 @@ interface MapScreenProps {
   onOpenStory?: (storyId: string) => void;
   getMarkerGroups?: (filters?: StoryFilters) => Promise<MapMarkerGroup[]>;
   onMarkerPreviewRequested?: (targetY: number) => void;
+  onMapGestureActiveChange?: (active: boolean) => void;
   showSearchControls?: boolean;
   onRegisterRefresh?: (handler: (() => Promise<void>) | null) => void;
   searchScope?: SearchFilterScope;
@@ -44,6 +45,7 @@ export function MapScreen({
   onOpenStory,
   getMarkerGroups = mapService.getMarkerGroups,
   onMarkerPreviewRequested,
+  onMapGestureActiveChange,
   showSearchControls = true,
   onRegisterRefresh,
   searchScope = 'map',
@@ -263,9 +265,20 @@ export function MapScreen({
           error={state.error}
           statusBadgeText={statusBadgeText}
           userLocation={userLocation}
-          onSelectMarker={(markerId) => setState((current) => ({ ...current, selectedMarkerId: markerId }))}
+          onSelectMarker={(markerId) => {
+            const shouldOpenPreview = state.selectedMarkerId !== markerId;
+
+            setState((current) => ({
+              ...current,
+              selectedMarkerId: current.selectedMarkerId === markerId ? undefined : markerId,
+            }));
+
+            if (shouldOpenPreview) {
+              handleMarkerPreviewRequest();
+            }
+          }}
           onOpenStory={(storyId) => onOpenStory?.(storyId)}
-          onMarkerPress={handleMarkerPreviewRequest}
+          onMapGestureActiveChange={onMapGestureActiveChange}
           onRegionChangeComplete={(region) => {
             setMapRegion(region);
             setVisibleRegion(region);

--- a/mobile/src/features/map/presentation/screens/MapScreen.tsx
+++ b/mobile/src/features/map/presentation/screens/MapScreen.tsx
@@ -16,7 +16,6 @@ interface MapScreenProps {
   onOpenStory?: (storyId: string) => void;
   getMarkerGroups?: (filters?: StoryFilters) => Promise<MapMarkerGroup[]>;
   onMarkerPreviewRequested?: (targetY: number) => void;
-  onMapGestureActiveChange?: (active: boolean) => void;
   showSearchControls?: boolean;
   onRegisterRefresh?: (handler: (() => Promise<void>) | null) => void;
   searchScope?: SearchFilterScope;
@@ -45,7 +44,6 @@ export function MapScreen({
   onOpenStory,
   getMarkerGroups = mapService.getMarkerGroups,
   onMarkerPreviewRequested,
-  onMapGestureActiveChange,
   showSearchControls = true,
   onRegisterRefresh,
   searchScope = 'map',
@@ -201,8 +199,6 @@ export function MapScreen({
   );
 
   const userLocation = filters.proximityRadiusKm && filters.proximityCoordinates ? filters.proximityCoordinates : undefined;
-  const fitToMarkers = state.markers.length > 0 && (!state.selectedMarkerId || hasActiveFilters);
-
   const statusStoryCount = useMemo(() => {
     if (statusIndicatorMode !== 'area' || !hasInteractedWithArea || !visibleRegion) {
       return totalStoryCount;
@@ -266,12 +262,10 @@ export function MapScreen({
           isLoading={state.isLoading}
           error={state.error}
           statusBadgeText={statusBadgeText}
-          fitToMarkers={fitToMarkers}
           userLocation={userLocation}
           onSelectMarker={(markerId) => setState((current) => ({ ...current, selectedMarkerId: markerId }))}
           onOpenStory={(storyId) => onOpenStory?.(storyId)}
           onMarkerPress={handleMarkerPreviewRequest}
-          onMapGestureActiveChange={onMapGestureActiveChange}
           onRegionChangeComplete={(region) => {
             setMapRegion(region);
             setVisibleRegion(region);

--- a/mobile/src/features/map/presentation/screens/__tests__/MapScreen.test.tsx
+++ b/mobile/src/features/map/presentation/screens/__tests__/MapScreen.test.tsx
@@ -216,6 +216,21 @@ describe('MapScreen', () => {
     expect(onOpenStory).toHaveBeenCalledWith('story-001');
   });
 
+  it('hides the selected marker preview when the same marker is pressed again', async () => {
+    renderScreen(<MapScreen getMarkerGroups={async () => markerGroups} />);
+
+    await screen.findByText('Select a story marker to preview.');
+    fireEvent.press(screen.getAllByTestId('story-marker')[0]);
+    expect(await screen.findByText('The Day the Harbor Fell Silent')).toBeTruthy();
+
+    fireEvent.press(screen.getAllByTestId('story-marker')[0]);
+
+    await waitFor(() => {
+      expect(screen.queryByText('The Day the Harbor Fell Silent')).toBeNull();
+      expect(screen.getByText('Select a story marker to preview.')).toBeTruthy();
+    });
+  });
+
   it('keeps manual map panning available after a marker is selected', async () => {
     renderScreen(<MapScreen getMarkerGroups={async () => markerGroups} />);
 

--- a/mobile/src/features/map/presentation/screens/__tests__/MapScreen.test.tsx
+++ b/mobile/src/features/map/presentation/screens/__tests__/MapScreen.test.tsx
@@ -210,7 +210,9 @@ describe('MapScreen', () => {
 
     await screen.findByText('Select a story marker to preview.');
     fireEvent.press(screen.getAllByTestId('story-marker')[0]);
-    expect(await screen.findByText('The Day the Harbor Fell Silent')).toBeTruthy();
+    const selectedStoryTitle = await screen.findByText('The Day the Harbor Fell Silent');
+    expect(selectedStoryTitle).toBeTruthy();
+    expect(selectedStoryTitle.props.pointerEvents).toBe('none');
     fireEvent.press(screen.getByText('Read full story'));
 
     expect(onOpenStory).toHaveBeenCalledWith('story-001');

--- a/mobile/src/features/map/presentation/screens/__tests__/MapScreen.test.tsx
+++ b/mobile/src/features/map/presentation/screens/__tests__/MapScreen.test.tsx
@@ -216,6 +216,25 @@ describe('MapScreen', () => {
     expect(onOpenStory).toHaveBeenCalledWith('story-001');
   });
 
+  it('keeps manual map panning available after a marker is selected', async () => {
+    renderScreen(<MapScreen getMarkerGroups={async () => markerGroups} />);
+
+    await screen.findByText('Select a story marker to preview.');
+    fireEvent.press(screen.getAllByTestId('story-marker')[0]);
+    await screen.findByText('The Day the Harbor Fell Silent');
+
+    fireEvent.press(screen.getByTestId('map-region-empty'));
+
+    await waitFor(() => {
+      const manualRegion = getRenderedMapRegion();
+
+      expect(manualRegion.latitude).toBeCloseTo(40.5);
+      expect(manualRegion.longitude).toBeCloseTo(29.8);
+      expect(manualRegion.latitudeDelta).toBeCloseTo(0.02);
+      expect(manualRegion.longitudeDelta).toBeCloseTo(0.02);
+    });
+  });
+
   it('shows nearby stories when a clustered marker is pressed', async () => {
     renderScreen(<MapScreen getMarkerGroups={async () => markerGroups} />);
 

--- a/mobile/src/features/map/presentation/screens/__tests__/MapScreen.test.tsx
+++ b/mobile/src/features/map/presentation/screens/__tests__/MapScreen.test.tsx
@@ -318,7 +318,7 @@ describe('MapScreen', () => {
     });
   });
 
-  it('keeps the current map view when a location filter has no stories', async () => {
+  it('zooms to selected location bounds when a location filter has no stories', async () => {
     const getMarkerGroups = jest.fn<Promise<MapMarkerGroup[]>, [any]>().mockImplementation(async (filters) =>
       filters?.location ? [] : markerGroups,
     );
@@ -342,10 +342,10 @@ describe('MapScreen', () => {
     expect(await screen.findByText('No stories found in Golden Horn')).toBeTruthy();
     const region = getRenderedMapRegion();
 
-    expect(region.latitude).toBeCloseTo(41.0192);
-    expect(region.longitude).toBeCloseTo(28.96735);
-    expect(region.latitudeDelta).toBeCloseTo(0.06);
-    expect(region.longitudeDelta).toBeCloseTo(0.06);
+    expect(region.latitude).toBeCloseTo(41.025);
+    expect(region.longitude).toBeCloseTo(28.965);
+    expect(region.latitudeDelta).toBeCloseTo(0.0575);
+    expect(region.longitudeDelta).toBeCloseTo(0.0575);
   });
 
   it('keeps a manually adjusted map view when markers refresh in the same context', async () => {

--- a/mobile/src/features/map/presentation/screens/__tests__/MapScreen.test.tsx
+++ b/mobile/src/features/map/presentation/screens/__tests__/MapScreen.test.tsx
@@ -348,6 +348,44 @@ describe('MapScreen', () => {
     expect(region.longitudeDelta).toBeCloseTo(0.0575);
   });
 
+  it('re-zooms to the selected location when the same location filter is applied again', async () => {
+    const getMarkerGroups = jest.fn<Promise<MapMarkerGroup[]>, [any]>().mockResolvedValue(markerGroups);
+    (geocodeLocationQuery as jest.Mock).mockResolvedValue(goldenHornBounds);
+
+    renderScreen(<MapScreen getMarkerGroups={getMarkerGroups} />);
+
+    await screen.findByText('Select a story marker to preview.');
+    fireEvent.press(screen.getByText('Show filters'));
+    fireEvent.changeText(screen.getByLabelText('Location filter'), 'Golden Horn');
+    expect(await screen.findByText('Filtering by map area.')).toBeTruthy();
+    fireEvent.press(screen.getByLabelText('Apply filters'));
+
+    await waitFor(() => {
+      const region = getRenderedMapRegion();
+
+      expect(region.latitude).toBeCloseTo(41.025);
+      expect(region.longitude).toBeCloseTo(28.965);
+    });
+
+    fireEvent.press(screen.getByTestId('map-region-empty'));
+    await waitFor(() => {
+      const manualRegion = getRenderedMapRegion();
+
+      expect(manualRegion.latitude).toBeCloseTo(40.5);
+      expect(manualRegion.longitude).toBeCloseTo(29.8);
+    });
+
+    fireEvent.press(screen.getByText('Show filters'));
+    fireEvent.press(screen.getByLabelText('Apply filters'));
+
+    await waitFor(() => {
+      const region = getRenderedMapRegion();
+
+      expect(region.latitude).toBeCloseTo(41.025);
+      expect(region.longitude).toBeCloseTo(28.965);
+    });
+  });
+
   it('keeps a manually adjusted map view when markers refresh in the same context', async () => {
     const getMarkerGroups = jest
       .fn<Promise<MapMarkerGroup[]>, [any]>()

--- a/mobile/src/features/map/presentation/screens/__tests__/MapScreen.test.tsx
+++ b/mobile/src/features/map/presentation/screens/__tests__/MapScreen.test.tsx
@@ -167,6 +167,17 @@ function getRenderedMapRegion() {
   };
 }
 
+function createDeferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+
+  return { promise, resolve, reject };
+}
+
 describe('MapScreen', () => {
   beforeEach(async () => {
     (geocodeLocationQuery as jest.Mock).mockResolvedValue(null);
@@ -377,6 +388,54 @@ describe('MapScreen', () => {
     expect(refreshedRegion.longitude).toBeCloseTo(29.8);
     expect(refreshedRegion.latitudeDelta).toBeCloseTo(0.02);
     expect(refreshedRegion.longitudeDelta).toBeCloseTo(0.02);
+  });
+
+  it('ignores stale marker responses after a newer filter request completes', async () => {
+    const initialMarkers = createDeferred<MapMarkerGroup[]>();
+    const filteredMarkers = createDeferred<MapMarkerGroup[]>();
+    const getMarkerGroups = jest.fn<Promise<MapMarkerGroup[]>, [any]>().mockImplementation(async (filters) => {
+      if (filters?.q === 'ridge') {
+        return filteredMarkers.promise;
+      }
+
+      return initialMarkers.promise;
+    });
+
+    renderScreen(<MapScreen getMarkerGroups={getMarkerGroups} />);
+
+    await waitFor(() => {
+      expect(getMarkerGroups).toHaveBeenCalled();
+    });
+    fireEvent.changeText(screen.getByLabelText('Search stories'), 'ridge');
+    await screen.findByLabelText('Clear search');
+    fireEvent.press(screen.getByLabelText('Apply search'));
+
+    await waitFor(() => {
+      expect(getMarkerGroups.mock.calls.some(([filters]) => filters?.q === 'ridge')).toBe(true);
+    });
+
+    await act(async () => {
+      filteredMarkers.resolve(refreshedMarkerGroups);
+    });
+
+    await waitFor(() => {
+      const region = getRenderedMapRegion();
+
+      expect(region.latitude).toBeCloseTo(41.32);
+      expect(region.longitude).toBeCloseTo(29.02);
+    });
+
+    await act(async () => {
+      initialMarkers.resolve(markerGroups);
+    });
+
+    await waitFor(() => {
+      expect(getMarkerGroups.mock.calls.length).toBeGreaterThanOrEqual(3);
+    });
+    const region = getRenderedMapRegion();
+
+    expect(region.latitude).toBeCloseTo(41.32);
+    expect(region.longitude).toBeCloseTo(29.02);
   });
 
   it('keeps unapplied location filters disabled when the place cannot be found', async () => {

--- a/mobile/src/features/map/presentation/screens/__tests__/MapScreen.test.tsx
+++ b/mobile/src/features/map/presentation/screens/__tests__/MapScreen.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { fireEvent, render, screen, waitFor } from '@testing-library/react-native';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react-native';
 import { MapScreen } from '../MapScreen';
 import { MapMarkerGroup } from '../../../domain/entities';
 import { SearchFiltersProvider } from '../../../../search/presentation/context/SearchFiltersContext';
@@ -134,6 +134,39 @@ const markerGroups: MapMarkerGroup[] = [
   },
 ];
 
+const refreshedMarkerGroups: MapMarkerGroup[] = [
+  {
+    id: '41.32:29.02',
+    latitude: 41.32,
+    longitude: 29.02,
+    count: 1,
+    isCluster: false,
+    stories: [
+      {
+        id: 'story-004',
+        title: 'A Different Hilltop',
+        placeName: 'Uskudar Ridge',
+        timePeriod: '1970s',
+        previewText: 'Families watched the city lights arrive one by one.',
+        latitude: 41.32,
+        longitude: 29.02,
+      },
+    ],
+  },
+];
+
+function getRenderedMapRegion() {
+  const label = screen.getByTestId('map-region-props').props.accessibilityLabel as string;
+  const [, latitude, longitude, latitudeDelta, longitudeDelta] = label.split(':');
+
+  return {
+    latitude: Number(latitude),
+    longitude: Number(longitude),
+    latitudeDelta: Number(latitudeDelta),
+    longitudeDelta: Number(longitudeDelta),
+  };
+}
+
 describe('MapScreen', () => {
   beforeEach(async () => {
     (geocodeLocationQuery as jest.Mock).mockResolvedValue(null);
@@ -251,6 +284,99 @@ describe('MapScreen', () => {
       expect(screen.getByTestId('map-region-props').props.accessibilityLabel).toContain('region:41.0192:28.96735:');
       expect(screen.getByTestId('map-region-props').props.accessibilityLabel).toContain(':0.06');
     });
+  });
+
+  it('zooms to selected location bounds when a location filter returns stories', async () => {
+    (geocodeLocationQuery as jest.Mock).mockResolvedValueOnce(goldenHornBounds);
+
+    renderScreen(<MapScreen getMarkerGroups={async () => markerGroups} />);
+
+    await screen.findByText('Select a story marker to preview.');
+    fireEvent.press(screen.getByText('Show filters'));
+    fireEvent.changeText(screen.getByLabelText('Location filter'), 'Golden Horn');
+    expect(await screen.findByText('Filtering by map area.')).toBeTruthy();
+    fireEvent.press(screen.getByLabelText('Apply filters'));
+
+    await waitFor(() => {
+      const region = getRenderedMapRegion();
+
+      expect(region.latitude).toBeCloseTo(41.025);
+      expect(region.longitude).toBeCloseTo(28.965);
+      expect(region.latitudeDelta).toBeCloseTo(0.0575);
+      expect(region.longitudeDelta).toBeCloseTo(0.0575);
+    });
+  });
+
+  it('keeps the current map view when a location filter has no stories', async () => {
+    const getMarkerGroups = jest.fn<Promise<MapMarkerGroup[]>, [any]>().mockImplementation(async (filters) =>
+      filters?.location ? [] : markerGroups,
+    );
+    (geocodeLocationQuery as jest.Mock).mockResolvedValueOnce(goldenHornBounds);
+
+    renderScreen(<MapScreen getMarkerGroups={getMarkerGroups} />);
+
+    await screen.findByText('Select a story marker to preview.');
+    await waitFor(() => {
+      const initialRegion = getRenderedMapRegion();
+
+      expect(initialRegion.latitude).toBeCloseTo(41.0192);
+      expect(initialRegion.longitude).toBeCloseTo(28.96735);
+    });
+
+    fireEvent.press(screen.getByText('Show filters'));
+    fireEvent.changeText(screen.getByLabelText('Location filter'), 'Golden Horn');
+    expect(await screen.findByText('Filtering by map area.')).toBeTruthy();
+    fireEvent.press(screen.getByLabelText('Apply filters'));
+
+    expect(await screen.findByText('No stories found in Golden Horn')).toBeTruthy();
+    const region = getRenderedMapRegion();
+
+    expect(region.latitude).toBeCloseTo(41.0192);
+    expect(region.longitude).toBeCloseTo(28.96735);
+    expect(region.latitudeDelta).toBeCloseTo(0.06);
+    expect(region.longitudeDelta).toBeCloseTo(0.06);
+  });
+
+  it('keeps a manually adjusted map view when markers refresh in the same context', async () => {
+    const getMarkerGroups = jest
+      .fn<Promise<MapMarkerGroup[]>, [any]>()
+      .mockResolvedValueOnce(markerGroups)
+      .mockResolvedValueOnce(refreshedMarkerGroups);
+    let refreshHandler: (() => Promise<void>) | null = null;
+
+    renderScreen(
+      <MapScreen
+        getMarkerGroups={getMarkerGroups}
+        onRegisterRefresh={(handler) => {
+          refreshHandler = handler;
+        }}
+      />,
+    );
+
+    await screen.findByText('Select a story marker to preview.');
+    fireEvent.press(screen.getByTestId('map-region-empty'));
+    await waitFor(() => {
+      const manualRegion = getRenderedMapRegion();
+
+      expect(manualRegion.latitude).toBeCloseTo(40.5);
+      expect(manualRegion.longitude).toBeCloseTo(29.8);
+      expect(manualRegion.latitudeDelta).toBeCloseTo(0.02);
+      expect(manualRegion.longitudeDelta).toBeCloseTo(0.02);
+    });
+
+    await act(async () => {
+      await refreshHandler?.();
+    });
+
+    await waitFor(() => {
+      expect(getMarkerGroups).toHaveBeenCalledTimes(2);
+    });
+    const refreshedRegion = getRenderedMapRegion();
+
+    expect(refreshedRegion.latitude).toBeCloseTo(40.5);
+    expect(refreshedRegion.longitude).toBeCloseTo(29.8);
+    expect(refreshedRegion.latitudeDelta).toBeCloseTo(0.02);
+    expect(refreshedRegion.longitudeDelta).toBeCloseTo(0.02);
   });
 
   it('keeps unapplied location filters disabled when the place cannot be found', async () => {

--- a/mobile/src/features/search/presentation/components/StorySearchControls.tsx
+++ b/mobile/src/features/search/presentation/components/StorySearchControls.tsx
@@ -168,9 +168,11 @@ export function StorySearchControls({ helperText, hideHeading = false, scope }: 
       return;
     }
 
-    if (selectedLocationQueryRef.current === location && draftLocationBounds) {
+    if (draftLocationBounds) {
       selectedLocationQueryRef.current = undefined;
       setIsLocationResolving(false);
+      setIsLocationError(false);
+      setLocationStatusText('Filtering by map area.');
       return;
     }
 
@@ -204,7 +206,7 @@ export function StorySearchControls({ helperText, hideHeading = false, scope }: 
           setIsLocationResolving(false);
         }
       });
-  }, [debouncedDraftLocation, showFilters]);
+  }, [debouncedDraftLocation, draftLocationBounds, showFilters]);
 
   return (
     <View style={{ gap: spacing.md }}>

--- a/mobile/src/shared/components/WebMapView.tsx
+++ b/mobile/src/shared/components/WebMapView.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react';
+import React, { useEffect, useRef } from 'react';
 import { StyleSheet, View } from 'react-native';
 import { WebView } from 'react-native-webview';
 
@@ -30,18 +30,33 @@ interface WebMapViewProps {
   onMarkerPress?: (markerId: string) => void;
   onMapPress?: (coords: { latitude: number; longitude: number }) => void;
   onRegionChangeComplete?: (region: RegionLike) => void;
+  transitionDurationMs?: number;
 }
+
+type WebViewHandle = {
+  injectJavaScript: (script: string) => void;
+};
+
+type MapUpdatePayload = {
+  region: RegionLike;
+  markers: MarkerItem[];
+  userLocation: UserLocationLike | null;
+  animated: boolean;
+  transitionDurationMs: number;
+};
 
 const mapHtml = ({
   region,
   markers,
   userLocation,
   interactive,
+  transitionDurationMs,
 }: {
   region: RegionLike;
   markers: MarkerItem[];
   userLocation?: UserLocationLike;
   interactive: boolean;
+  transitionDurationMs: number;
 }) => `<!DOCTYPE html>
 <html>
   <head>
@@ -109,24 +124,30 @@ const mapHtml = ({
     <script src="https://unpkg.com/maplibre-gl@4.7.1/dist/maplibre-gl.js"></script>
     <script>
       const region = ${JSON.stringify(region)};
-      const markers = ${JSON.stringify(markers)};
-      const userLocation = ${JSON.stringify(userLocation ?? null)};
+      let markerData = ${JSON.stringify(markers)};
+      let userLocationData = ${JSON.stringify(userLocation ?? null)};
       const interactive = ${interactive ? 'true' : 'false'};
+      const defaultTransitionDurationMs = ${transitionDurationMs};
       let hasCompletedInitialMove = false;
+      let isProgrammaticMove = false;
+      let programmaticMoveTimer;
+      let markerInstances = [];
+      let userLocationMarker = null;
 
-      const zoom = Math.max(
-        2,
-        Math.min(
-          16,
-          Math.round(Math.log2(360 / Math.max(region.longitudeDelta, 0.0001)))
-        )
-      );
+      const getZoomForRegion = (nextRegion) =>
+        Math.max(
+          2,
+          Math.min(
+            16,
+            Math.round(Math.log2(360 / Math.max(nextRegion.longitudeDelta, 0.0001)))
+          )
+        );
 
       const map = new maplibregl.Map({
         container: 'map',
         style: 'https://tiles.openfreemap.org/styles/liberty',
         center: [region.longitude, region.latitude],
-        zoom,
+        zoom: getZoomForRegion(region),
         attributionControl: false,
         dragPan: interactive,
         scrollZoom: interactive,
@@ -153,7 +174,27 @@ const mapHtml = ({
         );
       };
 
-      markers.forEach((marker) => {
+      const clearProgrammaticMove = () => {
+        if (programmaticMoveTimer) {
+          window.clearTimeout(programmaticMoveTimer);
+        }
+
+        isProgrammaticMove = false;
+      };
+
+      const markProgrammaticMove = (duration) => {
+        isProgrammaticMove = true;
+
+        if (programmaticMoveTimer) {
+          window.clearTimeout(programmaticMoveTimer);
+        }
+
+        programmaticMoveTimer = window.setTimeout(() => {
+          isProgrammaticMove = false;
+        }, Math.max(duration, 0) + 120);
+      };
+
+      const createStoryMarker = (marker) => {
         const element = document.createElement('div');
         element.className = marker.selected ? 'marker selected' : 'marker';
 
@@ -164,25 +205,83 @@ const mapHtml = ({
           element.appendChild(label);
         }
 
-        element.addEventListener('click', () => {
+        element.addEventListener('click', (event) => {
+          event.stopPropagation();
           window.ReactNativeWebView?.postMessage(
             JSON.stringify({ type: 'markerPress', markerId: marker.id })
           );
         });
 
-        new maplibregl.Marker({ element, anchor: 'center' })
+        return new maplibregl.Marker({ element, anchor: 'center' })
           .setLngLat([marker.longitude, marker.latitude])
           .addTo(map);
-      });
+      };
 
-      if (userLocation) {
-        const element = document.createElement('div');
-        element.className = 'user-location-marker';
+      const renderMarkers = (nextMarkers, nextUserLocation) => {
+        markerInstances.forEach((marker) => marker.remove());
+        markerInstances = [];
 
-        new maplibregl.Marker({ element, anchor: 'center' })
-          .setLngLat([userLocation.longitude, userLocation.latitude])
-          .addTo(map);
-      }
+        nextMarkers.forEach((marker) => {
+          markerInstances.push(createStoryMarker(marker));
+        });
+
+        if (userLocationMarker) {
+          userLocationMarker.remove();
+          userLocationMarker = null;
+        }
+
+        if (nextUserLocation) {
+          const element = document.createElement('div');
+          element.className = 'user-location-marker';
+
+          userLocationMarker = new maplibregl.Marker({ element, anchor: 'center' })
+            .setLngLat([nextUserLocation.longitude, nextUserLocation.latitude])
+            .addTo(map);
+        }
+
+        markerData = nextMarkers;
+        userLocationData = nextUserLocation ?? null;
+      };
+
+      const moveToRegion = (nextRegion, animated, durationOverride) => {
+        const duration = Number.isFinite(durationOverride)
+          ? durationOverride
+          : defaultTransitionDurationMs;
+        const camera = {
+          center: [nextRegion.longitude, nextRegion.latitude],
+          zoom: getZoomForRegion(nextRegion),
+        };
+
+        markProgrammaticMove(animated ? duration : 0);
+
+        if (animated && duration > 0) {
+          map.easeTo({
+            ...camera,
+            duration,
+            easing: (progress) => progress,
+          });
+          return;
+        }
+
+        map.jumpTo(camera);
+      };
+
+      renderMarkers(markerData, userLocationData);
+
+      window.__storyMapUpdate = (payload = {}) => {
+        if (Array.isArray(payload.markers) || Object.prototype.hasOwnProperty.call(payload, 'userLocation')) {
+          const nextMarkers = Array.isArray(payload.markers) ? payload.markers : markerData;
+          const nextUserLocation = Object.prototype.hasOwnProperty.call(payload, 'userLocation')
+            ? payload.userLocation
+            : userLocationData;
+
+          renderMarkers(nextMarkers, nextUserLocation);
+        }
+
+        if (payload.region) {
+          moveToRegion(payload.region, payload.animated !== false, payload.transitionDurationMs);
+        }
+      };
 
       if (!interactive) {
         map.boxZoom.disable();
@@ -212,6 +311,11 @@ const mapHtml = ({
           return;
         }
 
+        if (isProgrammaticMove) {
+          clearProgrammaticMove();
+          return;
+        }
+
         postCurrentRegion();
       });
     </script>
@@ -226,19 +330,39 @@ export function WebMapView({
   onMarkerPress,
   onMapPress,
   onRegionChangeComplete,
+  transitionDurationMs = 450,
 }: WebMapViewProps) {
-  const source = useMemo(
-    () => ({
-      html: mapHtml({ region, markers, userLocation, interactive }),
-    }),
-    [interactive, markers, region, userLocation],
-  );
+  const webViewRef = useRef<WebViewHandle | null>(null);
+  const sourceRef = useRef<{ html: string } | null>(null);
+  const latestUpdatePayloadRef = useRef<MapUpdatePayload | null>(null);
+
+  if (sourceRef.current === null) {
+    sourceRef.current = {
+      html: mapHtml({ region, markers, userLocation, interactive, transitionDurationMs }),
+    };
+  }
+
+  const updatePayload = {
+    region,
+    markers,
+    userLocation: userLocation ?? null,
+    animated: true,
+    transitionDurationMs,
+  };
+  latestUpdatePayloadRef.current = updatePayload;
+
+  useEffect(() => {
+    injectMapUpdate(webViewRef.current, updatePayload);
+  }, [markers, region, transitionDurationMs, userLocation]);
 
   return (
     <View style={styles.container}>
       <WebView
+        ref={(ref: unknown) => {
+          webViewRef.current = ref as WebViewHandle | null;
+        }}
         originWhitelist={['*']}
-        source={source}
+        source={sourceRef.current}
         style={styles.webview}
         javaScriptEnabled
         domStorageEnabled
@@ -246,6 +370,11 @@ export function WebMapView({
         nestedScrollEnabled
         androidLayerType="hardware"
         setSupportMultipleWindows={false}
+        onLoadEnd={() => {
+          if (latestUpdatePayloadRef.current) {
+            injectMapUpdate(webViewRef.current, latestUpdatePayloadRef.current);
+          }
+        }}
         onMessage={(event: { nativeEvent: { data: string } }) => {
           try {
             const payload = JSON.parse(event.nativeEvent.data);
@@ -297,3 +426,17 @@ const styles = StyleSheet.create({
     backgroundColor: 'transparent',
   },
 });
+
+function injectMapUpdate(webView: WebViewHandle | null, payload: MapUpdatePayload) {
+  webView?.injectJavaScript(
+    `window.__storyMapUpdate && window.__storyMapUpdate(${escapeInjectedJson(payload)}); true;`,
+  );
+}
+
+function escapeInjectedJson(value: unknown) {
+  return JSON.stringify(value)
+    .replace(/</g, '\\u003c')
+    .replace(/>/g, '\\u003e')
+    .replace(/\u2028/g, '\\u2028')
+    .replace(/\u2029/g, '\\u2029');
+}

--- a/mobile/src/shared/components/WebMapView.tsx
+++ b/mobile/src/shared/components/WebMapView.tsx
@@ -134,14 +134,18 @@ const mapHtml = ({
       let markerInstances = [];
       let userLocationMarker = null;
 
-      const getZoomForRegion = (nextRegion) =>
-        Math.max(
-          2,
-          Math.min(
-            16,
-            Math.round(Math.log2(360 / Math.max(nextRegion.longitudeDelta, 0.0001)))
-          )
+      const getZoomForRegion = (nextRegion) => {
+        const requestedDelta = Math.max(
+          Math.abs(nextRegion.latitudeDelta || 0),
+          Math.abs(nextRegion.longitudeDelta || 0),
+          0.0001
         );
+
+        return Math.max(
+          2,
+          Math.min(16, Math.floor(Math.log2(360 / requestedDelta)))
+        );
+      };
 
       const map = new maplibregl.Map({
         container: 'map',

--- a/mobile/src/shared/components/WebMapView.tsx
+++ b/mobile/src/shared/components/WebMapView.tsx
@@ -38,11 +38,11 @@ type WebViewHandle = {
 };
 
 type MapUpdatePayload = {
-  region: RegionLike;
-  markers: MarkerItem[];
-  userLocation: UserLocationLike | null;
-  animated: boolean;
-  transitionDurationMs: number;
+  region?: RegionLike;
+  markers?: MarkerItem[];
+  userLocation?: UserLocationLike | null;
+  animated?: boolean;
+  transitionDurationMs?: number;
 };
 
 const mapHtml = ({
@@ -339,6 +339,7 @@ const mapHtml = ({
 
       map.on('load', () => {
         isMapReady = true;
+        hasCompletedInitialMove = true;
 
         if (pendingUpdatePayload) {
           applyMapUpdate(pendingUpdatePayload);
@@ -362,6 +363,9 @@ export function WebMapView({
   const webViewRef = useRef<WebViewHandle | null>(null);
   const sourceRef = useRef<{ html: string } | null>(null);
   const latestUpdatePayloadRef = useRef<MapUpdatePayload | null>(null);
+  const lastSentRegionRef = useRef<RegionLike | null>(null);
+  const lastSentMarkersRef = useRef<MarkerItem[] | null>(null);
+  const lastSentUserLocationRef = useRef<UserLocationLike | null | undefined>(undefined);
 
   if (sourceRef.current === null) {
     sourceRef.current = {
@@ -369,17 +373,42 @@ export function WebMapView({
     };
   }
 
-  const updatePayload = {
+  const fullUpdatePayload = {
     region,
     markers,
     userLocation: userLocation ?? null,
     animated: true,
     transitionDurationMs,
   };
-  latestUpdatePayloadRef.current = updatePayload;
+  latestUpdatePayloadRef.current = fullUpdatePayload;
 
   useEffect(() => {
-    injectMapUpdate(webViewRef.current, updatePayload);
+    const updatePayload: MapUpdatePayload = {};
+    const nextUserLocation = userLocation ?? null;
+
+    if (!lastSentRegionRef.current || !regionsEqual(lastSentRegionRef.current, region)) {
+      updatePayload.region = region;
+      updatePayload.animated = true;
+      updatePayload.transitionDurationMs = transitionDurationMs;
+      lastSentRegionRef.current = region;
+    }
+
+    if (!lastSentMarkersRef.current || !markersEqual(lastSentMarkersRef.current, markers)) {
+      updatePayload.markers = markers;
+      lastSentMarkersRef.current = markers;
+    }
+
+    if (
+      lastSentUserLocationRef.current === undefined ||
+      !userLocationsEqual(lastSentUserLocationRef.current, nextUserLocation)
+    ) {
+      updatePayload.userLocation = nextUserLocation;
+      lastSentUserLocationRef.current = nextUserLocation;
+    }
+
+    if (Object.keys(updatePayload).length > 0) {
+      injectMapUpdate(webViewRef.current, updatePayload);
+    }
   }, [markers, region, transitionDurationMs, userLocation]);
 
   return (
@@ -458,6 +487,41 @@ function injectMapUpdate(webView: WebViewHandle | null, payload: MapUpdatePayloa
   webView?.injectJavaScript(
     `window.__storyMapUpdate && window.__storyMapUpdate(${escapeInjectedJson(payload)}); true;`,
   );
+}
+
+function regionsEqual(left: RegionLike, right: RegionLike) {
+  return (
+    left.latitude === right.latitude &&
+    left.longitude === right.longitude &&
+    left.latitudeDelta === right.latitudeDelta &&
+    left.longitudeDelta === right.longitudeDelta
+  );
+}
+
+function userLocationsEqual(left: UserLocationLike | null, right: UserLocationLike | null) {
+  if (left === null || right === null) {
+    return left === right;
+  }
+
+  return left.latitude === right.latitude && left.longitude === right.longitude;
+}
+
+function markersEqual(left: MarkerItem[], right: MarkerItem[]) {
+  if (left.length !== right.length) {
+    return false;
+  }
+
+  return left.every((marker, index) => {
+    const nextMarker = right[index];
+
+    return (
+      marker.id === nextMarker.id &&
+      marker.latitude === nextMarker.latitude &&
+      marker.longitude === nextMarker.longitude &&
+      marker.selected === nextMarker.selected &&
+      marker.label === nextMarker.label
+    );
+  });
 }
 
 function escapeInjectedJson(value: unknown) {

--- a/mobile/src/shared/components/WebMapView.tsx
+++ b/mobile/src/shared/components/WebMapView.tsx
@@ -29,7 +29,6 @@ interface WebMapViewProps {
   interactive?: boolean;
   onMarkerPress?: (markerId: string) => void;
   onMapPress?: (coords: { latitude: number; longitude: number }) => void;
-  onGestureActiveChange?: (active: boolean) => void;
   onRegionChangeComplete?: (region: RegionLike) => void;
   transitionDurationMs?: number;
 }
@@ -357,7 +356,6 @@ export function WebMapView({
   interactive = true,
   onMarkerPress,
   onMapPress,
-  onGestureActiveChange,
   onRegionChangeComplete,
   transitionDurationMs = 450,
 }: WebMapViewProps) {
@@ -385,13 +383,7 @@ export function WebMapView({
   }, [markers, region, transitionDurationMs, userLocation]);
 
   return (
-    <View
-      testID="web-map-view"
-      style={styles.container}
-      onTouchStart={() => onGestureActiveChange?.(true)}
-      onTouchEnd={() => onGestureActiveChange?.(false)}
-      onTouchCancel={() => onGestureActiveChange?.(false)}
-    >
+    <View testID="web-map-view" style={styles.container}>
       <WebView
         ref={(ref: unknown) => {
           webViewRef.current = ref as WebViewHandle | null;
@@ -405,9 +397,6 @@ export function WebMapView({
         nestedScrollEnabled
         androidLayerType="hardware"
         setSupportMultipleWindows={false}
-        onTouchStart={() => onGestureActiveChange?.(true)}
-        onTouchEnd={() => onGestureActiveChange?.(false)}
-        onTouchCancel={() => onGestureActiveChange?.(false)}
         onLoadEnd={() => {
           if (latestUpdatePayloadRef.current) {
             injectMapUpdate(webViewRef.current, latestUpdatePayloadRef.current);

--- a/mobile/src/shared/components/WebMapView.tsx
+++ b/mobile/src/shared/components/WebMapView.tsx
@@ -29,6 +29,7 @@ interface WebMapViewProps {
   interactive?: boolean;
   onMarkerPress?: (markerId: string) => void;
   onMapPress?: (coords: { latitude: number; longitude: number }) => void;
+  onGestureActiveChange?: (active: boolean) => void;
   onRegionChangeComplete?: (region: RegionLike) => void;
   transitionDurationMs?: number;
 }
@@ -129,9 +130,11 @@ const mapHtml = ({
       const interactive = ${interactive ? 'true' : 'false'};
       const defaultTransitionDurationMs = ${transitionDurationMs};
       let hasCompletedInitialMove = false;
+      let isMapReady = false;
       let isProgrammaticMove = false;
       let programmaticMoveTimer;
       let markerInstances = [];
+      let pendingUpdatePayload = null;
       let userLocationMarker = null;
 
       const getZoomForRegion = (nextRegion) => {
@@ -270,9 +273,7 @@ const mapHtml = ({
         map.jumpTo(camera);
       };
 
-      renderMarkers(markerData, userLocationData);
-
-      window.__storyMapUpdate = (payload = {}) => {
+      const applyMapUpdate = (payload = {}) => {
         if (Array.isArray(payload.markers) || Object.prototype.hasOwnProperty.call(payload, 'userLocation')) {
           const nextMarkers = Array.isArray(payload.markers) ? payload.markers : markerData;
           const nextUserLocation = Object.prototype.hasOwnProperty.call(payload, 'userLocation')
@@ -285,6 +286,20 @@ const mapHtml = ({
         if (payload.region) {
           moveToRegion(payload.region, payload.animated !== false, payload.transitionDurationMs);
         }
+      };
+
+      renderMarkers(markerData, userLocationData);
+
+      window.__storyMapUpdate = (payload = {}) => {
+        if (!isMapReady) {
+          pendingUpdatePayload = {
+            ...(pendingUpdatePayload ?? {}),
+            ...payload,
+          };
+          return;
+        }
+
+        applyMapUpdate(payload);
       };
 
       if (!interactive) {
@@ -322,6 +337,15 @@ const mapHtml = ({
 
         postCurrentRegion();
       });
+
+      map.on('load', () => {
+        isMapReady = true;
+
+        if (pendingUpdatePayload) {
+          applyMapUpdate(pendingUpdatePayload);
+          pendingUpdatePayload = null;
+        }
+      });
     </script>
   </body>
 </html>`;
@@ -333,6 +357,7 @@ export function WebMapView({
   interactive = true,
   onMarkerPress,
   onMapPress,
+  onGestureActiveChange,
   onRegionChangeComplete,
   transitionDurationMs = 450,
 }: WebMapViewProps) {
@@ -360,7 +385,13 @@ export function WebMapView({
   }, [markers, region, transitionDurationMs, userLocation]);
 
   return (
-    <View style={styles.container}>
+    <View
+      testID="web-map-view"
+      style={styles.container}
+      onTouchStart={() => onGestureActiveChange?.(true)}
+      onTouchEnd={() => onGestureActiveChange?.(false)}
+      onTouchCancel={() => onGestureActiveChange?.(false)}
+    >
       <WebView
         ref={(ref: unknown) => {
           webViewRef.current = ref as WebViewHandle | null;
@@ -374,6 +405,9 @@ export function WebMapView({
         nestedScrollEnabled
         androidLayerType="hardware"
         setSupportMultipleWindows={false}
+        onTouchStart={() => onGestureActiveChange?.(true)}
+        onTouchEnd={() => onGestureActiveChange?.(false)}
+        onTouchCancel={() => onGestureActiveChange?.(false)}
         onLoadEnd={() => {
           if (latestUpdatePayloadRef.current) {
             injectMapUpdate(webViewRef.current, latestUpdatePayloadRef.current);


### PR DESCRIPTION
# 📝 Description
Fixes #491  

Implemented mobile map auto-zoom behavior for better map UX.

The mobile map now automatically adjusts its camera based on story marker content and active search/filter context. Location search results trigger a smooth zoom to the selected location bounds when stories are found. If no stories are found for a searched location, the map keeps the current view instead of unexpectedly jumping back to Istanbul.

This PR also preserves manual pan/zoom interactions by preventing background marker refreshes from overriding the user's current map view in the same context.

# 📊 Type of Change
- [x] Bug fix
- [x] New feature
- [ ] Refactoring
- [ ] Documentation

# ✅ Acceptance Criteria / Checklist
- [x] Mobile map auto-adjusts zoom level based on visible story content
- [x] Mobile location search results trigger automatic zoom-in to the searched location
- [x] Smooth transition animation is used when zooming or moving the map camera
- [x] Auto-zoom behavior does not break manual pan and pinch zoom interactions
- [x] Clustered and spread-out stories are handled predictably
- [x] Empty or no-result location search states do not unexpectedly change the current map view
- [x] Tests cover location-search zoom behavior and edge cases
- [x] Existing tests pass

# 🧪 Tests
- [x] `npm run typecheck`
- [x] `npm test -- MapScreen.test.tsx --runInBand --silent`
- [x] `npm test -- --runInBand --silent`

# ⏱️ Estimated Review Time
- [ ] < 5 min
- [ ] 5-15 min
- [x] > 15 min



