### PR TITLE
feat: notification panel, bell badge, and preferences page

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -19,6 +19,7 @@ import ProfilePage from "@/pages/ProfilePage";
 import SubmitStoryPage from "@/pages/SubmitStoryPage";
 import StoryDetailPage from "@/pages/StoryDetailPage";
 import TagPage from "@/pages/TagPage";
+import NotificationPreferencesPage from "@/pages/NotificationPreferencesPage";
 
 function App() {
   return (
@@ -56,6 +57,14 @@ function App() {
                 element={(
                   <ProtectedRoute>
                     <SubmitStoryPage />
+                  </ProtectedRoute>
+                )}
+              />
+              <Route
+                path="/notifications/preferences"
+                element={(
+                  <ProtectedRoute>
+                    <NotificationPreferencesPage />
                   </ProtectedRoute>
                 )}
               />

--- a/frontend/src/components/AppLayout/AppLayout.jsx
+++ b/frontend/src/components/AppLayout/AppLayout.jsx
@@ -12,6 +12,7 @@ import {
   SheetTrigger,
 } from "@/components/ui/sheet";
 import { useAuth } from "@/hooks/useAuth";
+import NotificationBell from "@/components/Notifications/NotificationBell";
 
 const publicLinks = [
   { to: "/map", label: "Map", preserveSearch: true },
@@ -83,6 +84,9 @@ function AppLayout() {
           </nav>
 
           <div className="ml-auto flex items-center space-x-2">
+            {/* Notification bell — renders nothing for unauthenticated users */}
+            <NotificationBell />
+
             {/* Desktop auth section */}
             <div className="hidden md:flex items-center space-x-2">
               {isAuthenticated ? (

--- a/frontend/src/components/AppLayout/__tests__/AppLayout.test.jsx
+++ b/frontend/src/components/AppLayout/__tests__/AppLayout.test.jsx
@@ -13,6 +13,11 @@ vi.mock("@/hooks/useAuth", () => ({
   useAuth: () => mockAuthState,
 }));
 
+// Stub the bell — its own tests cover behavior; here we just want it to mount cleanly.
+vi.mock("@/components/Notifications/NotificationBell", () => ({
+  default: () => null,
+}));
+
 function renderWithRouter(initialRoute = "/") {
   return render(
     <MemoryRouter initialEntries={[initialRoute]}>

--- a/frontend/src/components/Notifications/NotificationBell.jsx
+++ b/frontend/src/components/Notifications/NotificationBell.jsx
@@ -1,0 +1,84 @@
+import { useEffect, useRef, useState } from "react";
+import { Bell } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { useAuth } from "@/hooks/useAuth";
+import { useNotifications } from "@/hooks/useNotifications";
+import NotificationPanel from "./NotificationPanel";
+
+function NotificationBell() {
+  const { isAuthenticated } = useAuth();
+  const [open, setOpen] = useState(false);
+  const containerRef = useRef(null);
+
+  const { notifications, unreadCount, loading, markRead, markAllRead } =
+    useNotifications();
+
+  useEffect(() => {
+    if (!open) return undefined;
+
+    function handleClickOutside(event) {
+      if (containerRef.current && !containerRef.current.contains(event.target)) {
+        setOpen(false);
+      }
+    }
+    function handleEscape(event) {
+      if (event.key === "Escape") setOpen(false);
+    }
+
+    document.addEventListener("mousedown", handleClickOutside);
+    document.addEventListener("keydown", handleEscape);
+    return () => {
+      document.removeEventListener("mousedown", handleClickOutside);
+      document.removeEventListener("keydown", handleEscape);
+    };
+  }, [open]);
+
+  if (!isAuthenticated) return null;
+
+  const badgeLabel = unreadCount > 99 ? "99+" : String(unreadCount);
+
+  return (
+    <div ref={containerRef} className="relative">
+      <Button
+        variant="ghost"
+        size="icon"
+        onClick={() => setOpen((v) => !v)}
+        aria-label={
+          unreadCount > 0
+            ? `Notifications, ${unreadCount} unread`
+            : "Notifications"
+        }
+        aria-haspopup="dialog"
+        aria-expanded={open}
+        className="relative"
+      >
+        <Bell className="h-5 w-5" aria-hidden="true" />
+        {unreadCount > 0 && (
+          <span
+            data-testid="notification-badge"
+            aria-hidden="true"
+            className="absolute -right-0.5 -top-0.5 flex min-w-[1.1rem] items-center justify-center rounded-full bg-destructive px-1 text-[10px] font-semibold leading-none text-destructive-foreground"
+          >
+            {badgeLabel}
+          </span>
+        )}
+      </Button>
+
+      {open && (
+        <div className="absolute right-0 top-full z-50 mt-2">
+          <NotificationPanel
+            notifications={notifications}
+            unreadCount={unreadCount}
+            loading={loading}
+            onMarkRead={markRead}
+            onMarkAllRead={markAllRead}
+            onClose={() => setOpen(false)}
+          />
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default NotificationBell;

--- a/frontend/src/components/Notifications/NotificationItem.jsx
+++ b/frontend/src/components/Notifications/NotificationItem.jsx
@@ -12,9 +12,10 @@ function NotificationItem({ notification, onMarkRead, onClose }) {
   const navigate = useNavigate();
   const isUnread = !notification.is_read;
 
-  const handleClick = async () => {
+  const handleClick = () => {
     if (isUnread) {
-      await onMarkRead?.(notification.id);
+      // Fire-and-forget: optimistic update lands locally; don't block navigation on the PATCH.
+      onMarkRead?.(notification.id);
     }
     const route = getNotificationRoute(notification);
     if (route) {

--- a/frontend/src/components/Notifications/NotificationItem.jsx
+++ b/frontend/src/components/Notifications/NotificationItem.jsx
@@ -1,0 +1,74 @@
+import { createElement } from "react";
+import { useNavigate } from "react-router-dom";
+
+import { cn } from "@/lib/utils";
+import {
+  formatRelativeTime,
+  getNotificationIcon,
+  getNotificationRoute,
+} from "@/utils/notificationFormat";
+
+function NotificationItem({ notification, onMarkRead, onClose }) {
+  const navigate = useNavigate();
+  const isUnread = !notification.is_read;
+
+  const handleClick = async () => {
+    if (isUnread) {
+      await onMarkRead?.(notification.id);
+    }
+    const route = getNotificationRoute(notification);
+    if (route) {
+      onClose?.();
+      navigate(route);
+    }
+  };
+
+  return (
+    <button
+      type="button"
+      onClick={handleClick}
+      className={cn(
+        "flex w-full items-start gap-3 px-4 py-3 text-left transition-colors hover:bg-muted/50 focus:outline-none focus-visible:bg-muted/50",
+        isUnread && "bg-primary/5"
+      )}
+      aria-label={
+        isUnread
+          ? `Unread notification: ${notification.message}`
+          : `Notification: ${notification.message}`
+      }
+    >
+      <div
+        className={cn(
+          "mt-0.5 flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-full",
+          isUnread ? "bg-primary/10 text-primary" : "bg-muted text-muted-foreground"
+        )}
+      >
+        {createElement(getNotificationIcon(notification.notification_type), {
+          className: "h-4 w-4",
+          "aria-hidden": "true",
+        })}
+      </div>
+      <div className="min-w-0 flex-1">
+        <p
+          className={cn(
+            "text-sm leading-snug",
+            isUnread ? "font-medium text-foreground" : "text-muted-foreground"
+          )}
+        >
+          {notification.message}
+        </p>
+        <p className="mt-0.5 text-xs text-muted-foreground">
+          {formatRelativeTime(notification.created_at)}
+        </p>
+      </div>
+      {isUnread && (
+        <span
+          className="mt-2 h-2 w-2 flex-shrink-0 rounded-full bg-primary"
+          aria-hidden="true"
+        />
+      )}
+    </button>
+  );
+}
+
+export default NotificationItem;

--- a/frontend/src/components/Notifications/NotificationPanel.jsx
+++ b/frontend/src/components/Notifications/NotificationPanel.jsx
@@ -1,0 +1,91 @@
+import { useNavigate } from "react-router-dom";
+import { Bell, Settings } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { EmptyState } from "@/components/ui/empty-state";
+import NotificationItem from "./NotificationItem";
+
+function NotificationPanel({
+  notifications,
+  unreadCount,
+  loading,
+  onMarkRead,
+  onMarkAllRead,
+  onClose,
+}) {
+  const navigate = useNavigate();
+
+  const handleOpenPreferences = () => {
+    onClose?.();
+    navigate("/notifications/preferences");
+  };
+
+  return (
+    <div
+      role="dialog"
+      aria-label="Notifications"
+      className="w-80 max-w-[90vw] overflow-hidden rounded-md border bg-popover text-popover-foreground shadow-md sm:w-96"
+    >
+      <div className="flex items-center justify-between border-b px-4 py-3">
+        <div>
+          <p className="text-sm font-semibold">Notifications</p>
+          {unreadCount > 0 && (
+            <p className="text-xs text-muted-foreground">
+              {unreadCount} unread
+            </p>
+          )}
+        </div>
+        <div className="flex items-center gap-1">
+          {unreadCount > 0 && (
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={onMarkAllRead}
+              className="h-8 px-2 text-xs"
+            >
+              Mark all as read
+            </Button>
+          )}
+          <Button
+            variant="ghost"
+            size="icon"
+            onClick={handleOpenPreferences}
+            aria-label="Notification preferences"
+            className="h-8 w-8"
+          >
+            <Settings className="h-4 w-4" aria-hidden="true" />
+          </Button>
+        </div>
+      </div>
+
+      <div className="max-h-96 overflow-y-auto">
+        {loading && notifications.length === 0 ? (
+          <p className="px-4 py-6 text-center text-sm text-muted-foreground">
+            Loading notifications…
+          </p>
+        ) : notifications.length === 0 ? (
+          <EmptyState
+            icon={Bell}
+            title="No notifications yet"
+            message="You'll see updates about your stories, comments, and badges here."
+            className="py-8"
+          />
+        ) : (
+          <ul className="divide-y" role="list">
+            {notifications.map((n) => (
+              <li key={n.id}>
+                <NotificationItem
+                  notification={n}
+                  onMarkRead={onMarkRead}
+                  onClose={onClose}
+                />
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export default NotificationPanel;

--- a/frontend/src/components/Notifications/__tests__/NotificationBell.test.jsx
+++ b/frontend/src/components/Notifications/__tests__/NotificationBell.test.jsx
@@ -88,4 +88,37 @@ describe("NotificationBell", () => {
 
     expect(screen.getByRole("dialog", { name: /notifications/i })).toBeInTheDocument();
   });
+
+  it("closes the panel when clicking outside", async () => {
+    const user = userEvent.setup();
+    render(
+      <MemoryRouter>
+        <div>
+          <NotificationBell />
+          <button type="button" data-testid="outside">
+            outside
+          </button>
+        </div>
+      </MemoryRouter>
+    );
+
+    await user.click(screen.getByRole("button", { name: /notifications/i }));
+    expect(screen.getByRole("dialog", { name: /notifications/i })).toBeInTheDocument();
+
+    await user.click(screen.getByTestId("outside"));
+
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+
+  it("closes the panel when Escape is pressed", async () => {
+    const user = userEvent.setup();
+    renderBell();
+
+    await user.click(screen.getByRole("button", { name: /notifications/i }));
+    expect(screen.getByRole("dialog", { name: /notifications/i })).toBeInTheDocument();
+
+    await user.keyboard("{Escape}");
+
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
 });

--- a/frontend/src/components/Notifications/__tests__/NotificationBell.test.jsx
+++ b/frontend/src/components/Notifications/__tests__/NotificationBell.test.jsx
@@ -1,0 +1,91 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter } from "react-router-dom";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+import NotificationBell from "@/components/Notifications/NotificationBell";
+
+let mockAuth = { isAuthenticated: true };
+let mockHook = {
+  notifications: [],
+  unreadCount: 0,
+  loading: false,
+  refresh: vi.fn(),
+  markRead: vi.fn(),
+  markAllRead: vi.fn(),
+};
+
+vi.mock("@/hooks/useAuth", () => ({
+  useAuth: () => mockAuth,
+}));
+
+vi.mock("@/hooks/useNotifications", () => ({
+  useNotifications: () => mockHook,
+}));
+
+function renderBell() {
+  return render(
+    <MemoryRouter>
+      <NotificationBell />
+    </MemoryRouter>
+  );
+}
+
+describe("NotificationBell", () => {
+  beforeEach(() => {
+    mockAuth = { isAuthenticated: true };
+    mockHook = {
+      notifications: [],
+      unreadCount: 0,
+      loading: false,
+      refresh: vi.fn(),
+      markRead: vi.fn(),
+      markAllRead: vi.fn(),
+    };
+  });
+
+  it("renders nothing when user is not authenticated", () => {
+    mockAuth = { isAuthenticated: false };
+    const { container } = renderBell();
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders bell button when authenticated", () => {
+    renderBell();
+    expect(
+      screen.getByRole("button", { name: /notifications/i })
+    ).toBeInTheDocument();
+  });
+
+  it("does not show a badge when unread count is 0", () => {
+    renderBell();
+    expect(screen.queryByTestId("notification-badge")).not.toBeInTheDocument();
+  });
+
+  it("shows the unread count in a badge", () => {
+    mockHook = { ...mockHook, unreadCount: 3 };
+    renderBell();
+    const badge = screen.getByTestId("notification-badge");
+    expect(badge).toHaveTextContent("3");
+    expect(
+      screen.getByRole("button", { name: /3 unread/i })
+    ).toBeInTheDocument();
+  });
+
+  it("shows '99+' when unread count exceeds 99", () => {
+    mockHook = { ...mockHook, unreadCount: 150 };
+    renderBell();
+    expect(screen.getByTestId("notification-badge")).toHaveTextContent("99+");
+  });
+
+  it("opens the panel when clicked", async () => {
+    const user = userEvent.setup();
+    renderBell();
+
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: /notifications/i }));
+
+    expect(screen.getByRole("dialog", { name: /notifications/i })).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/Notifications/__tests__/NotificationItem.test.jsx
+++ b/frontend/src/components/Notifications/__tests__/NotificationItem.test.jsx
@@ -1,0 +1,92 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter } from "react-router-dom";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+import NotificationItem from "@/components/Notifications/NotificationItem";
+
+const mockNavigate = vi.fn();
+vi.mock("react-router-dom", async () => {
+  const actual = await vi.importActual("react-router-dom");
+  return { ...actual, useNavigate: () => mockNavigate };
+});
+
+function makeNotification(overrides = {}) {
+  return {
+    id: 1,
+    notification_type: "new_like",
+    message: "Ali liked your story",
+    actor: { id: 42, username: "ali" },
+    story_id: 99,
+    comment_id: null,
+    is_read: false,
+    created_at: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+describe("NotificationItem", () => {
+  beforeEach(() => {
+    mockNavigate.mockClear();
+  });
+
+  it("labels itself as unread when is_read is false", () => {
+    render(
+      <MemoryRouter>
+        <NotificationItem notification={makeNotification({ is_read: false })} />
+      </MemoryRouter>
+    );
+    expect(
+      screen.getByRole("button", { name: /^Unread notification:/ })
+    ).toBeInTheDocument();
+  });
+
+  it("labels itself without 'unread' prefix when read", () => {
+    render(
+      <MemoryRouter>
+        <NotificationItem notification={makeNotification({ is_read: true })} />
+      </MemoryRouter>
+    );
+    const btn = screen.getByRole("button", { name: /^Notification:/ });
+    expect(btn).toBeInTheDocument();
+    expect(btn.getAttribute("aria-label")).not.toMatch(/Unread/);
+  });
+
+  it("calls onMarkRead and navigates to story on click for unread item", async () => {
+    const user = userEvent.setup();
+    const onMarkRead = vi.fn();
+    const onClose = vi.fn();
+    render(
+      <MemoryRouter>
+        <NotificationItem
+          notification={makeNotification({ is_read: false })}
+          onMarkRead={onMarkRead}
+          onClose={onClose}
+        />
+      </MemoryRouter>
+    );
+
+    await user.click(screen.getByRole("button"));
+
+    expect(onMarkRead).toHaveBeenCalledWith(1);
+    expect(onClose).toHaveBeenCalled();
+    expect(mockNavigate).toHaveBeenCalledWith("/stories/99");
+  });
+
+  it("does not call onMarkRead when item is already read", async () => {
+    const user = userEvent.setup();
+    const onMarkRead = vi.fn();
+    render(
+      <MemoryRouter>
+        <NotificationItem
+          notification={makeNotification({ is_read: true })}
+          onMarkRead={onMarkRead}
+          onClose={vi.fn()}
+        />
+      </MemoryRouter>
+    );
+
+    await user.click(screen.getByRole("button"));
+    expect(onMarkRead).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/components/Notifications/__tests__/NotificationPanel.test.jsx
+++ b/frontend/src/components/Notifications/__tests__/NotificationPanel.test.jsx
@@ -1,0 +1,119 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter } from "react-router-dom";
+import { describe, it, expect, vi } from "vitest";
+
+import NotificationPanel from "@/components/Notifications/NotificationPanel";
+
+const mockNavigate = vi.fn();
+vi.mock("react-router-dom", async () => {
+  const actual = await vi.importActual("react-router-dom");
+  return { ...actual, useNavigate: () => mockNavigate };
+});
+
+function renderPanel(props = {}) {
+  return render(
+    <MemoryRouter>
+      <NotificationPanel
+        notifications={[]}
+        unreadCount={0}
+        loading={false}
+        onMarkRead={vi.fn()}
+        onMarkAllRead={vi.fn()}
+        onClose={vi.fn()}
+        {...props}
+      />
+    </MemoryRouter>
+  );
+}
+
+describe("NotificationPanel", () => {
+  it("renders empty state when there are no notifications", () => {
+    renderPanel();
+    expect(screen.getByText(/no notifications yet/i)).toBeInTheDocument();
+  });
+
+  it("renders a list of notifications with messages", () => {
+    const notifications = [
+      {
+        id: 1,
+        notification_type: "new_like",
+        message: "Ali liked your story",
+        created_at: new Date().toISOString(),
+        is_read: false,
+      },
+      {
+        id: 2,
+        notification_type: "new_comment",
+        message: "Veli commented on your story",
+        created_at: new Date().toISOString(),
+        is_read: true,
+      },
+    ];
+    renderPanel({ notifications, unreadCount: 1 });
+
+    expect(screen.getByText("Ali liked your story")).toBeInTheDocument();
+    expect(screen.getByText("Veli commented on your story")).toBeInTheDocument();
+    expect(screen.getByText("1 unread")).toBeInTheDocument();
+  });
+
+  it("shows 'Mark all as read' button only when there is at least one unread", async () => {
+    const user = userEvent.setup();
+    const onMarkAllRead = vi.fn();
+
+    const { rerender } = renderPanel({
+      notifications: [
+        {
+          id: 1,
+          notification_type: "new_like",
+          message: "x",
+          created_at: new Date().toISOString(),
+          is_read: true,
+        },
+      ],
+      unreadCount: 0,
+      onMarkAllRead,
+    });
+    expect(
+      screen.queryByRole("button", { name: /mark all as read/i })
+    ).not.toBeInTheDocument();
+
+    rerender(
+      <MemoryRouter>
+        <NotificationPanel
+          notifications={[
+            {
+              id: 1,
+              notification_type: "new_like",
+              message: "x",
+              created_at: new Date().toISOString(),
+              is_read: false,
+            },
+          ]}
+          unreadCount={1}
+          loading={false}
+          onMarkRead={vi.fn()}
+          onMarkAllRead={onMarkAllRead}
+          onClose={vi.fn()}
+        />
+      </MemoryRouter>
+    );
+
+    const btn = screen.getByRole("button", { name: /mark all as read/i });
+    await user.click(btn);
+    expect(onMarkAllRead).toHaveBeenCalledTimes(1);
+  });
+
+  it("navigates to preferences when settings icon clicked", async () => {
+    const user = userEvent.setup();
+    const onClose = vi.fn();
+    renderPanel({ onClose });
+
+    await user.click(
+      screen.getByRole("button", { name: /notification preferences/i })
+    );
+
+    expect(onClose).toHaveBeenCalled();
+    expect(mockNavigate).toHaveBeenCalledWith("/notifications/preferences");
+  });
+});

--- a/frontend/src/hooks/__tests__/useNotifications.test.jsx
+++ b/frontend/src/hooks/__tests__/useNotifications.test.jsx
@@ -109,6 +109,36 @@ describe("useNotifications", () => {
     expect(result.current.unreadCount).toBe(1);
   });
 
+  it("rolls back the optimistic mark-read when the PATCH fails", async () => {
+    getNotifications
+      .mockResolvedValueOnce({
+        notifications: [{ id: 1, message: "x", is_read: false }],
+      })
+      // The rollback call refreshes from the server — return the unread state.
+      .mockResolvedValueOnce({
+        notifications: [{ id: 1, message: "x", is_read: false }],
+      });
+    markAsRead.mockRejectedValueOnce(new Error("nope"));
+
+    const { result } = renderHook(() => useNotifications());
+    await waitFor(() => {
+      expect(result.current.notifications).toHaveLength(1);
+    });
+
+    await act(async () => {
+      await result.current.markRead(1);
+    });
+
+    expect(markAsRead).toHaveBeenCalledWith(1, true);
+    // The rollback path re-fetches from the server, so getNotifications is
+    // called once on mount and again on rollback.
+    expect(getNotifications).toHaveBeenCalledTimes(2);
+    expect(
+      result.current.notifications.find((n) => n.id === 1).is_read
+    ).toBe(false);
+    expect(result.current.unreadCount).toBe(1);
+  });
+
   it("marks all unread notifications as read", async () => {
     getNotifications.mockResolvedValue({
       notifications: [

--- a/frontend/src/hooks/__tests__/useNotifications.test.jsx
+++ b/frontend/src/hooks/__tests__/useNotifications.test.jsx
@@ -1,0 +1,134 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+let mockAuth = { isAuthenticated: true };
+
+vi.mock("@/hooks/useAuth", () => ({
+  useAuth: () => mockAuth,
+}));
+
+vi.mock("@/services/notificationService", () => ({
+  getNotifications: vi.fn(),
+  markAsRead: vi.fn(),
+  markAllAsRead: vi.fn(),
+}));
+
+import {
+  getNotifications,
+  markAsRead,
+  markAllAsRead,
+} from "@/services/notificationService";
+import { useNotifications } from "@/hooks/useNotifications";
+
+describe("useNotifications", () => {
+  beforeEach(() => {
+    mockAuth = { isAuthenticated: true };
+    getNotifications.mockReset();
+    markAsRead.mockReset();
+    markAllAsRead.mockReset();
+  });
+
+  it("fetches notifications on mount when authenticated", async () => {
+    getNotifications.mockResolvedValue({
+      notifications: [
+        { id: 1, message: "x", is_read: false },
+        { id: 2, message: "y", is_read: true },
+      ],
+    });
+
+    const { result } = renderHook(() => useNotifications());
+
+    await waitFor(() => {
+      expect(result.current.notifications).toHaveLength(2);
+    });
+    expect(result.current.unreadCount).toBe(1);
+  });
+
+  it("does not fetch when unauthenticated", async () => {
+    mockAuth = { isAuthenticated: false };
+    getNotifications.mockResolvedValue({ notifications: [] });
+
+    renderHook(() => useNotifications());
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(getNotifications).not.toHaveBeenCalled();
+  });
+
+  it("polls for new notifications on the configured interval", async () => {
+    vi.useFakeTimers({ toFake: ["setInterval", "clearInterval"] });
+    getNotifications.mockResolvedValue({ notifications: [] });
+
+    renderHook(() => useNotifications({ pollIntervalMs: 1000 }));
+
+    // Wait for the initial fetch (real microtask queue still runs)
+    await waitFor(() => {
+      expect(getNotifications).toHaveBeenCalledTimes(1);
+    });
+
+    await act(async () => {
+      vi.advanceTimersByTime(1000);
+    });
+    await waitFor(() => {
+      expect(getNotifications).toHaveBeenCalledTimes(2);
+    });
+
+    await act(async () => {
+      vi.advanceTimersByTime(1000);
+    });
+    await waitFor(() => {
+      expect(getNotifications).toHaveBeenCalledTimes(3);
+    });
+
+    vi.useRealTimers();
+  });
+
+  it("optimistically marks a single notification as read", async () => {
+    getNotifications.mockResolvedValue({
+      notifications: [
+        { id: 1, message: "x", is_read: false },
+        { id: 2, message: "y", is_read: false },
+      ],
+    });
+    markAsRead.mockResolvedValue({});
+
+    const { result } = renderHook(() => useNotifications());
+    await waitFor(() => {
+      expect(result.current.notifications).toHaveLength(2);
+    });
+
+    await act(async () => {
+      await result.current.markRead(1);
+    });
+
+    expect(markAsRead).toHaveBeenCalledWith(1, true);
+    expect(
+      result.current.notifications.find((n) => n.id === 1).is_read
+    ).toBe(true);
+    expect(result.current.unreadCount).toBe(1);
+  });
+
+  it("marks all unread notifications as read", async () => {
+    getNotifications.mockResolvedValue({
+      notifications: [
+        { id: 1, message: "x", is_read: false },
+        { id: 2, message: "y", is_read: false },
+        { id: 3, message: "z", is_read: true },
+      ],
+    });
+    markAllAsRead.mockResolvedValue();
+
+    const { result } = renderHook(() => useNotifications());
+    await waitFor(() => {
+      expect(result.current.unreadCount).toBe(2);
+    });
+
+    await act(async () => {
+      await result.current.markAllRead();
+    });
+
+    expect(markAllAsRead).toHaveBeenCalledWith([1, 2]);
+    expect(result.current.unreadCount).toBe(0);
+  });
+});

--- a/frontend/src/hooks/useNotifications.js
+++ b/frontend/src/hooks/useNotifications.js
@@ -1,0 +1,87 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+
+import { useAuth } from "@/hooks/useAuth";
+import {
+  getNotifications,
+  markAsRead as markAsReadService,
+  markAllAsRead as markAllAsReadService,
+} from "@/services/notificationService";
+
+const POLL_INTERVAL_MS = 45_000;
+
+export function useNotifications({ pollIntervalMs = POLL_INTERVAL_MS } = {}) {
+  const { isAuthenticated } = useAuth();
+  const [notifications, setNotifications] = useState([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(null);
+
+  // Use a ref so the polling interval always sees fresh auth state.
+  const isAuthenticatedRef = useRef(isAuthenticated);
+  isAuthenticatedRef.current = isAuthenticated;
+
+  const refresh = useCallback(async () => {
+    if (!isAuthenticatedRef.current) {
+      setNotifications([]);
+      return;
+    }
+    setLoading(true);
+    try {
+      const data = await getNotifications();
+      setNotifications(Array.isArray(data?.notifications) ? data.notifications : []);
+      setError(null);
+    } catch (err) {
+      setError(err);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!isAuthenticated) {
+      setNotifications([]);
+      return undefined;
+    }
+    refresh();
+    const intervalId = setInterval(() => {
+      if (isAuthenticatedRef.current) refresh();
+    }, pollIntervalMs);
+    return () => clearInterval(intervalId);
+  }, [isAuthenticated, pollIntervalMs, refresh]);
+
+  const markRead = useCallback(async (id) => {
+    setNotifications((prev) =>
+      prev.map((n) => (n.id === id ? { ...n, is_read: true } : n))
+    );
+    try {
+      await markAsReadService(id, true);
+    } catch (err) {
+      setError(err);
+      // Roll back the optimistic update on failure.
+      await refresh();
+    }
+  }, [refresh]);
+
+  const markAllRead = useCallback(async () => {
+    const unreadIds = notifications.filter((n) => !n.is_read).map((n) => n.id);
+    if (unreadIds.length === 0) return;
+    setNotifications((prev) => prev.map((n) => ({ ...n, is_read: true })));
+    try {
+      await markAllAsReadService(unreadIds);
+    } catch (err) {
+      setError(err);
+      await refresh();
+    }
+  }, [notifications, refresh]);
+
+  const unreadCount = notifications.filter((n) => !n.is_read).length;
+
+  return {
+    notifications,
+    unreadCount,
+    loading,
+    error,
+    refresh,
+    markRead,
+    markAllRead,
+  };
+}

--- a/frontend/src/hooks/useNotifications.js
+++ b/frontend/src/hooks/useNotifications.js
@@ -19,6 +19,16 @@ export function useNotifications({ pollIntervalMs = POLL_INTERVAL_MS } = {}) {
   const isAuthenticatedRef = useRef(isAuthenticated);
   isAuthenticatedRef.current = isAuthenticated;
 
+  // Tracks how many mark-read PATCHes are in flight. While > 0, polling is
+  // suppressed so a stale server response can't clobber our optimistic
+  // is_read: true before the PATCH is persisted.
+  const inFlightMarksRef = useRef(0);
+
+  // Mirror of `notifications` so callbacks can read latest state without
+  // re-creating on every render (keeps the callback identity stable).
+  const notificationsRef = useRef(notifications);
+  notificationsRef.current = notifications;
+
   const refresh = useCallback(async () => {
     if (!isAuthenticatedRef.current) {
       setNotifications([]);
@@ -43,7 +53,9 @@ export function useNotifications({ pollIntervalMs = POLL_INTERVAL_MS } = {}) {
     }
     refresh();
     const intervalId = setInterval(() => {
-      if (isAuthenticatedRef.current) refresh();
+      if (isAuthenticatedRef.current && inFlightMarksRef.current === 0) {
+        refresh();
+      }
     }, pollIntervalMs);
     return () => clearInterval(intervalId);
   }, [isAuthenticated, pollIntervalMs, refresh]);
@@ -52,26 +64,34 @@ export function useNotifications({ pollIntervalMs = POLL_INTERVAL_MS } = {}) {
     setNotifications((prev) =>
       prev.map((n) => (n.id === id ? { ...n, is_read: true } : n))
     );
+    inFlightMarksRef.current += 1;
     try {
       await markAsReadService(id, true);
     } catch (err) {
       setError(err);
       // Roll back the optimistic update on failure.
       await refresh();
+    } finally {
+      inFlightMarksRef.current -= 1;
     }
   }, [refresh]);
 
   const markAllRead = useCallback(async () => {
-    const unreadIds = notifications.filter((n) => !n.is_read).map((n) => n.id);
+    const unreadIds = notificationsRef.current
+      .filter((n) => !n.is_read)
+      .map((n) => n.id);
     if (unreadIds.length === 0) return;
     setNotifications((prev) => prev.map((n) => ({ ...n, is_read: true })));
+    inFlightMarksRef.current += 1;
     try {
       await markAllAsReadService(unreadIds);
     } catch (err) {
       setError(err);
       await refresh();
+    } finally {
+      inFlightMarksRef.current -= 1;
     }
-  }, [notifications, refresh]);
+  }, [refresh]);
 
   const unreadCount = notifications.filter((n) => !n.is_read).length;
 

--- a/frontend/src/pages/NotificationPreferencesPage.jsx
+++ b/frontend/src/pages/NotificationPreferencesPage.jsx
@@ -1,0 +1,195 @@
+import { useEffect, useState } from "react";
+import { Link } from "react-router-dom";
+import { ArrowLeft, Bell, Loader2 } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { ErrorState } from "@/components/ui/error-state";
+import { SkeletonPage } from "@/components/ui/loading-skeleton";
+import { useToast } from "@/hooks/useToast";
+import {
+  getPreferences,
+  updatePreferences,
+} from "@/services/notificationService";
+import { NOTIFICATION_TYPES } from "@/utils/notificationFormat";
+
+function ToggleRow({ id, label, description, checked, disabled, onChange }) {
+  return (
+    <label
+      htmlFor={id}
+      className={`flex cursor-pointer items-start justify-between gap-4 rounded-md border p-4 ${
+        disabled ? "opacity-60" : ""
+      }`}
+    >
+      <div className="min-w-0 flex-1">
+        <span className="block text-sm font-medium text-foreground">{label}</span>
+        {description && (
+          <span className="mt-0.5 block text-xs text-muted-foreground">
+            {description}
+          </span>
+        )}
+      </div>
+      <input
+        id={id}
+        type="checkbox"
+        role="switch"
+        checked={checked}
+        disabled={disabled}
+        onChange={(e) => onChange(e.target.checked)}
+        className="mt-1 h-5 w-5 cursor-pointer accent-primary"
+      />
+    </label>
+  );
+}
+
+function NotificationPreferencesPage() {
+  const { toast } = useToast();
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+  const [muted, setMuted] = useState(false);
+  const [prefs, setPrefs] = useState({});
+  const [savingKey, setSavingKey] = useState(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    async function load() {
+      setLoading(true);
+      try {
+        const data = await getPreferences();
+        if (cancelled) return;
+        setMuted(Boolean(data?.notifications_muted));
+        setPrefs(data?.preferences ?? {});
+        setError(null);
+      } catch (err) {
+        if (!cancelled) {
+          setError(
+            err?.response?.data?.detail ||
+              err?.message ||
+              "Failed to load preferences."
+          );
+        }
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    }
+    load();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  async function persist(key, payload, optimistic) {
+    const previous = { muted, prefs };
+    optimistic();
+    setSavingKey(key);
+    try {
+      const data = await updatePreferences(payload);
+      setMuted(Boolean(data?.notifications_muted));
+      setPrefs(data?.preferences ?? {});
+    } catch (err) {
+      setMuted(previous.muted);
+      setPrefs(previous.prefs);
+      toast.error(
+        err?.response?.data?.detail ||
+          err?.message ||
+          "Failed to save preference."
+      );
+    } finally {
+      setSavingKey(null);
+    }
+  }
+
+  function handleToggleType(typeKey, checked) {
+    persist(typeKey, { [typeKey]: checked }, () => {
+      setPrefs((p) => ({ ...p, [typeKey]: checked }));
+    });
+  }
+
+  function handleToggleMuted(checked) {
+    persist("__muted__", { notifications_muted: checked }, () => {
+      setMuted(checked);
+    });
+  }
+
+  if (loading) {
+    return (
+      <main className="min-h-screen bg-background">
+        <div className="mx-auto max-w-3xl px-4 py-8 sm:px-6 lg:px-8">
+          <SkeletonPage />
+        </div>
+      </main>
+    );
+  }
+
+  if (error) {
+    return (
+      <main className="min-h-screen bg-background">
+        <div className="mx-auto max-w-3xl px-4 py-8 sm:px-6 lg:px-8">
+          <ErrorState message={error} />
+        </div>
+      </main>
+    );
+  }
+
+  return (
+    <main className="min-h-screen bg-background">
+      <div className="mx-auto max-w-3xl px-4 py-8 sm:px-6 lg:px-8">
+        <div className="mb-6 flex items-center gap-3">
+          <Button
+            variant="ghost"
+            size="sm"
+            asChild
+            className="text-muted-foreground"
+          >
+            <Link to="/profile">
+              <ArrowLeft className="mr-1 h-4 w-4" aria-hidden="true" />
+              Back to profile
+            </Link>
+          </Button>
+        </div>
+
+        <div className="mb-6 flex items-center gap-3">
+          <div className="flex h-10 w-10 items-center justify-center rounded-full bg-primary/10 text-primary">
+            <Bell className="h-5 w-5" aria-hidden="true" />
+          </div>
+          <div>
+            <h1 className="text-2xl font-semibold">Notification preferences</h1>
+            <p className="text-sm text-muted-foreground">
+              Choose which events trigger an in-app notification.
+            </p>
+          </div>
+          {savingKey && (
+            <Loader2
+              className="ml-auto h-4 w-4 animate-spin text-muted-foreground"
+              aria-label="Saving"
+            />
+          )}
+        </div>
+
+        <section className="mb-6">
+          <ToggleRow
+            id="pref-muted"
+            label="Stop all notifications"
+            description="Mute every notification type. Turn this off to use the per-type toggles below."
+            checked={muted}
+            onChange={handleToggleMuted}
+          />
+        </section>
+
+        <section aria-label="Per-type preferences" className="space-y-3">
+          {NOTIFICATION_TYPES.map(({ key, label }) => (
+            <ToggleRow
+              key={key}
+              id={`pref-${key}`}
+              label={label}
+              checked={prefs[key] !== false}
+              disabled={muted}
+              onChange={(checked) => handleToggleType(key, checked)}
+            />
+          ))}
+        </section>
+      </div>
+    </main>
+  );
+}
+
+export default NotificationPreferencesPage;

--- a/frontend/src/pages/NotificationPreferencesPage.jsx
+++ b/frontend/src/pages/NotificationPreferencesPage.jsx
@@ -16,8 +16,8 @@ function ToggleRow({ id, label, description, checked, disabled, onChange }) {
   return (
     <label
       htmlFor={id}
-      className={`flex cursor-pointer items-start justify-between gap-4 rounded-md border p-4 ${
-        disabled ? "opacity-60" : ""
+      className={`flex items-start justify-between gap-4 rounded-md border p-4 ${
+        disabled ? "cursor-not-allowed opacity-60" : "cursor-pointer"
       }`}
     >
       <div className="min-w-0 flex-1">
@@ -177,6 +177,8 @@ function NotificationPreferencesPage() {
 
         <section aria-label="Per-type preferences" className="space-y-3">
           {NOTIFICATION_TYPES.map(({ key, label }) => (
+            // Opt-out semantics: any unknown/missing key defaults to ON.
+            // Backend must mirror this default — only an explicit `false` mutes a type.
             <ToggleRow
               key={key}
               id={`pref-${key}`}

--- a/frontend/src/pages/ProfilePage.jsx
+++ b/frontend/src/pages/ProfilePage.jsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useCallback } from "react";
-import { useParams } from "react-router-dom";
-import { User, BookOpen, CalendarDays, MapPin, Star, Pencil, Lock, Loader2 } from "lucide-react";
+import { Link, useParams } from "react-router-dom";
+import { User, BookOpen, CalendarDays, MapPin, Star, Pencil, Lock, Loader2, Bell } from "lucide-react";
 
 import { SkeletonPage } from "@/components/ui/loading-skeleton";
 import { ErrorState } from "@/components/ui/error-state";
@@ -265,14 +265,22 @@ function ProfilePage() {
               </div>
               <div className="flex shrink-0 gap-2">
                 {isOwnProfile && (
-                  <Button
-                    variant="outline"
-                    size="sm"
-                    onClick={() => setEditMode(true)}
-                  >
-                    <Pencil className="h-4 w-4" />
-                    Edit Profile
-                  </Button>
+                  <>
+                    <Button variant="outline" size="sm" asChild>
+                      <Link to="/notifications/preferences">
+                        <Bell className="h-4 w-4" />
+                        Notifications
+                      </Link>
+                    </Button>
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      onClick={() => setEditMode(true)}
+                    >
+                      <Pencil className="h-4 w-4" />
+                      Edit Profile
+                    </Button>
+                  </>
                 )}
                 {!isOwnProfile && (
                   <FollowButton

--- a/frontend/src/pages/__tests__/NotificationPreferencesPage.test.jsx
+++ b/frontend/src/pages/__tests__/NotificationPreferencesPage.test.jsx
@@ -1,0 +1,150 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter } from "react-router-dom";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("@/services/notificationService", () => ({
+  getPreferences: vi.fn(),
+  updatePreferences: vi.fn(),
+}));
+
+const mockToast = { error: vi.fn(), success: vi.fn(), info: vi.fn(), default: vi.fn() };
+vi.mock("@/hooks/useToast", () => ({
+  useToast: () => ({ toast: mockToast, dismiss: vi.fn() }),
+}));
+
+import {
+  getPreferences,
+  updatePreferences,
+} from "@/services/notificationService";
+import NotificationPreferencesPage from "@/pages/NotificationPreferencesPage";
+
+function renderPage() {
+  return render(
+    <MemoryRouter>
+      <NotificationPreferencesPage />
+    </MemoryRouter>
+  );
+}
+
+describe("NotificationPreferencesPage", () => {
+  beforeEach(() => {
+    getPreferences.mockReset();
+    updatePreferences.mockReset();
+    mockToast.error.mockReset();
+  });
+
+  it("loads preferences on mount and renders all 8 type toggles plus master mute", async () => {
+    getPreferences.mockResolvedValue({
+      notifications_muted: false,
+      preferences: {
+        new_like: true,
+        new_comment: false,
+      },
+    });
+
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByText(/Notification preferences/i)).toBeInTheDocument();
+    });
+
+    // Master mute + 8 per-type toggles
+    const switches = screen.getAllByRole("switch");
+    expect(switches).toHaveLength(9);
+
+    expect(screen.getByText(/Stop all notifications/i)).toBeInTheDocument();
+    expect(screen.getByText(/New comments on your stories/i)).toBeInTheDocument();
+    expect(screen.getByText(/New likes on your stories/i)).toBeInTheDocument();
+
+    // new_like is true → checked; new_comment is false → unchecked
+    expect(screen.getByLabelText(/New likes on your stories/i)).toBeChecked();
+    expect(screen.getByLabelText(/New comments on your stories/i)).not.toBeChecked();
+  });
+
+  it("calls updatePreferences when a per-type toggle is changed", async () => {
+    const user = userEvent.setup();
+    getPreferences.mockResolvedValue({
+      notifications_muted: false,
+      preferences: { new_like: true },
+    });
+    updatePreferences.mockResolvedValue({
+      notifications_muted: false,
+      preferences: { new_like: false },
+    });
+
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByLabelText(/New likes on your stories/i)).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByLabelText(/New likes on your stories/i));
+
+    expect(updatePreferences).toHaveBeenCalledWith({ new_like: false });
+  });
+
+  it("toggling master mute disables per-type toggles and sends notifications_muted patch", async () => {
+    const user = userEvent.setup();
+    getPreferences.mockResolvedValue({
+      notifications_muted: false,
+      preferences: {},
+    });
+    updatePreferences.mockResolvedValue({
+      notifications_muted: true,
+      preferences: {},
+    });
+
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByLabelText(/Stop all notifications/i)).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByLabelText(/Stop all notifications/i));
+
+    expect(updatePreferences).toHaveBeenCalledWith({
+      notifications_muted: true,
+    });
+
+    await waitFor(() => {
+      expect(screen.getByLabelText(/New likes on your stories/i)).toBeDisabled();
+    });
+  });
+
+  it("rolls back optimistic state and shows a toast on save failure", async () => {
+    const user = userEvent.setup();
+    getPreferences.mockResolvedValue({
+      notifications_muted: false,
+      preferences: { new_like: true },
+    });
+    updatePreferences.mockRejectedValue({
+      response: { data: { detail: "Server is angry" } },
+    });
+
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByLabelText(/New likes on your stories/i)).toBeChecked();
+    });
+
+    await user.click(screen.getByLabelText(/New likes on your stories/i));
+
+    await waitFor(() => {
+      expect(mockToast.error).toHaveBeenCalledWith("Server is angry");
+    });
+    expect(screen.getByLabelText(/New likes on your stories/i)).toBeChecked();
+  });
+
+  it("shows error state when initial load fails", async () => {
+    getPreferences.mockRejectedValue({
+      response: { data: { detail: "Could not fetch" } },
+    });
+
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByText(/Could not fetch/i)).toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/src/services/__tests__/notificationService.test.js
+++ b/frontend/src/services/__tests__/notificationService.test.js
@@ -1,0 +1,114 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("../api", () => ({
+  default: {
+    get: vi.fn(),
+    patch: vi.fn(),
+    post: vi.fn(),
+    delete: vi.fn(),
+  },
+}));
+
+import api from "../api";
+import {
+  getNotifications,
+  markAsRead,
+  markAllAsRead,
+  getPreferences,
+  updatePreferences,
+} from "../notificationService";
+
+describe("notificationService", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("getNotifications", () => {
+    it("GETs /notifications/ and returns response data", async () => {
+      const body = { notifications: [{ id: 1 }, { id: 2 }] };
+      api.get.mockResolvedValue({ data: body });
+
+      const result = await getNotifications();
+
+      expect(api.get).toHaveBeenCalledWith("/notifications/");
+      expect(result).toEqual(body);
+    });
+
+    it("propagates API errors", async () => {
+      api.get.mockRejectedValue(new Error("Network error"));
+      await expect(getNotifications()).rejects.toThrow("Network error");
+    });
+  });
+
+  describe("markAsRead", () => {
+    it("PATCHes /notifications/<id>/read/ with is_read true by default", async () => {
+      api.patch.mockResolvedValue({ data: { id: 5, is_read: true } });
+
+      const result = await markAsRead(5);
+
+      expect(api.patch).toHaveBeenCalledWith("/notifications/5/read/", {
+        is_read: true,
+      });
+      expect(result).toEqual({ id: 5, is_read: true });
+    });
+
+    it("supports passing is_read explicitly", async () => {
+      api.patch.mockResolvedValue({ data: {} });
+      await markAsRead(7, false);
+      expect(api.patch).toHaveBeenCalledWith("/notifications/7/read/", {
+        is_read: false,
+      });
+    });
+  });
+
+  describe("markAllAsRead", () => {
+    it("fans out PATCH calls for each id", async () => {
+      api.patch.mockResolvedValue({ data: {} });
+      await markAllAsRead([1, 2, 3]);
+
+      expect(api.patch).toHaveBeenCalledTimes(3);
+      expect(api.patch).toHaveBeenNthCalledWith(1, "/notifications/1/read/", {
+        is_read: true,
+      });
+      expect(api.patch).toHaveBeenNthCalledWith(2, "/notifications/2/read/", {
+        is_read: true,
+      });
+      expect(api.patch).toHaveBeenNthCalledWith(3, "/notifications/3/read/", {
+        is_read: true,
+      });
+    });
+
+    it("does nothing when given an empty array", async () => {
+      await markAllAsRead([]);
+      expect(api.patch).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("getPreferences", () => {
+    it("GETs /notifications/preferences/", async () => {
+      const body = { notifications_muted: false, preferences: {} };
+      api.get.mockResolvedValue({ data: body });
+
+      const result = await getPreferences();
+
+      expect(api.get).toHaveBeenCalledWith("/notifications/preferences/");
+      expect(result).toEqual(body);
+    });
+  });
+
+  describe("updatePreferences", () => {
+    it("PATCHes /notifications/preferences/ with the payload", async () => {
+      const payload = { new_like: false, notifications_muted: true };
+      const body = { notifications_muted: true, preferences: { new_like: false } };
+      api.patch.mockResolvedValue({ data: body });
+
+      const result = await updatePreferences(payload);
+
+      expect(api.patch).toHaveBeenCalledWith(
+        "/notifications/preferences/",
+        payload
+      );
+      expect(result).toEqual(body);
+    });
+  });
+});

--- a/frontend/src/services/notificationService.js
+++ b/frontend/src/services/notificationService.js
@@ -11,7 +11,11 @@ export async function markAsRead(id, isRead = true) {
 }
 
 export async function markAllAsRead(ids) {
-  await Promise.all(ids.map((id) => markAsRead(id, true)));
+  const results = await Promise.allSettled(
+    ids.map((id) => markAsRead(id, true))
+  );
+  const firstRejection = results.find((r) => r.status === "rejected");
+  if (firstRejection) throw firstRejection.reason;
 }
 
 export async function getPreferences() {

--- a/frontend/src/services/notificationService.js
+++ b/frontend/src/services/notificationService.js
@@ -1,0 +1,25 @@
+import api from "./api";
+
+export async function getNotifications() {
+  const response = await api.get("/notifications/");
+  return response.data;
+}
+
+export async function markAsRead(id, isRead = true) {
+  const response = await api.patch(`/notifications/${id}/read/`, { is_read: isRead });
+  return response.data;
+}
+
+export async function markAllAsRead(ids) {
+  await Promise.all(ids.map((id) => markAsRead(id, true)));
+}
+
+export async function getPreferences() {
+  const response = await api.get("/notifications/preferences/");
+  return response.data;
+}
+
+export async function updatePreferences(prefs) {
+  const response = await api.patch("/notifications/preferences/", prefs);
+  return response.data;
+}

--- a/frontend/src/utils/__tests__/notificationFormat.test.js
+++ b/frontend/src/utils/__tests__/notificationFormat.test.js
@@ -1,0 +1,135 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  Heart,
+  MessageCircle,
+  UserPlus,
+  Trophy,
+  Bell,
+} from "lucide-react";
+
+import {
+  getNotificationIcon,
+  getNotificationRoute,
+  formatRelativeTime,
+  NOTIFICATION_TYPES,
+} from "../notificationFormat";
+
+describe("getNotificationIcon", () => {
+  it("returns the correct icon component for each known type", () => {
+    expect(getNotificationIcon("new_comment")).toBe(MessageCircle);
+    expect(getNotificationIcon("new_like")).toBe(Heart);
+    expect(getNotificationIcon("new_follower")).toBe(UserPlus);
+    expect(getNotificationIcon("badge_earned")).toBe(Trophy);
+  });
+
+  it("falls back to Bell for unknown types", () => {
+    expect(getNotificationIcon("totally_unknown")).toBe(Bell);
+    expect(getNotificationIcon(undefined)).toBe(Bell);
+  });
+});
+
+describe("getNotificationRoute", () => {
+  it("routes to actor profile for new_follower", () => {
+    expect(
+      getNotificationRoute({
+        notification_type: "new_follower",
+        actor: { id: 42, username: "ali" },
+      })
+    ).toBe("/profile/42");
+  });
+
+  it("routes to story page when story_id present", () => {
+    expect(
+      getNotificationRoute({
+        notification_type: "new_like",
+        story_id: 99,
+      })
+    ).toBe("/stories/99");
+  });
+
+  it("routes to comment anchor when both story and comment present", () => {
+    expect(
+      getNotificationRoute({
+        notification_type: "new_comment",
+        story_id: 99,
+        comment_id: 7,
+      })
+    ).toBe("/stories/99#comment-7");
+  });
+
+  it("routes to /profile for badge_earned without story context", () => {
+    expect(
+      getNotificationRoute({ notification_type: "badge_earned" })
+    ).toBe("/profile");
+  });
+
+  it("returns null when no useful target exists", () => {
+    expect(
+      getNotificationRoute({ notification_type: "moderation_action" })
+    ).toBe(null);
+    expect(getNotificationRoute(null)).toBe(null);
+  });
+});
+
+describe("formatRelativeTime", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-05-06T12:00:00Z"));
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("returns 'Just now' for recent timestamps", () => {
+    expect(formatRelativeTime("2026-05-06T11:59:30Z")).toBe("Just now");
+  });
+
+  it("returns minutes for under-an-hour values", () => {
+    expect(formatRelativeTime("2026-05-06T11:55:00Z")).toBe("5 minutes ago");
+    expect(formatRelativeTime("2026-05-06T11:59:00Z")).toBe("1 minute ago");
+  });
+
+  it("returns hours for under-a-day values", () => {
+    expect(formatRelativeTime("2026-05-06T10:00:00Z")).toBe("2 hours ago");
+    expect(formatRelativeTime("2026-05-06T11:00:00Z")).toBe("1 hour ago");
+  });
+
+  it("returns 'Yesterday' for one-day-old timestamps", () => {
+    expect(formatRelativeTime("2026-05-05T10:00:00Z")).toBe("Yesterday");
+  });
+
+  it("returns days for 2–6 day old timestamps", () => {
+    expect(formatRelativeTime("2026-05-03T12:00:00Z")).toBe("3 days ago");
+  });
+
+  it("returns a locale date for week-old or older timestamps", () => {
+    const result = formatRelativeTime("2026-04-01T12:00:00Z");
+    expect(result).not.toMatch(/ago|Yesterday|Just now/);
+    expect(result.length).toBeGreaterThan(0);
+  });
+
+  it("returns empty string for falsy or invalid input", () => {
+    expect(formatRelativeTime(null)).toBe("");
+    expect(formatRelativeTime("")).toBe("");
+    expect(formatRelativeTime("not-a-date")).toBe("");
+  });
+});
+
+describe("NOTIFICATION_TYPES", () => {
+  it("covers all 8 backend notification types", () => {
+    const keys = NOTIFICATION_TYPES.map((t) => t.key);
+    expect(keys).toEqual(
+      expect.arrayContaining([
+        "new_comment",
+        "new_like",
+        "new_follower",
+        "moderation_action",
+        "story_removed",
+        "report_resolved",
+        "badge_earned",
+        "new_story_published",
+      ])
+    );
+    expect(keys).toHaveLength(8);
+  });
+});

--- a/frontend/src/utils/notificationFormat.js
+++ b/frontend/src/utils/notificationFormat.js
@@ -1,0 +1,80 @@
+import {
+  Heart,
+  MessageCircle,
+  Shield,
+  Trash2,
+  CheckCircle2,
+  Trophy,
+  UserPlus,
+  BookOpen,
+  Bell,
+} from "lucide-react";
+
+export const NOTIFICATION_TYPES = [
+  { key: "new_comment", label: "New comments on your stories" },
+  { key: "new_like", label: "New likes on your stories" },
+  { key: "new_follower", label: "New followers" },
+  { key: "moderation_action", label: "Moderation action on your content" },
+  { key: "story_removed", label: "Your story removed by moderation" },
+  { key: "report_resolved", label: "Resolution of reports you filed" },
+  { key: "badge_earned", label: "New badge earned" },
+  { key: "new_story_published", label: "New stories from people you follow" },
+];
+
+const ICON_MAP = {
+  new_comment: MessageCircle,
+  new_like: Heart,
+  new_follower: UserPlus,
+  moderation_action: Shield,
+  story_removed: Trash2,
+  report_resolved: CheckCircle2,
+  badge_earned: Trophy,
+  new_story_published: BookOpen,
+};
+
+export function getNotificationIcon(type) {
+  return ICON_MAP[type] ?? Bell;
+}
+
+export function getNotificationRoute(notification) {
+  if (!notification) return null;
+  const { notification_type: type, story_id: storyId, comment_id: commentId, actor } = notification;
+
+  if (type === "new_follower" && actor?.id) {
+    return `/profile/${actor.id}`;
+  }
+
+  if (storyId) {
+    return commentId ? `/stories/${storyId}#comment-${commentId}` : `/stories/${storyId}`;
+  }
+
+  if (type === "badge_earned") {
+    return "/profile";
+  }
+
+  return null;
+}
+
+export function formatRelativeTime(timestamp) {
+  if (!timestamp) return "";
+  const then = new Date(timestamp).getTime();
+  if (Number.isNaN(then)) return "";
+  const diffSec = Math.floor((Date.now() - then) / 1000);
+
+  if (diffSec < 0) return "Just now";
+  if (diffSec < 60) return "Just now";
+  if (diffSec < 3600) {
+    const m = Math.floor(diffSec / 60);
+    return `${m} minute${m === 1 ? "" : "s"} ago`;
+  }
+  if (diffSec < 86400) {
+    const h = Math.floor(diffSec / 3600);
+    return `${h} hour${h === 1 ? "" : "s"} ago`;
+  }
+  if (diffSec < 86400 * 2) return "Yesterday";
+  if (diffSec < 86400 * 7) {
+    const d = Math.floor(diffSec / 86400);
+    return `${d} days ago`;
+  }
+  return new Date(timestamp).toLocaleDateString();
+}


### PR DESCRIPTION
# Description
Fixes #184

Adds the in-app notification system: a bell icon in the navbar with an unread-count badge, a dropdown panel listing notifications in reverse chronological order, per-item and "Mark all as read" controls, polling every 45s for fresh notifications, and a per-type preferences page (with a master mute toggle).

### What's included
- **Service** (`notificationService.js`) — `getNotifications`, `markAsRead`, `markAllAsRead`, `getPreferences`, `updatePreferences`. Wraps `GET /notifications/`, `PATCH /notifications/{id}/read/`, and the preferences endpoints.
- **Hook** (`useNotifications`) — fetch + polling (default 45s) + optimistic mark-read with rollback on failure. Skips fetching when unauthenticated.
- **Components** — `NotificationBell`, `NotificationPanel`, `NotificationItem`. Bell renders nothing when unauthenticated; badge shows up to "99+".
- **Page** — `/notifications/preferences` (protected). Master "Stop all notifications" toggle disables per-type toggles. All 8 backend notification types are covered (including `new_follower` and `new_story_published` which are present in the model but not listed in the issue).
- **Integration** — bell mounted in `AppLayout`; "Notifications" button added on own `ProfilePage`.
- **Routing** — clicking a notification navigates to the most relevant target: `/stories/{id}#comment-{id}` for comments, `/stories/{id}` for likes/moderation, `/profile/{actorId}` for new followers, `/profile` for badges.

### Tests
45 new tests across service, utils, hook, components, and the preferences page. All affected suites pass locally (97 / 97). Lint + build are clean. Pre-existing unrelated failure in `StoryDetailPage.test.jsx` reproduces on `main` as well — not introduced by this PR.

### Backend Context (informational, not a change request)
- The notifications API at `/notifications/` is fully implemented and matched.
- There is no bulk "mark all as read" endpoint on the backend; the frontend fans out individual `PATCH .../read/` calls for each unread id. Acceptable for current inbox sizes.

# Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Refactoring
- [ ] Documentation

# Acceptance Criteria / Checklist
- [x] Project builds successfully
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, especially in hard-to-understand parts
- [x] I have performed a self-review of my code
- [x] I have added/updated tests
- [x] New and existing unit tests pass locally with my changes

# Screenshots / Recordings
<!-- Pending — UI walkthrough to be added once the dev server is up locally. -->

# Estimated Review Time
- [ ] < 5 min
- [ ] 5-15 min
- [x] > 15 min