### PR TITLE
Feat/ Add gamification endpoints for points and badges

### DIFF
--- a/backend/apps/gamification/serializers.py
+++ b/backend/apps/gamification/serializers.py
@@ -1,1 +1,46 @@
-# serializers.py — gamification
+from rest_framework import serializers
+
+from apps.gamification.models import Badge, PointTransaction, UserBadge
+
+
+class BadgeCatalogSerializer(serializers.ModelSerializer):
+    """Read-only serializer for a single Badge row — used in the catalog and nested in UserBadgeSerializer."""
+
+    class Meta:
+        model = Badge
+        fields = ['id', 'name', 'description', 'criteria_type', 'criteria_threshold']
+        read_only_fields = fields
+
+
+class UserBadgeSerializer(serializers.ModelSerializer):
+    """Read-only serializer for a user's earned badge entry, with the badge details nested inline."""
+
+    badge = BadgeCatalogSerializer(read_only=True)
+
+    class Meta:
+        model = UserBadge
+        fields = ['id', 'badge', 'awarded_at']
+        read_only_fields = fields
+
+
+class PointSummarySerializer(serializers.Serializer):
+    """Serializes the point balance for a user. Accepts a plain dict, not a model instance."""
+
+    user_id = serializers.IntegerField(read_only=True)
+    total_points = serializers.IntegerField(read_only=True)
+
+
+class PointTransactionSerializer(serializers.ModelSerializer):
+    """
+    Read-only serializer for a single point transaction.
+
+    story_id exposes the raw FK integer column directly — avoids AttributeError when the story FK is null,
+    matching the pattern used in NotificationSerializer for nullable FK columns.
+    """
+
+    story_id = serializers.IntegerField(read_only=True, allow_null=True)
+
+    class Meta:
+        model = PointTransaction
+        fields = ['id', 'amount', 'event_type', 'story_id', 'created_at']
+        read_only_fields = fields

--- a/backend/apps/gamification/services.py
+++ b/backend/apps/gamification/services.py
@@ -1,3 +1,7 @@
+from django.http import Http404
+
+from apps.gamification.models import Badge, PointTransaction, UserBadge
+from apps.users.models import User
 from django.db import transaction
 from django.db.models import F, Value
 from django.db.models.functions import Greatest
@@ -9,6 +13,46 @@ from apps.gamification.constants import (
     POINT_VALUES,
 )
 from apps.gamification.models import Badge, PointTransaction, UserBadge
+
+
+def _get_active_user(user_id):
+    """Return the active User for user_id, or raise Http404 if absent or inactive."""
+    try:
+        return User.objects.get(pk=user_id, is_active=True)
+    except User.DoesNotExist:
+        raise Http404
+
+
+def get_user_points(user_id):
+    """Return a dict with the user's total point balance."""
+    user = _get_active_user(user_id)
+    return {'user_id': user.pk, 'total_points': user.total_points}
+
+
+def get_user_badges(user_id):
+    """Return all badges earned by the user, ordered by award date ascending."""
+    _get_active_user(user_id)
+    return (
+        UserBadge.objects
+        .filter(user_id=user_id)
+        .select_related('badge')
+        .order_by('awarded_at')
+    )
+
+
+def get_user_point_history(user_id):
+    """Return the user's point transactions, ordered newest first."""
+    _get_active_user(user_id)
+    return (
+        PointTransaction.objects
+        .filter(user_id=user_id)
+        .order_by('-created_at')
+    )
+
+
+def get_badge_catalog():
+    """Return all available badges ordered by id."""
+    return Badge.objects.all().order_by('id')
 
 
 def award_points(user, event_type, story=None):

--- a/backend/apps/gamification/tests/test_serializers.py
+++ b/backend/apps/gamification/tests/test_serializers.py
@@ -1,0 +1,120 @@
+from decimal import Decimal
+
+import pytest
+
+from apps.gamification.models import Badge, PointTransaction, UserBadge
+from apps.gamification.serializers import (
+    BadgeCatalogSerializer,
+    PointSummarySerializer,
+    PointTransactionSerializer,
+    UserBadgeSerializer,
+)
+from apps.gamification.constants import BADGE_CRITERIA_STORIES_PUBLISHED, STORY_PUBLISHED
+from apps.stories.models import Story
+from apps.users.models import User
+
+
+def _make_user(email='u@example.com', username='u'):
+    return User.objects.create_user(email=email, username=username, password='Password1', is_active=True)
+
+
+def _make_badge(name='Pioneer'):
+    return Badge.objects.create(
+        name=name, description='First badge.',
+        criteria_type=BADGE_CRITERIA_STORIES_PUBLISHED, criteria_threshold=1,
+    )
+
+
+def _make_story(user):
+    return Story.objects.create(
+        user=user, title='T', narrative='N',
+        status=Story.STATUS_PUBLISHED,
+        location_lat=Decimal('0'), location_lng=Decimal('0'),
+        location_name='P', time_type=Story.TIME_EXACT, year=2000,
+    )
+
+
+@pytest.mark.django_db
+class TestBadgeCatalogSerializer:
+    def test_badge_catalog_serializer_contains_expected_fields(self):
+        badge = _make_badge()
+        data = BadgeCatalogSerializer(badge).data
+        assert set(data.keys()) == {'id', 'name', 'description', 'criteria_type', 'criteria_threshold'}
+
+    def test_badge_catalog_serializer_field_values_match_model(self):
+        badge = _make_badge(name='Historian')
+        data = BadgeCatalogSerializer(badge).data
+        assert data['id'] == badge.pk
+        assert data['name'] == 'Historian'
+        assert data['description'] == badge.description
+        assert data['criteria_type'] == badge.criteria_type
+        assert data['criteria_threshold'] == badge.criteria_threshold
+
+
+@pytest.mark.django_db
+class TestUserBadgeSerializer:
+    def setup_method(self):
+        self.user = _make_user()
+        self.badge = _make_badge()
+        self.user_badge = UserBadge.objects.create(user=self.user, badge=self.badge)
+
+    def test_user_badge_serializer_contains_expected_fields(self):
+        data = UserBadgeSerializer(self.user_badge).data
+        assert set(data.keys()) == {'id', 'badge', 'awarded_at'}
+
+    def test_user_badge_serializer_badge_is_nested_dict(self):
+        data = UserBadgeSerializer(self.user_badge).data
+        assert isinstance(data['badge'], dict)
+        assert set(data['badge'].keys()) == {'id', 'name', 'description', 'criteria_type', 'criteria_threshold'}
+
+    def test_user_badge_serializer_badge_values_match(self):
+        data = UserBadgeSerializer(self.user_badge).data
+        assert data['badge']['name'] == self.badge.name
+
+    def test_user_badge_serializer_awarded_at_is_not_null(self):
+        data = UserBadgeSerializer(self.user_badge).data
+        assert data['awarded_at'] is not None
+
+
+class TestPointSummarySerializer:
+    def test_point_summary_serializer_contains_expected_fields(self):
+        data = PointSummarySerializer({'user_id': 1, 'total_points': 50}).data
+        assert set(data.keys()) == {'user_id', 'total_points'}
+
+    def test_point_summary_serializer_values_match_input(self):
+        data = PointSummarySerializer({'user_id': 42, 'total_points': 200}).data
+        assert data['user_id'] == 42
+        assert data['total_points'] == 200
+
+    def test_point_summary_serializer_zero_points(self):
+        data = PointSummarySerializer({'user_id': 1, 'total_points': 0}).data
+        assert data['total_points'] == 0
+
+
+@pytest.mark.django_db
+class TestPointTransactionSerializer:
+    def setup_method(self):
+        self.user = _make_user()
+
+    def test_point_transaction_serializer_contains_expected_fields(self):
+        tx = PointTransaction.objects.create(user=self.user, amount=50, event_type=STORY_PUBLISHED)
+        data = PointTransactionSerializer(tx).data
+        assert set(data.keys()) == {'id', 'amount', 'event_type', 'story_id', 'created_at'}
+
+    def test_point_transaction_serializer_story_id_is_null_when_no_story(self):
+        tx = PointTransaction.objects.create(user=self.user, amount=50, event_type=STORY_PUBLISHED)
+        data = PointTransactionSerializer(tx).data
+        assert data['story_id'] is None
+
+    def test_point_transaction_serializer_story_id_matches_when_story_set(self):
+        story = _make_story(self.user)
+        tx = PointTransaction.objects.create(
+            user=self.user, amount=50, event_type=STORY_PUBLISHED, story=story,
+        )
+        data = PointTransactionSerializer(tx).data
+        assert data['story_id'] == story.pk
+
+    def test_point_transaction_serializer_negative_amount(self):
+        tx = PointTransaction.objects.create(user=self.user, amount=-50, event_type='story_removed')
+        data = PointTransactionSerializer(tx).data
+        assert data['amount'] == -50

--- a/backend/apps/gamification/tests/test_serializers.py
+++ b/backend/apps/gamification/tests/test_serializers.py
@@ -19,10 +19,11 @@ def _make_user(email='u@example.com', username='u'):
 
 
 def _make_badge(name='Pioneer'):
-    return Badge.objects.create(
-        name=name, description='First badge.',
-        criteria_type=BADGE_CRITERIA_STORIES_PUBLISHED, criteria_threshold=1,
+    badge, _ = Badge.objects.get_or_create(
+        name=name,
+        defaults={'description': 'First badge.', 'criteria_type': BADGE_CRITERIA_STORIES_PUBLISHED, 'criteria_threshold': 1},
     )
+    return badge
 
 
 def _make_story(user):

--- a/backend/apps/gamification/tests/test_services.py
+++ b/backend/apps/gamification/tests/test_services.py
@@ -3,25 +3,10 @@ from decimal import Decimal
 import pytest
 from django.http import Http404
 
-from apps.gamification.constants import BADGE_CRITERIA_STORIES_PUBLISHED, STORY_PUBLISHED
-from apps.gamification.models import Badge, PointTransaction, UserBadge
-from apps.gamification.services import (
-    get_badge_catalog,
-    get_user_badges,
-    get_user_point_history,
-    get_user_points,
-)
-from apps.stories.models import Story
-from apps.users.models import User
-from decimal import Decimal
-
-import pytest
-
 from apps.gamification.constants import (
     BADGE_CRITERIA_POINTS_TOTAL,
     BADGE_CRITERIA_REGISTRATION,
     BADGE_CRITERIA_STORIES_PUBLISHED,
-    STORY_COMMENTED,
     STORY_LIKED,
     STORY_LIKE_REMOVED,
     STORY_PUBLISHED,
@@ -35,12 +20,17 @@ from apps.gamification.services import (
     award_points,
     award_registration_badge,
     check_and_award_badges,
+    get_badge_catalog,
     get_published_story_count,
+    get_user_badges,
+    get_user_point_history,
+    get_user_points,
 )
 from apps.stories.models import Story
 from apps.users.models import User
 
 
+# ── Shared helpers ────────────────────────────────────────────────────────────
 
 def _make_user(email='u@example.com', username='u', active=True):
     return User.objects.create_user(
@@ -48,21 +38,28 @@ def _make_user(email='u@example.com', username='u', active=True):
     )
 
 
-def _make_badge(name='Pioneer'):
-    return Badge.objects.create(
-        name=name, description='desc',
-        criteria_type=BADGE_CRITERIA_STORIES_PUBLISHED, criteria_threshold=1,
+def _make_badge(name='Pioneer', criteria_type=BADGE_CRITERIA_STORIES_PUBLISHED, threshold=1):
+    badge, _ = Badge.objects.get_or_create(
+        name=name,
+        defaults={
+            'description': 'desc',
+            'criteria_type': criteria_type,
+            'criteria_threshold': threshold,
+        },
     )
+    return badge
 
 
-def _make_story(user):
+def _make_story(user, status=Story.STATUS_PUBLISHED):
     return Story.objects.create(
         user=user, title='T', narrative='N',
-        status=Story.STATUS_PUBLISHED,
+        status=status,
         location_lat=Decimal('0'), location_lng=Decimal('0'),
-        location_name='P', time_type=Story.TIME_EXACT, year=2000,
+        location_name='Place', time_type=Story.TIME_EXACT, year=2000,
     )
 
+
+# ── get_user_points ───────────────────────────────────────────────────────────
 
 @pytest.mark.django_db
 class TestGetUserPoints:
@@ -73,7 +70,7 @@ class TestGetUserPoints:
         assert result == {'user_id': user.pk, 'total_points': 100}
 
     def test_get_user_points_returns_zero_when_no_points(self):
-        user = _make_user()
+        user = _make_user(email='zero@example.com', username='zero')
         result = get_user_points(user.pk)
         assert result['total_points'] == 0
 
@@ -82,10 +79,12 @@ class TestGetUserPoints:
             get_user_points(99999)
 
     def test_get_user_points_inactive_user_raises_404(self):
-        user = _make_user(active=False)
+        user = _make_user(email='inactive@example.com', username='inactive', active=False)
         with pytest.raises(Http404):
             get_user_points(user.pk)
 
+
+# ── get_user_badges ───────────────────────────────────────────────────────────
 
 @pytest.mark.django_db
 class TestGetUserBadges:
@@ -97,15 +96,15 @@ class TestGetUserBadges:
         assert qs.count() == 0
 
     def test_get_user_badges_returns_all_earned_badges(self):
-        badge1 = _make_badge('First')
-        badge2 = _make_badge('Second')
+        badge1 = _make_badge('__b1__')
+        badge2 = _make_badge('__b2__')
         UserBadge.objects.create(user=self.user, badge=badge1)
         UserBadge.objects.create(user=self.user, badge=badge2)
         assert get_user_badges(self.user.pk).count() == 2
 
     def test_get_user_badges_ordered_by_awarded_at_ascending(self):
-        badge1 = _make_badge('First')
-        badge2 = _make_badge('Second')
+        badge1 = _make_badge('__ord1__')
+        badge2 = _make_badge('__ord2__')
         ub1 = UserBadge.objects.create(user=self.user, badge=badge1)
         ub2 = UserBadge.objects.create(user=self.user, badge=badge2)
         results = list(get_user_badges(self.user.pk))
@@ -114,7 +113,7 @@ class TestGetUserBadges:
 
     def test_get_user_badges_does_not_return_other_users_badges(self):
         other = _make_user('other@example.com', 'other')
-        badge = _make_badge()
+        badge = _make_badge('__other__')
         UserBadge.objects.create(user=other, badge=badge)
         assert get_user_badges(self.user.pk).count() == 0
 
@@ -123,10 +122,12 @@ class TestGetUserBadges:
             get_user_badges(99999)
 
     def test_get_user_badges_inactive_user_raises_404(self):
-        inactive = _make_user('inactive@example.com', 'inactive', active=False)
+        inactive = _make_user('inactive2@example.com', 'inactive2', active=False)
         with pytest.raises(Http404):
             get_user_badges(inactive.pk)
 
+
+# ── get_user_point_history ────────────────────────────────────────────────────
 
 @pytest.mark.django_db
 class TestGetUserPointHistory:
@@ -139,19 +140,18 @@ class TestGetUserPointHistory:
 
     def test_get_user_point_history_returns_all_transactions(self):
         PointTransaction.objects.create(user=self.user, amount=50, event_type=STORY_PUBLISHED)
-        PointTransaction.objects.create(user=self.user, amount=2, event_type='story_liked')
+        PointTransaction.objects.create(user=self.user, amount=2, event_type=STORY_LIKED)
         assert get_user_point_history(self.user.pk).count() == 2
 
     def test_get_user_point_history_ordered_newest_first(self):
         tx1 = PointTransaction.objects.create(user=self.user, amount=50, event_type=STORY_PUBLISHED)
-        tx2 = PointTransaction.objects.create(user=self.user, amount=2, event_type='story_liked')
+        tx2 = PointTransaction.objects.create(user=self.user, amount=2, event_type=STORY_LIKED)
         results = list(get_user_point_history(self.user.pk))
-        # tx2 was created after tx1, so it should appear first
         assert results[0].pk == tx2.pk
         assert results[1].pk == tx1.pk
 
     def test_get_user_point_history_does_not_return_other_users_transactions(self):
-        other = _make_user('other@example.com', 'other')
+        other = _make_user('other2@example.com', 'other2')
         PointTransaction.objects.create(user=other, amount=50, event_type=STORY_PUBLISHED)
         assert get_user_point_history(self.user.pk).count() == 0
 
@@ -160,59 +160,31 @@ class TestGetUserPointHistory:
             get_user_point_history(99999)
 
     def test_get_user_point_history_inactive_user_raises_404(self):
-        inactive = _make_user('inactive@example.com', 'inactive', active=False)
+        inactive = _make_user('inactive3@example.com', 'inactive3', active=False)
         with pytest.raises(Http404):
             get_user_point_history(inactive.pk)
 
 
+# ── get_badge_catalog ─────────────────────────────────────────────────────────
+
 @pytest.mark.django_db
 class TestGetBadgeCatalog:
-    def test_get_badge_catalog_returns_empty_when_no_badges(self):
-        assert get_badge_catalog().count() == 0
+    def test_get_badge_catalog_returns_seeded_badges(self):
+        # Seed migration pre-populates the badge table; catalog must return all of them.
+        seeded_count = Badge.objects.count()
+        assert get_badge_catalog().count() == seeded_count
 
-    def test_get_badge_catalog_returns_all_badges(self):
-        _make_badge('A')
-        _make_badge('B')
-        _make_badge('C')
-        assert get_badge_catalog().count() == 3
+    def test_get_badge_catalog_adding_badge_increments_count(self):
+        before = get_badge_catalog().count()
+        _make_badge('__new_catalog_badge__')
+        assert get_badge_catalog().count() == before + 1
 
     def test_get_badge_catalog_ordered_by_id_ascending(self):
-        b1 = _make_badge('A')
-        b2 = _make_badge('B')
-        b3 = _make_badge('C')
+        b1 = _make_badge('__cat_a__')
+        b2 = _make_badge('__cat_b__')
         results = list(get_badge_catalog())
-        assert results[0].pk == b1.pk
-        assert results[1].pk == b2.pk
-        assert results[2].pk == b3.pk
-
-
-# ── Helpers ───────────────────────────────────────────────────────────────────
-
-def _make_user(email='user@example.com', username='user'):
-    return User.objects.create_user(email=email, username=username, password='Password1!')
-
-
-def _make_story(user, status=Story.STATUS_PUBLISHED):
-    return Story.objects.create(
-        user=user, title='T', narrative='N',
-        status=status,
-        location_lat=Decimal('0'), location_lng=Decimal('0'),
-        location_name='Place', time_type=Story.TIME_EXACT, year=2000,
-    )
-
-
-def _make_badge(name, criteria_type, threshold=0):
-    # get_or_create so tests are safe when the seed migration has already created
-    # badges with the same name in the test DB.
-    badge, _ = Badge.objects.get_or_create(
-        name=name,
-        defaults={
-            'description': 'desc',
-            'criteria_type': criteria_type,
-            'criteria_threshold': threshold,
-        },
-    )
-    return badge
+        ids = [b.pk for b in results]
+        assert ids.index(b1.pk) < ids.index(b2.pk)
 
 
 # ── award_points ──────────────────────────────────────────────────────────────
@@ -227,9 +199,9 @@ class TestAwardPoints:
         assert PointTransaction.objects.filter(user=self.user, event_type=STORY_PUBLISHED).exists()
 
     def test_award_points_stores_correct_amount(self):
-        award_points(self.user, STORY_LIKED)
-        tx = PointTransaction.objects.get(user=self.user, event_type=STORY_LIKED)
-        assert tx.amount == 2
+        award_points(self.user, STORY_PUBLISHED)
+        tx = PointTransaction.objects.get(user=self.user, event_type=STORY_PUBLISHED)
+        assert tx.amount == 50
 
     def test_award_points_increments_total_points(self):
         award_points(self.user, STORY_PUBLISHED)
@@ -239,7 +211,7 @@ class TestAwardPoints:
     def test_multiple_events_accumulate_points(self):
         award_points(self.user, STORY_PUBLISHED)
         award_points(self.user, STORY_LIKED)
-        award_points(self.user, STORY_COMMENTED)
+        award_points(self.user, 'story_commented')
         self.user.refresh_from_db()
         assert self.user.total_points == 56  # 50 + 2 + 4
 
@@ -250,7 +222,6 @@ class TestAwardPoints:
         assert self.user.total_points == 48
 
     def test_floor_prevents_points_going_below_zero(self):
-        # User starts at 0; a deduction must not produce a negative total.
         award_points(self.user, STORY_LIKE_REMOVED)
         self.user.refresh_from_db()
         assert self.user.total_points == 0
@@ -273,12 +244,10 @@ class TestAwardPoints:
         assert tx.story is None
 
     def test_award_points_updates_user_instance_in_place(self):
-        # After the call the passed-in user object reflects the new total.
         award_points(self.user, STORY_PUBLISHED)
         assert self.user.total_points == 50
 
     def test_award_points_triggers_badge_check(self):
-        # A points-threshold badge should be awarded after crossing its threshold.
         _make_badge('Fifty Points', BADGE_CRITERIA_POINTS_TOTAL, threshold=50)
         award_points(self.user, STORY_PUBLISHED)  # +50 → crosses threshold
         assert UserBadge.objects.filter(user=self.user).exists()
@@ -308,7 +277,7 @@ class TestCheckAndAwardBadges:
 
     def test_does_not_award_stories_badge_below_threshold(self):
         badge = _make_badge('Three Stories', BADGE_CRITERIA_STORIES_PUBLISHED, threshold=3)
-        _make_story(self.user)  # only 1 story — below the 3-story threshold
+        _make_story(self.user)
         check_and_award_badges(self.user)
         assert not UserBadge.objects.filter(user=self.user, badge=badge).exists()
 
@@ -327,8 +296,6 @@ class TestCheckAndAwardBadges:
         assert not UserBadge.objects.filter(user=self.user, badge=badge).exists()
 
     def test_awards_multiple_badges_in_one_check(self):
-        # Verify that both specific badges are awarded — not asserting an exact
-        # total count because seeded badges may also be triggered.
         first_story_badge = _make_badge('First Story', BADGE_CRITERIA_STORIES_PUBLISHED, threshold=1)
         fifty_points_badge = _make_badge('Fifty Points', BADGE_CRITERIA_POINTS_TOTAL, threshold=50)
         _make_story(self.user)
@@ -342,11 +309,10 @@ class TestCheckAndAwardBadges:
         _make_badge('First Story', BADGE_CRITERIA_STORIES_PUBLISHED, threshold=1)
         _make_story(self.user)
         check_and_award_badges(self.user)
-        check_and_award_badges(self.user)  # second call must not duplicate
+        check_and_award_badges(self.user)
         assert UserBadge.objects.filter(user=self.user).count() == 1
 
     def test_skips_registration_badges(self):
-        # Registration badges must not be awarded through check_and_award_badges.
         _make_badge('Pioneer', BADGE_CRITERIA_REGISTRATION, threshold=0)
         check_and_award_badges(self.user)
         assert not UserBadge.objects.filter(user=self.user).exists()
@@ -364,7 +330,6 @@ class TestCheckAndAwardBadges:
         assert not UserBadge.objects.filter(user=self.user).exists()
 
     def test_no_badges_seeded_is_a_no_op(self):
-        # Should not raise even when the badge table is empty.
         check_and_award_badges(self.user)
         assert UserBadge.objects.filter(user=self.user).count() == 0
 
@@ -384,14 +349,12 @@ class TestAwardRegistrationBadge:
     def test_idempotent_does_not_duplicate_badge(self):
         _make_badge('Pioneer', BADGE_CRITERIA_REGISTRATION, threshold=0)
         award_registration_badge(self.user)
-        award_registration_badge(self.user)  # second call must not duplicate
+        award_registration_badge(self.user)
         assert UserBadge.objects.filter(user=self.user).count() == 1
 
     def test_no_error_when_registration_badge_not_seeded(self):
-        # Graceful no-op when the badge row does not exist (e.g., before migration).
-        # Delete the seeded registration badge to simulate a pre-migration environment.
         Badge.objects.filter(criteria_type=BADGE_CRITERIA_REGISTRATION).delete()
-        award_registration_badge(self.user)  # must not raise
+        award_registration_badge(self.user)
         assert UserBadge.objects.filter(user=self.user).count() == 0
 
     def test_does_not_award_non_registration_badges(self):
@@ -427,7 +390,7 @@ class TestGetPublishedStoryCount:
         assert get_published_story_count(self.user) == 0
 
     def test_counts_only_own_stories(self):
-        other = _make_user(email='other@example.com', username='other')
+        other = _make_user(email='other3@example.com', username='other3')
         _make_story(other)
         assert get_published_story_count(self.user) == 0
 

--- a/backend/apps/gamification/tests/test_services.py
+++ b/backend/apps/gamification/tests/test_services.py
@@ -1,6 +1,21 @@
 from decimal import Decimal
 
 import pytest
+from django.http import Http404
+
+from apps.gamification.constants import BADGE_CRITERIA_STORIES_PUBLISHED, STORY_PUBLISHED
+from apps.gamification.models import Badge, PointTransaction, UserBadge
+from apps.gamification.services import (
+    get_badge_catalog,
+    get_user_badges,
+    get_user_point_history,
+    get_user_points,
+)
+from apps.stories.models import Story
+from apps.users.models import User
+from decimal import Decimal
+
+import pytest
 
 from apps.gamification.constants import (
     BADGE_CRITERIA_POINTS_TOTAL,
@@ -24,6 +39,151 @@ from apps.gamification.services import (
 )
 from apps.stories.models import Story
 from apps.users.models import User
+
+
+
+def _make_user(email='u@example.com', username='u', active=True):
+    return User.objects.create_user(
+        email=email, username=username, password='Password1', is_active=active,
+    )
+
+
+def _make_badge(name='Pioneer'):
+    return Badge.objects.create(
+        name=name, description='desc',
+        criteria_type=BADGE_CRITERIA_STORIES_PUBLISHED, criteria_threshold=1,
+    )
+
+
+def _make_story(user):
+    return Story.objects.create(
+        user=user, title='T', narrative='N',
+        status=Story.STATUS_PUBLISHED,
+        location_lat=Decimal('0'), location_lng=Decimal('0'),
+        location_name='P', time_type=Story.TIME_EXACT, year=2000,
+    )
+
+
+@pytest.mark.django_db
+class TestGetUserPoints:
+    def test_get_user_points_returns_user_id_and_total_points(self):
+        user = _make_user()
+        User.objects.filter(pk=user.pk).update(total_points=100)
+        result = get_user_points(user.pk)
+        assert result == {'user_id': user.pk, 'total_points': 100}
+
+    def test_get_user_points_returns_zero_when_no_points(self):
+        user = _make_user()
+        result = get_user_points(user.pk)
+        assert result['total_points'] == 0
+
+    def test_get_user_points_nonexistent_user_raises_404(self):
+        with pytest.raises(Http404):
+            get_user_points(99999)
+
+    def test_get_user_points_inactive_user_raises_404(self):
+        user = _make_user(active=False)
+        with pytest.raises(Http404):
+            get_user_points(user.pk)
+
+
+@pytest.mark.django_db
+class TestGetUserBadges:
+    def setup_method(self):
+        self.user = _make_user()
+
+    def test_get_user_badges_returns_empty_queryset_when_none_earned(self):
+        qs = get_user_badges(self.user.pk)
+        assert qs.count() == 0
+
+    def test_get_user_badges_returns_all_earned_badges(self):
+        badge1 = _make_badge('First')
+        badge2 = _make_badge('Second')
+        UserBadge.objects.create(user=self.user, badge=badge1)
+        UserBadge.objects.create(user=self.user, badge=badge2)
+        assert get_user_badges(self.user.pk).count() == 2
+
+    def test_get_user_badges_ordered_by_awarded_at_ascending(self):
+        badge1 = _make_badge('First')
+        badge2 = _make_badge('Second')
+        ub1 = UserBadge.objects.create(user=self.user, badge=badge1)
+        ub2 = UserBadge.objects.create(user=self.user, badge=badge2)
+        results = list(get_user_badges(self.user.pk))
+        assert results[0].pk == ub1.pk
+        assert results[1].pk == ub2.pk
+
+    def test_get_user_badges_does_not_return_other_users_badges(self):
+        other = _make_user('other@example.com', 'other')
+        badge = _make_badge()
+        UserBadge.objects.create(user=other, badge=badge)
+        assert get_user_badges(self.user.pk).count() == 0
+
+    def test_get_user_badges_nonexistent_user_raises_404(self):
+        with pytest.raises(Http404):
+            get_user_badges(99999)
+
+    def test_get_user_badges_inactive_user_raises_404(self):
+        inactive = _make_user('inactive@example.com', 'inactive', active=False)
+        with pytest.raises(Http404):
+            get_user_badges(inactive.pk)
+
+
+@pytest.mark.django_db
+class TestGetUserPointHistory:
+    def setup_method(self):
+        self.user = _make_user()
+
+    def test_get_user_point_history_returns_empty_when_none(self):
+        qs = get_user_point_history(self.user.pk)
+        assert qs.count() == 0
+
+    def test_get_user_point_history_returns_all_transactions(self):
+        PointTransaction.objects.create(user=self.user, amount=50, event_type=STORY_PUBLISHED)
+        PointTransaction.objects.create(user=self.user, amount=2, event_type='story_liked')
+        assert get_user_point_history(self.user.pk).count() == 2
+
+    def test_get_user_point_history_ordered_newest_first(self):
+        tx1 = PointTransaction.objects.create(user=self.user, amount=50, event_type=STORY_PUBLISHED)
+        tx2 = PointTransaction.objects.create(user=self.user, amount=2, event_type='story_liked')
+        results = list(get_user_point_history(self.user.pk))
+        # tx2 was created after tx1, so it should appear first
+        assert results[0].pk == tx2.pk
+        assert results[1].pk == tx1.pk
+
+    def test_get_user_point_history_does_not_return_other_users_transactions(self):
+        other = _make_user('other@example.com', 'other')
+        PointTransaction.objects.create(user=other, amount=50, event_type=STORY_PUBLISHED)
+        assert get_user_point_history(self.user.pk).count() == 0
+
+    def test_get_user_point_history_nonexistent_user_raises_404(self):
+        with pytest.raises(Http404):
+            get_user_point_history(99999)
+
+    def test_get_user_point_history_inactive_user_raises_404(self):
+        inactive = _make_user('inactive@example.com', 'inactive', active=False)
+        with pytest.raises(Http404):
+            get_user_point_history(inactive.pk)
+
+
+@pytest.mark.django_db
+class TestGetBadgeCatalog:
+    def test_get_badge_catalog_returns_empty_when_no_badges(self):
+        assert get_badge_catalog().count() == 0
+
+    def test_get_badge_catalog_returns_all_badges(self):
+        _make_badge('A')
+        _make_badge('B')
+        _make_badge('C')
+        assert get_badge_catalog().count() == 3
+
+    def test_get_badge_catalog_ordered_by_id_ascending(self):
+        b1 = _make_badge('A')
+        b2 = _make_badge('B')
+        b3 = _make_badge('C')
+        results = list(get_badge_catalog())
+        assert results[0].pk == b1.pk
+        assert results[1].pk == b2.pk
+        assert results[2].pk == b3.pk
 
 
 # ── Helpers ───────────────────────────────────────────────────────────────────

--- a/backend/apps/gamification/tests/test_views.py
+++ b/backend/apps/gamification/tests/test_views.py
@@ -1,1 +1,239 @@
-# tests/test_views.py — gamification
+from decimal import Decimal
+
+import pytest
+from rest_framework.test import APIClient
+
+from apps.gamification.constants import BADGE_CRITERIA_STORIES_PUBLISHED, STORY_PUBLISHED
+from apps.gamification.models import Badge, PointTransaction, UserBadge
+from apps.stories.models import Story
+from apps.users.models import User
+
+
+BADGE_CATALOG_URL = '/gamification/badges/'
+
+
+def _points_url(user_id):
+    return f'/users/{user_id}/points/'
+
+
+def _badges_url(user_id):
+    return f'/users/{user_id}/badges/'
+
+
+def _history_url(user_id):
+    return f'/users/{user_id}/point-history/'
+
+
+def _make_user(email='u@example.com', username='u', active=True, role='registered_user'):
+    return User.objects.create_user(
+        email=email, username=username, password='Password1',
+        is_active=active, role=role,
+    )
+
+
+def _make_admin(email='admin@example.com', username='admin'):
+    return User.objects.create_user(
+        email=email, username=username, password='Password1',
+        is_active=True, role='admin',
+    )
+
+
+def _make_badge(name='Pioneer'):
+    return Badge.objects.create(
+        name=name, description='desc',
+        criteria_type=BADGE_CRITERIA_STORIES_PUBLISHED, criteria_threshold=1,
+    )
+
+
+def _make_story(user):
+    return Story.objects.create(
+        user=user, title='T', narrative='N',
+        status=Story.STATUS_PUBLISHED,
+        location_lat=Decimal('0'), location_lng=Decimal('0'),
+        location_name='P', time_type=Story.TIME_EXACT, year=2000,
+    )
+
+
+@pytest.mark.django_db
+class TestUserPointsView:
+    def setup_method(self):
+        self.client = APIClient()
+        self.user = _make_user()
+        User.objects.filter(pk=self.user.pk).update(total_points=42)
+
+    def test_get_user_points_returns_200_and_correct_shape(self):
+        response = self.client.get(_points_url(self.user.pk))
+        assert response.status_code == 200
+        assert response.data['user_id'] == self.user.pk
+        assert response.data['total_points'] == 42
+
+    def test_get_user_points_is_public_no_auth_required(self):
+        # Unauthenticated request should still succeed
+        response = self.client.get(_points_url(self.user.pk))
+        assert response.status_code == 200
+
+    def test_get_user_points_nonexistent_user_returns_404(self):
+        response = self.client.get(_points_url(99999))
+        assert response.status_code == 404
+
+    def test_get_user_points_inactive_user_returns_404(self):
+        inactive = _make_user('i@example.com', 'inactive', active=False)
+        response = self.client.get(_points_url(inactive.pk))
+        assert response.status_code == 404
+
+
+@pytest.mark.django_db
+class TestUserBadgesView:
+    def setup_method(self):
+        self.client = APIClient()
+        self.user = _make_user()
+
+    def test_get_user_badges_returns_200_and_paginated_response(self):
+        badge1 = _make_badge('First')
+        badge2 = _make_badge('Second')
+        UserBadge.objects.create(user=self.user, badge=badge1)
+        UserBadge.objects.create(user=self.user, badge=badge2)
+        response = self.client.get(_badges_url(self.user.pk))
+        assert response.status_code == 200
+        assert response.data['count'] == 2
+        assert isinstance(response.data['results'], list)
+
+    def test_get_user_badges_response_item_shape(self):
+        badge = _make_badge()
+        UserBadge.objects.create(user=self.user, badge=badge)
+        response = self.client.get(_badges_url(self.user.pk))
+        item = response.data['results'][0]
+        assert set(item.keys()) == {'id', 'badge', 'awarded_at'}
+        assert set(item['badge'].keys()) == {'id', 'name', 'description', 'criteria_type', 'criteria_threshold'}
+
+    def test_get_user_badges_is_public_no_auth_required(self):
+        response = self.client.get(_badges_url(self.user.pk))
+        assert response.status_code == 200
+
+    def test_get_user_badges_empty_list_when_no_badges_earned(self):
+        response = self.client.get(_badges_url(self.user.pk))
+        assert response.status_code == 200
+        assert response.data['count'] == 0
+        assert response.data['results'] == []
+
+    def test_get_user_badges_nonexistent_user_returns_404(self):
+        response = self.client.get(_badges_url(99999))
+        assert response.status_code == 404
+
+    def test_get_user_badges_inactive_user_returns_404(self):
+        inactive = _make_user('i@example.com', 'inactive', active=False)
+        response = self.client.get(_badges_url(inactive.pk))
+        assert response.status_code == 404
+
+    def test_get_user_badges_does_not_include_other_users_badges(self):
+        other = _make_user('other@example.com', 'other')
+        badge = _make_badge()
+        UserBadge.objects.create(user=other, badge=badge)
+        response = self.client.get(_badges_url(self.user.pk))
+        assert response.data['count'] == 0
+
+
+@pytest.mark.django_db
+class TestUserPointHistoryView:
+    def setup_method(self):
+        self.client = APIClient()
+        self.user = _make_user()
+
+    def _auth(self, user):
+        self.client.force_authenticate(user=user)
+
+    def test_get_point_history_owner_can_access(self):
+        self._auth(self.user)
+        response = self.client.get(_history_url(self.user.pk))
+        assert response.status_code == 200
+
+    def test_get_point_history_admin_can_access(self):
+        admin = _make_admin()
+        self._auth(admin)
+        response = self.client.get(_history_url(self.user.pk))
+        assert response.status_code == 200
+
+    def test_get_point_history_unauthenticated_returns_401(self):
+        response = self.client.get(_history_url(self.user.pk))
+        assert response.status_code == 401
+
+    def test_get_point_history_other_user_returns_403(self):
+        other = _make_user('other@example.com', 'other')
+        self._auth(other)
+        response = self.client.get(_history_url(self.user.pk))
+        assert response.status_code == 403
+
+    def test_get_point_history_returns_paginated_transactions(self):
+        PointTransaction.objects.create(user=self.user, amount=50, event_type=STORY_PUBLISHED)
+        PointTransaction.objects.create(user=self.user, amount=2, event_type='story_liked')
+        self._auth(self.user)
+        response = self.client.get(_history_url(self.user.pk))
+        assert response.status_code == 200
+        assert response.data['count'] == 2
+
+    def test_get_point_history_response_item_shape(self):
+        PointTransaction.objects.create(user=self.user, amount=50, event_type=STORY_PUBLISHED)
+        self._auth(self.user)
+        response = self.client.get(_history_url(self.user.pk))
+        item = response.data['results'][0]
+        assert set(item.keys()) == {'id', 'amount', 'event_type', 'story_id', 'created_at'}
+
+    def test_get_point_history_ordered_newest_first(self):
+        tx1 = PointTransaction.objects.create(user=self.user, amount=50, event_type=STORY_PUBLISHED)
+        tx2 = PointTransaction.objects.create(user=self.user, amount=2, event_type='story_liked')
+        self._auth(self.user)
+        response = self.client.get(_history_url(self.user.pk))
+        results = response.data['results']
+        assert results[0]['id'] == tx2.pk
+        assert results[1]['id'] == tx1.pk
+
+    def test_get_point_history_nonexistent_user_returns_404(self):
+        admin = _make_admin()
+        self._auth(admin)
+        response = self.client.get(_history_url(99999))
+        assert response.status_code == 404
+
+    def test_get_point_history_inactive_user_returns_404(self):
+        inactive = _make_user('i@example.com', 'inactive', active=False)
+        admin = _make_admin()
+        self._auth(admin)
+        response = self.client.get(_history_url(inactive.pk))
+        assert response.status_code == 404
+
+
+@pytest.mark.django_db
+class TestBadgeCatalogView:
+    def setup_method(self):
+        self.client = APIClient()
+
+    def test_get_badge_catalog_returns_200_and_paginated_response(self):
+        _make_badge('A')
+        _make_badge('B')
+        _make_badge('C')
+        response = self.client.get(BADGE_CATALOG_URL)
+        assert response.status_code == 200
+        assert response.data['count'] == 3
+
+    def test_get_badge_catalog_is_public_no_auth_required(self):
+        response = self.client.get(BADGE_CATALOG_URL)
+        assert response.status_code == 200
+
+    def test_get_badge_catalog_empty_when_no_badges(self):
+        response = self.client.get(BADGE_CATALOG_URL)
+        assert response.status_code == 200
+        assert response.data['count'] == 0
+        assert response.data['results'] == []
+
+    def test_get_badge_catalog_response_item_shape(self):
+        _make_badge()
+        response = self.client.get(BADGE_CATALOG_URL)
+        item = response.data['results'][0]
+        assert set(item.keys()) == {'id', 'name', 'description', 'criteria_type', 'criteria_threshold'}
+
+    def test_get_badge_catalog_ordered_by_id(self):
+        b1 = _make_badge('A')
+        b2 = _make_badge('B')
+        response = self.client.get(BADGE_CATALOG_URL)
+        results = response.data['results']
+        assert results[0]['id'] == b1.pk
+        assert results[1]['id'] == b2.pk

--- a/backend/apps/gamification/tests/test_views.py
+++ b/backend/apps/gamification/tests/test_views.py
@@ -39,10 +39,11 @@ def _make_admin(email='admin@example.com', username='admin'):
 
 
 def _make_badge(name='Pioneer'):
-    return Badge.objects.create(
-        name=name, description='desc',
-        criteria_type=BADGE_CRITERIA_STORIES_PUBLISHED, criteria_threshold=1,
+    badge, _ = Badge.objects.get_or_create(
+        name=name,
+        defaults={'description': 'desc', 'criteria_type': BADGE_CRITERIA_STORIES_PUBLISHED, 'criteria_threshold': 1},
     )
+    return badge
 
 
 def _make_story(user):
@@ -207,33 +208,33 @@ class TestBadgeCatalogView:
         self.client = APIClient()
 
     def test_get_badge_catalog_returns_200_and_paginated_response(self):
-        _make_badge('A')
-        _make_badge('B')
-        _make_badge('C')
+        # Seed migration may pre-populate badges; verify HTTP 200 and paginated shape.
         response = self.client.get(BADGE_CATALOG_URL)
         assert response.status_code == 200
-        assert response.data['count'] == 3
+        assert 'count' in response.data
+        assert 'results' in response.data
 
     def test_get_badge_catalog_is_public_no_auth_required(self):
         response = self.client.get(BADGE_CATALOG_URL)
         assert response.status_code == 200
 
-    def test_get_badge_catalog_empty_when_no_badges(self):
+    def test_get_badge_catalog_adding_badge_increments_count(self):
+        baseline = self.client.get(BADGE_CATALOG_URL).data['count']
+        _make_badge('__test_unique_badge__')
         response = self.client.get(BADGE_CATALOG_URL)
-        assert response.status_code == 200
-        assert response.data['count'] == 0
-        assert response.data['results'] == []
+        assert response.data['count'] == baseline + 1
 
     def test_get_badge_catalog_response_item_shape(self):
-        _make_badge()
+        # At least one badge must exist (either seeded or created here).
+        _make_badge('__shape_test__')
         response = self.client.get(BADGE_CATALOG_URL)
         item = response.data['results'][0]
         assert set(item.keys()) == {'id', 'name', 'description', 'criteria_type', 'criteria_threshold'}
 
-    def test_get_badge_catalog_ordered_by_id(self):
-        b1 = _make_badge('A')
-        b2 = _make_badge('B')
-        response = self.client.get(BADGE_CATALOG_URL)
-        results = response.data['results']
-        assert results[0]['id'] == b1.pk
-        assert results[1]['id'] == b2.pk
+    def test_get_badge_catalog_new_badges_appear_at_end_ordered_by_id(self):
+        b1 = _make_badge('__ord_a__')
+        b2 = _make_badge('__ord_b__')
+        # Use large page_size so all badges (seed + new) fit on one page.
+        response = self.client.get(BADGE_CATALOG_URL, {'page_size': 100})
+        ids = [r['id'] for r in response.data['results']]
+        assert ids.index(b1.pk) < ids.index(b2.pk)

--- a/backend/apps/gamification/urls.py
+++ b/backend/apps/gamification/urls.py
@@ -1,1 +1,17 @@
-# urls.py — gamification
+from django.urls import path
+
+from apps.gamification.views import (
+    BadgeCatalogView,
+    UserBadgesView,
+    UserPointHistoryView,
+    UserPointsView,
+)
+
+app_name = 'gamification'
+
+urlpatterns = [
+    path('users/<int:user_id>/points/', UserPointsView.as_view(), name='user-points'),
+    path('users/<int:user_id>/badges/', UserBadgesView.as_view(), name='user-badges'),
+    path('users/<int:user_id>/point-history/', UserPointHistoryView.as_view(), name='user-point-history'),
+    path('gamification/badges/', BadgeCatalogView.as_view(), name='badge-catalog'),
+]

--- a/backend/apps/gamification/views.py
+++ b/backend/apps/gamification/views.py
@@ -1,1 +1,78 @@
-# views.py — gamification
+from django.http import Http404
+
+from rest_framework.permissions import AllowAny
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from common.pagination import StoryPagination
+from common.permissions import IsOwnerOrAdmin
+from apps.gamification.serializers import (
+    BadgeCatalogSerializer,
+    PointSummarySerializer,
+    PointTransactionSerializer,
+    UserBadgeSerializer,
+)
+from apps.gamification.services import (
+    get_badge_catalog,
+    get_user_badges,
+    get_user_point_history,
+    get_user_points,
+)
+from apps.users.models import User
+
+
+class UserPointsView(APIView):
+    """GET /users/<user_id>/points/ — returns the user's total point balance."""
+
+    permission_classes = [AllowAny]
+
+    def get(self, request, user_id):
+        data = get_user_points(user_id)
+        return Response(PointSummarySerializer(data).data)
+
+
+class UserBadgesView(APIView):
+    """GET /users/<user_id>/badges/ — paginated list of badges the user has earned."""
+
+    permission_classes = [AllowAny]
+
+    def get(self, request, user_id):
+        qs = get_user_badges(user_id)
+        paginator = StoryPagination()
+        page = paginator.paginate_queryset(qs, request)
+        return paginator.get_paginated_response(UserBadgeSerializer(page, many=True).data)
+
+
+class UserPointHistoryView(APIView):
+    """
+    GET /users/<user_id>/point-history/ — paginated point transaction log.
+
+    Only the account owner or an admin may view this — point breakdowns are private.
+    check_object_permissions must be called explicitly because APIView does not
+    call it automatically (unlike GenericAPIView with get_object()).
+    """
+
+    permission_classes = [IsOwnerOrAdmin]
+
+    def get(self, request, user_id):
+        try:
+            target_user = User.objects.get(pk=user_id, is_active=True)
+        except User.DoesNotExist:
+            raise Http404
+        self.check_object_permissions(request, target_user)
+        qs = get_user_point_history(user_id)
+        paginator = StoryPagination()
+        page = paginator.paginate_queryset(qs, request)
+        return paginator.get_paginated_response(PointTransactionSerializer(page, many=True).data)
+
+
+class BadgeCatalogView(APIView):
+    """GET /gamification/badges/ — full catalog of all available badges."""
+
+    permission_classes = [AllowAny]
+
+    def get(self, request):
+        qs = get_badge_catalog()
+        paginator = StoryPagination()
+        page = paginator.paginate_queryset(qs, request)
+        return paginator.get_paginated_response(BadgeCatalogSerializer(page, many=True).data)

--- a/backend/apps/notifications/tests/test_signals.py
+++ b/backend/apps/notifications/tests/test_signals.py
@@ -158,6 +158,14 @@ class TestBadgeEarnedSignal:
         notif = Notification.objects.get(recipient=self.user, notification_type=NotificationType.BADGE_EARNED)
         assert notif.actor is None
 
+    def test_resaving_user_badge_does_not_duplicate_notification(self):
+        # Covers the `if not created: return` guard in on_badge_earned
+        ub = UserBadge.objects.create(user=self.user, badge=self.badge)
+        ub.save()
+        assert Notification.objects.filter(
+            recipient=self.user, notification_type=NotificationType.BADGE_EARNED,
+        ).count() == 1
+
 
 @pytest.mark.django_db
 class TestNewStoryPublishedSignal:

--- a/backend/config/urls.py
+++ b/backend/config/urls.py
@@ -9,6 +9,7 @@ urlpatterns = [
     path('users/', include('apps.users.profile_urls')),
     path('', include('apps.interactions.urls', namespace='interactions')),
     path('', include('apps.notifications.urls', namespace='notifications')),
+    path('', include('apps.gamification.urls', namespace='gamification')),
     path('', include('apps.media.urls', namespace='media')),
     path('stories/', include('apps.stories.urls', namespace='stories')),
     path('tags/', include('apps.tags.urls', namespace='tags')),


### PR DESCRIPTION
# 📝 Description 
Fixes #516 

This PR adds read-only gamification endpoints for user points, earned badges, point history, and the badge catalog.

The new endpoints are:

- `GET /users/<user_id>/points/`
  - Returns the user’s current total point balance.
  - Publicly accessible.
  - Returns `404` for inactive or nonexistent users.

- `GET /users/<user_id>/badges/`
  - Returns the badges earned by the user.
  - Publicly accessible and paginated.
  - Includes nested badge details such as name, description, criteria type, and threshold.

- `GET /users/<user_id>/point-history/`
  - Returns the user’s point transaction history.
  - Accessible only by the account owner or an admin.
  - Returns transactions with amount, event type, related story id, and creation time.

- `GET /gamification/badges/`
  - Returns the public badge catalog.
  - Publicly accessible and paginated.

This PR also adds serializers, service-layer helpers, API views, URL routes, and tests for the new functionality. It keeps detailed point history private while allowing public access to profile-level gamification data such as total points and earned badges.

# 📊 Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactoring
- [ ] Documentation

# ✅ Acceptance Criteria / Checklist

- [x] The project builds successfully.
- [x] The code follows the project style guidelines.
- [x] New endpoints are added for points, badges, point history, and badge catalog.
- [x] Public gamification data is accessible without authentication.
- [x] Point history is restricted to the user themself or an admin.
- [x] Inactive or nonexistent users return `404`.
- [x] Serializer, service, and view tests are added.
- [x] I have performed a self-review of my code.

# ⏱️ Estimated Review Time

- [ ] <5 min
- [x] 5–15 min
- [ ] >15 min