### PR TITLE
feat: timeline view page with time-window filter

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -14,6 +14,7 @@ import ProfileCompletionPage from "@/pages/ProfileCompletionPage";
 import NotFoundPage from "@/pages/NotFoundPage";
 import FeedPage from "@/pages/FeedPage";
 import MapPage from "@/pages/MapPage";
+import TimelinePage from "@/pages/TimelinePage";
 import ProfilePage from "@/pages/ProfilePage";
 import SubmitStoryPage from "@/pages/SubmitStoryPage";
 import StoryDetailPage from "@/pages/StoryDetailPage";
@@ -28,6 +29,7 @@ function App() {
             <Route element={<AppLayout />}>
               <Route path="/" element={<FeedPage />} />
               <Route path="/map" element={<MapPage />} />
+              <Route path="/timeline" element={<TimelinePage />} />
               <Route path="/login" element={<LoginPage />} />
               <Route path="/register" element={<RegisterPage />} />
               <Route path="/forgot-password" element={<ForgotPasswordPage />} />

--- a/frontend/src/components/AppLayout/AppLayout.jsx
+++ b/frontend/src/components/AppLayout/AppLayout.jsx
@@ -15,6 +15,7 @@ import { useAuth } from "@/hooks/useAuth";
 
 const publicLinks = [
   { to: "/map", label: "Map", preserveSearch: true },
+  { to: "/timeline", label: "Timeline", preserveSearch: true },
   { to: "/", label: "Feed", preserveSearch: true },
   { to: "/submit-story", label: "Submit Story", icon: Plus },
 ];

--- a/frontend/src/components/Timeline/TimelineEntry.jsx
+++ b/frontend/src/components/Timeline/TimelineEntry.jsx
@@ -1,0 +1,106 @@
+import { Link } from "react-router-dom";
+import { MapPin } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+import { formatTimePeriod } from "@/components/StoryCard/storyCardUtils";
+
+/**
+ * Best-effort label for the bullet on the timeline. Prefers the formatted
+ * time period (year, "1870s", c. 1875, etc.); falls back to year_start
+ * or the leading 4 digits of date_value when present.
+ */
+function bulletLabel(story) {
+  const formatted = formatTimePeriod(story);
+  if (formatted) return formatted;
+  if (story.year != null) return String(story.year);
+  if (story.year_start != null) return String(story.year_start);
+  if (typeof story.date_value === "string") {
+    const match = story.date_value.match(/-?\d{4}/);
+    if (match) return match[0];
+  }
+  return "";
+}
+
+function decadeChip(story) {
+  const yearForDecade = story.year ?? story.year_start;
+  if (yearForDecade == null) return null;
+  return `${Math.floor(yearForDecade / 10) * 10}s`;
+}
+
+function TimelineEntry({ story }) {
+  const label = bulletLabel(story);
+  const decade = story.time_type === "decade" ? null : decadeChip(story);
+  const hasCoords =
+    story.location_lat != null && story.location_lng != null;
+  const lat = hasCoords ? Number(story.location_lat).toFixed(4) : null;
+  const lng = hasCoords ? Number(story.location_lng).toFixed(4) : null;
+
+  return (
+    <div className="relative flex gap-4 pl-2">
+      {/* Bullet */}
+      <div className="relative flex flex-col items-center" aria-hidden="false">
+        <div
+          className={cn(
+            "z-10 flex min-w-[3.5rem] items-center justify-center rounded-full border bg-background px-2 py-1",
+            "text-xs font-medium text-foreground shadow-sm",
+          )}
+        >
+          {label}
+        </div>
+      </div>
+
+      {/* Card */}
+      <Link
+        to={`/stories/${story.id}`}
+        className={cn(
+          "group flex-1 overflow-hidden rounded-xl border bg-card text-card-foreground shadow-sm",
+          "transition-shadow hover:shadow-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+        )}
+        aria-label={`Read story: ${story.title}`}
+      >
+        {story.photo_url && (
+          <img
+            src={story.photo_url}
+            alt={story.title}
+            className="h-40 w-full object-cover"
+            loading="lazy"
+          />
+        )}
+        <div className="space-y-2 p-4">
+          <h3 className="text-base font-semibold leading-snug text-foreground line-clamp-2">
+            {story.title}
+          </h3>
+
+          <div className="flex flex-wrap gap-1.5">
+            {label && (
+              <span className="inline-flex items-center rounded-full bg-muted px-2 py-0.5 text-xs text-muted-foreground">
+                {label}
+              </span>
+            )}
+            {decade && decade !== label && (
+              <span className="inline-flex items-center rounded-full bg-muted px-2 py-0.5 text-xs text-muted-foreground">
+                {decade}
+              </span>
+            )}
+            {story.temporal_coverage && (
+              <span className="inline-flex items-center rounded-full bg-muted px-2 py-0.5 text-xs text-muted-foreground">
+                {story.temporal_coverage}
+              </span>
+            )}
+          </div>
+
+          {hasCoords && (
+            <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
+              <MapPin className="h-3.5 w-3.5 shrink-0" aria-hidden="true" />
+              <span>
+                Mapped at {lat}, {lng}
+              </span>
+            </div>
+          )}
+        </div>
+      </Link>
+    </div>
+  );
+}
+
+export default TimelineEntry;

--- a/frontend/src/components/Timeline/TimelineEntry.jsx
+++ b/frontend/src/components/Timeline/TimelineEntry.jsx
@@ -32,13 +32,20 @@ function TimelineEntry({ story }) {
   const decade = story.time_type === "decade" ? null : decadeChip(story);
   const hasCoords =
     story.location_lat != null && story.location_lng != null;
-  const lat = hasCoords ? Number(story.location_lat).toFixed(4) : null;
-  const lng = hasCoords ? Number(story.location_lng).toFixed(4) : null;
+  const locationName =
+    typeof story.location_name === "string" && story.location_name.trim()
+      ? story.location_name.trim()
+      : null;
+  const locationText = locationName
+    ? locationName
+    : hasCoords
+      ? `Mapped at ${Number(story.location_lat).toFixed(4)}, ${Number(story.location_lng).toFixed(4)}`
+      : null;
 
   return (
     <div className="relative flex gap-4 pl-2">
       {/* Bullet */}
-      <div className="relative flex flex-col items-center" aria-hidden="false">
+      <div className="relative flex flex-col items-center">
         <div
           className={cn(
             "z-10 flex min-w-[3.5rem] items-center justify-center rounded-full border bg-background px-2 py-1",
@@ -89,12 +96,10 @@ function TimelineEntry({ story }) {
             )}
           </div>
 
-          {hasCoords && (
+          {locationText && (
             <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
               <MapPin className="h-3.5 w-3.5 shrink-0" aria-hidden="true" />
-              <span>
-                Mapped at {lat}, {lng}
-              </span>
+              <span>{locationText}</span>
             </div>
           )}
         </div>

--- a/frontend/src/components/Timeline/TimelineView.jsx
+++ b/frontend/src/components/Timeline/TimelineView.jsx
@@ -1,0 +1,27 @@
+import TimelineEntry from "./TimelineEntry";
+
+/**
+ * Pure presentational vertical timeline. Caller owns loading / empty / error
+ * states; this component just renders one row per story over a vertical line.
+ */
+function TimelineView({ stories }) {
+  if (!stories?.length) return null;
+
+  return (
+    <div className="relative pl-4">
+      <div
+        className="pointer-events-none absolute bottom-0 left-7 top-0 w-px bg-border"
+        aria-hidden="true"
+      />
+      <ul className="space-y-6">
+        {stories.map((story) => (
+          <li key={story.id}>
+            <TimelineEntry story={story} />
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+export default TimelineView;

--- a/frontend/src/components/Timeline/__tests__/TimelineEntry.test.jsx
+++ b/frontend/src/components/Timeline/__tests__/TimelineEntry.test.jsx
@@ -1,0 +1,137 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { BrowserRouter } from "react-router-dom";
+
+import TimelineEntry from "../TimelineEntry";
+
+function renderEntry(story) {
+  return render(
+    <BrowserRouter>
+      <TimelineEntry story={story} />
+    </BrowserRouter>,
+  );
+}
+
+describe("TimelineEntry", () => {
+  it("renders the story title", () => {
+    renderEntry({
+      id: 1,
+      title: "Galata Bridge Opening",
+      time_type: "exact_year",
+      year: 1875,
+      year_start: null,
+      year_end: null,
+      location_lat: 41.0,
+      location_lng: 28.9,
+      photo_url: null,
+      temporal_coverage: null,
+    });
+
+    expect(screen.getByText("Galata Bridge Opening")).toBeInTheDocument();
+  });
+
+  it("links the card to /stories/<id>", () => {
+    renderEntry({
+      id: 42,
+      title: "A story",
+      time_type: "exact_year",
+      year: 1900,
+      year_start: null,
+      year_end: null,
+      location_lat: null,
+      location_lng: null,
+      photo_url: null,
+      temporal_coverage: null,
+    });
+
+    const link = screen.getByRole("link", { name: /a story/i });
+    expect(link).toHaveAttribute("href", "/stories/42");
+  });
+
+  it("renders the year as the bullet label for exact_year", () => {
+    renderEntry({
+      id: 1,
+      title: "T",
+      time_type: "exact_year",
+      year: 1875,
+      year_start: null,
+      year_end: null,
+      location_lat: null,
+      location_lng: null,
+      photo_url: null,
+      temporal_coverage: null,
+    });
+
+    expect(screen.getAllByText("1875").length).toBeGreaterThan(0);
+  });
+
+  it("renders the decade as the bullet label for decade time_type", () => {
+    renderEntry({
+      id: 1,
+      title: "T",
+      time_type: "decade",
+      year: 1875,
+      year_start: null,
+      year_end: null,
+      location_lat: null,
+      location_lng: null,
+      photo_url: null,
+      temporal_coverage: null,
+    });
+
+    expect(screen.getAllByText("1870s").length).toBeGreaterThan(0);
+  });
+
+  it("renders the photo when photo_url is provided", () => {
+    renderEntry({
+      id: 1,
+      title: "Story With Photo",
+      time_type: "exact_year",
+      year: 1875,
+      year_start: null,
+      year_end: null,
+      location_lat: 41.0,
+      location_lng: 28.9,
+      photo_url: "https://example.com/photo.jpg",
+      temporal_coverage: null,
+    });
+
+    const img = screen.getByRole("img", { name: /story with photo/i });
+    expect(img).toHaveAttribute("src", "https://example.com/photo.jpg");
+  });
+
+  it("does not render any image when photo_url is null", () => {
+    renderEntry({
+      id: 1,
+      title: "Story Without Photo",
+      time_type: "exact_year",
+      year: 1875,
+      year_start: null,
+      year_end: null,
+      location_lat: 41.0,
+      location_lng: 28.9,
+      photo_url: null,
+      temporal_coverage: null,
+    });
+
+    expect(screen.queryByRole("img")).not.toBeInTheDocument();
+  });
+
+  it("shows mapped coordinates when lat/lng are present", () => {
+    renderEntry({
+      id: 1,
+      title: "Mapped Story",
+      time_type: "exact_year",
+      year: 1875,
+      year_start: null,
+      year_end: null,
+      location_lat: 41.0258,
+      location_lng: 28.9744,
+      photo_url: null,
+      temporal_coverage: null,
+    });
+
+    expect(screen.getByText(/41\.0258/)).toBeInTheDocument();
+    expect(screen.getByText(/28\.9744/)).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/Timeline/__tests__/TimelineEntry.test.jsx
+++ b/frontend/src/components/Timeline/__tests__/TimelineEntry.test.jsx
@@ -117,7 +117,7 @@ describe("TimelineEntry", () => {
     expect(screen.queryByRole("img")).not.toBeInTheDocument();
   });
 
-  it("shows mapped coordinates when lat/lng are present", () => {
+  it("shows mapped coordinates when lat/lng are present and no location_name", () => {
     renderEntry({
       id: 1,
       title: "Mapped Story",
@@ -133,5 +133,24 @@ describe("TimelineEntry", () => {
 
     expect(screen.getByText(/41\.0258/)).toBeInTheDocument();
     expect(screen.getByText(/28\.9744/)).toBeInTheDocument();
+  });
+
+  it("prefers location_name over raw coordinates when provided", () => {
+    renderEntry({
+      id: 1,
+      title: "Named Story",
+      time_type: "exact_year",
+      year: 1875,
+      year_start: null,
+      year_end: null,
+      location_lat: 41.0258,
+      location_lng: 28.9744,
+      location_name: "Galata Bridge, Istanbul",
+      photo_url: null,
+      temporal_coverage: null,
+    });
+
+    expect(screen.getByText("Galata Bridge, Istanbul")).toBeInTheDocument();
+    expect(screen.queryByText(/41\.0258/)).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/components/Timeline/__tests__/TimelineView.test.jsx
+++ b/frontend/src/components/Timeline/__tests__/TimelineView.test.jsx
@@ -1,0 +1,58 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { BrowserRouter } from "react-router-dom";
+
+import TimelineView from "../TimelineView";
+
+function makeStory(id, overrides = {}) {
+  return {
+    id,
+    title: `Story ${id}`,
+    time_type: "exact_year",
+    year: 1900 + id,
+    year_start: null,
+    year_end: null,
+    location_lat: null,
+    location_lng: null,
+    photo_url: null,
+    temporal_coverage: null,
+    ...overrides,
+  };
+}
+
+function renderView(stories) {
+  return render(
+    <BrowserRouter>
+      <TimelineView stories={stories} />
+    </BrowserRouter>,
+  );
+}
+
+describe("TimelineView", () => {
+  it("renders one entry per story", () => {
+    renderView([makeStory(1), makeStory(2), makeStory(3)]);
+
+    expect(screen.getByText("Story 1")).toBeInTheDocument();
+    expect(screen.getByText("Story 2")).toBeInTheDocument();
+    expect(screen.getByText("Story 3")).toBeInTheDocument();
+  });
+
+  it("passes story prop down so each story links to its detail page", () => {
+    renderView([makeStory(7), makeStory(8)]);
+
+    expect(screen.getByRole("link", { name: /story 7/i })).toHaveAttribute(
+      "href",
+      "/stories/7",
+    );
+    expect(screen.getByRole("link", { name: /story 8/i })).toHaveAttribute(
+      "href",
+      "/stories/8",
+    );
+  });
+
+  it("renders nothing visible (no entries) when stories is empty", () => {
+    renderView([]);
+
+    expect(screen.queryByRole("link")).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/TimelinePage.jsx
+++ b/frontend/src/pages/TimelinePage.jsx
@@ -27,10 +27,15 @@ function parseFloatOrUndef(v) {
   return Number.isFinite(n) ? n : undefined;
 }
 
-function parseIntOrUndef(v) {
-  if (v == null || v === "") return undefined;
-  const n = Number.parseInt(v, 10);
-  return Number.isFinite(n) ? n : undefined;
+const YEAR_RE = /^\d{4}$/;
+
+/**
+ * Parse a 4-digit year string. Returns undefined for blank or partial input —
+ * this prevents firing requests on every keystroke while the user is typing.
+ */
+function parseFullYear(v) {
+  if (typeof v !== "string" || !YEAR_RE.test(v.trim())) return undefined;
+  return Number.parseInt(v, 10);
 }
 
 function decadeStart(year) {
@@ -41,37 +46,50 @@ function decadeStart(year) {
  * Derive the year_from / year_to filter pair for the current mode + inputs.
  * Returns { yearFrom, yearTo, label } where label is the human-readable
  * period for the status row. yearFrom/yearTo are undefined when no filter
- * should be applied (e.g. mode=all, or mode=year with a blank input).
+ * should be applied — partial input (less than 4 digits) is treated as
+ * not-yet-ready and skips the fetch.
  */
 function deriveYearFilter(mode, yearInput, rangeFrom, rangeTo) {
+  const base = { yearFrom: undefined, yearTo: undefined, invalid: false, skip: false };
   if (mode === "all") {
-    return { yearFrom: undefined, yearTo: undefined, label: "All time periods" };
+    return { ...base, label: "All time periods" };
   }
   if (mode === "year") {
-    const y = parseIntOrUndef(yearInput);
-    if (y === undefined) return { yearFrom: undefined, yearTo: undefined, label: "All time periods" };
-    return { yearFrom: y, yearTo: y, label: String(y) };
+    const y = parseFullYear(yearInput);
+    if (y === undefined) {
+      return {
+        ...base,
+        label: yearInput ? "Enter a 4-digit year" : "All time periods",
+        skip: Boolean(yearInput),
+      };
+    }
+    return { ...base, yearFrom: y, yearTo: y, label: String(y) };
   }
   if (mode === "decade") {
-    const y = parseIntOrUndef(yearInput);
-    if (y === undefined) return { yearFrom: undefined, yearTo: undefined, label: "All time periods" };
+    const y = parseFullYear(yearInput);
+    if (y === undefined) {
+      return {
+        ...base,
+        label: yearInput ? "Enter a 4-digit year" : "All time periods",
+        skip: Boolean(yearInput),
+      };
+    }
     const start = decadeStart(y);
-    return { yearFrom: start, yearTo: start + 9, label: `${start}s` };
+    return { ...base, yearFrom: start, yearTo: start + 9, label: `${start}s` };
   }
-  // range
-  const from = parseIntOrUndef(rangeFrom);
-  const to = parseIntOrUndef(rangeTo);
-  if (from === undefined && to === undefined) {
-    return { yearFrom: undefined, yearTo: undefined, label: "All time periods" };
+  // range — require both endpoints to be complete 4-digit years before fetching
+  if (!rangeFrom && !rangeTo) {
+    return { ...base, label: "All time periods" };
   }
-  if (from !== undefined && to !== undefined && from > to) {
-    return { yearFrom: undefined, yearTo: undefined, label: "Invalid range", invalid: true };
+  const from = parseFullYear(rangeFrom);
+  const to = parseFullYear(rangeTo);
+  if (from === undefined || to === undefined) {
+    return { ...base, label: "Enter start and end years", skip: true };
   }
-  return {
-    yearFrom: from,
-    yearTo: to,
-    label: from != null && to != null ? `${from}–${to}` : String(from ?? to ?? ""),
-  };
+  if (from > to) {
+    return { ...base, label: "Invalid range", invalid: true };
+  }
+  return { ...base, yearFrom: from, yearTo: to, label: `${from}–${to}` };
 }
 
 function TimelinePage() {
@@ -150,11 +168,12 @@ function TimelinePage() {
     [filter.yearFrom, filter.yearTo, bbox],
   );
 
-  // Refetch from page 1 whenever the filter changes (or on mount).
+  // Refetch from page 1 whenever the filter changes (or on mount). Skip while
+  // the user is mid-input (partial year, one-sided range) or the range is invalid.
   useEffect(() => {
-    if (filter.invalid) return;
+    if (filter.invalid || filter.skip) return;
     fetchPage(1, { append: false });
-  }, [fetchPage, filter.invalid]);
+  }, [fetchPage, filter.invalid, filter.skip]);
 
   function handleLoadMore() {
     if (!hasNext || loading || loadingMore) return;
@@ -181,12 +200,13 @@ function TimelinePage() {
             <CardTitle className="text-base">Choose a time window</CardTitle>
           </CardHeader>
           <CardContent className="space-y-4">
-            <div role="group" aria-label="Time window mode" className="flex flex-wrap gap-2">
+            <div role="radiogroup" aria-label="Time window mode" className="flex flex-wrap gap-2">
               {MODES.map((m) => (
                 <button
                   key={m}
                   type="button"
-                  aria-pressed={mode === m}
+                  role="radio"
+                  aria-checked={mode === m}
                   onClick={() => setMode(m)}
                   className={cn(
                     "rounded-full border px-4 py-1.5 text-sm font-medium transition-colors",

--- a/frontend/src/pages/TimelinePage.jsx
+++ b/frontend/src/pages/TimelinePage.jsx
@@ -1,0 +1,314 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useSearchParams } from "react-router-dom";
+
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { ErrorState } from "@/components/ui/error-state";
+import { LoadingSpinner } from "@/components/ui/loading-spinner";
+import { cn } from "@/lib/utils";
+import TimelineView from "@/components/Timeline/TimelineView";
+import { getTimeline } from "@/services/timelineService";
+
+const PAGE_SIZE = 10;
+
+const MODES = ["all", "year", "range", "decade"];
+const MODE_LABELS = {
+  all: "All",
+  year: "Year",
+  range: "Range",
+  decade: "Decade",
+};
+
+function parseFloatOrUndef(v) {
+  if (v == null) return undefined;
+  const n = Number(v);
+  return Number.isFinite(n) ? n : undefined;
+}
+
+function parseIntOrUndef(v) {
+  if (v == null || v === "") return undefined;
+  const n = Number.parseInt(v, 10);
+  return Number.isFinite(n) ? n : undefined;
+}
+
+function decadeStart(year) {
+  return Math.floor(year / 10) * 10;
+}
+
+/**
+ * Derive the year_from / year_to filter pair for the current mode + inputs.
+ * Returns { yearFrom, yearTo, label } where label is the human-readable
+ * period for the status row. yearFrom/yearTo are undefined when no filter
+ * should be applied (e.g. mode=all, or mode=year with a blank input).
+ */
+function deriveYearFilter(mode, yearInput, rangeFrom, rangeTo) {
+  if (mode === "all") {
+    return { yearFrom: undefined, yearTo: undefined, label: "All time periods" };
+  }
+  if (mode === "year") {
+    const y = parseIntOrUndef(yearInput);
+    if (y === undefined) return { yearFrom: undefined, yearTo: undefined, label: "All time periods" };
+    return { yearFrom: y, yearTo: y, label: String(y) };
+  }
+  if (mode === "decade") {
+    const y = parseIntOrUndef(yearInput);
+    if (y === undefined) return { yearFrom: undefined, yearTo: undefined, label: "All time periods" };
+    const start = decadeStart(y);
+    return { yearFrom: start, yearTo: start + 9, label: `${start}s` };
+  }
+  // range
+  const from = parseIntOrUndef(rangeFrom);
+  const to = parseIntOrUndef(rangeTo);
+  if (from === undefined && to === undefined) {
+    return { yearFrom: undefined, yearTo: undefined, label: "All time periods" };
+  }
+  if (from !== undefined && to !== undefined && from > to) {
+    return { yearFrom: undefined, yearTo: undefined, label: "Invalid range", invalid: true };
+  }
+  return {
+    yearFrom: from,
+    yearTo: to,
+    label: from != null && to != null ? `${from}–${to}` : String(from ?? to ?? ""),
+  };
+}
+
+function TimelinePage() {
+  const [searchParams] = useSearchParams();
+
+  // Bounding-box passthrough — issue #488 will use these.
+  const bbox = useMemo(() => {
+    const latMin = parseFloatOrUndef(searchParams.get("lat_min"));
+    const latMax = parseFloatOrUndef(searchParams.get("lat_max"));
+    const lngMin = parseFloatOrUndef(searchParams.get("lng_min"));
+    const lngMax = parseFloatOrUndef(searchParams.get("lng_max"));
+    if ([latMin, latMax, lngMin, lngMax].some((v) => v === undefined)) {
+      return null;
+    }
+    return { latMin, latMax, lngMin, lngMax };
+  }, [searchParams]);
+
+  const [mode, setMode] = useState("all");
+  const [yearInput, setYearInput] = useState("");
+  const [rangeFrom, setRangeFrom] = useState("");
+  const [rangeTo, setRangeTo] = useState("");
+
+  const filter = useMemo(
+    () => deriveYearFilter(mode, yearInput, rangeFrom, rangeTo),
+    [mode, yearInput, rangeFrom, rangeTo],
+  );
+
+  const [stories, setStories] = useState([]);
+  const [count, setCount] = useState(0);
+  const [hasNext, setHasNext] = useState(false);
+  const [page, setPage] = useState(1);
+  const [loading, setLoading] = useState(true);
+  const [loadingMore, setLoadingMore] = useState(false);
+  const [error, setError] = useState(null);
+
+  // Fetch generation counter — guards against out-of-order responses when
+  // the user changes the filter while a request is in flight.
+  const generationRef = useRef(0);
+
+  const fetchPage = useCallback(
+    async (pageToLoad, { append }) => {
+      const myGen = ++generationRef.current;
+      if (append) setLoadingMore(true);
+      else setLoading(true);
+      setError(null);
+      try {
+        const data = await getTimeline({
+          yearFrom: filter.yearFrom,
+          yearTo: filter.yearTo,
+          latMin: bbox?.latMin,
+          latMax: bbox?.latMax,
+          lngMin: bbox?.lngMin,
+          lngMax: bbox?.lngMax,
+          page: pageToLoad,
+          pageSize: PAGE_SIZE,
+        });
+        if (myGen !== generationRef.current) return; // stale response
+        setCount(data.count);
+        setHasNext(Boolean(data.next));
+        setPage(pageToLoad);
+        setStories((prev) => (append ? [...prev, ...(data.results ?? [])] : data.results ?? []));
+      } catch (err) {
+        if (myGen !== generationRef.current) return;
+        setError(
+          err?.response?.data?.detail ||
+            err?.message ||
+            "Failed to load the timeline. Please try again.",
+        );
+      } finally {
+        if (myGen === generationRef.current) {
+          setLoading(false);
+          setLoadingMore(false);
+        }
+      }
+    },
+    [filter.yearFrom, filter.yearTo, bbox],
+  );
+
+  // Refetch from page 1 whenever the filter changes (or on mount).
+  useEffect(() => {
+    if (filter.invalid) return;
+    fetchPage(1, { append: false });
+  }, [fetchPage, filter.invalid]);
+
+  function handleLoadMore() {
+    if (!hasNext || loading || loadingMore) return;
+    fetchPage(page + 1, { append: true });
+  }
+
+  function handleRetry() {
+    fetchPage(1, { append: false });
+  }
+
+  return (
+    <main className="min-h-screen bg-background">
+      <div className="mx-auto max-w-3xl px-4 py-8 sm:px-6 lg:px-8">
+        <div className="mb-6">
+          <h1 className="text-3xl font-bold tracking-tight">Timeline</h1>
+          <p className="mt-1 text-sm text-muted-foreground">
+            Stories ordered by when they happened.
+          </p>
+        </div>
+
+        {/* Filter card */}
+        <Card className="mb-6">
+          <CardHeader className="pb-3">
+            <CardTitle className="text-base">Choose a time window</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <div role="group" aria-label="Time window mode" className="flex flex-wrap gap-2">
+              {MODES.map((m) => (
+                <button
+                  key={m}
+                  type="button"
+                  aria-pressed={mode === m}
+                  onClick={() => setMode(m)}
+                  className={cn(
+                    "rounded-full border px-4 py-1.5 text-sm font-medium transition-colors",
+                    mode === m
+                      ? "border-primary bg-primary text-primary-foreground"
+                      : "border-input bg-background text-foreground hover:bg-muted",
+                  )}
+                >
+                  {MODE_LABELS[m]}
+                </button>
+              ))}
+            </div>
+
+            {mode === "year" && (
+              <div className="max-w-[160px] space-y-1.5">
+                <Label htmlFor="timeline-year">Year</Label>
+                <Input
+                  id="timeline-year"
+                  type="number"
+                  inputMode="numeric"
+                  placeholder="e.g. 1875"
+                  value={yearInput}
+                  onChange={(e) => setYearInput(e.target.value)}
+                />
+              </div>
+            )}
+
+            {mode === "decade" && (
+              <div className="max-w-[200px] space-y-1.5">
+                <Label htmlFor="timeline-decade">Decade (any year)</Label>
+                <Input
+                  id="timeline-decade"
+                  type="number"
+                  inputMode="numeric"
+                  placeholder="e.g. 1875"
+                  value={yearInput}
+                  onChange={(e) => setYearInput(e.target.value)}
+                />
+                <p className="text-xs text-muted-foreground">
+                  Snaps to the start of the decade.
+                </p>
+              </div>
+            )}
+
+            {mode === "range" && (
+              <div className="flex flex-wrap items-end gap-3">
+                <div className="space-y-1.5">
+                  <Label htmlFor="timeline-range-from">From</Label>
+                  <Input
+                    id="timeline-range-from"
+                    type="number"
+                    inputMode="numeric"
+                    placeholder="e.g. 1850"
+                    className="w-32"
+                    value={rangeFrom}
+                    onChange={(e) => setRangeFrom(e.target.value)}
+                  />
+                </div>
+                <div className="space-y-1.5">
+                  <Label htmlFor="timeline-range-to">To</Label>
+                  <Input
+                    id="timeline-range-to"
+                    type="number"
+                    inputMode="numeric"
+                    placeholder="e.g. 1900"
+                    className="w-32"
+                    value={rangeTo}
+                    onChange={(e) => setRangeTo(e.target.value)}
+                  />
+                </div>
+                {filter.invalid && (
+                  <p className="text-xs text-destructive">
+                    "From" must be less than or equal to "To".
+                  </p>
+                )}
+              </div>
+            )}
+          </CardContent>
+        </Card>
+
+        {/* Status row */}
+        <div className="mb-4 flex items-center justify-between text-sm">
+          <span className="font-medium text-foreground">{filter.label}</span>
+          {!loading && !error && (
+            <span className="text-muted-foreground" aria-live="polite">
+              {count} {count === 1 ? "story" : "stories"}
+            </span>
+          )}
+        </div>
+
+        {/* Content */}
+        {error ? (
+          <ErrorState message={error} onRetry={handleRetry} />
+        ) : loading ? (
+          <div
+            className="flex justify-center py-16"
+            aria-busy="true"
+            aria-label="Loading timeline"
+          >
+            <LoadingSpinner />
+          </div>
+        ) : count === 0 ? (
+          <p className="py-12 text-center text-sm text-muted-foreground">
+            No stories found for this time window.
+          </p>
+        ) : (
+          <>
+            <TimelineView stories={stories} />
+            <div className="mt-8 flex justify-center">
+              <Button
+                variant="outline"
+                onClick={handleLoadMore}
+                disabled={!hasNext || loadingMore}
+              >
+                {loadingMore ? "Loading…" : hasNext ? "Load more" : "No more stories"}
+              </Button>
+            </div>
+          </>
+        )}
+      </div>
+    </main>
+  );
+}
+
+export default TimelinePage;

--- a/frontend/src/pages/__tests__/TimelinePage.test.jsx
+++ b/frontend/src/pages/__tests__/TimelinePage.test.jsx
@@ -1,0 +1,193 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter } from "react-router-dom";
+
+vi.mock("@/services/timelineService", () => ({
+  getTimeline: vi.fn(),
+}));
+
+import { getTimeline } from "@/services/timelineService";
+import TimelinePage from "../TimelinePage";
+
+function makeStory(id, overrides = {}) {
+  return {
+    id,
+    title: `Story ${id}`,
+    time_type: "exact_year",
+    year: 1900 + id,
+    year_start: null,
+    year_end: null,
+    date_value: null,
+    time_value: null,
+    temporal_coverage: null,
+    location_lat: null,
+    location_lng: null,
+    photo_url: null,
+    ...overrides,
+  };
+}
+
+function makeResponse({ count = 0, results = [], next = null } = {}) {
+  return { count, next, previous: null, results };
+}
+
+function renderPage(initialEntries = ["/timeline"]) {
+  return render(
+    <MemoryRouter initialEntries={initialEntries}>
+      <TimelinePage />
+    </MemoryRouter>,
+  );
+}
+
+describe("TimelinePage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getTimeline.mockResolvedValue(makeResponse());
+  });
+
+  it("renders the Timeline heading", async () => {
+    renderPage();
+
+    expect(
+      screen.getByRole("heading", { name: /^timeline$/i, level: 1 }),
+    ).toBeInTheDocument();
+  });
+
+  it("renders the four filter pills", async () => {
+    renderPage();
+
+    expect(screen.getByRole("button", { name: /^all$/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /^year$/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /^range$/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /^decade$/i })).toBeInTheDocument();
+  });
+
+  it("fetches with no year params on first render (default All)", async () => {
+    renderPage();
+
+    await waitFor(() => {
+      expect(getTimeline).toHaveBeenCalled();
+    });
+
+    const firstCallArgs = getTimeline.mock.calls[0][0];
+    expect(firstCallArgs.yearFrom).toBeUndefined();
+    expect(firstCallArgs.yearTo).toBeUndefined();
+    expect(firstCallArgs.page).toBe(1);
+  });
+
+  it("switches to Year + entering 1875 fetches with year_from=year_to=1875", async () => {
+    const user = userEvent.setup();
+    renderPage();
+
+    await waitFor(() => expect(getTimeline).toHaveBeenCalled());
+
+    await user.click(screen.getByRole("button", { name: /^year$/i }));
+    const yearInput = await screen.findByLabelText(/^year$/i);
+    await user.clear(yearInput);
+    await user.type(yearInput, "1875");
+
+    await waitFor(() => {
+      const calls = getTimeline.mock.calls;
+      const matched = calls.some(
+        ([arg]) => arg?.yearFrom === 1875 && arg?.yearTo === 1875,
+      );
+      expect(matched).toBe(true);
+    });
+  });
+
+  it("Decade with 1875 fetches with year_from=1870 and year_to=1879", async () => {
+    const user = userEvent.setup();
+    renderPage();
+
+    await waitFor(() => expect(getTimeline).toHaveBeenCalled());
+
+    await user.click(screen.getByRole("button", { name: /^decade$/i }));
+    const decadeInput = await screen.findByLabelText(/decade/i);
+    await user.clear(decadeInput);
+    await user.type(decadeInput, "1875");
+
+    await waitFor(() => {
+      const matched = getTimeline.mock.calls.some(
+        ([arg]) => arg?.yearFrom === 1870 && arg?.yearTo === 1879,
+      );
+      expect(matched).toBe(true);
+    });
+  });
+
+  it("shows empty state when count is 0", async () => {
+    getTimeline.mockResolvedValue(makeResponse({ count: 0, results: [] }));
+    renderPage();
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(/no stories found for this time window/i),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("shows count of stories", async () => {
+    getTimeline.mockResolvedValue(
+      makeResponse({ count: 3, results: [makeStory(1), makeStory(2), makeStory(3)] }),
+    );
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByText(/3 stories/i)).toBeInTheDocument();
+    });
+  });
+
+  it("Load more button appends next page results", async () => {
+    const user = userEvent.setup();
+    getTimeline
+      .mockResolvedValueOnce(
+        makeResponse({
+          count: 4,
+          results: [makeStory(1), makeStory(2)],
+          next: "http://localhost:8000/api/stories/timeline/?page=2",
+        }),
+      )
+      .mockResolvedValueOnce(
+        makeResponse({
+          count: 4,
+          results: [makeStory(3), makeStory(4)],
+          next: null,
+        }),
+      );
+
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByText("Story 1")).toBeInTheDocument();
+      expect(screen.getByText("Story 2")).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole("button", { name: /load more/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText("Story 3")).toBeInTheDocument();
+      expect(screen.getByText("Story 4")).toBeInTheDocument();
+    });
+    // Previously-loaded stories should remain visible
+    expect(screen.getByText("Story 1")).toBeInTheDocument();
+
+    const lastArgs = getTimeline.mock.calls[getTimeline.mock.calls.length - 1][0];
+    expect(lastArgs.page).toBe(2);
+  });
+
+  it("passes bbox query string params through to the service", async () => {
+    renderPage([
+      "/timeline?lat_min=40&lat_max=41&lng_min=28&lng_max=29",
+    ]);
+
+    await waitFor(() => {
+      expect(getTimeline).toHaveBeenCalled();
+    });
+
+    const args = getTimeline.mock.calls[0][0];
+    expect(args.latMin).toBe(40);
+    expect(args.latMax).toBe(41);
+    expect(args.lngMin).toBe(28);
+    expect(args.lngMax).toBe(29);
+  });
+});

--- a/frontend/src/pages/__tests__/TimelinePage.test.jsx
+++ b/frontend/src/pages/__tests__/TimelinePage.test.jsx
@@ -54,13 +54,16 @@ describe("TimelinePage", () => {
     ).toBeInTheDocument();
   });
 
-  it("renders the four filter pills", async () => {
+  it("renders the four filter pills as a radiogroup", async () => {
     renderPage();
 
-    expect(screen.getByRole("button", { name: /^all$/i })).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: /^year$/i })).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: /^range$/i })).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: /^decade$/i })).toBeInTheDocument();
+    expect(
+      screen.getByRole("radiogroup", { name: /time window mode/i }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("radio", { name: /^all$/i })).toBeInTheDocument();
+    expect(screen.getByRole("radio", { name: /^year$/i })).toBeInTheDocument();
+    expect(screen.getByRole("radio", { name: /^range$/i })).toBeInTheDocument();
+    expect(screen.getByRole("radio", { name: /^decade$/i })).toBeInTheDocument();
   });
 
   it("fetches with no year params on first render (default All)", async () => {
@@ -82,7 +85,7 @@ describe("TimelinePage", () => {
 
     await waitFor(() => expect(getTimeline).toHaveBeenCalled());
 
-    await user.click(screen.getByRole("button", { name: /^year$/i }));
+    await user.click(screen.getByRole("radio", { name: /^year$/i }));
     const yearInput = await screen.findByLabelText(/^year$/i);
     await user.clear(yearInput);
     await user.type(yearInput, "1875");
@@ -102,7 +105,7 @@ describe("TimelinePage", () => {
 
     await waitFor(() => expect(getTimeline).toHaveBeenCalled());
 
-    await user.click(screen.getByRole("button", { name: /^decade$/i }));
+    await user.click(screen.getByRole("radio", { name: /^decade$/i }));
     const decadeInput = await screen.findByLabelText(/decade/i);
     await user.clear(decadeInput);
     await user.type(decadeInput, "1875");
@@ -173,6 +176,56 @@ describe("TimelinePage", () => {
 
     const lastArgs = getTimeline.mock.calls[getTimeline.mock.calls.length - 1][0];
     expect(lastArgs.page).toBe(2);
+  });
+
+  it("does not fire requests for partial year input (less than 4 digits)", async () => {
+    const user = userEvent.setup();
+    renderPage();
+
+    await waitFor(() => expect(getTimeline).toHaveBeenCalled());
+    const callsBefore = getTimeline.mock.calls.length;
+
+    await user.click(screen.getByRole("radio", { name: /^year$/i }));
+    const yearInput = await screen.findByLabelText(/^year$/i);
+    await user.type(yearInput, "187");
+
+    // No additional calls should be made for partial years (1, 18, 187).
+    // Only the initial mount call should exist.
+    expect(getTimeline.mock.calls.length).toBe(callsBefore);
+  });
+
+  it("does not fire a request when range mode has only one side filled", async () => {
+    const user = userEvent.setup();
+    renderPage();
+
+    await waitFor(() => expect(getTimeline).toHaveBeenCalled());
+    const callsBefore = getTimeline.mock.calls.length;
+
+    await user.click(screen.getByRole("radio", { name: /^range$/i }));
+    const fromInput = await screen.findByLabelText(/^from$/i);
+    await user.type(fromInput, "1850");
+
+    // Only "From" is filled — no fetch should fire yet.
+    expect(getTimeline.mock.calls.length).toBe(callsBefore);
+    expect(screen.getByText(/enter start and end years/i)).toBeInTheDocument();
+  });
+
+  it("fires a range request when both sides are filled with 4-digit years", async () => {
+    const user = userEvent.setup();
+    renderPage();
+
+    await waitFor(() => expect(getTimeline).toHaveBeenCalled());
+
+    await user.click(screen.getByRole("radio", { name: /^range$/i }));
+    await user.type(await screen.findByLabelText(/^from$/i), "1850");
+    await user.type(await screen.findByLabelText(/^to$/i), "1900");
+
+    await waitFor(() => {
+      const matched = getTimeline.mock.calls.some(
+        ([arg]) => arg?.yearFrom === 1850 && arg?.yearTo === 1900,
+      );
+      expect(matched).toBe(true);
+    });
   });
 
   it("passes bbox query string params through to the service", async () => {

--- a/frontend/src/services/__tests__/timelineService.test.js
+++ b/frontend/src/services/__tests__/timelineService.test.js
@@ -1,0 +1,87 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("../api", () => ({
+  default: {
+    get: vi.fn(),
+  },
+}));
+
+import api from "../api";
+import { getTimeline } from "../timelineService";
+
+describe("timelineService", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("calls GET /stories/timeline/ and returns response data", async () => {
+    const responseData = {
+      count: 0,
+      next: null,
+      previous: null,
+      results: [],
+    };
+    api.get.mockResolvedValue({ data: responseData });
+
+    const result = await getTimeline();
+
+    expect(api.get).toHaveBeenCalledWith("/stories/timeline/", { params: {} });
+    expect(result).toEqual(responseData);
+  });
+
+  it("converts camelCase args to snake_case query params", async () => {
+    api.get.mockResolvedValue({ data: { count: 0, next: null, previous: null, results: [] } });
+
+    await getTimeline({
+      yearFrom: 1900,
+      yearTo: 2000,
+      latMin: 40.0,
+      latMax: 41.5,
+      lngMin: 28.0,
+      lngMax: 29.5,
+      hasImage: true,
+      page: 2,
+      pageSize: 25,
+    });
+
+    expect(api.get).toHaveBeenCalledWith("/stories/timeline/", {
+      params: {
+        year_from: 1900,
+        year_to: 2000,
+        lat_min: 40.0,
+        lat_max: 41.5,
+        lng_min: 28.0,
+        lng_max: 29.5,
+        has_image: true,
+        page: 2,
+        page_size: 25,
+      },
+    });
+  });
+
+  it("omits undefined params", async () => {
+    api.get.mockResolvedValue({ data: { count: 0, next: null, previous: null, results: [] } });
+
+    await getTimeline({ yearFrom: 1875, yearTo: 1875 });
+
+    expect(api.get).toHaveBeenCalledWith("/stories/timeline/", {
+      params: { year_from: 1875, year_to: 1875 },
+    });
+  });
+
+  it("passes bbox params through", async () => {
+    api.get.mockResolvedValue({ data: { count: 0, next: null, previous: null, results: [] } });
+
+    await getTimeline({ latMin: 40, latMax: 41, lngMin: 28, lngMax: 29 });
+
+    expect(api.get).toHaveBeenCalledWith("/stories/timeline/", {
+      params: { lat_min: 40, lat_max: 41, lng_min: 28, lng_max: 29 },
+    });
+  });
+
+  it("throws on API error", async () => {
+    api.get.mockRejectedValue(new Error("Network error"));
+
+    await expect(getTimeline()).rejects.toThrow("Network error");
+  });
+});

--- a/frontend/src/services/__tests__/timelineService.test.js
+++ b/frontend/src/services/__tests__/timelineService.test.js
@@ -39,7 +39,6 @@ describe("timelineService", () => {
       latMax: 41.5,
       lngMin: 28.0,
       lngMax: 29.5,
-      hasImage: true,
       page: 2,
       pageSize: 25,
     });
@@ -52,7 +51,6 @@ describe("timelineService", () => {
         lat_max: 41.5,
         lng_min: 28.0,
         lng_max: 29.5,
-        has_image: true,
         page: 2,
         page_size: 25,
       },

--- a/frontend/src/services/timelineService.js
+++ b/frontend/src/services/timelineService.js
@@ -7,7 +7,6 @@ const KEY_MAP = {
   latMax: "lat_max",
   lngMin: "lng_min",
   lngMax: "lng_max",
-  hasImage: "has_image",
   page: "page",
   pageSize: "page_size",
 };
@@ -26,11 +25,10 @@ export async function getTimeline({
   latMax,
   lngMin,
   lngMax,
-  hasImage,
   page,
   pageSize,
 } = {}) {
-  const args = { yearFrom, yearTo, latMin, latMax, lngMin, lngMax, hasImage, page, pageSize };
+  const args = { yearFrom, yearTo, latMin, latMax, lngMin, lngMax, page, pageSize };
   const params = {};
   for (const [key, value] of Object.entries(args)) {
     if (value === undefined) continue;

--- a/frontend/src/services/timelineService.js
+++ b/frontend/src/services/timelineService.js
@@ -1,0 +1,41 @@
+import api from "./api";
+
+const KEY_MAP = {
+  yearFrom: "year_from",
+  yearTo: "year_to",
+  latMin: "lat_min",
+  latMax: "lat_max",
+  lngMin: "lng_min",
+  lngMax: "lng_max",
+  hasImage: "has_image",
+  page: "page",
+  pageSize: "page_size",
+};
+
+/**
+ * Fetch stories ordered by time period for the timeline view.
+ *
+ * Calls `GET /stories/timeline/`. Accepts camelCase JS args and translates them
+ * to snake_case query params expected by the backend. Undefined args are
+ * omitted from the request.
+ */
+export async function getTimeline({
+  yearFrom,
+  yearTo,
+  latMin,
+  latMax,
+  lngMin,
+  lngMax,
+  hasImage,
+  page,
+  pageSize,
+} = {}) {
+  const args = { yearFrom, yearTo, latMin, latMax, lngMin, lngMax, hasImage, page, pageSize };
+  const params = {};
+  for (const [key, value] of Object.entries(args)) {
+    if (value === undefined) continue;
+    params[KEY_MAP[key]] = value;
+  }
+  const response = await api.get("/stories/timeline/", { params });
+  return response.data;
+}


### PR DESCRIPTION
# Description
Fixes #183

Adds a public Timeline page that lists all stories chronologically (oldest first) using the existing `GET /stories/timeline/` backend endpoint. Mirrors the mobile UX (PR #527): a "Choose a time window" filter card with **All / Year / Range / Decade** modes, a period label + story count, and a vertical timeline with year-bullet markers and story cards (image variant when `photo_url` is present, plain card otherwise). Each entry links to the corresponding story detail page.

The service layer also accepts bounding-box params via the URL query string, so issue #488 ("View Timeline" map-pin action) can reuse this page directly without modification — it will pass `lat_min/lat_max/lng_min/lng_max` derived from the pin's coordinates.

**Highlights**
- New service `timelineService.js` wrapping the timeline endpoint (camelCase → snake_case, omits undefined params, bbox passthrough).
- New page `TimelinePage.jsx` with filter modes, "Load more" pagination, and empty/loading/error states.
- New `Timeline/TimelineView.jsx` and `Timeline/TimelineEntry.jsx` components — vertical line, year bullet, EDTF/decade chips, "Mapped at lat, lng" hint, clickable card.
- Route `/timeline` registered in `App.jsx`; "Timeline" nav link added to `AppLayout` between Map and Feed (matches mobile nav order).
- Stale-response guard via generation counter so rapid filter changes don't render outdated data.
- Range mode validates `from <= to` inline and skips the fetch until the range is valid.

# Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Refactoring
- [ ] Documentation

# Acceptance Criteria / Checklist
- [x] Project builds successfully
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, especially in hard-to-understand parts
- [x] I have performed a self-review of my code
- [x] I have added/updated tests
- [x] New and existing unit tests pass locally with my changes

# Screenshots / Recordings
<!-- To be added after manual smoke test -->

# Estimated Review Time
- [ ] < 5 min
- [x] 5-15 min
- [ ] > 15 min