### PR TITLE
Feat/admin ban user and delete tag endpoints

### DIFF
--- a/backend/apps/tags/admin_urls.py
+++ b/backend/apps/tags/admin_urls.py
@@ -1,0 +1,7 @@
+from django.urls import path
+
+from apps.tags.admin_views import AdminTagDeleteView
+
+urlpatterns = [
+    path('tags/<int:pk>/', AdminTagDeleteView.as_view(), name='admin-tag-delete'),
+]

--- a/backend/apps/tags/admin_views.py
+++ b/backend/apps/tags/admin_views.py
@@ -1,0 +1,20 @@
+from django.shortcuts import get_object_or_404
+from rest_framework import status
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from common.permissions import IsAdminUser
+
+from .models import Tag
+from .services import delete_tag
+
+
+class AdminTagDeleteView(APIView):
+    """DELETE /moderation/tags/{id}/ — remove a tag and all story associations (admin only)."""
+
+    permission_classes = [IsAdminUser]
+
+    def delete(self, request, pk):
+        tag = get_object_or_404(Tag, pk=pk)
+        delete_tag(tag)
+        return Response(status=status.HTTP_204_NO_CONTENT)

--- a/backend/apps/tags/services.py
+++ b/backend/apps/tags/services.py
@@ -45,8 +45,15 @@ def create_tag(validated_data: dict, *, is_predefined: bool = False) -> tuple:
 
 
 def delete_tag(tag: Tag) -> None:
-    """Delete the tag. StoryTag rows cascade via FK."""
-    tag.delete()
+    """
+    Delete a tag and all its story associations.
+
+    StoryTag rows are deleted explicitly so that post_delete signals fire and
+    Tag.story_count is decremented before the tag itself is removed.
+    """
+    with transaction.atomic():
+        StoryTag.objects.filter(tag=tag).delete()
+        tag.delete()
 
 
 def attach_tags_to_story(story, tag_ids: list) -> None:

--- a/backend/apps/tags/tests/test_services.py
+++ b/backend/apps/tags/tests/test_services.py
@@ -122,28 +122,51 @@ class TestCreateTag:
 
 @pytest.mark.django_db
 class TestDeleteTag:
-    def test_deletes_tag(self):
-        tag = Tag.objects.create(name='svc-to-delete')
-        delete_tag(tag)
-        assert not Tag.objects.filter(name='svc-to-delete').exists()
-
-    def test_cascade_deletes_story_tags(self):
+    def _make_story(self, email, username):
         from apps.stories.models import Story
         from apps.users.models import User
-
-        user = User.objects.create_user(
-            email='tagger-svc@example.com', username='tagger-svc', password='Pass1234',
-        )
-        story = Story.objects.create(
+        user = User.objects.create_user(email=email, username=username, password='Pass1234')
+        return Story.objects.create(
             user=user, title='T', narrative='N',
             status=Story.STATUS_PUBLISHED,
             location_lat=Decimal('0'), location_lng=Decimal('0'),
             location_name='P', time_type=Story.TIME_EXACT, year=2000,
         )
+
+    def test_deletes_tag(self):
+        tag = Tag.objects.create(name='svc-to-delete')
+        delete_tag(tag)
+        assert not Tag.objects.filter(name='svc-to-delete').exists()
+
+    def test_removes_story_tag_associations(self):
+        story = self._make_story('tagger-svc@example.com', 'tagger-svc')
         tag = Tag.objects.create(name='svc-cascade-tag')
         st = StoryTag.objects.create(story=story, tag=tag)
         delete_tag(tag)
         assert not StoryTag.objects.filter(pk=st.pk).exists()
+
+    def test_decrements_story_count_via_signals(self):
+        story = self._make_story('tagger-cnt@example.com', 'tagger-cnt')
+        tag = Tag.objects.create(name='svc-count-tag')
+        StoryTag.objects.create(story=story, tag=tag)  # signal → story_count=1
+        # story_count decrement signal fires when StoryTag is explicitly deleted
+        # (tag itself is then deleted, so we verify no IntegrityError escapes)
+        delete_tag(tag)
+        assert not Tag.objects.filter(name='svc-count-tag').exists()
+
+    def test_delete_tag_with_no_associations_does_not_raise(self):
+        tag = Tag.objects.create(name='svc-no-assoc-tag')
+        delete_tag(tag)  # must not raise
+        assert not Tag.objects.filter(name='svc-no-assoc-tag').exists()
+
+    def test_delete_tag_removes_multiple_associations(self):
+        story1 = self._make_story('multi1@example.com', 'multi1')
+        story2 = self._make_story('multi2@example.com', 'multi2')
+        tag = Tag.objects.create(name='svc-multi-assoc-tag')
+        StoryTag.objects.create(story=story1, tag=tag)
+        StoryTag.objects.create(story=story2, tag=tag)
+        delete_tag(tag)
+        assert StoryTag.objects.filter(tag_id=tag.pk).count() == 0
 
 
 def _make_story(email, username):

--- a/backend/apps/tags/tests/test_views.py
+++ b/backend/apps/tags/tests/test_views.py
@@ -176,3 +176,67 @@ class TestTagDeleteView:
         client.force_authenticate(user=admin)
         response = client.delete(tag_detail_url(99999))
         assert response.status_code == status.HTTP_404_NOT_FOUND
+
+
+def admin_tag_moderation_url(pk):
+    return f'/moderation/tags/{pk}/'
+
+
+@pytest.mark.django_db
+class TestAdminTagDeleteView:
+    def test_admin_deletes_tag_returns_204(self):
+        tag = Tag.objects.create(name='mod-delete-me')
+        admin = make_admin(email='madadmin@example.com', username='madadmin')
+        client = APIClient()
+        client.force_authenticate(user=admin)
+        response = client.delete(admin_tag_moderation_url(tag.pk))
+        assert response.status_code == status.HTTP_204_NO_CONTENT
+
+    def test_admin_deletes_tag_removes_from_db(self):
+        tag = Tag.objects.create(name='mod-gone-tag')
+        admin = make_admin(email='madadmin2@example.com', username='madadmin2')
+        client = APIClient()
+        client.force_authenticate(user=admin)
+        client.delete(admin_tag_moderation_url(tag.pk))
+        assert not Tag.objects.filter(pk=tag.pk).exists()
+
+    def test_delete_removes_story_tag_associations(self):
+        from decimal import Decimal
+        from apps.stories.models import Story
+        from apps.tags.models import StoryTag
+
+        user = make_user(email='assocuser@example.com', username='assocuser')
+        story = Story.objects.create(
+            user=user, title='T', narrative='N',
+            status=Story.STATUS_PUBLISHED,
+            location_lat=Decimal('0'), location_lng=Decimal('0'),
+            location_name='P', time_type=Story.TIME_EXACT, year=2000,
+        )
+        tag = Tag.objects.create(name='mod-assoc-tag')
+        st = StoryTag.objects.create(story=story, tag=tag)
+        admin = make_admin(email='madadmin3@example.com', username='madadmin3')
+        client = APIClient()
+        client.force_authenticate(user=admin)
+        client.delete(admin_tag_moderation_url(tag.pk))
+        assert not StoryTag.objects.filter(pk=st.pk).exists()
+
+    def test_registered_user_gets_403(self):
+        tag = Tag.objects.create(name='mod-no-delete')
+        user = make_user(email='modnodelete@example.com', username='modnodelete')
+        client = APIClient()
+        client.force_authenticate(user=user)
+        response = client.delete(admin_tag_moderation_url(tag.pk))
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+
+    def test_guest_gets_401(self):
+        tag = Tag.objects.create(name='mod-unauth-delete')
+        client = APIClient()
+        response = client.delete(admin_tag_moderation_url(tag.pk))
+        assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
+    def test_nonexistent_tag_returns_404(self):
+        admin = make_admin(email='mod404admin@example.com', username='mod404admin')
+        client = APIClient()
+        client.force_authenticate(user=admin)
+        response = client.delete(admin_tag_moderation_url(99999))
+        assert response.status_code == status.HTTP_404_NOT_FOUND

--- a/backend/apps/users/admin_urls.py
+++ b/backend/apps/users/admin_urls.py
@@ -1,0 +1,7 @@
+from django.urls import path
+
+from apps.users.admin_views import AdminUserBanView
+
+urlpatterns = [
+    path('users/<int:pk>/ban/', AdminUserBanView.as_view(), name='admin-user-ban'),
+]

--- a/backend/apps/users/admin_views.py
+++ b/backend/apps/users/admin_views.py
@@ -1,0 +1,21 @@
+from django.shortcuts import get_object_or_404
+from rest_framework import status
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from common.permissions import IsAdminUser
+
+from .models import User
+from .serializers import UserBanResponseSerializer
+from .services import ban_user
+
+
+class AdminUserBanView(APIView):
+    """PATCH /moderation/users/{id}/ban/ — disable a user account (admin only)."""
+
+    permission_classes = [IsAdminUser]
+
+    def patch(self, request, pk):
+        target = get_object_or_404(User, pk=pk)
+        banned = ban_user(target)
+        return Response(UserBanResponseSerializer(banned).data, status=status.HTTP_200_OK)

--- a/backend/apps/users/serializers.py
+++ b/backend/apps/users/serializers.py
@@ -50,6 +50,15 @@ class UserResponseSerializer(serializers.ModelSerializer):
         read_only_fields = fields
 
 
+class UserBanResponseSerializer(serializers.ModelSerializer):
+    """Read-only serializer returned by the admin ban endpoint."""
+
+    class Meta:
+        model = User
+        fields = ['id', 'email', 'username', 'role', 'is_active']
+        read_only_fields = fields
+
+
 class UpdateProfileSerializer(serializers.Serializer):
     """Validates editable UserProfile fields accepted by PATCH /users/me/.
 

--- a/backend/apps/users/services.py
+++ b/backend/apps/users/services.py
@@ -486,3 +486,17 @@ def reset_password(token_str: str, new_password: str) -> None:
         token.save(update_fields=['is_used'])
         for outstanding in OutstandingToken.objects.filter(user=token.user):
             BlacklistedToken.objects.get_or_create(token=outstanding)
+
+
+def ban_user(target_user: User) -> User:
+    """
+    Disable a user account by setting is_active=False.
+
+    The account record and all content are preserved. Idempotent — banning
+    an already-banned user is a no-op that returns the unchanged user.
+    """
+    if not target_user.is_active:
+        return target_user
+    target_user.is_active = False
+    target_user.save(update_fields=['is_active'])
+    return target_user

--- a/backend/apps/users/tests/test_services.py
+++ b/backend/apps/users/tests/test_services.py
@@ -13,6 +13,7 @@ from rest_framework.exceptions import AuthenticationFailed, PermissionDenied, Va
 
 from apps.users.models import EmailVerificationCode, Follow, User, UserProfile
 from apps.users.services import (
+    ban_user,
     delete_account,
     delete_profile_photo,
     follow_user,
@@ -952,3 +953,56 @@ class TestResendVerification:
         mail.outbox.clear()
         resend_verification(user.email)
         assert len(mail.outbox) == 0
+
+
+# ── ban_user ──────────────────────────────────────────────────────────────────
+
+@pytest.mark.django_db
+class TestBanUser:
+    def setup_method(self):
+        self.user = User.objects.create_user(
+            email='target@example.com',
+            username='targetuser',
+            password='Password1',
+            is_active=True,
+        )
+
+    def _make_story(self):
+        from decimal import Decimal
+        return Story.objects.create(
+            user=self.user,
+            title='Story',
+            narrative='Narrative.',
+            status=Story.STATUS_PUBLISHED,
+            location_lat=Decimal('0'),
+            location_lng=Decimal('0'),
+            location_name='Place',
+            time_type=Story.TIME_EXACT,
+            year=2000,
+        )
+
+    def test_ban_user_sets_is_active_false(self):
+        ban_user(self.user)
+        self.user.refresh_from_db()
+        assert self.user.is_active is False
+
+    def test_ban_user_returns_updated_user(self):
+        result = ban_user(self.user)
+        assert result.is_active is False
+
+    def test_ban_user_is_idempotent_when_already_banned(self):
+        self.user.is_active = False
+        self.user.save()
+        result = ban_user(self.user)
+        assert result.is_active is False
+        # Confirm still a single user row — no duplicate or error
+        assert User.objects.filter(pk=self.user.pk).count() == 1
+
+    def test_ban_user_preserves_account(self):
+        ban_user(self.user)
+        assert User.objects.filter(pk=self.user.pk).exists()
+
+    def test_ban_user_preserves_stories(self):
+        story = self._make_story()
+        ban_user(self.user)
+        assert Story.objects.filter(pk=story.pk).exists()

--- a/backend/apps/users/tests/test_views.py
+++ b/backend/apps/users/tests/test_views.py
@@ -693,6 +693,10 @@ class TestDeleteAccountView:
         response = client.delete(self.url, {'password': 'Password1'}, format='json')
         assert response.status_code == status.HTTP_401_UNAUTHORIZED
 
+    def test_missing_password_returns_400(self, auth_client):
+        response = auth_client.delete(self.url, {}, format='json')
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+
     def test_hard_delete_returns_204(self, auth_client):
         response = auth_client.delete(self.url, {'password': 'Password1'}, format='json')
         assert response.status_code == status.HTTP_204_NO_CONTENT

--- a/backend/apps/users/tests/test_views.py
+++ b/backend/apps/users/tests/test_views.py
@@ -747,9 +747,58 @@ class TestDeleteAccountView:
         response = auth_client.delete(self.url, {'password': 'WrongPassword'}, format='json')
         assert 'password' in response.data['errors']
 
-    def test_missing_password_returns_400(self, auth_client):
-        response = auth_client.delete(self.url, {}, format='json')
-        assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+# ── AdminUserBanView ──────────────────────────────────────────────────────────
+
+@pytest.fixture
+def admin_client(client, admin_user):
+    response = client.post('/auth/login/', {
+        'email': 'admin@example.com',
+        'password': 'Password1',
+    })
+    client.credentials(HTTP_AUTHORIZATION=f'Bearer {response.data["access"]}')
+    return client
+
+
+@pytest.mark.django_db
+class TestAdminUserBanView:
+    def _url(self, pk):
+        return f'/moderation/users/{pk}/ban/'
+
+    def test_ban_user_returns_200(self, admin_client, user):
+        response = admin_client.patch(self._url(user.pk))
+        assert response.status_code == status.HTTP_200_OK
+
+    def test_ban_user_response_contains_expected_fields(self, admin_client, user):
+        response = admin_client.patch(self._url(user.pk))
+        assert set(response.data.keys()) >= {'id', 'email', 'username', 'role', 'is_active'}
+
+    def test_ban_user_response_shows_is_active_false(self, admin_client, user):
+        response = admin_client.patch(self._url(user.pk))
+        assert response.data['is_active'] is False
+
+    def test_ban_user_persists_in_db(self, admin_client, user):
+        admin_client.patch(self._url(user.pk))
+        user.refresh_from_db()
+        assert user.is_active is False
+
+    def test_ban_already_banned_user_returns_200(self, admin_client, user):
+        user.is_active = False
+        user.save()
+        response = admin_client.patch(self._url(user.pk))
+        assert response.status_code == status.HTTP_200_OK
+
+    def test_ban_user_returns_404_for_nonexistent_user(self, admin_client):
+        response = admin_client.patch(self._url(99999))
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+
+    def test_ban_user_returns_403_for_registered_user(self, auth_client, user, second_user):
+        response = auth_client.patch(self._url(second_user.pk))
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+
+    def test_ban_user_returns_401_for_guest(self, client, user):
+        response = client.patch(self._url(user.pk))
+        assert response.status_code == status.HTTP_401_UNAUTHORIZED
 
 
 # ── POST/DELETE /users/:id/follow/ ───────────────────────────────────────────

--- a/backend/config/urls.py
+++ b/backend/config/urls.py
@@ -16,6 +16,7 @@ urlpatterns = [
     path('', include('apps.reports.urls', namespace='reports')),
     path('moderation/', include([
         path('', include('apps.users.admin_urls')),
+        path('', include('apps.tags.admin_urls')),
         path('', include('apps.stories.admin_urls')),
         path('', include('apps.interactions.admin_urls')),
         path('', include('apps.reports.admin_urls')),

--- a/backend/config/urls.py
+++ b/backend/config/urls.py
@@ -15,6 +15,7 @@ urlpatterns = [
     path('tags/', include('apps.tags.urls', namespace='tags')),
     path('', include('apps.reports.urls', namespace='reports')),
     path('moderation/', include([
+        path('', include('apps.users.admin_urls')),
         path('', include('apps.stories.admin_urls')),
         path('', include('apps.interactions.admin_urls')),
         path('', include('apps.reports.admin_urls')),


### PR DESCRIPTION
# 📝 Description

Fixes #231

This PR adds new admin moderation capabilities for banning users and deleting tags.

The purpose of this change is to give admins safer and more direct tools for moderation. Admins can now disable problematic user accounts without deleting their data, and they can remove tags from the system together with their story associations when needed.

This PR adds an admin-only user ban endpoint:

`PATCH /moderation/users/{id}/ban/`

This endpoint disables the target user by setting `is_active=False`. The user account itself is preserved, and the user's existing content is not deleted. This makes the ban operation safer because it prevents future access while keeping the related data available for moderation, auditing, or future review.

Implemented user moderation changes:
- Added `AdminUserBanView` for admin-only user banning.
- Added the `ban_user` service function to keep the ban logic outside the view.
- Made `ban_user` idempotent, so banning an already banned user is treated as a no-op and still returns the user safely.
- Added `UserBanResponseSerializer` to return the banned user's basic information.
- Preserved the user account and existing stories after banning.

This PR also adds an admin-only tag deletion endpoint:

`DELETE /moderation/tags/{id}/`

This endpoint allows admins to delete a tag through the moderation route. When a tag is deleted, its related `StoryTag` associations are explicitly removed before deleting the tag itself. This ensures the cleanup happens in a controlled way and allows related delete signals to run properly.

Implemented tag moderation changes:
- Added `AdminTagDeleteView` for admin-only tag deletion.
- Updated the `delete_tag` service to explicitly delete related `StoryTag` rows before deleting the tag.
- Wrapped tag deletion logic in `transaction.atomic()` so the operation is handled safely.
- Registered the new moderation routes in `backend/config/urls.py`.

This PR also adds service and view tests covering:
- Successful admin user banning.
- Idempotent behavior when banning an already banned user.
- Preservation of the user account and stories after banning.
- Permission checks for admin, registered user, and guest users.
- `404` behavior for nonexistent users and tags.
- Successful admin tag deletion.
- Removal of story-tag associations.
- Tag deletion with no associations and multiple associations.

# 📊 Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactoring
- [ ] Documentation
 
# ✅ Acceptance Criteria / Checklist

- [x] Project builds successfully
- [x] Code follows project style guidelines
- [x] Code is commented where necessary
- [x] Self-review performed
- [x] Tests added/updated
- [x] Tests pass locally

# ⏱️ Estimated Review Time

- [ ] < 5 min
- [x] 5–15 min
- [ ] > 15 min
