### PR TITLE
feat: add admin content removal endpoints for stories and comments

### DIFF
--- a/backend/apps/interactions/admin_urls.py
+++ b/backend/apps/interactions/admin_urls.py
@@ -1,0 +1,7 @@
+from django.urls import path
+
+from apps.interactions.admin_views import AdminCommentRemovalView
+
+urlpatterns = [
+    path('comments/<int:pk>/', AdminCommentRemovalView.as_view(), name='admin-comment-remove'),
+]

--- a/backend/apps/interactions/admin_views.py
+++ b/backend/apps/interactions/admin_views.py
@@ -1,0 +1,19 @@
+from django.shortcuts import get_object_or_404
+from rest_framework import status
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from apps.interactions.models import Comment
+from apps.interactions.services import delete_comment
+from common.permissions import IsAdminUser
+
+
+class AdminCommentRemovalView(APIView):
+    """DELETE /moderation/comments/{id}/ — hard-delete a comment (admin only)."""
+
+    permission_classes = [IsAdminUser]
+
+    def delete(self, request, pk):
+        comment = get_object_or_404(Comment, pk=pk)
+        delete_comment(comment)
+        return Response(status=status.HTTP_204_NO_CONTENT)

--- a/backend/apps/interactions/tests/test_admin_views.py
+++ b/backend/apps/interactions/tests/test_admin_views.py
@@ -1,0 +1,71 @@
+"""Admin content-removal tests: DELETE /moderation/comments/{id}/"""
+import pytest
+
+from rest_framework.test import APIClient
+
+from apps.interactions.models import Comment
+from apps.users.models import RoleChoices, User
+
+
+@pytest.fixture
+def client():
+    return APIClient()
+
+
+@pytest.fixture
+def admin_user(db):
+    return User.objects.create_user(
+        email='admin@example.com',
+        username='adminuser',
+        password='Password1',
+        role=RoleChoices.ADMIN,
+        is_staff=True,
+    )
+
+
+@pytest.fixture
+def admin_client(client, admin_user):
+    client.force_authenticate(user=admin_user)
+    return client
+
+
+@pytest.fixture
+def auth_client(client, user):
+    client.force_authenticate(user=user)
+    return client
+
+
+@pytest.fixture
+def comment(user, story):
+    return Comment.objects.create(story=story, author=user, text='A comment.')
+
+
+def _url(comment_id):
+    return f'/moderation/comments/{comment_id}/'
+
+
+# ── DELETE /moderation/comments/{id}/ ────────────────────────────────────────
+
+@pytest.mark.django_db
+class TestAdminCommentRemoval:
+
+    def test_admin_delete_comment_returns_204(self, admin_client, comment):
+        resp = admin_client.delete(_url(comment.pk))
+        assert resp.status_code == 204
+
+    def test_comment_is_hard_deleted(self, admin_client, comment):
+        pk = comment.pk
+        admin_client.delete(_url(comment.pk))
+        assert not Comment.objects.filter(pk=pk).exists()
+
+    def test_non_admin_gets_403(self, auth_client, comment):
+        resp = auth_client.delete(_url(comment.pk))
+        assert resp.status_code == 403
+
+    def test_unauthenticated_gets_401(self, client, comment):
+        resp = client.delete(_url(comment.pk))
+        assert resp.status_code == 401
+
+    def test_nonexistent_comment_gets_404(self, admin_client):
+        resp = admin_client.delete(_url(999999))
+        assert resp.status_code == 404

--- a/backend/apps/stories/admin_urls.py
+++ b/backend/apps/stories/admin_urls.py
@@ -1,0 +1,7 @@
+from django.urls import path
+
+from apps.stories.admin_views import AdminStoryRemovalView
+
+urlpatterns = [
+    path('stories/<int:pk>/', AdminStoryRemovalView.as_view(), name='admin-story-remove'),
+]

--- a/backend/apps/stories/admin_views.py
+++ b/backend/apps/stories/admin_views.py
@@ -1,0 +1,25 @@
+from django.shortcuts import get_object_or_404
+from rest_framework import serializers, status
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from apps.stories.models import Story
+from apps.stories.services import remove_story
+from common.permissions import IsAdminUser
+
+
+class _ModerationReasonSerializer(serializers.Serializer):
+    moderation_reason = serializers.CharField(min_length=1)
+
+
+class AdminStoryRemovalView(APIView):
+    """DELETE /moderation/stories/{id}/ — soft-remove a story (admin only)."""
+
+    permission_classes = [IsAdminUser]
+
+    def delete(self, request, pk):
+        serializer = _ModerationReasonSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        story = get_object_or_404(Story, pk=pk)
+        remove_story(story, serializer.validated_data['moderation_reason'])
+        return Response(status=status.HTTP_204_NO_CONTENT)

--- a/backend/apps/stories/services.py
+++ b/backend/apps/stories/services.py
@@ -56,6 +56,13 @@ def delete_story(story: Story) -> None:
     story.delete()
 
 
+def remove_story(story: Story, moderation_reason: str) -> None:
+    """Soft-delete a story by setting its status to REMOVED and recording the moderation reason."""
+    story.status = Story.STATUS_REMOVED
+    story.moderation_reason = moderation_reason
+    story.save(update_fields=['status', 'moderation_reason'])
+
+
 def get_story_feed(
     sort_by='recent',
     year_from=None,

--- a/backend/apps/stories/tests/test_admin_views.py
+++ b/backend/apps/stories/tests/test_admin_views.py
@@ -1,0 +1,86 @@
+"""Admin content-removal tests: DELETE /moderation/stories/{id}/"""
+import pytest
+
+from rest_framework.test import APIClient
+
+from apps.stories.models import Story
+from apps.users.models import RoleChoices, User
+
+
+@pytest.fixture
+def client():
+    return APIClient()
+
+
+@pytest.fixture
+def admin_user(db):
+    return User.objects.create_user(
+        email='admin@example.com',
+        username='adminuser',
+        password='Password1',
+        role=RoleChoices.ADMIN,
+        is_staff=True,
+    )
+
+
+@pytest.fixture
+def admin_client(client, admin_user):
+    client.force_authenticate(user=admin_user)
+    return client
+
+
+@pytest.fixture
+def auth_client(client, user):
+    client.force_authenticate(user=user)
+    return client
+
+
+def _url(story_id):
+    return f'/moderation/stories/{story_id}/'
+
+
+# ── DELETE /moderation/stories/{id}/ ─────────────────────────────────────────
+
+@pytest.mark.django_db
+class TestAdminStoryRemoval:
+
+    def test_admin_remove_story_returns_204(self, admin_client, story):
+        resp = admin_client.delete(_url(story.pk), {'moderation_reason': 'Violates policy.'}, format='json')
+        assert resp.status_code == 204
+
+    def test_remove_sets_status_to_removed(self, admin_client, story):
+        admin_client.delete(_url(story.pk), {'moderation_reason': 'Spam content.'}, format='json')
+        story.refresh_from_db()
+        assert story.status == Story.STATUS_REMOVED
+
+    def test_remove_stores_moderation_reason(self, admin_client, story):
+        admin_client.delete(_url(story.pk), {'moderation_reason': 'Explicit content.'}, format='json')
+        story.refresh_from_db()
+        assert story.moderation_reason == 'Explicit content.'
+
+    def test_moderation_reason_is_required(self, admin_client, story):
+        resp = admin_client.delete(_url(story.pk), {}, format='json')
+        assert resp.status_code == 400
+
+    def test_blank_moderation_reason_is_rejected(self, admin_client, story):
+        resp = admin_client.delete(_url(story.pk), {'moderation_reason': ''}, format='json')
+        assert resp.status_code == 400
+
+    def test_non_admin_gets_403(self, auth_client, story):
+        resp = auth_client.delete(_url(story.pk), {'moderation_reason': 'X'}, format='json')
+        assert resp.status_code == 403
+
+    def test_unauthenticated_gets_401(self, client, story):
+        resp = client.delete(_url(story.pk), {'moderation_reason': 'X'}, format='json')
+        assert resp.status_code == 401
+
+    def test_nonexistent_story_gets_404(self, admin_client):
+        resp = admin_client.delete(_url(999999), {'moderation_reason': 'X'}, format='json')
+        assert resp.status_code == 404
+
+    def test_already_removed_story_is_idempotent(self, admin_client, story):
+        admin_client.delete(_url(story.pk), {'moderation_reason': 'First removal.'}, format='json')
+        resp = admin_client.delete(_url(story.pk), {'moderation_reason': 'Second removal.'}, format='json')
+        assert resp.status_code == 204
+        story.refresh_from_db()
+        assert story.moderation_reason == 'Second removal.'

--- a/backend/config/urls.py
+++ b/backend/config/urls.py
@@ -12,6 +12,10 @@ urlpatterns = [
     path('', include('apps.media.urls', namespace='media')),
     path('stories/', include('apps.stories.urls', namespace='stories')),
     path('tags/', include('apps.tags.urls', namespace='tags')),
+    path('moderation/', include([
+        path('', include('apps.stories.admin_urls')),
+        path('', include('apps.interactions.admin_urls')),
+    ])),
 ]
 
 if settings.DEBUG and 'debug_toolbar' in settings.INSTALLED_APPS:


### PR DESCRIPTION
# 📝 Description
Fixes #230

Implements two admin-only moderation endpoints under the `moderation/` URL prefix:

**`DELETE /moderation/stories/{id}/`** — soft-removes a story:
- Sets `status` to `REMOVED` and stores the required `moderation_reason`
- Preserves the record for audit purposes (no hard delete)
- Returns 400 if `moderation_reason` is missing or blank

**`DELETE /moderation/comments/{id}/`** — hard-deletes a comment:
- Permanently removes the comment from the database
- No request body required

Both return 403 for non-admin users, 401 for unauthenticated requests, and 404 for unknown targets.

# 📊 Type of Change
- [x] New feature

# ✅ Acceptance Criteria / Checklist
- [x] Project builds successfully
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, especially in hard-to-understand parts
- [x] I have performed a self-review of my code
- [x] I have added/updated tests
- [x] New and existing unit tests pass locally with my changes

# 📸 Screenshots / Recordings
<!-- N/A — backend API endpoints -->

# ⏱️ Estimated Review Time
- [x] 5-15 min
- [ ] < 5 min
- [ ] > 15 min
