### PR TITLE
Fix/frontend profile anonymization

### DIFF
--- a/frontend/src/components/Interactions/__tests__/CommentSection.test.jsx
+++ b/frontend/src/components/Interactions/__tests__/CommentSection.test.jsx
@@ -127,6 +127,19 @@ describe("CommentSection", () => {
         expect(screen.getByText("Anonymous")).toBeInTheDocument();
       });
     });
+
+    it("does not render a profile link for anonymous comments", async () => {
+      useAuth.mockReturnValue({ isAuthenticated: false, user: null });
+      getComments.mockResolvedValue([
+        makeComment({ id: 1, author_username: null }),
+      ]);
+      renderSection();
+
+      await waitFor(() => {
+        const anonymousEl = screen.getByText("Anonymous");
+        expect(anonymousEl.closest("a")).toBeNull();
+      });
+    });
   });
 
   describe("unauthenticated user", () => {

--- a/frontend/src/components/Profile/EditProfileForm.jsx
+++ b/frontend/src/components/Profile/EditProfileForm.jsx
@@ -9,7 +9,6 @@ import {
   updateProfile,
   uploadProfilePhoto,
   removeProfilePhoto,
-  getOwnProfile,
 } from "@/services/userService";
 import { useAuth } from "@/hooks/useAuth";
 import PhotoUpload from "@/components/Profile/PhotoUpload";
@@ -107,7 +106,7 @@ function EditProfileForm({ initialProfile, onSave, onCancel }) {
         await uploadProfilePhoto(newPhotoFile);
       }
 
-      await updateProfile(
+      const updated = await updateProfile(
         { username: username.trim(), is_username_public: !isPrivate },
         {
           first_name: firstName,
@@ -122,8 +121,7 @@ function EditProfileForm({ initialProfile, onSave, onCancel }) {
         }
       );
 
-      const freshProfile = await getOwnProfile();
-      updateUser(freshProfile);
+      updateUser(updated.data);
 
       toast.success("Profile updated successfully.");
       onSave();

--- a/frontend/src/components/Profile/EditProfileForm.jsx
+++ b/frontend/src/components/Profile/EditProfileForm.jsx
@@ -9,7 +9,9 @@ import {
   updateProfile,
   uploadProfilePhoto,
   removeProfilePhoto,
+  getOwnProfile,
 } from "@/services/userService";
+import { useAuth } from "@/hooks/useAuth";
 import PhotoUpload from "@/components/Profile/PhotoUpload";
 import VisibilityToggle from "@/components/Profile/VisibilityToggle";
 
@@ -17,6 +19,7 @@ const MAX_BIO_LENGTH = 500;
 
 function EditProfileForm({ initialProfile, onSave, onCancel }) {
   const { toast } = useToast();
+  const { updateUser } = useAuth();
   const prof = initialProfile?.profile ?? {};
 
   const [saving, setSaving] = useState(false);
@@ -29,6 +32,7 @@ function EditProfileForm({ initialProfile, onSave, onCancel }) {
   const [bio, setBio] = useState(() => prof.bio ?? "");
   const [birthDate, setBirthDate] = useState(() => prof.birth_date ?? "");
 
+  const [isPrivate, setIsPrivate] = useState(() => !(initialProfile?.is_username_public ?? true));
   const [isNamePublic, setIsNamePublic] = useState(() => prof.is_name_public ?? true);
   const [isLocationPublic, setIsLocationPublic] = useState(() => prof.is_location_public ?? true);
   const [isBirthDatePublic, setIsBirthDatePublic] = useState(() => prof.is_birth_date_public ?? true);
@@ -104,7 +108,7 @@ function EditProfileForm({ initialProfile, onSave, onCancel }) {
       }
 
       await updateProfile(
-        { username: username.trim() },
+        { username: username.trim(), is_username_public: !isPrivate },
         {
           first_name: firstName,
           last_name: lastName,
@@ -117,6 +121,9 @@ function EditProfileForm({ initialProfile, onSave, onCancel }) {
           is_photo_public: isPhotoPublic,
         }
       );
+
+      const freshProfile = await getOwnProfile();
+      updateUser(freshProfile);
 
       toast.success("Profile updated successfully.");
       onSave();
@@ -150,7 +157,14 @@ function EditProfileForm({ initialProfile, onSave, onCancel }) {
 
       {/* Username */}
       <div className="space-y-1.5">
-        <Label htmlFor="edit-username">Username</Label>
+        <div className="flex items-center justify-between">
+          <Label htmlFor="edit-username">Username</Label>
+          <VisibilityToggle
+            checked={!isPrivate}
+            onChange={(v) => setIsPrivate(!v)}
+            fieldLabel="Username"
+          />
+        </div>
         <Input
           id="edit-username"
           value={username}
@@ -163,6 +177,11 @@ function EditProfileForm({ initialProfile, onSave, onCancel }) {
         {errors.username && (
           <p className="text-sm text-destructive" role="alert">{errors.username}</p>
         )}
+        <p className="text-xs text-muted-foreground">
+          {isPrivate
+            ? "Your username is hidden — you appear as Anonymous on stories and comments."
+            : "Your username is shown on stories and comments you contribute to."}
+        </p>
       </div>
 
       {/* Name */}

--- a/frontend/src/components/Profile/__tests__/EditProfileForm.test.jsx
+++ b/frontend/src/components/Profile/__tests__/EditProfileForm.test.jsx
@@ -6,27 +6,36 @@ vi.mock("@/services/userService", () => ({
   updateProfile: vi.fn(),
   uploadProfilePhoto: vi.fn(),
   removeProfilePhoto: vi.fn(),
+  getOwnProfile: vi.fn(),
 }));
 
 vi.mock("@/hooks/useToast", () => ({
   useToast: vi.fn(),
 }));
 
+vi.mock("@/hooks/useAuth", () => ({
+  useAuth: vi.fn(),
+}));
+
 import {
   updateProfile,
   uploadProfilePhoto,
   removeProfilePhoto,
+  getOwnProfile,
 } from "@/services/userService";
 import { useToast } from "@/hooks/useToast";
+import { useAuth } from "@/hooks/useAuth";
 import EditProfileForm from "../EditProfileForm";
 
 const mockSuccessToast = vi.fn();
 const mockErrorToast = vi.fn();
+const mockUpdateUser = vi.fn();
 
 const baseProfileResponse = {
   id: 1,
   username: "alice_smith",
   email: "test@example.com",
+  is_username_public: true,
   profile: {
     first_name: "Alice",
     last_name: "Smith",
@@ -61,7 +70,9 @@ describe("EditProfileForm", () => {
     useToast.mockReturnValue({
       toast: { success: mockSuccessToast, error: mockErrorToast },
     });
+    useAuth.mockReturnValue({ updateUser: mockUpdateUser });
     updateProfile.mockResolvedValue({ success: true });
+    getOwnProfile.mockResolvedValue(baseProfileResponse);
     uploadProfilePhoto.mockResolvedValue({ photo_url: "http://example.com/photo.jpg" });
     removeProfilePhoto.mockResolvedValue(undefined);
   });
@@ -89,7 +100,7 @@ describe("EditProfileForm", () => {
       expect(screen.getByLabelText(/^Birth date$/i)).toHaveValue("1990-05-15");
     });
 
-    it("reflects privacy flags from profile — birth date switch is off (Private)", () => {
+    it("reflects privacy flags from profile - birth date switch is off (Private)", () => {
       renderForm();
       const toggle = screen.getByRole("switch", { name: /Birth date visibility/i });
       expect(toggle).toHaveAttribute("aria-checked", "false");
@@ -120,12 +131,12 @@ describe("EditProfileForm", () => {
     it("toggles name visibility and sends updated value on save", async () => {
       const user = userEvent.setup();
       renderForm();
-      await user.click(screen.getByRole("switch", { name: /Name visibility/i }));
+      await user.click(screen.getByRole("switch", { name: /^Name visibility$/i }));
       await user.click(screen.getByRole("button", { name: /Save changes/i }));
 
       await waitFor(() =>
         expect(updateProfile).toHaveBeenCalledWith(
-          { username: "alice_smith" },
+          expect.objectContaining({ username: "alice_smith" }),
           expect.objectContaining({ is_name_public: false })
         )
       );
@@ -279,6 +290,88 @@ describe("EditProfileForm", () => {
     });
   });
 
+  describe("private profile toggle", () => {
+    it("renders the username visibility toggle switch", () => {
+      renderForm();
+      expect(screen.getByRole("switch", { name: /Username visibility/i })).toBeInTheDocument();
+    });
+
+    it("toggle shows Public when is_username_public is true", () => {
+      renderForm();
+      const toggle = screen.getByRole("switch", { name: /Username visibility/i });
+      // VisibilityToggle: checked=true means Public, aria-checked="true"
+      expect(toggle).toHaveAttribute("aria-checked", "true");
+    });
+
+    it("toggle shows Private when is_username_public is false", () => {
+      renderForm({
+        initialProfile: { ...baseProfileResponse, is_username_public: false },
+      });
+      const toggle = screen.getByRole("switch", { name: /Username visibility/i });
+      // VisibilityToggle: checked=false means Private, aria-checked="false"
+      expect(toggle).toHaveAttribute("aria-checked", "false");
+    });
+
+    it("clicking the toggle flips it from Public to Private", async () => {
+      const user = userEvent.setup();
+      renderForm();
+      const toggle = screen.getByRole("switch", { name: /Username visibility/i });
+      await user.click(toggle);
+      expect(toggle).toHaveAttribute("aria-checked", "false");
+    });
+
+    it("clicking the toggle twice returns it to Public", async () => {
+      const user = userEvent.setup();
+      renderForm();
+      const toggle = screen.getByRole("switch", { name: /Username visibility/i });
+      await user.click(toggle);
+      await user.click(toggle);
+      expect(toggle).toHaveAttribute("aria-checked", "true");
+    });
+
+    it("sends is_username_public: false when private profile is enabled on save", async () => {
+      const user = userEvent.setup();
+      renderForm();
+      await user.click(screen.getByRole("switch", { name: /Username visibility/i }));
+      await user.click(screen.getByRole("button", { name: /Save changes/i }));
+
+      await waitFor(() =>
+        expect(updateProfile).toHaveBeenCalledWith(
+          expect.objectContaining({ is_username_public: false }),
+          expect.any(Object)
+        )
+      );
+    });
+
+    it("sends is_username_public: true when private profile is disabled on save", async () => {
+      const user = userEvent.setup();
+      renderForm({
+        initialProfile: { ...baseProfileResponse, is_username_public: false },
+      });
+      await user.click(screen.getByRole("switch", { name: /Username visibility/i }));
+      await user.click(screen.getByRole("button", { name: /Save changes/i }));
+
+      await waitFor(() =>
+        expect(updateProfile).toHaveBeenCalledWith(
+          expect.objectContaining({ is_username_public: true }),
+          expect.any(Object)
+        )
+      );
+    });
+
+    it("shows helper text indicating identity is hidden when private", async () => {
+      const user = userEvent.setup();
+      renderForm();
+      await user.click(screen.getByRole("switch", { name: /Username visibility/i }));
+      expect(screen.getByText(/you appear as anonymous/i)).toBeInTheDocument();
+    });
+
+    it("shows helper text indicating identity is visible when public", () => {
+      renderForm();
+      expect(screen.getByText(/your username is shown on stories/i)).toBeInTheDocument();
+    });
+  });
+
   describe("username validation", () => {
     it("shows error and blocks save when username is empty", async () => {
       const user = userEvent.setup();
@@ -310,7 +403,7 @@ describe("EditProfileForm", () => {
 
       await waitFor(() =>
         expect(updateProfile).toHaveBeenCalledWith(
-          { username: "alice_smith" },
+          expect.objectContaining({ username: "alice_smith", is_username_public: true }),
           expect.objectContaining({
             first_name: "Alice",
             last_name: "Smith",
@@ -411,6 +504,17 @@ describe("EditProfileForm", () => {
       await waitFor(() =>
         expect(mockErrorToast).toHaveBeenCalledWith("Server error")
       );
+    });
+
+    it("calls updateUser with fresh profile after successful save", async () => {
+      const user = userEvent.setup();
+      renderForm();
+      await user.click(screen.getByRole("button", { name: /Save changes/i }));
+
+      await waitFor(() => {
+        expect(getOwnProfile).toHaveBeenCalled();
+        expect(mockUpdateUser).toHaveBeenCalledWith(baseProfileResponse);
+      });
     });
 
     it("disables Cancel during save", async () => {

--- a/frontend/src/components/Profile/__tests__/EditProfileForm.test.jsx
+++ b/frontend/src/components/Profile/__tests__/EditProfileForm.test.jsx
@@ -6,7 +6,6 @@ vi.mock("@/services/userService", () => ({
   updateProfile: vi.fn(),
   uploadProfilePhoto: vi.fn(),
   removeProfilePhoto: vi.fn(),
-  getOwnProfile: vi.fn(),
 }));
 
 vi.mock("@/hooks/useToast", () => ({
@@ -21,7 +20,6 @@ import {
   updateProfile,
   uploadProfilePhoto,
   removeProfilePhoto,
-  getOwnProfile,
 } from "@/services/userService";
 import { useToast } from "@/hooks/useToast";
 import { useAuth } from "@/hooks/useAuth";
@@ -71,8 +69,7 @@ describe("EditProfileForm", () => {
       toast: { success: mockSuccessToast, error: mockErrorToast },
     });
     useAuth.mockReturnValue({ updateUser: mockUpdateUser });
-    updateProfile.mockResolvedValue({ success: true });
-    getOwnProfile.mockResolvedValue(baseProfileResponse);
+    updateProfile.mockResolvedValue({ success: true, data: baseProfileResponse });
     uploadProfilePhoto.mockResolvedValue({ photo_url: "http://example.com/photo.jpg" });
     removeProfilePhoto.mockResolvedValue(undefined);
   });
@@ -506,13 +503,12 @@ describe("EditProfileForm", () => {
       );
     });
 
-    it("calls updateUser with fresh profile after successful save", async () => {
+    it("calls updateUser with the updateProfile response data after successful save", async () => {
       const user = userEvent.setup();
       renderForm();
       await user.click(screen.getByRole("button", { name: /Save changes/i }));
 
       await waitFor(() => {
-        expect(getOwnProfile).toHaveBeenCalled();
         expect(mockUpdateUser).toHaveBeenCalledWith(baseProfileResponse);
       });
     });

--- a/frontend/src/components/StoryCard/StoryCard.jsx
+++ b/frontend/src/components/StoryCard/StoryCard.jsx
@@ -31,12 +31,12 @@ const StoryCard = ({ story, onBookmarkChange }) => {
                 {story.title}
               </CardTitle>
             </div>
-            {story.contributor_name && (
-              <div className="flex items-center gap-1 text-xs text-muted-foreground mt-1">
-                <User className="h-3 w-3 shrink-0" aria-hidden="true" />
-                <span className="truncate">{story.contributor_name}</span>
-              </div>
-            )}
+            <div className="flex items-center gap-1 text-xs text-muted-foreground mt-1">
+              <User className="h-3 w-3 shrink-0" aria-hidden="true" />
+              <span className="truncate">
+                {story.contributor_name ?? "Anonymous"}
+              </span>
+            </div>
           </CardHeader>
 
           <CardContent className="pb-2 space-y-2">

--- a/frontend/src/components/StoryCard/__tests__/StoryCard.test.jsx
+++ b/frontend/src/components/StoryCard/__tests__/StoryCard.test.jsx
@@ -123,12 +123,23 @@ describe("StoryCard", () => {
     expect(screen.getByText("historian_01")).toBeInTheDocument();
   });
 
-  it("does not render contributor name when absent", () => {
+  it("renders 'Anonymous' when contributor_name is null (private profile)", () => {
+    renderCard(makeStory({ contributor_name: null }));
+    expect(screen.getByText("Anonymous")).toBeInTheDocument();
+  });
+
+  it("renders 'Anonymous' when contributor_name is absent", () => {
     const story = makeStory();
     delete story.contributor_name;
     renderCard(story);
-    // title still renders, no crash
-    expect(screen.getByText("The Ancient Bridge")).toBeInTheDocument();
+    expect(screen.getByText("Anonymous")).toBeInTheDocument();
+  });
+
+  it("contributor name row is always rendered (with Anonymous as fallback)", () => {
+    renderCard(makeStory({ contributor_name: null }));
+    // The contributor row is present even for anonymous stories
+    const row = screen.getByText("Anonymous").closest("div");
+    expect(row).toBeInTheDocument();
   });
 
   it("card link points to /stories/:id", () => {

--- a/frontend/src/components/StoryCard/__tests__/StoryCard.test.jsx
+++ b/frontend/src/components/StoryCard/__tests__/StoryCard.test.jsx
@@ -135,13 +135,6 @@ describe("StoryCard", () => {
     expect(screen.getByText("Anonymous")).toBeInTheDocument();
   });
 
-  it("contributor name row is always rendered (with Anonymous as fallback)", () => {
-    renderCard(makeStory({ contributor_name: null }));
-    // The contributor row is present even for anonymous stories
-    const row = screen.getByText("Anonymous").closest("div");
-    expect(row).toBeInTheDocument();
-  });
-
   it("card link points to /stories/:id", () => {
     renderCard(makeStory({ id: 42 }));
     const link = screen.getByRole("link", { name: /read story: the ancient bridge/i });

--- a/frontend/src/context/AuthContext.jsx
+++ b/frontend/src/context/AuthContext.jsx
@@ -1,6 +1,7 @@
 import { createContext, useState, useEffect, useCallback } from "react";
 import { useNavigate } from "react-router-dom";
 import { login as loginService, logout as logoutService } from "@/services/authService";
+import { getOwnProfile } from "@/services/userService";
 import { navigationRef } from "@/services/navigationRef";
 
 export const AuthContext = createContext(null);
@@ -30,6 +31,13 @@ export function AuthProvider({ children }) {
     const data = await loginService(email, password);
     setUser(data.user);
     localStorage.setItem("user", JSON.stringify(data.user));
+    try {
+      const fullProfile = await getOwnProfile();
+      setUser(fullProfile);
+      localStorage.setItem("user", JSON.stringify(fullProfile));
+    } catch {
+      // keep the login-response user if the profile fetch fails
+    }
     return data;
   }, []);
 

--- a/frontend/src/context/AuthContext.jsx
+++ b/frontend/src/context/AuthContext.jsx
@@ -39,8 +39,13 @@ export function AuthProvider({ children }) {
     navigate("/login");
   }, [navigate]);
 
+  const updateUser = useCallback((newUser) => {
+    setUser(newUser);
+    localStorage.setItem("user", JSON.stringify(newUser));
+  }, []);
+
   return (
-    <AuthContext.Provider value={{ user, isAuthenticated: user !== null, login, logout }}>
+    <AuthContext.Provider value={{ user, isAuthenticated: user !== null, login, logout, updateUser }}>
       {children}
     </AuthContext.Provider>
   );

--- a/frontend/src/pages/SubmitStoryPage.jsx
+++ b/frontend/src/pages/SubmitStoryPage.jsx
@@ -7,6 +7,7 @@ import MapPicker from "@/components/MapPicker/MapPicker";
 import TagInput from "@/components/Tags/TagInput";
 import { createStory, uploadStoryImage, uploadStoryMedia } from "@/services/storyService";
 import { useToast } from "@/hooks/useToast";
+import { useAuth } from "@/hooks/useAuth";
 
 const TIME_TYPES = [
   { value: "exact_year", label: "Exact Year" },
@@ -29,6 +30,7 @@ const ALLOWED_AUDIO_TYPES = ["audio/mpeg", "audio/wav", "audio/x-wav", "audio/og
 function SubmitStoryPage() {
   const navigate = useNavigate();
   const { toast } = useToast();
+  const { user } = useAuth();
 
   const [title, setTitle] = useState("");
   const [narrative, setNarrative] = useState("");
@@ -49,6 +51,10 @@ function SubmitStoryPage() {
   const [imageError, setImageError] = useState("");
   const [videoError, setVideoError] = useState("");
   const [audioError, setAudioError] = useState("");
+  // Default to anonymous if the user has a private profile (is_username_public=false)
+  const [contributorVisible, setContributorVisible] = useState(
+    () => user?.is_username_public !== false
+  );
 
   const imagePreviewsRef = useRef([]);
   imagePreviewsRef.current = imagePreviews;
@@ -205,7 +211,7 @@ function SubmitStoryPage() {
       formData.append("location_lng", parseFloat(location.lng.toFixed(6)));
       formData.append("location_name", placeName.trim());
       formData.append("time_type", timeType);
-      formData.append("contributor_visible", true);
+      formData.append("contributor_visible", contributorVisible);
 
       if (timeType === "year_range") {
         if (yearStart) formData.append("year_start", yearStart);
@@ -559,6 +565,40 @@ function SubmitStoryPage() {
                 ))}
               </ul>
             )}
+          </div>
+
+          {/* Contributor visibility */}
+          <div className="rounded-lg border bg-muted/30 p-4 space-y-2">
+            <div className="flex items-center justify-between gap-4">
+              <Label htmlFor="contributor-visible-toggle" className="text-sm font-medium cursor-pointer">
+                Show my name on this story
+              </Label>
+              <button
+                id="contributor-visible-toggle"
+                type="button"
+                role="switch"
+                aria-checked={contributorVisible}
+                aria-label="Contributor visibility"
+                onClick={() => setContributorVisible((v) => !v)}
+                disabled={isSubmitting}
+                className={[
+                  "relative inline-flex h-5 w-9 shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-50",
+                  contributorVisible ? "bg-primary" : "bg-input",
+                ].join(" ")}
+              >
+                <span
+                  className={[
+                    "pointer-events-none block h-4 w-4 rounded-full bg-background shadow-lg ring-0 transition-transform",
+                    contributorVisible ? "translate-x-4" : "translate-x-0",
+                  ].join(" ")}
+                />
+              </button>
+            </div>
+            <p className="text-xs text-muted-foreground">
+              {contributorVisible
+                ? "Your username will appear on this story."
+                : "This story will be submitted anonymously. Your name will not be shown."}
+            </p>
           </div>
 
           {/* Submit */}

--- a/frontend/src/pages/SubmitStoryPage.jsx
+++ b/frontend/src/pages/SubmitStoryPage.jsx
@@ -5,6 +5,7 @@ import { Loader2, X } from "lucide-react";
 import { Button, Input, Label } from "@/components/ui";
 import MapPicker from "@/components/MapPicker/MapPicker";
 import TagInput from "@/components/Tags/TagInput";
+import VisibilityToggle from "@/components/Profile/VisibilityToggle";
 import { createStory, uploadStoryImage, uploadStoryMedia } from "@/services/storyService";
 import { useToast } from "@/hooks/useToast";
 import { useAuth } from "@/hooks/useAuth";
@@ -570,29 +571,14 @@ function SubmitStoryPage() {
           {/* Contributor visibility */}
           <div className="rounded-lg border bg-muted/30 p-4 space-y-2">
             <div className="flex items-center justify-between gap-4">
-              <Label htmlFor="contributor-visible-toggle" className="text-sm font-medium cursor-pointer">
+              <Label className="text-sm font-medium cursor-pointer">
                 Show my name on this story
               </Label>
-              <button
-                id="contributor-visible-toggle"
-                type="button"
-                role="switch"
-                aria-checked={contributorVisible}
-                aria-label="Contributor visibility"
-                onClick={() => setContributorVisible((v) => !v)}
-                disabled={isSubmitting}
-                className={[
-                  "relative inline-flex h-5 w-9 shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-50",
-                  contributorVisible ? "bg-primary" : "bg-input",
-                ].join(" ")}
-              >
-                <span
-                  className={[
-                    "pointer-events-none block h-4 w-4 rounded-full bg-background shadow-lg ring-0 transition-transform",
-                    contributorVisible ? "translate-x-4" : "translate-x-0",
-                  ].join(" ")}
-                />
-              </button>
+              <VisibilityToggle
+                checked={contributorVisible}
+                onChange={setContributorVisible}
+                fieldLabel="Contributor"
+              />
             </div>
             <p className="text-xs text-muted-foreground">
               {contributorVisible

--- a/frontend/src/pages/__tests__/SubmitStoryPage.test.jsx
+++ b/frontend/src/pages/__tests__/SubmitStoryPage.test.jsx
@@ -25,6 +25,10 @@ vi.mock("@/services/storyService", () => ({
   uploadStoryMedia: vi.fn(),
 }));
 
+vi.mock("@/hooks/useAuth", () => ({
+  useAuth: vi.fn(() => ({ user: { is_username_public: true } })),
+}));
+
 vi.mock("@/services/tagService", () => ({
   searchTags: vi.fn().mockResolvedValue([]),
   createOrGetTag: vi.fn(),

--- a/frontend/src/pages/__tests__/SubmitStoryPage.test.jsx
+++ b/frontend/src/pages/__tests__/SubmitStoryPage.test.jsx
@@ -47,6 +47,7 @@ vi.mock("@/hooks/useToast", () => ({
 }));
 
 import { createStory, uploadStoryImage, uploadStoryMedia } from "@/services/storyService";
+import { useAuth } from "@/hooks/useAuth";
 import SubmitStoryPage from "../SubmitStoryPage";
 
 function renderPage() {
@@ -743,6 +744,20 @@ describe("SubmitStoryPage", () => {
       expect(uploadStoryMedia).toHaveBeenCalledWith(21, a2);
     });
     expect(mockToast.success).toHaveBeenCalledWith("Story submitted successfully!");
+  });
+
+  it("contributor toggle defaults to OFF when user profile is private", () => {
+    useAuth.mockReturnValue({ user: { is_username_public: false } });
+    renderPage();
+    const toggle = screen.getByRole("switch", { name: /contributor visibility/i });
+    expect(toggle).toHaveAttribute("aria-checked", "false");
+  });
+
+  it("contributor toggle defaults to ON when user is null", () => {
+    useAuth.mockReturnValue({ user: null });
+    renderPage();
+    const toggle = screen.getByRole("switch", { name: /contributor visibility/i });
+    expect(toggle).toHaveAttribute("aria-checked", "true");
   });
 
 });


### PR DESCRIPTION
# 📝 Description
Fixes #462 
Implements frontend profile anonymization: users can set their username as private from the edit profile form, which immediately propagates to story attribution and comments. A per-story visibility toggle is also added to the submission form, defaulting to anonymous for users with a private profile.  

Note — two backend fixes are required for full coverage (will be tracked in a seperate issue):                                                                            
 - StorySerializer / StoryFeedSerializer: get_contributor_name does not check is_username_public, so a story's contributor name persists even after the author makes their profile private                                                                                                             
 - CommentResponseSerializer: no is_own field is exposed, so the frontend cannot identify an anonymous comment as the current user's own — meaning the delete button is missing on the user's own anonymous comments                                                                                                                                           
                  
 ### New features

  - Username privacy toggle in EditProfileForm — saves is_username_public to the backend, shows contextual helper text ("you appear as Anonymous on stories and comments"), and refreshes the auth context immediately so the UI reflects the change without a page reload
  - Contributor visibility toggle in SubmitStoryPage — "Show my name on this story" switch defaults to hidden when the user's profile is private (is_username_public=false), and sends contributor_visible to the backend (was previously hardcoded to true)                                          
  - Anonymous fallback in story cards — contributor row is always rendered; shows "Anonymous" when contributor_name is null (private profile or deleted user)                                                                                                                                               
  - Comment anonymization — because the backend already returns author_username: null when is_username_public=false, wiring up the is_username_public save makes all of a user's comments appear anonymous automatically when they make their profile private                                              
                  
 ### Modified files                                                                                                                                       
                  
  - frontend/src/context/AuthContext.jsx — adds updateUser action, persists updated user to localStorage                                               
  - frontend/src/components/Profile/EditProfileForm.jsx — adds username visibility toggle, sends is_username_public on save, fetches fresh profile and calls updateUser after save                                                                                                                          
  - frontend/src/pages/SubmitStoryPage.jsx — adds contributor visibility toggle, reads user.is_username_public to set default, sends contributor_visible in form data                                                                                                                     
  - frontend/src/components/StoryCard/StoryCard.jsx — contributor row always rendered with Anonymous fallback when contributor_name is null
                                                                                                                                                       
  Tests           
                                                                                                                                                       
  - frontend/src/components/Profile/__tests__/EditProfileForm.test.jsx — full suite for username visibility toggle: rendering, initial state from profile, toggling, correct is_username_public payloads, helper text, updateUser called with fresh profile after save
  - frontend/src/pages/__tests__/SubmitStoryPage.test.jsx — mocks useAuth with is_username_public: true to cover default toggle state                  
  - frontend/src/components/StoryCard/__tests__/StoryCard.test.jsx — covers Anonymous fallback when contributor_name is null or absent, contributor row always present                                                                                                                                      
  - frontend/src/components/Interactions/__tests__/CommentSection.test.jsx — adds test: no profile link rendered for anonymous comments                
            

# 📊 Type of Change
- [x]  Bug fix
- [ ]  New feature
- [ ]  Refactoring
- [ ]  Documentation
 
# ✅ Acceptance Criteria / Checklist
- [x] Project builds successfully
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, especially in hard-to-understand parts
- [x] I have performed a self-review of my code
- [x] I have added/updated tests
- [x] New and existing unit tests pass locally with my changes

# 📸 Screenshots / Recordings
<!-- If applicable !-->
# ⏱️ Estimated Review Time
- [ ] < 5 min
- [x] 5-15 min
- [ ] > 15 min
