### PR TITLE
feat: add map pin view timeline action

### DIFF
--- a/mobile/src/app/navigation/RootNavigator.tsx
+++ b/mobile/src/app/navigation/RootNavigator.tsx
@@ -165,6 +165,7 @@ function BottomNavButton({
     <Pressable
       accessibilityRole="button"
       accessibilityLabel={label}
+      accessibilityState={{ selected: active }}
       onPress={onPress}
       style={({ pressed }) => ({
         flex: 1,
@@ -200,6 +201,8 @@ function ScreenShell({
   disableScrollViewPanResponder = false,
   scrollEnabled = true,
   canCancelContentTouches = true,
+  refreshEnabled = true,
+  refreshSuppressed = false,
   testID,
   preservedScrollY = 0,
   onScrollOffsetChange,
@@ -221,6 +224,8 @@ function ScreenShell({
   disableScrollViewPanResponder?: boolean;
   scrollEnabled?: boolean;
   canCancelContentTouches?: boolean;
+  refreshEnabled?: boolean;
+  refreshSuppressed?: boolean;
   testID?: string;
   preservedScrollY?: number;
   onScrollOffsetChange?: (y: number) => void;
@@ -249,7 +254,7 @@ function ScreenShell({
     typeof children === 'function' ? children({ scrollTo, registerRefreshHandler }) : children;
 
   const handleRefresh = useCallback(async () => {
-    if (!refreshHandler || isRefreshing) {
+    if (!refreshHandler || isRefreshing || refreshSuppressed) {
       return;
     }
 
@@ -260,7 +265,7 @@ function ScreenShell({
     } finally {
       setIsRefreshing(false);
     }
-  }, [isRefreshing, refreshHandler]);
+  }, [isRefreshing, refreshHandler, refreshSuppressed]);
 
   useEffect(() => {
     if (!scrollable || !active) {
@@ -310,12 +315,17 @@ function ScreenShell({
         contentContainerStyle={{ padding: spacing.lg, paddingBottom: flushBottom ? 0 : spacing.xl }}
         showsVerticalScrollIndicator={false}
         disableScrollViewPanResponder={disableScrollViewPanResponder}
-        scrollEnabled={scrollEnabled}
+        scrollEnabled={scrollEnabled && !refreshSuppressed}
         canCancelContentTouches={canCancelContentTouches}
         scrollEventThrottle={16}
         refreshControl={
-          refreshHandler ? (
-            <RefreshControl refreshing={isRefreshing} onRefresh={() => void handleRefresh()} tintColor={colors.primary} />
+          refreshEnabled && refreshHandler ? (
+            <RefreshControl
+              enabled={!refreshSuppressed}
+              refreshing={!refreshSuppressed && isRefreshing}
+              onRefresh={() => void handleRefresh()}
+              tintColor={colors.primary}
+            />
           ) : undefined
         }
         onScroll={(event: NativeSyntheticEvent<NativeScrollEvent>) => {
@@ -354,9 +364,13 @@ export function RootNavigator() {
   const [feedSort, setFeedSort] = useState<FeedSortOption>('recent');
   const [storyInteractionUpdates, setStoryInteractionUpdates] = useState<Record<string, FeedStoryInteractionUpdate>>({});
   const [unreadNotificationCount, setUnreadNotificationCount] = useState(0);
+  const [isMapTouchActive, setIsMapTouchActive] = useState(false);
   const [hasResolvedInitialSession, setHasResolvedInitialSession] = useState(false);
   const [backStack, setBackStack] = useState<RouteSnapshot[]>([]);
   const pagerRef = useRef<ScrollView>(null);
+  const animatedPagerRouteRef = useRef<AppRoute | null>(null);
+  const isPagerDragActiveRef = useRef(false);
+  const pagerDragResetTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const mapScrollOffsetRef = useRef(0);
 
   const currentSnapshot = useMemo<RouteSnapshot>(
@@ -397,6 +411,32 @@ export function RootNavigator() {
     setActiveStoryId(snapshot.route === ROUTES.STORY_DETAIL ? snapshot.storyId ?? null : null);
     setActiveUserId(snapshot.route === ROUTES.USER_PROFILE ? snapshot.userId ?? null : null);
   }, []);
+
+  const scrollMainPagerToRoute = useCallback(
+    (route: AppRoute, options?: { animated?: boolean }) => {
+      const pageIndex = MAIN_PAGER_ROUTES.indexOf(route);
+
+      if (pageIndex < 0) {
+        return;
+      }
+
+      const x = pageIndex * width;
+      const animated = Boolean(options?.animated);
+
+      if (animated) {
+        animatedPagerRouteRef.current = route;
+        pagerRef.current?.scrollTo({ x, y: 0, animated: true });
+        return;
+      }
+
+      animatedPagerRouteRef.current = null;
+      pagerRef.current?.scrollTo({ x, y: 0, animated: false });
+      requestAnimationFrame(() => {
+        pagerRef.current?.scrollTo({ x, y: 0, animated: false });
+      });
+    },
+    [width],
+  );
 
   const navigateToSnapshot = useCallback(
     (snapshot: RouteSnapshot, options?: { resetStack?: boolean; preserveCurrent?: boolean }) => {
@@ -495,6 +535,7 @@ export function RootNavigator() {
 
   const handleNavigate = (route: AppRoute) => {
     if (MAIN_PAGER_ROUTES.includes(route)) {
+      scrollMainPagerToRoute(route, { animated: true });
       navigateToSnapshot({ route }, { resetStack: true, preserveCurrent: false });
       return;
     }
@@ -519,12 +560,36 @@ export function RootNavigator() {
 
   useEffect(() => {
     if (!isMainRoute) {
+      setIsMapTouchActive(false);
+      isPagerDragActiveRef.current = false;
+      if (pagerDragResetTimerRef.current) {
+        clearTimeout(pagerDragResetTimerRef.current);
+        pagerDragResetTimerRef.current = null;
+      }
       return;
     }
 
+    if (currentRoute !== ROUTES.MAP) {
+      setIsMapTouchActive(false);
+    }
+
     const pageIndex = Math.max(MAIN_PAGER_ROUTES.indexOf(currentRoute), 0);
-    pagerRef.current?.scrollTo({ x: pageIndex * width, animated: false });
-  }, [currentRoute, isMainRoute, width]);
+    if (animatedPagerRouteRef.current === MAIN_PAGER_ROUTES[pageIndex]) {
+      animatedPagerRouteRef.current = null;
+      return;
+    }
+
+    scrollMainPagerToRoute(MAIN_PAGER_ROUTES[pageIndex]);
+  }, [currentRoute, isMainRoute, scrollMainPagerToRoute]);
+
+  useEffect(
+    () => () => {
+      if (pagerDragResetTimerRef.current) {
+        clearTimeout(pagerDragResetTimerRef.current);
+      }
+    },
+    [],
+  );
 
   const handleLoginComplete = (context?: { source: 'signIn' | 'register' }) => {
     if (context?.source === 'register') {
@@ -600,6 +665,28 @@ export function RootNavigator() {
     navigateToSnapshot({ route: ROUTES.STORY_DETAIL, storyId });
   };
 
+  const handleViewTimelineNearPin = useCallback(
+    (coordinates: { latitude: number; longitude: number }) => {
+      updateFilters(
+        {
+          query: '',
+          location: '',
+          locationBounds: undefined,
+          proximityRadiusKm: 0.5,
+          proximityCoordinates: coordinates,
+          proximitySource: 'map_pin',
+          timeFrom: '',
+          timeTo: '',
+          tags: [],
+        },
+        { refresh: true },
+      );
+      scrollMainPagerToRoute(ROUTES.TIMELINE, { animated: true });
+      navigateToSnapshot({ route: ROUTES.TIMELINE }, { resetStack: true, preserveCurrent: false });
+    },
+    [navigateToSnapshot, scrollMainPagerToRoute, updateFilters],
+  );
+
   const handleNotificationsChanged = useCallback((notifications: NotificationEntity[]) => {
     setUnreadNotificationCount(notifications.filter((notification) => !notification.isRead).length);
   }, []);
@@ -636,6 +723,7 @@ export function RootNavigator() {
           locationBounds: undefined,
           proximityRadiusKm: undefined,
           proximityCoordinates: undefined,
+          proximitySource: undefined,
           timeFrom: '',
           timeTo: '',
           tags: [tag],
@@ -775,7 +863,39 @@ export function RootNavigator() {
           contentOffset={{ x: Math.max(MAIN_PAGER_ROUTES.indexOf(currentRoute), 0) * width, y: 0 }}
           showsHorizontalScrollIndicator={false}
           scrollEventThrottle={16}
+          onScrollBeginDrag={() => {
+            if (pagerDragResetTimerRef.current) {
+              clearTimeout(pagerDragResetTimerRef.current);
+              pagerDragResetTimerRef.current = null;
+            }
+            isPagerDragActiveRef.current = true;
+          }}
+          onScrollEndDrag={() => {
+            if (pagerDragResetTimerRef.current) {
+              clearTimeout(pagerDragResetTimerRef.current);
+            }
+
+            pagerDragResetTimerRef.current = setTimeout(() => {
+              isPagerDragActiveRef.current = false;
+              pagerDragResetTimerRef.current = null;
+            }, 500);
+          }}
+          onMomentumScrollBegin={() => {
+            if (pagerDragResetTimerRef.current) {
+              clearTimeout(pagerDragResetTimerRef.current);
+              pagerDragResetTimerRef.current = null;
+            }
+          }}
           onMomentumScrollEnd={(event) => {
+            if (!isPagerDragActiveRef.current) {
+              return;
+            }
+
+            isPagerDragActiveRef.current = false;
+            if (pagerDragResetTimerRef.current) {
+              clearTimeout(pagerDragResetTimerRef.current);
+              pagerDragResetTimerRef.current = null;
+            }
             const offsetX = event.nativeEvent.contentOffset.x;
             const pageIndex = Math.max(0, Math.min(MAIN_PAGER_ROUTES.length - 1, Math.round(offsetX / width)));
             const nextRoute = MAIN_PAGER_ROUTES[pageIndex];
@@ -794,6 +914,7 @@ export function RootNavigator() {
               hideHeader
               active={currentRoute === ROUTES.MAP}
               canCancelContentTouches={false}
+              refreshSuppressed={isMapTouchActive}
               testID="map-route-scroll"
               preservedScrollY={mapScrollOffsetRef.current}
               onScrollOffsetChange={(y) => {
@@ -803,9 +924,11 @@ export function RootNavigator() {
               {({ scrollTo, registerRefreshHandler }) => (
                 <MapScreen
                   onOpenStory={handleOpenStoryDetail}
+                  onViewTimeline={handleViewTimelineNearPin}
                   onMarkerPreviewRequested={(targetY) => scrollTo(targetY)}
                   showSearchControls={false}
                   onRegisterRefresh={registerRefreshHandler}
+                  onMapTouchChange={setIsMapTouchActive}
                   searchScope="main"
                 />
               )}

--- a/mobile/src/app/navigation/__tests__/RootNavigator.test.tsx
+++ b/mobile/src/app/navigation/__tests__/RootNavigator.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { fireEvent, render, screen, waitFor } from '@testing-library/react-native';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react-native';
 import { RootNavigator } from '../RootNavigator';
 import { storage } from '../../../core/storage/storage';
 import { storageKeys } from '../../../core/storage/keys';
@@ -13,6 +13,21 @@ jest.mock('../../../features/search/application/services', () => ({
   searchTags: jest.fn(async () => []),
   searchLocationSuggestions: jest.fn(),
 }));
+
+jest.mock('../../../shared/components/WebMapView', () => {
+  const React = require('react');
+  const { Pressable, View } = require('react-native');
+
+  return {
+    WebMapView: ({ markers = [], onMarkerPress }: { markers?: Array<{ id: string }>; onMarkerPress?: (markerId: string) => void }) => (
+      <View testID="web-map-view">
+        {markers.map((marker) => (
+          <Pressable key={marker.id} testID="story-marker" onPress={() => onMarkerPress?.(marker.id)} />
+        ))}
+      </View>
+    ),
+  };
+});
 
 function renderNavigator() {
   return render(
@@ -58,6 +73,8 @@ const timelineResults = feedResults.map((story) => ({
 }));
 
 const goldenHornBounds = { latMin: 41, latMax: 41.05, lngMin: 28.94, lngMax: 28.99 };
+const apiRequests: string[] = [];
+let nearbyTimelineFeedResults: typeof feedResults | undefined;
 
 const storyDetail = {
   id: 'story-001',
@@ -147,6 +164,27 @@ const notificationPreferences = {
 
 function installAuthTransport() {
   setApiTransport(async (method, config) => {
+    apiRequests.push(`${method} ${config.url ?? ''}`);
+
+    if (
+      method === 'GET' &&
+      (config.url?.startsWith('/stories/feed/') || config.url?.startsWith('/stories/search/')) &&
+      config.url.includes('radius_km=0.5')
+    ) {
+      const results = nearbyTimelineFeedResults ?? feedResults;
+
+      return {
+        status: 200,
+        data: {
+          count: results.length,
+          next: null,
+          previous: null,
+          results,
+        } as never,
+        config,
+      };
+    }
+
     if (method === 'GET' && (config.url?.startsWith('/stories/feed/') || config.url?.startsWith('/stories/search/'))) {
       return {
         status: 200,
@@ -370,6 +408,8 @@ describe('RootNavigator auth flow', () => {
     (geocodeLocationQuery as jest.Mock).mockResolvedValue(null);
     (searchLocationSuggestions as jest.Mock).mockResolvedValue([]);
     await storage.clear();
+    apiRequests.length = 0;
+    nearbyTimelineFeedResults = undefined;
     interceptors.clear();
     resetApiTransport();
     installAuthTransport();
@@ -397,7 +437,7 @@ describe('RootNavigator auth flow', () => {
     });
   });
 
-  it('keeps parent scrolling available while preserving map child touches', async () => {
+  it('keeps pull-to-refresh available away from the map and suppresses it during map gestures', async () => {
     renderNavigator();
 
     await screen.findByLabelText('Map');
@@ -406,11 +446,34 @@ describe('RootNavigator auth flow', () => {
     const mapView = await screen.findByTestId('web-map-view');
     expect(mapView.props.onTouchStart).toBeUndefined();
 
-    expect(screen.getByTestId('interactive-map-touch-area').props.onTouchStart).toBeUndefined();
+    const mapTouchArea = screen.getByTestId('interactive-map-touch-area');
+    expect(mapTouchArea.props.onTouchStart).toEqual(expect.any(Function));
+    expect(mapTouchArea.props.onStartShouldSetResponderCapture).toEqual(expect.any(Function));
     expect(screen.getByTestId('main-route-pager').props.scrollEnabled).not.toBe(false);
     expect(screen.getByTestId('main-route-pager').props.canCancelContentTouches).toBe(false);
     expect(screen.getByTestId('map-route-scroll').props.scrollEnabled).toBe(true);
     expect(screen.getByTestId('map-route-scroll').props.canCancelContentTouches).toBe(false);
+    await waitFor(() => {
+      expect(screen.getByTestId('map-route-scroll').props.refreshControl).toBeTruthy();
+      expect(screen.getByTestId('map-route-scroll').props.refreshControl.props.enabled).toBe(true);
+      expect(screen.getByTestId('map-route-scroll').props.scrollEnabled).toBe(true);
+    });
+
+    fireEvent(mapTouchArea, 'startShouldSetResponderCapture');
+
+    await waitFor(() => {
+      expect(screen.getByTestId('map-route-scroll').props.refreshControl).toBeTruthy();
+      expect(screen.getByTestId('map-route-scroll').props.refreshControl.props.enabled).toBe(false);
+      expect(screen.getByTestId('map-route-scroll').props.scrollEnabled).toBe(false);
+    });
+
+    fireEvent(mapTouchArea, 'touchEnd');
+
+    await waitFor(() => {
+      expect(screen.getByTestId('map-route-scroll').props.refreshControl).toBeTruthy();
+      expect(screen.getByTestId('map-route-scroll').props.refreshControl.props.enabled).toBe(true);
+      expect(screen.getByTestId('map-route-scroll').props.scrollEnabled).toBe(true);
+    });
   });
 
   it('shows only the StoryMap brand in the main header', async () => {
@@ -731,6 +794,73 @@ describe('RootNavigator auth flow', () => {
     expect(screen.getByLabelText('Search stories').props.value).toBe('harbor');
   });
 
+  it('keeps the timeline tab active when filters are applied there', async () => {
+    (geocodeLocationQuery as jest.Mock).mockResolvedValueOnce(goldenHornBounds);
+
+    renderNavigator();
+
+    await screen.findByLabelText('Timeline');
+    fireEvent.press(screen.getByLabelText('Timeline'));
+    expect(screen.getByLabelText('Timeline').props.accessibilityState.selected).toBe(true);
+
+    fireEvent.press(screen.getByText('Show filters'));
+    fireEvent.changeText(screen.getByLabelText('Location filter'), 'Golden Horn');
+    expect(await screen.findByText('Filtering by map area.')).toBeTruthy();
+    fireEvent.press(screen.getByLabelText('Apply filters'));
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('Remove Location: Golden Horn')).toBeTruthy();
+    });
+
+    fireEvent(screen.getByTestId('main-route-pager'), 'momentumScrollEnd', {
+      nativeEvent: {
+        contentOffset: { x: 0, y: 0 },
+      },
+    });
+
+    expect(screen.getByLabelText('Timeline').props.accessibilityState.selected).toBe(true);
+    expect(screen.getByLabelText('Map').props.accessibilityState.selected).toBe(false);
+  });
+
+  it('keeps the timeline tab active when an existing filter is removed after a stale pager drag', async () => {
+    (geocodeLocationQuery as jest.Mock).mockResolvedValueOnce(goldenHornBounds);
+
+    renderNavigator();
+
+    await screen.findByLabelText('Timeline');
+    fireEvent.press(screen.getByLabelText('Timeline'));
+
+    fireEvent.press(screen.getByText('Show filters'));
+    fireEvent.changeText(screen.getByLabelText('Location filter'), 'Golden Horn');
+    expect(await screen.findByText('Filtering by map area.')).toBeTruthy();
+    fireEvent.press(screen.getByLabelText('Apply filters'));
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('Remove Location: Golden Horn')).toBeTruthy();
+    });
+
+    jest.useFakeTimers();
+    fireEvent(screen.getByTestId('main-route-pager'), 'scrollBeginDrag');
+    fireEvent(screen.getByTestId('main-route-pager'), 'scrollEndDrag');
+    act(() => {
+      jest.advanceTimersByTime(500);
+    });
+    jest.useRealTimers();
+
+    fireEvent.press(screen.getByLabelText('Remove Location: Golden Horn'));
+    await waitFor(() => {
+      expect(screen.queryByLabelText('Remove Location: Golden Horn')).toBeNull();
+    });
+    fireEvent(screen.getByTestId('main-route-pager'), 'momentumScrollEnd', {
+      nativeEvent: {
+        contentOffset: { x: 0, y: 0 },
+      },
+    });
+
+    expect(screen.getByLabelText('Timeline').props.accessibilityState.selected).toBe(true);
+    expect(screen.getByLabelText('Map').props.accessibilityState.selected).toBe(false);
+  });
+
   it('opens a story from the timeline and returns to the timeline', async () => {
     render(
       <AppProviders>
@@ -750,6 +880,44 @@ describe('RootNavigator auth flow', () => {
     await waitFor(() => {
       expect(screen.getByLabelText('Open timeline story: Harbor Memory')).toBeTruthy();
     });
+  });
+
+  it('opens a 500 m nearby timeline from a map pin and navigates to story detail', async () => {
+    renderNavigator();
+
+    fireEvent.press(await screen.findByLabelText('Map'));
+    await waitFor(() => {
+      expect(screen.getAllByTestId('story-marker').length).toBeGreaterThan(0);
+    });
+    fireEvent.press(screen.getAllByTestId('story-marker')[0]);
+    fireEvent.press(await screen.findByLabelText('View timeline near Harbor Memory'));
+
+    await waitFor(() => {
+      expect(apiRequests).toContain(
+        'GET /stories/feed/?page_size=100&sort_by=recent&latitude=41.02&longitude=28.96&radius_km=0.5&page=1',
+      );
+    });
+    expect(screen.getByLabelText('Remove Distance: 500 m from red location pin')).toBeTruthy();
+
+    fireEvent.press(await screen.findByLabelText('Open timeline story: Harbor Memory'));
+
+    expect(await screen.findByText('Harbor Memory')).toBeTruthy();
+  });
+
+  it('shows an empty state for a map pin nearby timeline with no stories', async () => {
+    nearbyTimelineFeedResults = [];
+
+    renderNavigator();
+
+    fireEvent.press(await screen.findByLabelText('Map'));
+    await waitFor(() => {
+      expect(screen.getAllByTestId('story-marker').length).toBeGreaterThan(0);
+    });
+    fireEvent.press(screen.getAllByTestId('story-marker')[0]);
+    fireEvent.press(await screen.findByLabelText('View timeline near Harbor Memory'));
+
+    expect(await screen.findByText('No stories on this timeline')).toBeTruthy();
+    expect(screen.getByText('Try a wider year range, a different period, or removing a place or distance filter.')).toBeTruthy();
   });
 
   it('opens a protected screen after login and returns with the back button', async () => {

--- a/mobile/src/features/feed/presentation/screens/FeedScreen.tsx
+++ b/mobile/src/features/feed/presentation/screens/FeedScreen.tsx
@@ -441,10 +441,14 @@ function toSearchState(filters: StoryFilters): SearchFiltersState {
     query: filters.q ?? '',
     location: filters.location ?? '',
     locationBounds: filters.locationBounds,
-    proximityRadiusKm: filters.radiusKm === 1 || filters.radiusKm === 10 || filters.radiusKm === 100 ? filters.radiusKm : undefined,
+    proximityRadiusKm: filters.radiusKm === 0.5 || filters.radiusKm === 1 || filters.radiusKm === 10 || filters.radiusKm === 100 ? filters.radiusKm : undefined,
     proximityCoordinates:
       filters.latitude !== undefined && filters.longitude !== undefined
         ? { latitude: filters.latitude, longitude: filters.longitude }
+        : undefined,
+    proximitySource:
+      filters.radiusKm !== undefined && filters.latitude !== undefined && filters.longitude !== undefined
+        ? 'current_location'
         : undefined,
     timeFrom: filters.yearFrom ? String(filters.yearFrom) : '',
     timeTo: filters.yearTo ? String(filters.yearTo) : '',
@@ -471,6 +475,7 @@ function areSearchStatesEqual(left: SearchFiltersState, right: SearchFiltersStat
     JSON.stringify(left.locationBounds) === JSON.stringify(right.locationBounds) &&
     left.proximityRadiusKm === right.proximityRadiusKm &&
     JSON.stringify(left.proximityCoordinates) === JSON.stringify(right.proximityCoordinates) &&
+    left.proximitySource === right.proximitySource &&
     left.timeFrom === right.timeFrom &&
     left.timeTo === right.timeTo &&
     JSON.stringify(left.tags) === JSON.stringify(right.tags)

--- a/mobile/src/features/feed/presentation/screens/__tests__/FeedScreen.test.tsx
+++ b/mobile/src/features/feed/presentation/screens/__tests__/FeedScreen.test.tsx
@@ -522,9 +522,9 @@ describe('FeedScreen', () => {
 
     await screen.findByText('Story 1');
     fireEvent.press(screen.getByText('Show filters'));
-    fireEvent.press(screen.getByLabelText('Distance 10 km'));
+    fireEvent.press(screen.getByLabelText('Distance 1 km'));
 
-    expect(await screen.findByText('Filtering within 10 km of 41.0082, 28.9784.')).toBeTruthy();
+    expect(await screen.findByText('Filtering within 1000 m of 41.0082, 28.9784.')).toBeTruthy();
     fireEvent.press(screen.getByLabelText('Apply filters'));
 
     await waitFor(() => {
@@ -537,14 +537,14 @@ describe('FeedScreen', () => {
           locationBounds: undefined,
           latitude: 41.0082,
           longitude: 28.9784,
-          radiusKm: 10,
+          radiusKm: 1,
           yearFrom: undefined,
           yearTo: undefined,
         },
       });
     });
 
-    expect(screen.getByLabelText('Remove Distance: 10 km')).toBeTruthy();
+    expect(screen.getByLabelText('Remove Distance: 1000 m from current location blue pin')).toBeTruthy();
   });
 
   it('shows loading feedback while current location is fetched', async () => {
@@ -603,7 +603,7 @@ describe('FeedScreen', () => {
       });
     });
 
-    expect(screen.queryByLabelText('Remove Distance: 10 km')).toBeNull();
+    expect(screen.queryByLabelText('Remove Distance: 10 km from current location blue pin')).toBeNull();
   });
 
   it('closes the filter panel when tapping outside of it', async () => {

--- a/mobile/src/features/map/presentation/components/MapCard.tsx
+++ b/mobile/src/features/map/presentation/components/MapCard.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef } from 'react';
 import { ActivityIndicator, LayoutChangeEvent, Pressable, ScrollView, Text, View } from 'react-native';
 import { Region } from 'react-native-maps';
 import { useAppTheme } from '../../../../core/hooks/useAppTheme';
@@ -10,32 +10,40 @@ interface MapCardProps {
   region: Region;
   markers: MapMarkerGroup[];
   selectedMarkerId?: string;
+  highlightedMarkerId?: string;
   isLoading?: boolean;
   error?: string;
   statusBadgeText?: string;
   userLocation?: { latitude: number; longitude: number };
   onSelectMarker: (markerId: string) => void;
   onOpenStory: (storyId: string) => void;
+  onViewTimeline?: (coordinates: { latitude: number; longitude: number }) => void;
   onRegionChangeComplete?: (region: Region) => void;
   onPreviewLayout?: (event: LayoutChangeEvent) => void;
+  onMapTouchChange?: (isTouchingMap: boolean) => void;
 }
 
 const PREVIEW_MAX_LENGTH = 140;
+const MAP_GESTURE_SUPPRESSION_MS = 1200;
 const passivePreviewTextProps = { pointerEvents: 'none' as const };
 export function MapCard({
   region,
   markers,
   selectedMarkerId,
+  highlightedMarkerId,
   isLoading = false,
   error,
   statusBadgeText,
   userLocation,
   onSelectMarker,
   onOpenStory,
+  onViewTimeline,
   onRegionChangeComplete,
   onPreviewLayout,
+  onMapTouchChange,
 }: MapCardProps) {
   const { colors, spacing, typography } = useAppTheme();
+  const mapTouchReleaseTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const selectedMarker = selectedMarkerId ? markers.find((marker) => marker.id === selectedMarkerId) : undefined;
   const mapMarkers = useMemo(
     () =>
@@ -43,10 +51,41 @@ export function MapCard({
         id: marker.id,
         latitude: marker.latitude,
         longitude: marker.longitude,
-        selected: marker.id === selectedMarkerId,
+        selected: marker.id === (highlightedMarkerId ?? selectedMarkerId),
         label: marker.isCluster ? String(marker.count) : undefined,
       })),
-    [markers, selectedMarkerId],
+    [highlightedMarkerId, markers, selectedMarkerId],
+  );
+  const clearMapTouchReleaseTimer = useCallback(() => {
+    if (mapTouchReleaseTimerRef.current) {
+      clearTimeout(mapTouchReleaseTimerRef.current);
+      mapTouchReleaseTimerRef.current = null;
+    }
+  }, []);
+  const markMapGestureActive = useCallback(() => {
+    onMapTouchChange?.(true);
+    clearMapTouchReleaseTimer();
+    mapTouchReleaseTimerRef.current = setTimeout(() => {
+      onMapTouchChange?.(false);
+      mapTouchReleaseTimerRef.current = null;
+    }, MAP_GESTURE_SUPPRESSION_MS);
+
+    return false;
+  }, [clearMapTouchReleaseTimer, onMapTouchChange]);
+  const markMapGestureFinished = useCallback(() => {
+    clearMapTouchReleaseTimer();
+    mapTouchReleaseTimerRef.current = setTimeout(() => {
+      onMapTouchChange?.(false);
+      mapTouchReleaseTimerRef.current = null;
+    }, 120);
+  }, [clearMapTouchReleaseTimer, onMapTouchChange]);
+
+  useEffect(
+    () => () => {
+      clearMapTouchReleaseTimer();
+      onMapTouchChange?.(false);
+    },
+    [clearMapTouchReleaseTimer, onMapTouchChange],
   );
 
   return (
@@ -61,6 +100,12 @@ export function MapCard({
     >
       <View
         testID="interactive-map-touch-area"
+        onStartShouldSetResponderCapture={markMapGestureActive}
+        onMoveShouldSetResponderCapture={markMapGestureActive}
+        onTouchStart={markMapGestureActive}
+        onTouchMove={markMapGestureActive}
+        onTouchEnd={markMapGestureFinished}
+        onTouchCancel={markMapGestureFinished}
         style={{ height: 420 }}
       >
         <WebMapView
@@ -71,6 +116,7 @@ export function MapCard({
           onMarkerPress={(markerId) => {
             onSelectMarker(markerId);
           }}
+          onMapGestureChange={onMapTouchChange}
           onRegionChangeComplete={onRegionChangeComplete}
         />
 
@@ -161,32 +207,41 @@ export function MapCard({
             {markers.length ? 'Select a story marker to preview.' : 'No stories match the current filters.'}
           </Text>
         ) : selectedMarker.isCluster ? (
-          <ScrollView
-            style={{ maxHeight: 240 }}
-            contentContainerStyle={{ gap: spacing.sm }}
-            nestedScrollEnabled
-            showsVerticalScrollIndicator
-            testID="cluster-preview-list"
-          >
-            {selectedMarker.stories.map((story) => (
-              <Pressable
-                key={story.id}
-                onPress={() => onOpenStory(story.id)}
-                style={{
-                  padding: spacing.md,
-                  borderRadius: 16,
-                  backgroundColor: colors.background,
-                  borderWidth: 1,
-                  borderColor: colors.border,
-                }}
-              >
-                <Text {...passivePreviewTextProps} style={{ color: colors.text, fontWeight: '700' }}>{story.title}</Text>
-                <Text {...passivePreviewTextProps} style={{ marginTop: spacing.xs, color: colors.muted }}>{story.placeName}</Text>
-                <Text {...passivePreviewTextProps} style={{ marginTop: spacing.xs, color: colors.muted }}>{story.timePeriod}</Text>
-                <Text {...passivePreviewTextProps} style={{ marginTop: spacing.sm, color: colors.text }}>{truncatePreview(story.previewText)}</Text>
-              </Pressable>
-            ))}
-          </ScrollView>
+          <>
+            <Button
+              variant="outline"
+              accessibilityLabel={`View timeline near ${selectedMarker.count} nearby stories`}
+              onPress={() => onViewTimeline?.({ latitude: selectedMarker.latitude, longitude: selectedMarker.longitude })}
+            >
+              View Timeline
+            </Button>
+            <ScrollView
+              style={{ maxHeight: 240 }}
+              contentContainerStyle={{ gap: spacing.sm }}
+              nestedScrollEnabled
+              showsVerticalScrollIndicator
+              testID="cluster-preview-list"
+            >
+              {selectedMarker.stories.map((story) => (
+                <Pressable
+                  key={story.id}
+                  onPress={() => onOpenStory(story.id)}
+                  style={{
+                    padding: spacing.md,
+                    borderRadius: 16,
+                    backgroundColor: colors.background,
+                    borderWidth: 1,
+                    borderColor: colors.border,
+                  }}
+                >
+                  <Text {...passivePreviewTextProps} style={{ color: colors.text, fontWeight: '700' }}>{story.title}</Text>
+                  <Text {...passivePreviewTextProps} style={{ marginTop: spacing.xs, color: colors.muted }}>{story.placeName}</Text>
+                  <Text {...passivePreviewTextProps} style={{ marginTop: spacing.xs, color: colors.muted }}>{story.timePeriod}</Text>
+                  <Text {...passivePreviewTextProps} style={{ marginTop: spacing.sm, color: colors.text }}>{truncatePreview(story.previewText)}</Text>
+                </Pressable>
+              ))}
+            </ScrollView>
+          </>
         ) : (
           <>
             <Text {...passivePreviewTextProps} style={{ color: colors.text, fontSize: typography.subtitle, fontWeight: '700' }}>
@@ -195,7 +250,22 @@ export function MapCard({
             <Text {...passivePreviewTextProps} style={{ color: colors.muted }}>{selectedMarker.stories[0].placeName}</Text>
             <Text {...passivePreviewTextProps} style={{ color: colors.muted }}>{selectedMarker.stories[0].timePeriod}</Text>
             <Text {...passivePreviewTextProps} style={{ color: colors.text }}>{truncatePreview(selectedMarker.stories[0].previewText)}</Text>
-            <Button onPress={() => onOpenStory(selectedMarker.stories[0].id)}>Read full story</Button>
+            <View style={{ flexDirection: 'row', flexWrap: 'wrap', gap: spacing.sm }}>
+              <Button
+                style={{ flexGrow: 1, flexBasis: 140 }}
+                onPress={() => onOpenStory(selectedMarker.stories[0].id)}
+              >
+                Read full story
+              </Button>
+              <Button
+                variant="outline"
+                style={{ flexGrow: 1, flexBasis: 140 }}
+                accessibilityLabel={`View timeline near ${selectedMarker.stories[0].title}`}
+                onPress={() => onViewTimeline?.({ latitude: selectedMarker.latitude, longitude: selectedMarker.longitude })}
+              >
+                View Timeline
+              </Button>
+            </View>
           </>
         )}
       </View>

--- a/mobile/src/features/map/presentation/screens/MapScreen.tsx
+++ b/mobile/src/features/map/presentation/screens/MapScreen.tsx
@@ -7,7 +7,12 @@ import { MapMarkerGroup } from '../../domain/entities';
 import { mapService } from '../../application/services';
 import { createInitialMapUiState, MapUiState } from '../state/mapUiState';
 import { MapCard } from '../components/MapCard';
-import { SearchFilterScope, useSearchFilters, toSearchParams } from '../../../search/presentation/context/SearchFiltersContext';
+import {
+  SearchFilterScope,
+  SearchFiltersState,
+  useSearchFilters,
+  toSearchParams,
+} from '../../../search/presentation/context/SearchFiltersContext';
 import { useDebounce } from '../../../../shared/hooks/useDebounce';
 import { StorySearchControls } from '../../../search/presentation/components/StorySearchControls';
 
@@ -16,8 +21,10 @@ interface MapScreenProps {
   onOpenStory?: (storyId: string) => void;
   getMarkerGroups?: (filters?: StoryFilters) => Promise<MapMarkerGroup[]>;
   onMarkerPreviewRequested?: (targetY: number) => void;
+  onViewTimeline?: (coordinates: { latitude: number; longitude: number }) => void;
   showSearchControls?: boolean;
   onRegisterRefresh?: (handler: (() => Promise<void>) | null) => void;
+  onMapTouchChange?: (isTouchingMap: boolean) => void;
   searchScope?: SearchFilterScope;
 }
 
@@ -44,8 +51,10 @@ export function MapScreen({
   onOpenStory,
   getMarkerGroups = mapService.getMarkerGroups,
   onMarkerPreviewRequested,
+  onViewTimeline,
   showSearchControls = true,
   onRegisterRefresh,
+  onMapTouchChange,
   searchScope = 'map',
 }: MapScreenProps) {
   const { colors, spacing, typography } = useAppTheme();
@@ -59,6 +68,7 @@ export function MapScreen({
   const [hasInteractedWithArea, setHasInteractedWithArea] = useState(false);
   const [statusIndicatorMode, setStatusIndicatorMode] = useState<StatusIndicatorMode>('hidden');
   const lastAutoZoomContextKeyRef = useRef<string | null>(null);
+  const previousMapPinFilterKeyRef = useRef<string | null>(null);
   const loadRequestIdRef = useRef(0);
   const previewOffsetRef = useRef<number | null>(null);
 
@@ -94,6 +104,20 @@ export function MapScreen({
     () => `${buildAutoZoomContextKey(activeFilters)}:${refreshToken}`,
     [activeFilters, refreshToken],
   );
+  const mapPinFilterKey = useMemo(() => getMapPinFilterKey(filters), [filters]);
+
+  useEffect(() => {
+    const previousMapPinFilterKey = previousMapPinFilterKeyRef.current;
+
+    if (previousMapPinFilterKey && !mapPinFilterKey) {
+      setState((current) => ({
+        ...current,
+        selectedMarkerId: undefined,
+      }));
+    }
+
+    previousMapPinFilterKeyRef.current = mapPinFilterKey;
+  }, [mapPinFilterKey]);
 
   const loadMarkers = React.useCallback(async () => {
     const requestId = loadRequestIdRef.current + 1;
@@ -182,14 +206,6 @@ export function MapScreen({
     if (state.filters.yearFrom || state.filters.yearTo) {
       parts.push(`Years: ${state.filters.yearFrom ?? 'Any'}-${state.filters.yearTo ?? 'Any'}`);
     }
-    if (state.filters.radiusKm) {
-      const coordinates =
-        state.filters.latitude !== undefined && state.filters.longitude !== undefined
-          ? ` from ${state.filters.latitude.toFixed(4)}, ${state.filters.longitude.toFixed(4)}`
-          : '';
-
-      parts.push(`Distance: ${state.filters.radiusKm} km${coordinates}`);
-    }
     if (state.filters.tags?.length) {
       parts.push(`Tag: ${state.filters.tags.join(', ')}`);
     }
@@ -202,7 +218,14 @@ export function MapScreen({
     [state.markers],
   );
 
-  const userLocation = filters.proximityRadiusKm && filters.proximityCoordinates ? filters.proximityCoordinates : undefined;
+  const userLocation =
+    filters.proximityRadiusKm && filters.proximityCoordinates && filters.proximitySource !== 'map_pin'
+      ? filters.proximityCoordinates
+      : undefined;
+  const mapPinFilterMarkerId = useMemo(
+    () => getMapPinFilterMarkerId(state.markers, filters),
+    [filters, state.markers],
+  );
   const statusStoryCount = useMemo(() => {
     if (statusIndicatorMode !== 'area' || !hasInteractedWithArea || !visibleRegion) {
       return totalStoryCount;
@@ -263,6 +286,7 @@ export function MapScreen({
           region={mapRegion}
           markers={state.markers}
           selectedMarkerId={state.selectedMarkerId}
+          highlightedMarkerId={mapPinFilterMarkerId}
           isLoading={state.isLoading}
           error={state.error}
           statusBadgeText={statusBadgeText}
@@ -280,6 +304,7 @@ export function MapScreen({
             }
           }}
           onOpenStory={(storyId) => onOpenStory?.(storyId)}
+          onViewTimeline={onViewTimeline}
           onRegionChangeComplete={(region) => {
             setMapRegion(region);
             setVisibleRegion(region);
@@ -287,6 +312,7 @@ export function MapScreen({
             setStatusIndicatorMode('area');
           }}
           onPreviewLayout={handlePreviewLayout}
+          onMapTouchChange={onMapTouchChange}
         />
       </View>
     </View>
@@ -366,6 +392,31 @@ function countStoriesInRegion(markers: MapMarkerGroup[], region: Region) {
 
 function formatStoryCount(count: number) {
   return `${count} ${count === 1 ? 'story' : 'stories'}`;
+}
+
+function getMapPinFilterKey(filters: SearchFiltersState) {
+  if (filters.proximitySource !== 'map_pin' || !filters.proximityCoordinates) {
+    return null;
+  }
+
+  return `${filters.proximityCoordinates.latitude}:${filters.proximityCoordinates.longitude}:${filters.proximityRadiusKm ?? ''}`;
+}
+
+function getMapPinFilterMarkerId(markers: MapMarkerGroup[], filters: SearchFiltersState) {
+  if (filters.proximitySource !== 'map_pin' || !filters.proximityCoordinates) {
+    return undefined;
+  }
+
+  const { latitude, longitude } = filters.proximityCoordinates;
+  const matchingMarker = markers.find(
+    (marker) => coordinatesEqual(marker.latitude, latitude) && coordinatesEqual(marker.longitude, longitude),
+  );
+
+  return matchingMarker?.id;
+}
+
+function coordinatesEqual(left: number, right: number) {
+  return Math.abs(left - right) < 0.000001;
 }
 
 function buildAutoZoomContextKey(filters: StoryFilters) {

--- a/mobile/src/features/map/presentation/screens/__tests__/MapScreen.test.tsx
+++ b/mobile/src/features/map/presentation/screens/__tests__/MapScreen.test.tsx
@@ -33,7 +33,7 @@ jest.mock('../../../../../shared/components/WebMapView', () => {
         latitudeDelta: number;
         longitudeDelta: number;
       };
-      markers?: Array<{ id: string }>;
+      markers?: Array<{ id: string; selected?: boolean }>;
       userLocation?: {
         latitude: number;
         longitude: number;
@@ -80,7 +80,12 @@ jest.mock('../../../../../shared/components/WebMapView', () => {
           }
         />
         {markers.map((marker) => (
-          <Pressable key={marker.id} onPress={() => onMarkerPress?.(marker.id)} testID="story-marker" />
+          <Pressable
+            key={marker.id}
+            onPress={() => onMarkerPress?.(marker.id)}
+            testID="story-marker"
+            accessibilityState={{ selected: Boolean(marker.selected) }}
+          />
         ))}
       </View>
     ),
@@ -219,6 +224,44 @@ describe('MapScreen', () => {
     expect(onOpenStory).toHaveBeenCalledWith('story-001');
   });
 
+  it('offers a timeline action for a selected marker', async () => {
+    const onViewTimeline = jest.fn();
+
+    renderScreen(<MapScreen getMarkerGroups={async () => markerGroups} onViewTimeline={onViewTimeline} />);
+
+    await screen.findByText('Select a story marker to preview.');
+    fireEvent.press(screen.getAllByTestId('story-marker')[0]);
+    fireEvent.press(await screen.findByLabelText('View timeline near The Day the Harbor Fell Silent'));
+
+    expect(onViewTimeline).toHaveBeenCalledWith({
+      latitude: 41.0284,
+      longitude: 28.9647,
+    });
+  });
+
+  it('highlights the active map pin distance filter until the filter is removed', async () => {
+    await storage.set(storageKeys.mapSearchFilters, {
+      proximityRadiusKm: 0.5,
+      proximityCoordinates: {
+        latitude: 41.0284,
+        longitude: 28.9647,
+      },
+      proximitySource: 'map_pin',
+    });
+
+    renderScreen(<MapScreen getMarkerGroups={async () => markerGroups} />);
+
+    await waitFor(() => {
+      expect(screen.getAllByTestId('story-marker')[0].props.accessibilityState.selected).toBe(true);
+    });
+
+    fireEvent.press(screen.getByLabelText('Remove Distance: 500 m from red location pin'));
+
+    await waitFor(() => {
+      expect(screen.getAllByTestId('story-marker')[0].props.accessibilityState.selected).toBe(false);
+    });
+  });
+
   it('hides the selected marker preview when the same marker is pressed again', async () => {
     renderScreen(<MapScreen getMarkerGroups={async () => markerGroups} />);
 
@@ -264,6 +307,21 @@ describe('MapScreen', () => {
     });
     expect(screen.getByText('Lanterns Above the Hill Market')).toBeTruthy();
     expect(screen.getByText('Voices of the Ferry Pier')).toBeTruthy();
+  });
+
+  it('offers a timeline action for a clustered marker', async () => {
+    const onViewTimeline = jest.fn();
+
+    renderScreen(<MapScreen getMarkerGroups={async () => markerGroups} onViewTimeline={onViewTimeline} />);
+
+    await screen.findByText('Select a story marker to preview.');
+    fireEvent.press(screen.getAllByTestId('story-marker')[1]);
+    fireEvent.press(await screen.findByLabelText('View timeline near 2 nearby stories'));
+
+    expect(onViewTimeline).toHaveBeenCalledWith({
+      latitude: 41.01,
+      longitude: 28.97,
+    });
   });
 
   it('requests scrolling to the preview when a marker is pressed', async () => {
@@ -625,6 +683,30 @@ describe('MapScreen', () => {
       expect(screen.queryByTestId('user-location-marker')).toBeNull();
     });
   });
+
+  it('does not show the blue current-location marker for map-pin proximity filters', async () => {
+    await storage.set(storageKeys.mapSearchFilters, {
+      query: '',
+      location: '',
+      proximityRadiusKm: 0.5,
+      proximityCoordinates: {
+        latitude: 41.0284,
+        longitude: 28.9647,
+      },
+      proximitySource: 'map_pin',
+      timeFrom: '',
+      timeTo: '',
+    });
+
+    renderScreen(<MapScreen getMarkerGroups={async () => markerGroups} />);
+
+    await screen.findByText('Select a story marker to preview.');
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('user-location-marker')).toBeNull();
+    });
+  });
+
 
   it('refetches all markers when a chip filter is removed', async () => {
     const getMarkerGroups = jest.fn<Promise<MapMarkerGroup[]>, [any]>().mockResolvedValue(markerGroups);

--- a/mobile/src/features/search/presentation/components/StorySearchControls.tsx
+++ b/mobile/src/features/search/presentation/components/StorySearchControls.tsx
@@ -21,7 +21,14 @@ function buildChips(filters: ReturnType<typeof useSearchFilters>['filters']): Fi
   }
 
   if (filters.proximityRadiusKm && filters.proximityCoordinates) {
-    chips.push({ key: 'proximityRadiusKm', label: `Distance: ${filters.proximityRadiusKm} km` });
+    const isMapPinFilter = filters.proximitySource === 'map_pin';
+
+    chips.push({
+      key: 'proximityRadiusKm',
+      label: `Distance: ${formatDistance(filters.proximityRadiusKm)} from`,
+      visual: isMapPinFilter ? 'redPin' : 'bluePin',
+      visualAccessibilityLabel: isMapPinFilter ? 'red location pin' : 'current location blue pin',
+    });
   }
 
   if (filters.timeFrom.trim()) {
@@ -157,7 +164,7 @@ export function StorySearchControls({ helperText, hideHeading = false, scope }: 
     if (result.status === 'granted') {
       setDraftProximityCoordinates(result.coordinates);
       setProximityStatusText(
-        `Filtering within ${radiusKm} km of ${result.coordinates.latitude.toFixed(4)}, ${result.coordinates.longitude.toFixed(4)}.`,
+        `Filtering within ${formatDistance(radiusKm)} of ${result.coordinates.latitude.toFixed(4)}, ${result.coordinates.longitude.toFixed(4)}.`,
       );
       return;
     }
@@ -385,6 +392,7 @@ export function StorySearchControls({ helperText, hideHeading = false, scope }: 
                     locationBounds: draftLocation.trim() ? draftLocationBounds : undefined,
                     proximityRadiusKm: draftProximityRadiusKm,
                     proximityCoordinates: draftProximityRadiusKm ? draftProximityCoordinates : undefined,
+                    proximitySource: draftProximityRadiusKm ? 'current_location' : undefined,
                     timeFrom: draftTimeFrom,
                     timeTo: draftTimeTo,
                     tags: draftTags,
@@ -415,6 +423,10 @@ export function StorySearchControls({ helperText, hideHeading = false, scope }: 
       />
     </View>
   );
+}
+
+function formatDistance(radiusKm: number) {
+  return radiusKm <= 1 ? `${Math.round(radiusKm * 1000)} m` : `${radiusKm} km`;
 }
 
 function buildFallbackBounds(latitude: number, longitude: number): LocationBounds {

--- a/mobile/src/features/search/presentation/context/SearchFiltersContext.tsx
+++ b/mobile/src/features/search/presentation/context/SearchFiltersContext.tsx
@@ -5,7 +5,8 @@ import { StoryFilters } from '../../../stories/domain/repositories';
 import { LocationBounds } from '../../application/services';
 
 export type SearchFilterScope = 'feed' | 'map' | 'main';
-export type ProximityRadiusKm = 1 | 10 | 100;
+export type ProximityRadiusKm = 0.5 | 1 | 10 | 100;
+export type ProximitySource = 'current_location' | 'map_pin';
 
 export interface ProximityCoordinates {
   latitude: number;
@@ -18,6 +19,7 @@ export interface SearchFiltersState {
   locationBounds?: LocationBounds;
   proximityRadiusKm?: ProximityRadiusKm;
   proximityCoordinates?: ProximityCoordinates;
+  proximitySource?: ProximitySource;
   timeFrom: string;
   timeTo: string;
   tags: string[];
@@ -40,6 +42,7 @@ const initialFilters: SearchFiltersState = {
   locationBounds: undefined,
   proximityRadiusKm: undefined,
   proximityCoordinates: undefined,
+  proximitySource: undefined,
   timeFrom: '',
   timeTo: '',
   tags: [],
@@ -151,8 +154,9 @@ export function SearchFiltersProvider({ children }: PropsWithChildren) {
             ...currentFilters,
             [key]: key === 'tags' ? [] : '',
             ...(key === 'location' ? { locationBounds: undefined } : {}),
-            ...(key === 'proximityRadiusKm' ? { proximityRadiusKm: undefined, proximityCoordinates: undefined } : {}),
-            ...(key === 'proximityCoordinates' ? { proximityRadiusKm: undefined, proximityCoordinates: undefined } : {}),
+            ...(key === 'proximityRadiusKm' ? { proximityRadiusKm: undefined, proximityCoordinates: undefined, proximitySource: undefined } : {}),
+            ...(key === 'proximityCoordinates' ? { proximityRadiusKm: undefined, proximityCoordinates: undefined, proximitySource: undefined } : {}),
+            ...(key === 'proximitySource' ? { proximityRadiusKm: undefined, proximityCoordinates: undefined, proximitySource: undefined } : {}),
           }),
           { refresh: true },
         );
@@ -231,6 +235,7 @@ function normalizeStoredFilters(filters?: Partial<SearchFiltersState> | null): S
     locationBounds: normalizeLocationBounds(filters?.locationBounds),
     proximityRadiusKm: normalizeProximityRadius(filters?.proximityRadiusKm),
     proximityCoordinates: normalizeProximityCoordinates(filters?.proximityCoordinates),
+    proximitySource: normalizeProximitySource(filters?.proximitySource),
     timeFrom: filters?.timeFrom ?? '',
     timeTo: filters?.timeTo ?? '',
     tags: normalizeTags(filters?.tags),
@@ -248,7 +253,11 @@ function normalizeTags(tags?: string[] | null): string[] {
 }
 
 function normalizeProximityRadius(radius?: number | null): ProximityRadiusKm | undefined {
-  return radius === 1 || radius === 10 || radius === 100 ? radius : undefined;
+  return radius === 0.5 || radius === 1 || radius === 10 || radius === 100 ? radius : undefined;
+}
+
+function normalizeProximitySource(source?: string | null): ProximitySource | undefined {
+  return source === 'map_pin' || source === 'current_location' ? source : undefined;
 }
 
 function normalizeProximityCoordinates(coordinates?: ProximityCoordinates | null): ProximityCoordinates | undefined {

--- a/mobile/src/features/timeline/data/sources/__tests__/timelineRemoteSource.test.ts
+++ b/mobile/src/features/timeline/data/sources/__tests__/timelineRemoteSource.test.ts
@@ -216,4 +216,65 @@ describe('timelineRemoteSource', () => {
       '/stories/search/?page_size=100&year_from=1900&year_to=1950&tag=architecture&q=harbor&page=1',
     );
   });
+
+  it('falls back with proximity params and keeps nearby stories chronological', async () => {
+    const requests: string[] = [];
+
+    setApiTransport(async (_method, config) => {
+      requests.push(config.url ?? '');
+
+      return {
+        status: 200,
+        data: {
+          count: 3,
+          next: null,
+          previous: null,
+          results: [
+            {
+              id: 2,
+              title: 'Nearby New',
+              time_type: 'exact_year',
+              year: 1950,
+              location_lat: 41.0202,
+              location_lng: 28.9602,
+            },
+            {
+              id: 3,
+              title: 'Too Far',
+              time_type: 'exact_year',
+              year: 1900,
+              location_lat: 41.08,
+              location_lng: 28.96,
+            },
+            {
+              id: 1,
+              title: 'Nearby Old',
+              time_type: 'exact_year',
+              year: 1900,
+              location_lat: 41.02,
+              location_lng: 28.96,
+            },
+          ],
+        } as never,
+        config,
+      };
+    });
+
+    const response = await timelineRemoteSource.getTimeline({
+      filters: {
+        latitude: 41.02,
+        longitude: 28.96,
+        radiusKm: 0.5,
+      },
+    });
+
+    expect(requests[0]).toBe(
+      '/stories/feed/?page_size=100&sort_by=recent&latitude=41.02&longitude=28.96&radius_km=0.5&page=1',
+    );
+    expect(response.count).toBe(2);
+    expect(response.results?.map((story) => (story as { title: string }).title)).toEqual([
+      'Nearby Old',
+      'Nearby New',
+    ]);
+  });
 });

--- a/mobile/src/features/timeline/data/sources/index.ts
+++ b/mobile/src/features/timeline/data/sources/index.ts
@@ -218,6 +218,14 @@ function normalizeFallbackFilters(filters: StoryFilters, yearFrom?: number, year
     params.location = filters.location.trim();
   }
 
+  const proximity = getProximityFilter(filters);
+
+  if (proximity) {
+    params.latitude = proximity.latitude;
+    params.longitude = proximity.longitude;
+    params.radius_km = proximity.radiusKm;
+  }
+
   return params;
 }
 

--- a/mobile/src/features/timeline/presentation/screens/TimelineScreen.tsx
+++ b/mobile/src/features/timeline/presentation/screens/TimelineScreen.tsx
@@ -266,7 +266,7 @@ export function TimelineScreen({
           title={hasActiveFilters ? 'No stories on this timeline' : 'Timeline is empty'}
           message={
             hasActiveFilters
-              ? 'Try a wider year range, a different period, or removing a place filter.'
+              ? 'Try a wider year range, a different period, or removing a place or distance filter.'
               : 'Published stories will appear here from oldest to newest.'
           }
           actionLabel="Refresh"
@@ -429,10 +429,14 @@ function toSearchState(filters: StoryFilters): SearchFiltersState {
     query: filters.q ?? '',
     location: filters.location ?? '',
     locationBounds: filters.locationBounds,
-    proximityRadiusKm: filters.radiusKm === 1 || filters.radiusKm === 10 || filters.radiusKm === 100 ? filters.radiusKm : undefined,
+    proximityRadiusKm: filters.radiusKm === 0.5 || filters.radiusKm === 1 || filters.radiusKm === 10 || filters.radiusKm === 100 ? filters.radiusKm : undefined,
     proximityCoordinates:
       filters.latitude !== undefined && filters.longitude !== undefined
         ? { latitude: filters.latitude, longitude: filters.longitude }
+        : undefined,
+    proximitySource:
+      filters.radiusKm !== undefined && filters.latitude !== undefined && filters.longitude !== undefined
+        ? 'current_location'
         : undefined,
     timeFrom: filters.yearFrom ? String(filters.yearFrom) : '',
     timeTo: filters.yearTo ? String(filters.yearTo) : '',
@@ -459,6 +463,7 @@ function areSearchStatesEqual(left: SearchFiltersState, right: SearchFiltersStat
     JSON.stringify(left.locationBounds) === JSON.stringify(right.locationBounds) &&
     left.proximityRadiusKm === right.proximityRadiusKm &&
     JSON.stringify(left.proximityCoordinates) === JSON.stringify(right.proximityCoordinates) &&
+    left.proximitySource === right.proximitySource &&
     left.timeFrom === right.timeFrom &&
     left.timeTo === right.timeTo &&
     JSON.stringify(left.tags) === JSON.stringify(right.tags)

--- a/mobile/src/shared/components/FilterChips.tsx
+++ b/mobile/src/shared/components/FilterChips.tsx
@@ -1,11 +1,15 @@
 import React from 'react';
 import { Pressable, Text, View } from 'react-native';
+import { MapPin } from 'lucide-react-native';
 import { useAppTheme } from '../../core/hooks/useAppTheme';
 import { formatTagLabel, TagChip } from './TagChip';
 
 export interface FilterChipItem {
   key: string;
   label: string;
+  visual?: 'redPin' | 'bluePin';
+  visualAccessibilityLabel?: string;
+  showRemoveGlyph?: boolean;
 }
 
 interface FilterChipsProps {
@@ -39,9 +43,12 @@ export function FilterChips({ chips, onRemove, onClearAll }: FilterChipsProps) {
             <Pressable
               key={chip.key}
               accessibilityRole="button"
-              accessibilityLabel={`Remove ${chip.label}`}
+              accessibilityLabel={`Remove ${chip.label}${chip.visualAccessibilityLabel ? ` ${chip.visualAccessibilityLabel}` : ''}`}
               onPress={() => onRemove(chip.key)}
               style={({ pressed }) => ({
+                flexDirection: 'row',
+                alignItems: 'center',
+                gap: spacing.xs,
                 paddingHorizontal: spacing.md,
                 paddingVertical: spacing.sm,
                 borderRadius: 999,
@@ -52,8 +59,17 @@ export function FilterChips({ chips, onRemove, onClearAll }: FilterChipsProps) {
               })}
             >
               <Text style={{ color: colors.text, fontSize: typography.caption + 1, fontWeight: '600' }}>
-                {chip.label} x
+                {chip.label}
               </Text>
+              {chip.visual === 'redPin' ? (
+                <MapPin color="#dc2626" fill="#dc2626" size={16} strokeWidth={2.2} />
+              ) : null}
+              {chip.visual === 'bluePin' ? (
+                <MapPin color="#1d4ed8" fill="#1d4ed8" size={16} strokeWidth={2.2} />
+              ) : null}
+              {chip.showRemoveGlyph === false ? null : (
+                <Text style={{ color: colors.text, fontSize: typography.caption + 1, fontWeight: '600' }}>x</Text>
+              )}
             </Pressable>
           )
         ))}

--- a/mobile/src/shared/components/FilterPanel.tsx
+++ b/mobile/src/shared/components/FilterPanel.tsx
@@ -10,7 +10,7 @@ export const DEFAULT_FROM_YEAR = '1980';
 export const DEFAULT_TO_YEAR = '2026';
 export const MIN_YEAR = 1000;
 export const MAX_YEAR = 2030;
-export type ProximityRadiusOption = 1 | 10 | 100;
+export type ProximityRadiusOption = 0.5 | 1 | 10 | 100;
 export interface LocationFilterSuggestion {
   id: string;
   title: string;
@@ -27,6 +27,7 @@ export interface LocationFilterSuggestion {
 
 const PROXIMITY_OPTIONS: Array<{ label: string; value?: ProximityRadiusOption }> = [
   { label: 'Anywhere' },
+  { label: '500 m', value: 0.5 },
   { label: '1 km', value: 1 },
   { label: '10 km', value: 10 },
   { label: '100 km', value: 100 },

--- a/mobile/src/shared/components/WebMapView.tsx
+++ b/mobile/src/shared/components/WebMapView.tsx
@@ -29,6 +29,7 @@ interface WebMapViewProps {
   interactive?: boolean;
   onMarkerPress?: (markerId: string) => void;
   onMapPress?: (coords: { latitude: number; longitude: number }) => void;
+  onMapGestureChange?: (isGestureActive: boolean) => void;
   onRegionChangeComplete?: (region: RegionLike) => void;
   transitionDurationMs?: number;
 }
@@ -44,6 +45,8 @@ type MapUpdatePayload = {
   animated?: boolean;
   transitionDurationMs?: number;
 };
+
+const MAP_HTML_VERSION = 'current-location-pin-size-v2';
 
 const mapHtml = ({
   region,
@@ -81,6 +84,20 @@ const mapHtml = ({
       }
 
       .marker {
+        width: 24px;
+        height: 24px;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+      }
+
+      .marker.selected {
+        width: 34px;
+        height: 34px;
+      }
+
+      .marker-dot {
+        position: relative;
         width: 18px;
         height: 18px;
         border-radius: 9999px;
@@ -89,8 +106,20 @@ const mapHtml = ({
         box-shadow: 0 3px 10px rgba(0, 0, 0, 0.25);
       }
 
-      .marker.selected {
-        background: #0a0a0a;
+      .marker-pin {
+        position: relative;
+        width: 24px;
+        height: 24px;
+        border-radius: 50% 50% 50% 0;
+        background: #dc2626;
+        border: 3px solid #ffffff;
+        transform: rotate(-45deg);
+        box-shadow: 0 4px 12px rgba(220, 38, 38, 0.32);
+      }
+
+      .marker.selected .marker-pin {
+        width: 18px;
+        height: 18px;
       }
 
       .marker-label {
@@ -109,13 +138,31 @@ const mapHtml = ({
         pointer-events: none;
       }
 
+      .marker-pin .marker-label {
+        transform: translate(-50%, -50%) rotate(45deg);
+      }
+
       .user-location-marker {
-        width: 18px;
-        height: 18px;
-        border-radius: 9999px;
+        width: 34px;
+        height: 34px;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+      }
+
+      .user-location-pin {
+        position: relative;
+        width: 28px;
+        height: 28px;
+        box-sizing: border-box;
+        border-radius: 50% 50% 50% 0;
         background: #1d4ed8;
         border: 3px solid #ffffff;
-        box-shadow: 0 0 0 6px rgba(29, 78, 216, 0.18);
+        transform: rotate(-45deg);
+        transform-origin: center;
+        box-shadow:
+          0 0 0 7px rgba(29, 78, 216, 0.18),
+          0 4px 12px rgba(29, 78, 216, 0.34);
       }
     </style>
   </head>
@@ -135,6 +182,7 @@ const mapHtml = ({
       let markerInstances = [];
       let pendingUpdatePayload = null;
       let userLocationMarker = null;
+      let mapGestureReleaseTimer = null;
 
       const getZoomForRegion = (nextRegion) => {
         const requestedDelta = Math.max(
@@ -180,6 +228,26 @@ const mapHtml = ({
         );
       };
 
+      const postMapGestureChange = (isActive) => {
+        if (mapGestureReleaseTimer) {
+          window.clearTimeout(mapGestureReleaseTimer);
+          mapGestureReleaseTimer = null;
+        }
+
+        window.ReactNativeWebView?.postMessage(
+          JSON.stringify({ type: 'mapGesture', isActive })
+        );
+
+        if (isActive) {
+          mapGestureReleaseTimer = window.setTimeout(() => {
+            window.ReactNativeWebView?.postMessage(
+              JSON.stringify({ type: 'mapGesture', isActive: false })
+            );
+            mapGestureReleaseTimer = null;
+          }, 1200);
+        }
+      };
+
       const clearProgrammaticMove = () => {
         if (programmaticMoveTimer) {
           window.clearTimeout(programmaticMoveTimer);
@@ -203,12 +271,15 @@ const mapHtml = ({
       const createStoryMarker = (marker) => {
         const element = document.createElement('div');
         element.className = marker.selected ? 'marker selected' : 'marker';
+        const markerBody = document.createElement('div');
+        markerBody.className = marker.selected ? 'marker-pin' : 'marker-dot';
+        element.appendChild(markerBody);
 
         if (marker.label) {
           const label = document.createElement('span');
           label.className = 'marker-label';
           label.textContent = marker.label;
-          element.appendChild(label);
+          markerBody.appendChild(label);
         }
 
         element.addEventListener('click', (event) => {
@@ -218,7 +289,7 @@ const mapHtml = ({
           );
         });
 
-        return new maplibregl.Marker({ element, anchor: 'center' })
+        return new maplibregl.Marker({ element, anchor: marker.selected ? 'bottom' : 'center' })
           .setLngLat([marker.longitude, marker.latitude])
           .addTo(map);
       };
@@ -239,8 +310,11 @@ const mapHtml = ({
         if (nextUserLocation) {
           const element = document.createElement('div');
           element.className = 'user-location-marker';
+          const markerBody = document.createElement('div');
+          markerBody.className = 'user-location-pin';
+          element.appendChild(markerBody);
 
-          userLocationMarker = new maplibregl.Marker({ element, anchor: 'center' })
+          userLocationMarker = new maplibregl.Marker({ element, anchor: 'bottom' })
             .setLngLat([nextUserLocation.longitude, nextUserLocation.latitude])
             .addTo(map);
         }
@@ -305,6 +379,19 @@ const mapHtml = ({
         map.boxZoom.disable();
       }
 
+      const mapCanvas = map.getCanvas();
+      mapCanvas.addEventListener('touchstart', () => postMapGestureChange(true), { passive: true });
+      mapCanvas.addEventListener('touchmove', () => postMapGestureChange(true), { passive: true });
+      mapCanvas.addEventListener('touchend', () => postMapGestureChange(false), { passive: true });
+      mapCanvas.addEventListener('touchcancel', () => postMapGestureChange(false), { passive: true });
+      mapCanvas.addEventListener('pointerdown', () => postMapGestureChange(true));
+      mapCanvas.addEventListener('pointermove', () => postMapGestureChange(true));
+      mapCanvas.addEventListener('pointerup', () => postMapGestureChange(false));
+      mapCanvas.addEventListener('pointercancel', () => postMapGestureChange(false));
+
+      map.on('dragstart', () => postMapGestureChange(true));
+      map.on('dragend', () => postMapGestureChange(false));
+
       map.on('click', (event) => {
         if (!interactive) {
           return;
@@ -357,19 +444,21 @@ export function WebMapView({
   interactive = true,
   onMarkerPress,
   onMapPress,
+  onMapGestureChange,
   onRegionChangeComplete,
   transitionDurationMs = 450,
 }: WebMapViewProps) {
   const webViewRef = useRef<WebViewHandle | null>(null);
-  const sourceRef = useRef<{ html: string } | null>(null);
+  const sourceRef = useRef<{ html: string; version: string } | null>(null);
   const latestUpdatePayloadRef = useRef<MapUpdatePayload | null>(null);
   const lastSentRegionRef = useRef<RegionLike | null>(null);
   const lastSentMarkersRef = useRef<MarkerItem[] | null>(null);
   const lastSentUserLocationRef = useRef<UserLocationLike | null | undefined>(undefined);
 
-  if (sourceRef.current === null) {
+  if (sourceRef.current === null || sourceRef.current.version !== MAP_HTML_VERSION) {
     sourceRef.current = {
       html: mapHtml({ region, markers, userLocation, interactive, transitionDurationMs }),
+      version: MAP_HTML_VERSION,
     };
   }
 
@@ -418,7 +507,8 @@ export function WebMapView({
           webViewRef.current = ref as WebViewHandle | null;
         }}
         originWhitelist={['*']}
-        source={sourceRef.current}
+        source={{ html: sourceRef.current.html }}
+        key={sourceRef.current.version}
         style={styles.webview}
         javaScriptEnabled
         domStorageEnabled
@@ -457,12 +547,19 @@ export function WebMapView({
               typeof payload.latitudeDelta === 'number' &&
               typeof payload.longitudeDelta === 'number'
             ) {
-              onRegionChangeComplete?.({
+              const nextRegion = {
                 latitude: payload.latitude,
                 longitude: payload.longitude,
                 latitudeDelta: payload.latitudeDelta,
                 longitudeDelta: payload.longitudeDelta,
-              });
+              };
+
+              lastSentRegionRef.current = nextRegion;
+              onRegionChangeComplete?.(nextRegion);
+            }
+
+            if (payload.type === 'mapGesture' && typeof payload.isActive === 'boolean') {
+              onMapGestureChange?.(payload.isActive);
             }
           } catch {
             return;


### PR DESCRIPTION
# 📝 Description
Fixes #492

Adds a **View Timeline** action to map marker previews so users can jump from a map pin or cluster into the timeline filtered to nearby stories. The change also adds 500 m proximity support, tracks whether a distance filter came from a map pin or current location, and improves map gesture handling so the parent scroll/refresh controls do not interfere while interacting with the embedded map.

# 📊 Type of Change
- [ ]  Bug fix
- [x]  New feature
- [ ]  Refactoring
- [ ]  Documentation
 
# ✅ Acceptance Criteria / Checklist
- [x] Project builds successfully
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, especially in hard-to-understand parts
- [x] I have performed a self-review of my code
- [x] I have added/updated tests
- [x] New and existing unit tests pass locally with my changes

# 📸 Screenshots / Recordings
N/A

# ⏱️ Estimated Review Time
- [ ] < 5 min
- [ ] 5-15 min
- [x] > 15 min

Validation:
- `npm run typecheck`
- `npm test -- --runInBand`
