### PR TITLE
Feat/frontend temporal resolution edtf

### DIFF
--- a/frontend/src/components/StoryCard/__tests__/StoryCard.test.jsx
+++ b/frontend/src/components/StoryCard/__tests__/StoryCard.test.jsx
@@ -82,6 +82,23 @@ describe("formatTimePeriod", () => {
     ).toBe("1400\u20131500");
   });
 
+  it("formats exact_date as a human-readable date", () => {
+    const result = formatTimePeriod({
+      time_type: "exact_date",
+      date_value: "1965-04-12",
+    });
+    expect(result).toMatch(/^Apr\s*12,\s*1965$/);
+  });
+
+  it("formats exact_date with a time when provided", () => {
+    const result = formatTimePeriod({
+      time_type: "exact_date",
+      date_value: "1965-04-12",
+      time_value: "14:30",
+    });
+    expect(result).toMatch(/^Apr\s*12,\s*1965\s*14:30$/);
+  });
+
   it("returns empty string for unknown time_type", () => {
     expect(formatTimePeriod({ time_type: "unknown" })).toBe("");
   });

--- a/frontend/src/components/StoryCard/storyCardUtils.js
+++ b/frontend/src/components/StoryCard/storyCardUtils.js
@@ -5,8 +5,29 @@ export function truncateAtWord(text, maxChars = 80) {
   return (lastSpace > 0 ? truncated.slice(0, lastSpace) : truncated) + "…";
 }
 
+const MONTHS = [
+  "Jan", "Feb", "Mar", "Apr", "May", "Jun",
+  "Jul", "Aug", "Sep", "Oct", "Nov", "Dec",
+];
+
+function formatExactDate(dateValue, timeValue) {
+  if (typeof dateValue !== "string") return "";
+  const m = dateValue.match(/^(\d{4})-(\d{2})-(\d{2})/);
+  if (!m) return "";
+  const year = m[1];
+  const monthIdx = Number(m[2]) - 1;
+  const day = Number(m[3]);
+  const month = MONTHS[monthIdx] ?? m[2];
+  const base = `${month}\u00a0${day},\u00a0${year}`;
+  if (typeof timeValue === "string") {
+    const t = timeValue.match(/^(\d{2}):(\d{2})/);
+    if (t) return `${base}\u00a0${t[1]}:${t[2]}`;
+  }
+  return base;
+}
+
 export function formatTimePeriod(story) {
-  const { time_type, year, year_start, year_end } = story;
+  const { time_type, year, year_start, year_end, date_value, time_value } = story;
   switch (time_type) {
     case "exact_year":
       return String(year);
@@ -17,6 +38,8 @@ export function formatTimePeriod(story) {
     case "year_range":
       if (year_start == null || year_end == null) return "";
       return `${year_start}\u2013${year_end}`;
+    case "exact_date":
+      return formatExactDate(date_value, time_value);
     default:
       return "";
   }

--- a/frontend/src/components/StructuredData/StructuredData.jsx
+++ b/frontend/src/components/StructuredData/StructuredData.jsx
@@ -1,4 +1,5 @@
 import { SITE_URL } from "./constants";
+import { toISO8601 } from "@/utils/edtf";
 
 function assignIfDefined(target, key, value) {
   if (value !== null && value !== undefined) {
@@ -6,25 +7,16 @@ function assignIfDefined(target, key, value) {
   }
 }
 
+/**
+ * Story.temporalCoverage for JSON-LD must be a valid ISO 8601 string so Google's
+ * Rich Results validator accepts it. We prefer the backend-derived ISO string
+ * (`temporal_coverage_iso`) when present; otherwise we derive a lossy ISO 8601
+ * from the EDTF-aware fields. The full EDTF form lives in `temporal_coverage`
+ * and is used elsewhere in the UI.
+ */
 function deriveTemporalCoverage(story) {
-  if (story.temporal_coverage_iso8601) return story.temporal_coverage_iso8601;
-  const { time_type, year, year_start, year_end } = story;
-  switch (time_type) {
-    case "exact_year":
-    case "approximate_year":
-      return year != null ? String(year) : undefined;
-    case "decade": {
-      if (year == null) return undefined;
-      const start = Math.floor(year / 10) * 10;
-      return `${start}/${start + 9}`;
-    }
-    case "year_range":
-      return year_start != null && year_end != null
-        ? `${year_start}/${year_end}`
-        : undefined;
-    default:
-      return undefined;
-  }
+  if (story.temporal_coverage_iso) return story.temporal_coverage_iso;
+  return toISO8601(story);
 }
 
 function buildStoryStructuredData(story) {

--- a/frontend/src/components/StructuredData/__tests__/StructuredData.test.jsx
+++ b/frontend/src/components/StructuredData/__tests__/StructuredData.test.jsx
@@ -177,18 +177,56 @@ describe("StructuredData", () => {
         expect(getJsonLd(container).temporalCoverage).toBe("1950/1975");
       });
 
-      it("prefers temporal_coverage_iso8601 from the API over derivation", () => {
+      it("exact_date yields the ISO date", () => {
+        const { container } = render(
+          <StructuredData
+            story={makeStory({
+              time_type: "exact_date",
+              year: null,
+              date_value: "1965-04-12",
+            })}
+          />
+        );
+        expect(getJsonLd(container).temporalCoverage).toBe("1965-04-12");
+      });
+
+      it("exact_date with a time yields ISO date+time", () => {
+        const { container } = render(
+          <StructuredData
+            story={makeStory({
+              time_type: "exact_date",
+              year: null,
+              date_value: "1965-04-12",
+              time_value: "14:30",
+            })}
+          />
+        );
+        expect(getJsonLd(container).temporalCoverage).toBe("1965-04-12T14:30");
+      });
+
+      it("approximate_year is rendered as a bare year (lossy ISO 8601 from EDTF)", () => {
+        const { container } = render(
+          <StructuredData
+            story={makeStory({ time_type: "approximate_year", year: 1965 })}
+          />
+        );
+        // EDTF "1965~" must be lossily mapped to "1965" for Schema.org/Google validators.
+        expect(getJsonLd(container).temporalCoverage).toBe("1965");
+      });
+
+      it("prefers temporal_coverage_iso from the backend over derivation", () => {
         const { container } = render(
           <StructuredData
             story={makeStory({
               time_type: "decade",
               year: 1960,
-              temporal_coverage_iso8601: "1961-03",
+              temporal_coverage_iso: "1961-03",
             })}
           />
         );
         expect(getJsonLd(container).temporalCoverage).toBe("1961-03");
       });
+
     });
   });
 

--- a/frontend/src/pages/SubmitStoryPage.jsx
+++ b/frontend/src/pages/SubmitStoryPage.jsx
@@ -15,6 +15,7 @@ const TIME_TYPES = [
   { value: "approximate_year", label: "Approximate Year" },
   { value: "decade", label: "Decade" },
   { value: "year_range", label: "Year Range" },
+  { value: "exact_date", label: "Specific Date" },
 ];
 
 const MAX_TAGS = 3;
@@ -41,6 +42,8 @@ function SubmitStoryPage() {
   const [year, setYear] = useState("");
   const [yearStart, setYearStart] = useState("");
   const [yearEnd, setYearEnd] = useState("");
+  const [dateValue, setDateValue] = useState("");
+  const [timeValue, setTimeValue] = useState("");
   const [selectedTags, setSelectedTags] = useState([]);
   const [imageFiles, setImageFiles] = useState([]);
   const [imagePreviews, setImagePreviews] = useState([]);
@@ -80,6 +83,15 @@ function SubmitStoryPage() {
       else if (isNaN(Number(yearEnd))) errors.yearEnd = "End year must be a valid number";
       if (!errors.yearStart && !errors.yearEnd && Number(yearStart) >= Number(yearEnd)) {
         errors.yearStart = "Start year must be before end year";
+      }
+    } else if (timeType === "exact_date") {
+      if (!dateValue.trim()) {
+        errors.dateValue = "Date is required";
+      } else if (!/^\d{4}-\d{2}-\d{2}$/.test(dateValue)) {
+        errors.dateValue = "Date must be in YYYY-MM-DD format";
+      }
+      if (timeValue && !/^\d{2}:\d{2}$/.test(timeValue)) {
+        errors.timeValue = "Time must be in HH:MM format";
       }
     } else {
       if (!year.toString().trim()) errors.year = "Year is required";
@@ -217,6 +229,9 @@ function SubmitStoryPage() {
       if (timeType === "year_range") {
         if (yearStart) formData.append("year_start", yearStart);
         if (yearEnd) formData.append("year_end", yearEnd);
+      } else if (timeType === "exact_date") {
+        if (dateValue) formData.append("date_value", dateValue);
+        if (timeValue) formData.append("time_value", timeValue);
       } else {
         if (year) formData.append("year", year);
       }
@@ -385,8 +400,45 @@ function SubmitStoryPage() {
             </select>
           </div>
 
-          {/* Year inputs */}
-          {timeType === "year_range" ? (
+          {/* Year / date inputs */}
+          {timeType === "exact_date" ? (
+            <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+              <div className="space-y-2">
+                <Label htmlFor="dateValue">Date</Label>
+                <Input
+                  id="dateValue"
+                  type="date"
+                  value={dateValue}
+                  onChange={(e) => {
+                    setDateValue(e.target.value);
+                    if (fieldErrors.dateValue)
+                      setFieldErrors((prev) => ({ ...prev, dateValue: "" }));
+                  }}
+                  disabled={isSubmitting}
+                />
+                {fieldErrors.dateValue && (
+                  <p className="text-sm text-destructive">{fieldErrors.dateValue}</p>
+                )}
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="timeValue">Time (optional)</Label>
+                <Input
+                  id="timeValue"
+                  type="time"
+                  value={timeValue}
+                  onChange={(e) => {
+                    setTimeValue(e.target.value);
+                    if (fieldErrors.timeValue)
+                      setFieldErrors((prev) => ({ ...prev, timeValue: "" }));
+                  }}
+                  disabled={isSubmitting || !dateValue}
+                />
+                {fieldErrors.timeValue && (
+                  <p className="text-sm text-destructive">{fieldErrors.timeValue}</p>
+                )}
+              </div>
+            </div>
+          ) : timeType === "year_range" ? (
             <div className="grid grid-cols-2 gap-4">
               <div className="space-y-2">
                 <Label htmlFor="yearStart">Start Year</Label>

--- a/frontend/src/pages/__tests__/SubmitStoryPage.test.jsx
+++ b/frontend/src/pages/__tests__/SubmitStoryPage.test.jsx
@@ -760,4 +760,62 @@ describe("SubmitStoryPage", () => {
     expect(toggle).toHaveAttribute("aria-checked", "true");
   });
 
+  it("shows date and time inputs when Specific Date is selected", async () => {
+    const user = userEvent.setup();
+    renderPage();
+
+    await user.selectOptions(screen.getByLabelText(/time type/i), "exact_date");
+
+    expect(screen.getByLabelText(/^date$/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/time \(optional\)/i)).toBeInTheDocument();
+  });
+
+  it("disables the time input until a date is chosen", async () => {
+    const user = userEvent.setup();
+    renderPage();
+
+    await user.selectOptions(screen.getByLabelText(/time type/i), "exact_date");
+    expect(screen.getByLabelText(/time \(optional\)/i)).toBeDisabled();
+
+    fireEvent.change(screen.getByLabelText(/^date$/i), { target: { value: "1965-04-12" } });
+    expect(screen.getByLabelText(/time \(optional\)/i)).not.toBeDisabled();
+  });
+
+  it("requires a date when exact_date is selected", async () => {
+    const user = userEvent.setup();
+    renderPage();
+
+    await user.selectOptions(screen.getByLabelText(/time type/i), "exact_date");
+    await user.click(screen.getByRole("button", { name: /submit story/i }));
+
+    expect(screen.getByText(/date is required/i)).toBeInTheDocument();
+  });
+
+  it("submits date_value (and optional time_value) for exact_date", async () => {
+    const user = userEvent.setup();
+    createStory.mockResolvedValue({ id: 99 });
+    renderPage();
+
+    await user.type(screen.getByLabelText(/title/i), "My Story");
+    await user.type(screen.getByLabelText(/narrative/i), "A great narrative");
+    await user.type(screen.getByLabelText(/place name/i), "Istanbul");
+    await user.click(screen.getByTestId("mock-map-click"));
+
+    await user.selectOptions(screen.getByLabelText(/time type/i), "exact_date");
+    fireEvent.change(screen.getByLabelText(/^date$/i), { target: { value: "1965-04-12" } });
+    fireEvent.change(screen.getByLabelText(/time \(optional\)/i), { target: { value: "14:30" } });
+
+    await user.click(screen.getByRole("button", { name: /submit story/i }));
+
+    await waitFor(() => {
+      expect(createStory).toHaveBeenCalled();
+    });
+
+    const formData = createStory.mock.calls[0][0];
+    expect(formData.get("time_type")).toBe("exact_date");
+    expect(formData.get("date_value")).toBe("1965-04-12");
+    expect(formData.get("time_value")).toBe("14:30");
+    expect(formData.get("year")).toBeNull();
+  });
+
 });

--- a/frontend/src/utils/__tests__/edtf.test.js
+++ b/frontend/src/utils/__tests__/edtf.test.js
@@ -1,0 +1,78 @@
+import { describe, it, expect } from "vitest";
+
+import { toEDTF, toISO8601 } from "../edtf";
+
+describe("toEDTF", () => {
+  it("formats exact_year as a plain year", () => {
+    expect(toEDTF({ time_type: "exact_year", year: 1965 })).toBe("1965");
+  });
+
+  it("formats approximate_year with the EDTF '~' suffix", () => {
+    expect(toEDTF({ time_type: "approximate_year", year: 1965 })).toBe("1965~");
+  });
+
+  it("formats decade as the EDTF 'X' form", () => {
+    expect(toEDTF({ time_type: "decade", year: 1960 })).toBe("196X");
+    expect(toEDTF({ time_type: "decade", year: 1875 })).toBe("187X");
+  });
+
+  it("formats year_range as start/end", () => {
+    expect(
+      toEDTF({ time_type: "year_range", year_start: 1950, year_end: 1975 })
+    ).toBe("1950/1975");
+  });
+
+  it("formats exact_date without a time as YYYY-MM-DD", () => {
+    expect(
+      toEDTF({ time_type: "exact_date", date_value: "1965-04-12" })
+    ).toBe("1965-04-12");
+  });
+
+  it("formats exact_date with a time as YYYY-MM-DDTHH:MM", () => {
+    expect(
+      toEDTF({
+        time_type: "exact_date",
+        date_value: "1965-04-12",
+        time_value: "14:30",
+      })
+    ).toBe("1965-04-12T14:30");
+  });
+
+  it("returns undefined for missing required fields", () => {
+    expect(toEDTF({ time_type: "exact_year" })).toBeUndefined();
+    expect(toEDTF({ time_type: "year_range", year_start: 1950 })).toBeUndefined();
+    expect(toEDTF({ time_type: "exact_date" })).toBeUndefined();
+    expect(toEDTF({ time_type: "unknown", year: 1900 })).toBeUndefined();
+  });
+});
+
+describe("toISO8601", () => {
+  it("renders approximate_year as the bare year (lossy)", () => {
+    expect(toISO8601({ time_type: "approximate_year", year: 1965 })).toBe("1965");
+  });
+
+  it("renders a decade as a closed ISO 8601 interval", () => {
+    expect(toISO8601({ time_type: "decade", year: 1960 })).toBe("1960/1969");
+    expect(toISO8601({ time_type: "decade", year: 1875 })).toBe("1870/1879");
+  });
+
+  it("renders year_range identically to EDTF", () => {
+    expect(
+      toISO8601({ time_type: "year_range", year_start: 1950, year_end: 1975 })
+    ).toBe("1950/1975");
+  });
+
+  it("renders exact_date and exact_year unchanged", () => {
+    expect(toISO8601({ time_type: "exact_year", year: 1965 })).toBe("1965");
+    expect(
+      toISO8601({ time_type: "exact_date", date_value: "1965-04-12" })
+    ).toBe("1965-04-12");
+    expect(
+      toISO8601({
+        time_type: "exact_date",
+        date_value: "1965-04-12",
+        time_value: "14:30",
+      })
+    ).toBe("1965-04-12T14:30");
+  });
+});

--- a/frontend/src/utils/edtf.js
+++ b/frontend/src/utils/edtf.js
@@ -1,0 +1,112 @@
+/**
+ * EDTF (Extended Date/Time Format) helpers for story temporal coverage.
+ *
+ * Mirrors backend/apps/stories/temporal.py — keep both in sync.
+ *
+ * EDTF examples:
+ *   exact_year:       "1965"
+ *   approximate_year: "1965~"
+ *   decade:           "196X"          (year=1960 → "196X")
+ *   year_range:       "1950/1975"
+ *   exact_date:       "1965-04-12" or "1965-04-12T14:30"
+ *
+ * ISO 8601 (lossy) for JSON-LD / Schema.org:
+ *   approximate_year: "1965"
+ *   decade:           "1960/1969"
+ *   exact_date:       same as EDTF (already ISO-compatible)
+ */
+
+function pad2(n) {
+  return String(n).padStart(2, "0");
+}
+
+function decadeBase(year) {
+  return Math.floor(Number(year) / 10) * 10;
+}
+
+export function toEDTF({
+  time_type,
+  year,
+  year_start,
+  year_end,
+  date_value,
+  time_value,
+} = {}) {
+  switch (time_type) {
+    case "exact_year":
+      return year != null && year !== "" ? String(year) : undefined;
+    case "approximate_year":
+      return year != null && year !== "" ? `${year}~` : undefined;
+    case "decade":
+      if (year == null || year === "") return undefined;
+      return `${Math.floor(Number(year) / 10)}X`;
+    case "year_range":
+      if (year_start == null || year_start === "") return undefined;
+      if (year_end == null || year_end === "") return undefined;
+      return `${year_start}/${year_end}`;
+    case "exact_date": {
+      if (!date_value) return undefined;
+      const base = formatDate(date_value);
+      if (!base) return undefined;
+      const t = formatTime(time_value);
+      return t ? `${base}T${t}` : base;
+    }
+    default:
+      return undefined;
+  }
+}
+
+export function toISO8601({
+  time_type,
+  year,
+  year_start,
+  year_end,
+  date_value,
+  time_value,
+} = {}) {
+  switch (time_type) {
+    case "exact_year":
+    case "approximate_year":
+      return year != null && year !== "" ? String(year) : undefined;
+    case "decade": {
+      if (year == null || year === "") return undefined;
+      const base = decadeBase(year);
+      return `${base}/${base + 9}`;
+    }
+    case "year_range":
+      if (year_start == null || year_start === "") return undefined;
+      if (year_end == null || year_end === "") return undefined;
+      return `${year_start}/${year_end}`;
+    case "exact_date": {
+      if (!date_value) return undefined;
+      const base = formatDate(date_value);
+      if (!base) return undefined;
+      const t = formatTime(time_value);
+      return t ? `${base}T${t}` : base;
+    }
+    default:
+      return undefined;
+  }
+}
+
+function formatDate(value) {
+  if (!value) return undefined;
+  if (typeof value === "string") {
+    // Already ISO-like (YYYY-MM-DD); take first 10 chars.
+    const m = value.match(/^(\d{4})-(\d{2})-(\d{2})/);
+    return m ? `${m[1]}-${m[2]}-${m[3]}` : undefined;
+  }
+  if (value instanceof Date && !Number.isNaN(value.getTime())) {
+    return `${value.getFullYear()}-${pad2(value.getMonth() + 1)}-${pad2(value.getDate())}`;
+  }
+  return undefined;
+}
+
+function formatTime(value) {
+  if (!value) return undefined;
+  if (typeof value === "string") {
+    const m = value.match(/^(\d{2}):(\d{2})/);
+    return m ? `${m[1]}:${m[2]}` : undefined;
+  }
+  return undefined;
+}


### PR DESCRIPTION
# 📝 Description
Fixes #381 

Adds Extended Date/Time Format (EDTF) support to the story submission flow so narrators can record specific dates (with optional times) in addition to year-based memories. Internally, all temporal data is represented as EDTF (1965~, 196X, 1950/1975, 1965-04-12T14:30), while JSON-LD output emits a lossy ISO 8601 form so Google Rich Results validates correctly. Existing time-type rendering is unchanged for users.                                
                                                            
###  New features

  - New Specific Date option in the time-type dropdown on the submission form, with a required date input and an optional time input (disabled until a date is set).
  - New src/utils/edtf.js with toEDTF / toISO8601 helpers, mirroring backend/apps/stories/temporal.py 1:1.                                             
  - StructuredData now derives temporalCoverage via the EDTF→ISO 8601 helper (e.g., 196X → 1960/1969, 1965~ → 1965, 1965-04-12T14:30 passthrough).     
  - formatTimePeriod renders exact_date as a human-readable date (Apr 12, 1965, optionally with 14:30).                                                
                                                                                                                                                       
### Modified files                                                                                                                                       
                                                                                                                                                       
  - frontend/src/pages/SubmitStoryPage.jsx — exact_date branch in validation, FormData payload, and form UI.                                           
  - frontend/src/components/StructuredData/StructuredData.jsx — replaces inline switch with toISO8601; drops unused temporal_coverage_iso8601 legacy field, prefers backend's temporal_coverage_iso.                                                                                                      
  - frontend/src/components/StoryCard/storyCardUtils.js — adds exact_date arm to formatTimePeriod; existing arms unchanged.
                                                                                                                                                       
 ### Tests                                                     
                                                                                                                                                       
  - src/utils/__tests__/edtf.test.js — full coverage for all five EDTF forms and lossy ISO mapping.                                                    
  - SubmitStoryPage.test.jsx — Specific Date renders date+time inputs, time disabled until date set, date is required, FormData sends time_type=exact_date with date_value (and time_value when given).                                                                                    
  - StructuredData.test.jsx — exact_date, exact_date+time, approximate-year lossy mapping, prefers backend-supplied temporal_coverage_iso.
  - StoryCard.test.jsx — formatTimePeriod for exact_date with and without time. 

# 📊 Type of Change
- [ ]  Bug fix
- [x]  New feature
- [ ]  Refactoring
- [ ]  Documentation
 
# ✅ Acceptance Criteria / Checklist
- [x] Project builds successfully
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, especially in hard-to-understand parts
- [x] I have performed a self-review of my code
- [x] I have added/updated tests
- [x] New and existing unit tests pass locally with my changes

# 📸 Screenshots / Recordings
<!-- If applicable !-->
# ⏱️ Estimated Review Time
- [ ] < 5 min
- [x] 5-15 min
- [ ] > 15 min
