### PR TITLE
Fix/ expose comment ownership flag for frontend

### DIFF
--- a/backend/apps/interactions/serializers.py
+++ b/backend/apps/interactions/serializers.py
@@ -14,10 +14,12 @@ class CommentResponseSerializer(serializers.ModelSerializer):
 
     # Show username when author exists and comment is not anonymized; null otherwise.
     author_username = serializers.SerializerMethodField()
+    # True when the requesting user is the comment author, regardless of username visibility.
+    is_own_comment = serializers.SerializerMethodField()
 
     class Meta:
         model = Comment
-        fields = ['id', 'story_id', 'author_username', 'text', 'is_anonymized', 'created_at']
+        fields = ['id', 'story_id', 'author_username', 'text', 'is_anonymized', 'created_at', 'is_own_comment']
 
     def get_author_username(self, obj):
         if obj.is_anonymized or obj.author is None:
@@ -25,6 +27,12 @@ class CommentResponseSerializer(serializers.ModelSerializer):
         if not obj.author.is_username_public:
             return None
         return obj.author.username
+
+    def get_is_own_comment(self, obj):
+        request = self.context.get('request')
+        if request is None or not request.user.is_authenticated:
+            return False
+        return obj.author_id == request.user.id
 
 
 class LikeResponseSerializer(serializers.ModelSerializer):

--- a/backend/apps/interactions/tests/test_serializers.py
+++ b/backend/apps/interactions/tests/test_serializers.py
@@ -83,8 +83,7 @@ class TestCommentResponseSerializer:
     def test_get_is_own_comment_returns_true_for_author(self, user, story):
         comment = Comment.objects.create(story=story, author=user, text='Mine')
         request = MagicMock()
-        request.user = user
-        request.user.is_authenticated = True
+        request.user = user  # is_authenticated is a property that returns True for active users
         data = CommentResponseSerializer(comment, context={'request': request}).data
         assert data['is_own_comment'] is True
 
@@ -95,7 +94,6 @@ class TestCommentResponseSerializer:
         comment = Comment.objects.create(story=story, author=user, text='Not yours')
         request = MagicMock()
         request.user = other
-        request.user.is_authenticated = True
         data = CommentResponseSerializer(comment, context={'request': request}).data
         assert data['is_own_comment'] is False
 
@@ -105,9 +103,10 @@ class TestCommentResponseSerializer:
         assert data['is_own_comment'] is False
 
     def test_get_is_own_comment_returns_false_for_unauthenticated(self, user, story):
+        from django.contrib.auth.models import AnonymousUser
         comment = Comment.objects.create(story=story, author=user, text='Anon viewer')
         request = MagicMock()
-        request.user.is_authenticated = False
+        request.user = AnonymousUser()
         data = CommentResponseSerializer(comment, context={'request': request}).data
         assert data['is_own_comment'] is False
 
@@ -120,7 +119,6 @@ class TestCommentResponseSerializer:
         comment = Comment.objects.create(story=story, author=private_user, text='Incognito')
         request = MagicMock()
         request.user = private_user
-        request.user.is_authenticated = True
         data = CommentResponseSerializer(comment, context={'request': request}).data
         assert data['author_username'] is None
         assert data['is_own_comment'] is True

--- a/backend/apps/interactions/tests/test_serializers.py
+++ b/backend/apps/interactions/tests/test_serializers.py
@@ -1,5 +1,6 @@
 """Unit tests for interaction serializers."""
 from decimal import Decimal
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -57,7 +58,7 @@ class TestCommentResponseSerializer:
     def test_response_serializer_includes_required_fields(self, user, story):
         comment = Comment.objects.create(story=story, author=user, text='Hi')
         data = CommentResponseSerializer(comment).data
-        for field in ['id', 'story_id', 'author_username', 'text', 'is_anonymized', 'created_at']:
+        for field in ['id', 'story_id', 'author_username', 'text', 'is_anonymized', 'created_at', 'is_own_comment']:
             assert field in data
 
     def test_response_serializer_hides_username_when_private(self, story):
@@ -78,6 +79,51 @@ class TestCommentResponseSerializer:
         comment = Comment.objects.create(story=story, author=public_user, text='Visible')
         data = CommentResponseSerializer(comment).data
         assert data['author_username'] == 'publicuser'
+
+    def test_get_is_own_comment_returns_true_for_author(self, user, story):
+        comment = Comment.objects.create(story=story, author=user, text='Mine')
+        request = MagicMock()
+        request.user = user
+        request.user.is_authenticated = True
+        data = CommentResponseSerializer(comment, context={'request': request}).data
+        assert data['is_own_comment'] is True
+
+    def test_get_is_own_comment_returns_false_for_other_user(self, user, story):
+        other = User.objects.create_user(
+            email='other_ser@example.com', username='otherser', password='Password1', is_active=True,
+        )
+        comment = Comment.objects.create(story=story, author=user, text='Not yours')
+        request = MagicMock()
+        request.user = other
+        request.user.is_authenticated = True
+        data = CommentResponseSerializer(comment, context={'request': request}).data
+        assert data['is_own_comment'] is False
+
+    def test_get_is_own_comment_returns_false_when_no_request_context(self, user, story):
+        comment = Comment.objects.create(story=story, author=user, text='No ctx')
+        data = CommentResponseSerializer(comment).data
+        assert data['is_own_comment'] is False
+
+    def test_get_is_own_comment_returns_false_for_unauthenticated(self, user, story):
+        comment = Comment.objects.create(story=story, author=user, text='Anon viewer')
+        request = MagicMock()
+        request.user.is_authenticated = False
+        data = CommentResponseSerializer(comment, context={'request': request}).data
+        assert data['is_own_comment'] is False
+
+    def test_get_is_own_comment_true_when_author_username_is_null(self, story):
+        # Regression: private profile hides username but must still flag own comment.
+        private_user = User.objects.create_user(
+            email='private_own@example.com', username='privateown', password='Password1',
+            is_username_public=False, is_active=True,
+        )
+        comment = Comment.objects.create(story=story, author=private_user, text='Incognito')
+        request = MagicMock()
+        request.user = private_user
+        request.user.is_authenticated = True
+        data = CommentResponseSerializer(comment, context={'request': request}).data
+        assert data['author_username'] is None
+        assert data['is_own_comment'] is True
 
 
 # ── LikeResponseSerializer ────────────────────────────────────────────────────

--- a/backend/apps/interactions/tests/test_views.py
+++ b/backend/apps/interactions/tests/test_views.py
@@ -100,8 +100,17 @@ class TestStoryCommentCreate:
         )
         assert response.status_code == 201
         comment_data = response.data['comment']
-        for field in ['id', 'story_id', 'author_username', 'text', 'is_anonymized', 'created_at']:
+        for field in ['id', 'story_id', 'author_username', 'text', 'is_anonymized', 'created_at', 'is_own_comment']:
             assert field in comment_data
+
+    def test_create_comment_response_is_own_comment_true(self, auth_client, story):
+        response = auth_client.post(
+            self.url.format(story_id=story.pk),
+            {'text': 'My own comment'},
+            format='json',
+        )
+        assert response.status_code == 201
+        assert response.data['comment']['is_own_comment'] is True
 
 
 # ── DELETE /comments/<comment_id>/ ───────────────────────────────────────────
@@ -257,7 +266,7 @@ class TestStoryCommentList:
         Comment.objects.create(story=story, author=user, text='Hello')
         response = client.get(self.url.format(story_id=story.pk))
         result = response.data['results'][0]
-        assert set(result.keys()) == {'id', 'story_id', 'author_username', 'text', 'is_anonymized', 'created_at'}
+        assert set(result.keys()) == {'id', 'story_id', 'author_username', 'text', 'is_anonymized', 'created_at', 'is_own_comment'}
 
     def test_comments_ordered_oldest_first(self, client, story, user):
         c1 = Comment.objects.create(story=story, author=user, text='Older')
@@ -320,6 +329,35 @@ class TestStoryCommentList:
         response = client.get(self.url.format(story_id=story.pk))
         assert response.data['count'] == 1
         assert response.data['results'][0]['text'] == 'For first story'
+
+    def test_list_comments_is_own_comment_true_for_authenticated_author(self, auth_client, user, story):
+        Comment.objects.create(story=story, author=user, text='My comment')
+        response = auth_client.get(self.url.format(story_id=story.pk))
+        assert response.data['results'][0]['is_own_comment'] is True
+
+    def test_list_comments_is_own_comment_false_for_other_user(self, client, user, story, second_user):
+        Comment.objects.create(story=story, author=user, text='Not mine')
+        client.force_authenticate(user=second_user)
+        response = client.get(self.url.format(story_id=story.pk))
+        assert response.data['results'][0]['is_own_comment'] is False
+
+    def test_list_comments_is_own_comment_false_for_unauthenticated(self, client, user, story):
+        Comment.objects.create(story=story, author=user, text='Anonymous viewer')
+        response = client.get(self.url.format(story_id=story.pk))
+        assert response.data['results'][0]['is_own_comment'] is False
+
+    def test_list_comments_is_own_comment_true_when_author_username_is_null(self, client, story):
+        # Regression: private profile hides author_username but is_own_comment must still be True.
+        private_user = User.objects.create_user(
+            email='private_view2@example.com', username='privateview2', password='Password1',
+            is_username_public=False, is_active=True,
+        )
+        Comment.objects.create(story=story, author=private_user, text='Hidden identity')
+        client.force_authenticate(user=private_user)
+        response = client.get(self.url.format(story_id=story.pk))
+        result = response.data['results'][0]
+        assert result['author_username'] is None
+        assert result['is_own_comment'] is True
 
 
 # ── POST /stories/<story_id>/bookmark/ ───────────────────────────────────────

--- a/backend/apps/interactions/views.py
+++ b/backend/apps/interactions/views.py
@@ -40,7 +40,7 @@ class StoryCommentListCreateView(APIView):
         qs = get_story_comments(story_id)
         paginator = StoryPagination()
         page = paginator.paginate_queryset(qs, request)
-        serializer = CommentResponseSerializer(page, many=True)
+        serializer = CommentResponseSerializer(page, many=True, context={'request': request})
         return paginator.get_paginated_response(serializer.data)
 
     def post(self, request, story_id):
@@ -50,7 +50,7 @@ class StoryCommentListCreateView(APIView):
         return Response(
             {
                 'message': 'Comment added successfully.',
-                'comment': CommentResponseSerializer(comment).data,
+                'comment': CommentResponseSerializer(comment, context={'request': request}).data,
             },
             status=status.HTTP_201_CREATED,
         )


### PR DESCRIPTION
# 📝 Description

Fixes #544

This PR fixes the problem where the frontend could not reliably determine whether a comment belongs to the currently authenticated user when the comment author's username is hidden.

Previously, comment responses only included `author_username`. However, `author_username` can be `null` when:
- the comment is anonymized,
- the author has a private username,
- or the author information should not be publicly displayed.

Because of this, the frontend could not safely decide whether to show owner-only actions such as edit/delete controls for a comment.

To solve this, this PR adds a new boolean field to comment responses:

`is_own_comment`

This field is independent from username visibility. It returns `true` only when the requesting authenticated user is the author of the comment, and `false` otherwise.

Implemented changes:
- Added `is_own_comment` to `CommentResponseSerializer`.
- Updated the comment list endpoint to pass `request` into serializer context.
- Updated the comment creation response to also include the correct `is_own_comment` value.
- Kept existing privacy behavior unchanged:
  - `author_username` is still hidden when the comment is anonymized or the author's username is private.
  - `is_own_comment` still works correctly even when `author_username` is `null`.
- Added serializer and view tests for authenticated users, unauthenticated users, other users, missing request context, comment creation, comment listing, and the private username regression case.

# 📊 Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactoring
- [ ] Documentation

# ✅ Acceptance Criteria / Checklist

- [x] Project builds successfully
- [x] Style guidelines followed
- [x] Code commented where necessary
- [x] Self-review performed
- [x] Tests added/updated
- [x] Tests pass locally


# ⏱️ Estimated Review Time

- [x] < 5 min
- [ ] 5–15 min
- [ ] > 15 min