### PR TITLE
feat: Add a public endpoint for listing a user's published stories

### DIFF
--- a/backend/apps/users/profile_urls.py
+++ b/backend/apps/users/profile_urls.py
@@ -8,6 +8,7 @@ from apps.users.views import (
     ProfilePhotoView,
     UserBookmarksView,
     UserPublicProfileView,
+    UserStoriesView,
 )
 
 app_name = 'users_profile'
@@ -23,4 +24,5 @@ urlpatterns = [
     path('<int:user_id>/followers/', FollowerListView.as_view(), name='user-followers'),
     path('<int:user_id>/following/', FollowingListView.as_view(), name='user-following'),
     path('<int:user_id>/bookmarks/', UserBookmarksView.as_view(), name='user-bookmarks'),
+    path('<int:user_id>/stories/', UserStoriesView.as_view(), name='user-stories'),
 ]

--- a/backend/apps/users/services.py
+++ b/backend/apps/users/services.py
@@ -434,6 +434,29 @@ def get_user_bookmarks(user_id: int, requesting_user):
     )
 
 
+def get_user_published_stories(user_id: int):
+    """
+    Return a queryset of published stories for the given user's public profile,
+    ordered most-recently-submitted first.
+
+    Raises Http404 if the user does not exist or is inactive (banned).
+    """
+    from apps.stories.models import Story  # local import to avoid circular imports
+
+    try:
+        target = User.objects.get(pk=user_id, is_active=True)
+    except User.DoesNotExist:
+        raise Http404
+
+    return (
+        Story.objects
+        .filter(user=target, status=Story.STATUS_PUBLISHED)
+        .select_related('user', 'user__profile')
+        .prefetch_related('tags')
+        .order_by('-submitted_at')
+    )
+
+
 def request_password_reset(email: str) -> None:
     """
     Generates a password reset token and emails the reset link to the given address.

--- a/backend/apps/users/tests/test_services.py
+++ b/backend/apps/users/tests/test_services.py
@@ -19,6 +19,7 @@ from apps.users.services import (
     get_own_profile,
     get_public_profile,
     get_user_bookmarks,
+    get_user_published_stories,
     login_user,
     logout_user,
     register_user,
@@ -756,6 +757,65 @@ class TestGetUserBookmarks:
     def test_non_owner_raises_permission_denied(self, user, second_user):
         with pytest.raises(PermissionDenied):
             get_user_bookmarks(user.pk, second_user)
+
+
+# ── get_user_published_stories ────────────────────────────────────────────────
+
+
+@pytest.mark.django_db
+class TestGetUserPublishedStories:
+    def _make_story(self, user, title='Story', status=Story.STATUS_PUBLISHED):
+        return Story.objects.create(
+            user=user,
+            title=title,
+            narrative='Narrative text.',
+            status=status,
+            location_lat=Decimal('41.0'),
+            location_lng=Decimal('29.0'),
+            location_name='Istanbul',
+            time_type=Story.TIME_EXACT,
+            year=2000,
+        )
+
+    def test_returns_published_stories(self, user):
+        story = self._make_story(user)
+        qs = get_user_published_stories(user.pk)
+        assert story in qs
+
+    def test_excludes_draft_stories(self, user):
+        draft = self._make_story(user, title='Draft', status=Story.STATUS_DRAFT)
+        qs = get_user_published_stories(user.pk)
+        assert draft not in qs
+
+    def test_excludes_removed_stories(self, user):
+        removed = self._make_story(user, title='Removed', status=Story.STATUS_REMOVED)
+        qs = get_user_published_stories(user.pk)
+        assert removed not in qs
+
+    def test_ordered_most_recent_first(self, user):
+        story1 = self._make_story(user, title='First')
+        story2 = self._make_story(user, title='Second')
+        Story.objects.filter(pk=story1.pk).update(
+            submitted_at=timezone.now() - datetime.timedelta(seconds=5)
+        )
+        result = list(get_user_published_stories(user.pk))
+        assert result[0] == story2
+        assert result[1] == story1
+
+    def test_nonexistent_user_raises_404(self):
+        with pytest.raises(Http404):
+            get_user_published_stories(99999)
+
+    def test_inactive_user_raises_404(self, user):
+        user.is_active = False
+        user.save()
+        with pytest.raises(Http404):
+            get_user_published_stories(user.pk)
+
+    def test_does_not_return_other_users_stories(self, user, second_user):
+        other_story = self._make_story(second_user, title='Other')
+        qs = get_user_published_stories(user.pk)
+        assert other_story not in qs
 
 
 # ── register_user: sends verification email ──────────────────────────────────

--- a/backend/apps/users/tests/test_views.py
+++ b/backend/apps/users/tests/test_views.py
@@ -1038,6 +1038,81 @@ class TestUserBookmarksView:
         assert response.status_code == 404
 
 
+# ── GET /users/<user_id>/stories/ ────────────────────────────────────────────
+
+@pytest.mark.django_db
+class TestUserStoriesView:
+    url = '/users/{user_id}/stories/'
+
+    def _make_story(self, user, title='Story', status=Story.STATUS_PUBLISHED):
+        return Story.objects.create(
+            user=user,
+            title=title,
+            narrative='Narrative text.',
+            status=status,
+            location_lat=Decimal('41.0'),
+            location_lng=Decimal('29.0'),
+            location_name='Istanbul',
+            time_type=Story.TIME_EXACT,
+            year=2000,
+        )
+
+    def test_unauthenticated_returns_200(self, client, user):
+        response = client.get(self.url.format(user_id=user.pk))
+        assert response.status_code == 200
+
+    def test_returns_only_published_stories(self, client, user):
+        self._make_story(user, title='Published')
+        self._make_story(user, title='Draft', status=Story.STATUS_DRAFT)
+        self._make_story(user, title='Removed', status=Story.STATUS_REMOVED)
+        response = client.get(self.url.format(user_id=user.pk))
+        assert response.data['count'] == 1
+        assert response.data['results'][0]['title'] == 'Published'
+
+    def test_response_is_paginated(self, client, user):
+        response = client.get(self.url.format(user_id=user.pk))
+        assert response.status_code == 200
+        for key in ['count', 'next', 'previous', 'results']:
+            assert key in response.data
+
+    def test_unauthenticated_interaction_flags_are_false(self, client, user):
+        self._make_story(user)
+        response = client.get(self.url.format(user_id=user.pk))
+        result = response.data['results'][0]
+        assert result['user_has_liked'] is False
+        assert result['user_has_saved'] is False
+
+    def test_authenticated_user_has_liked_flag_is_true(self, client, user, second_user):
+        from apps.interactions.models import Like
+        story = self._make_story(user)
+        Like.objects.create(user=second_user, story=story)
+        client.force_authenticate(user=second_user)
+        response = client.get(self.url.format(user_id=user.pk))
+        assert response.data['results'][0]['user_has_liked'] is True
+
+    def test_inactive_user_returns_404(self, client, user):
+        user.is_active = False
+        user.save()
+        response = client.get(self.url.format(user_id=user.pk))
+        assert response.status_code == 404
+
+    def test_nonexistent_user_returns_404(self, client):
+        response = client.get(self.url.format(user_id=99999))
+        assert response.status_code == 404
+
+    def test_empty_when_no_stories(self, client, user):
+        response = client.get(self.url.format(user_id=user.pk))
+        assert response.data['count'] == 0
+        assert response.data['results'] == []
+
+    def test_response_contains_story_feed_fields(self, client, user):
+        self._make_story(user)
+        response = client.get(self.url.format(user_id=user.pk))
+        result = response.data['results'][0]
+        for field in ['id', 'title', 'location_name', 'preview_text', 'submitted_at']:
+            assert field in result
+
+
 # ── POST /auth/register/ — sends verification email ─────────────────────────
 
 @pytest.mark.django_db

--- a/backend/apps/users/views.py
+++ b/backend/apps/users/views.py
@@ -32,6 +32,7 @@ from apps.users.services import (
     get_own_profile,
     get_public_profile,
     get_user_bookmarks,
+    get_user_published_stories,
     login_user,
     logout_user,
     register_user,
@@ -235,6 +236,21 @@ class UserBookmarksView(APIView):
 
     def get(self, request, user_id):
         qs = annotate_user_interactions(get_user_bookmarks(user_id, request.user), request.user)
+        paginator = StoryPagination()
+        page = paginator.paginate_queryset(qs, request)
+        serializer = StoryFeedSerializer(page, many=True, context={'request': request})
+        return paginator.get_paginated_response(serializer.data)
+
+
+class UserStoriesView(APIView):
+    """GET /users/<user_id>/stories/ — published stories for a public profile, paginated."""
+
+    permission_classes = [AllowAny]
+
+    def get(self, request, user_id):
+        qs = get_user_published_stories(user_id)
+        if request.user.is_authenticated:
+            qs = annotate_user_interactions(qs, request.user)
         paginator = StoryPagination()
         page = paginator.paginate_queryset(qs, request)
         serializer = StoryFeedSerializer(page, many=True, context={'request': request})


### PR DESCRIPTION
# 📝 Description

Fixes #541

This PR adds a new public and paginated endpoint for listing the published stories of a specific user:

`GET /users/<user_id>/stories/`

The purpose of this PR is to separate public profile information from the user's story list. Instead of embedding all stories directly inside the public profile response, this endpoint provides a dedicated and paginated way to fetch a user's published stories. This keeps the profile response lightweight and makes the story list easier to load, paginate, and extend on the frontend.

This endpoint is intended to be used on public profile pages where visitors need to see the stories shared by a user. It only returns stories that are publicly visible, so draft and removed stories are excluded from the response. If the requested user does not exist or the account is inactive/banned, the endpoint returns `404`.

Implemented changes:
- Added `UserStoriesView` to handle public profile story listing.
- Added the `get_user_published_stories(user_id)` service function to keep the queryset logic outside the view.
- Registered the new `/users/<user_id>/stories/` route in `profile_urls.py`.
- Reused the existing `StoryFeedSerializer` so the response format stays consistent with the story feed.
- Reused `StoryPagination` so the endpoint returns paginated results.
- Filtered the queryset to return only published stories.
- Excluded draft and removed stories from the public response.
- Added `404` behavior for nonexistent users and inactive/banned users.
- Allowed unauthenticated users to access the endpoint.
- Added authenticated interaction annotations so `user_has_liked` and `user_has_saved` are returned correctly when the requester is logged in.
- Ordered stories by `submitted_at` in descending order, so the most recently submitted stories appear first.
- Added service and view tests for filtering, pagination, unauthenticated access, interaction flags, empty results, ordering, and `404` cases.

# 📊 Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactoring
- [ ] Documentation

# ✅ Acceptance Criteria / Checklist

- [x] Project builds successfully
- [x] Style guidelines followed
- [x] Code commented where necessary
- [x] Self-review performed
- [x] Tests added/updated
- [x] Tests pass locally



# ⏱️ Estimated Review Time

- [ ] < 5 min
- [x] 5–15 min
- [ ] > 15 min