### PR TITLE
fix: unify password validation across registration and reset

### DIFF
--- a/backend/apps/users/serializers.py
+++ b/backend/apps/users/serializers.py
@@ -1,5 +1,3 @@
-from django.contrib.auth.password_validation import validate_password
-
 from rest_framework import serializers
 
 from apps.users.models import Follow, User
@@ -298,7 +296,7 @@ class PasswordResetConfirmSerializer(serializers.Serializer):
     new_password_confirmation = serializers.CharField(write_only=True)
 
     def validate_new_password(self, value):
-        validate_password(value)
+        validate_password_strength(value)
         return value
 
     def validate(self, attrs):

--- a/backend/apps/users/tests/test_views.py
+++ b/backend/apps/users/tests/test_views.py
@@ -1147,6 +1147,67 @@ class TestPasswordResetConfirmView:
         })
         assert response.status_code == status.HTTP_400_BAD_REQUEST
 
+    def test_common_but_complex_password_is_accepted(self, client, user):
+        # Regression for #532: password reset must use the same validator as
+        # registration — CommonPasswordValidator must NOT be applied here.
+        token = self._make_token(user)
+        response = client.post(self.url, {
+            'token': str(token.token),
+            'new_password': '123456Aa',
+            'new_password_confirmation': '123456Aa',
+        })
+        assert response.status_code == status.HTTP_200_OK
+
+
+# ── Password validation consistency (issue #532) ─────────────────────────────
+
+@pytest.mark.django_db
+class TestPasswordValidationConsistency:
+    """Both registration and password reset must enforce identical password rules."""
+
+    REGISTER_URL = '/auth/register/'
+    RESET_URL = '/auth/password-reset/confirm/'
+
+    def _make_token(self, user):
+        from apps.users.models import PasswordResetToken
+        return PasswordResetToken.objects.create(user=user)
+
+    def test_common_password_accepted_by_both_flows(self, client, user):
+        # '123456Aa' meets complexity rules but is in Django's common-password list.
+        # Registration must accept it, and so must password reset.
+        reg_response = client.post(self.REGISTER_URL, {
+            'email': 'consistency@example.com',
+            'username': 'consistencyuser',
+            'password': '123456Aa',
+            'password_confirmation': '123456Aa',
+        })
+        assert reg_response.status_code == status.HTTP_201_CREATED
+
+        token = self._make_token(user)
+        reset_response = client.post(self.RESET_URL, {
+            'token': str(token.token),
+            'new_password': '123456Aa',
+            'new_password_confirmation': '123456Aa',
+        })
+        assert reset_response.status_code == status.HTTP_200_OK
+
+    def test_weak_password_rejected_by_both_flows(self, client, user):
+        reg_response = client.post(self.REGISTER_URL, {
+            'email': 'consistency2@example.com',
+            'username': 'consistencyuser2',
+            'password': 'weak',
+            'password_confirmation': 'weak',
+        })
+        assert reg_response.status_code == status.HTTP_400_BAD_REQUEST
+
+        token = self._make_token(user)
+        reset_response = client.post(self.RESET_URL, {
+            'token': str(token.token),
+            'new_password': 'weak',
+            'new_password_confirmation': 'weak',
+        })
+        assert reset_response.status_code == status.HTTP_400_BAD_REQUEST
+
 
 # ── POST /auth/verify-email/ ─────────────────────────────────────────────────
 


### PR DESCRIPTION
# 📝 Description
Fixes #532

Both registration and password reset now enforce identical password rules by using the same `validate_password_strength()` validator. Previously, `PasswordResetConfirmSerializer` called Django's built-in `validate_password()`, which applies `CommonPasswordValidator` (among others) — rejecting passwords like `123456Aa` that registration happily accepted.

The fix: switch `PasswordResetConfirmSerializer.validate_new_password` to use the custom `validate_password_strength()`, which checks only the four criteria from Req. 1.2.1.4 (length ≥ 8, digit, uppercase, lowercase).

# 📊 Type of Change
- [x] Bug fix

# ✅ Acceptance Criteria / Checklist
- [x] Project builds successfully
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, especially in hard-to-understand parts
- [x] I have performed a self-review of my code
- [x] I have added/updated tests
- [x] New and existing unit tests pass locally with my changes

# 📸 Screenshots / Recordings
<!-- If applicable -->

# ⏱️ Estimated Review Time
- [x] < 5 min