### PR TITLE
fix:map-pins-mobile

### DIFF
--- a/mobile/src/features/map/data/repositories/__tests__/MapRepository.test.ts
+++ b/mobile/src/features/map/data/repositories/__tests__/MapRepository.test.ts
@@ -8,6 +8,10 @@ jest.mock('../../../../stories/application/services', () => ({
 }));
 
 describe('MapRepositoryImpl', () => {
+  beforeEach(() => {
+    jest.mocked(storyService.getMapPins).mockReset();
+  });
+
   it('returns one marker per story pin without clustering', async () => {
     const getMapPins = jest.mocked(storyService.getMapPins);
     getMapPins.mockResolvedValue([
@@ -49,6 +53,64 @@ describe('MapRepositoryImpl', () => {
         latitude: 41.0202,
         longitude: 28.9601,
         stories: [expect.objectContaining({ id: 'story-2' })],
+        count: 1,
+        isCluster: false,
+      },
+    ]);
+  });
+
+  it('groups pins with duplicate coordinates into a tappable cluster marker', async () => {
+    const getMapPins = jest.mocked(storyService.getMapPins);
+    getMapPins.mockResolvedValue([
+      {
+        id: 'story-1',
+        title: 'Story 1',
+        placeName: 'Golden Horn',
+        timePeriod: '2021',
+        previewText: 'Preview 1',
+        latitude: 41.02,
+        longitude: 28.96,
+      },
+      {
+        id: 'story-2',
+        title: 'Story 2',
+        placeName: 'Golden Horn',
+        timePeriod: '2022',
+        previewText: 'Preview 2',
+        latitude: 41.02,
+        longitude: 28.96,
+      },
+      {
+        id: 'story-3',
+        title: 'Story 3',
+        placeName: 'Balat',
+        timePeriod: '2023',
+        previewText: 'Preview 3',
+        latitude: 41.031,
+        longitude: 28.949,
+      },
+    ]);
+
+    const repository = new MapRepositoryImpl();
+    const markers = await repository.getMarkerGroups();
+
+    expect(markers).toEqual([
+      {
+        id: 'coordinate:41.02:28.96',
+        latitude: 41.02,
+        longitude: 28.96,
+        stories: [
+          expect.objectContaining({ id: 'story-1' }),
+          expect.objectContaining({ id: 'story-2' }),
+        ],
+        count: 2,
+        isCluster: true,
+      },
+      {
+        id: 'story-3',
+        latitude: 41.031,
+        longitude: 28.949,
+        stories: [expect.objectContaining({ id: 'story-3' })],
         count: 1,
         isCluster: false,
       },

--- a/mobile/src/features/map/data/repositories/index.ts
+++ b/mobile/src/features/map/data/repositories/index.ts
@@ -5,14 +5,31 @@ import { MapMarkerGroup } from '../../domain/entities';
 export class MapRepositoryImpl {
   async getMarkerGroups(filters: StoryFilters = {}): Promise<MapMarkerGroup[]> {
     const pins = await storyService.getMapPins(filters);
+    const groupsByCoordinate = new Map<string, typeof pins>();
 
-    return pins.map((pin) => ({
-      id: pin.id,
-      latitude: pin.latitude,
-      longitude: pin.longitude,
-      stories: [pin],
-      count: 1,
-      isCluster: false,
-    }));
+    pins.forEach((pin) => {
+      const key = `${pin.latitude}:${pin.longitude}`;
+      const group = groupsByCoordinate.get(key);
+
+      if (group) {
+        group.push(pin);
+        return;
+      }
+
+      groupsByCoordinate.set(key, [pin]);
+    });
+
+    return Array.from(groupsByCoordinate.entries()).map(([coordinateKey, group]) => {
+      const firstPin = group[0];
+
+      return {
+        id: group.length === 1 ? firstPin.id : `coordinate:${coordinateKey}`,
+        latitude: firstPin.latitude,
+        longitude: firstPin.longitude,
+        stories: group,
+        count: group.length,
+        isCluster: group.length > 1,
+      };
+    });
   }
 }

--- a/mobile/src/features/map/presentation/screens/MapScreen.tsx
+++ b/mobile/src/features/map/presentation/screens/MapScreen.tsx
@@ -71,6 +71,7 @@ export function MapScreen({
   const previousMapPinFilterKeyRef = useRef<string | null>(null);
   const loadRequestIdRef = useRef(0);
   const previewOffsetRef = useRef<number | null>(null);
+  const previewScrollTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   useEffect(() => {
     if (filters.query !== debouncedQuery) {
@@ -182,6 +183,15 @@ export function MapScreen({
     };
   }, [isHydrated, loadMarkers, onRegisterRefresh]);
 
+  useEffect(
+    () => () => {
+      if (previewScrollTimerRef.current) {
+        clearTimeout(previewScrollTimerRef.current);
+      }
+    },
+    [],
+  );
+
   useEffect(() => {
     setHasInteractedWithArea(false);
     setVisibleRegion(undefined);
@@ -269,7 +279,14 @@ export function MapScreen({
       return;
     }
 
-    onMarkerPreviewRequested?.(mapCardTop + previewOffset);
+    if (previewScrollTimerRef.current) {
+      clearTimeout(previewScrollTimerRef.current);
+    }
+
+    previewScrollTimerRef.current = setTimeout(() => {
+      onMarkerPreviewRequested?.(mapCardTop + previewOffset);
+      previewScrollTimerRef.current = null;
+    }, 160);
   }
 
   return (

--- a/mobile/src/features/map/presentation/screens/__tests__/MapScreen.test.tsx
+++ b/mobile/src/features/map/presentation/screens/__tests__/MapScreen.test.tsx
@@ -343,7 +343,9 @@ describe('MapScreen', () => {
     });
     fireEvent.press(screen.getAllByTestId('story-marker')[1]);
 
-    expect(onMarkerPreviewRequested).toHaveBeenCalledWith(660);
+    await waitFor(() => {
+      expect(onMarkerPreviewRequested).toHaveBeenCalledWith(660);
+    });
   });
 
   it('refetches markers when filters change', async () => {


### PR DESCRIPTION
# 📝 Description
Fixes #552

Fixed overlapping mobile map pins when multiple stories share the exact same latitude and longitude.

This PR:
- Groups duplicate-coordinate story pins into a single multi-story marker
- Shows the marker count for shared-location pins
- Keeps each story accessible through the existing cluster preview list
- Preserves the existing single-story marker behavior for unique coordinates
- Improves marker tap scrolling so the screen lands on the story preview panel more reliably
- Adds regression coverage for duplicate-coordinate map pins

# 📊 Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Refactoring
- [ ] Documentation
 
# ✅ Acceptance Criteria / Checklist
- [x] Project builds successfully
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, especially in hard-to-understand parts
- [x] I have performed a self-review of my code
- [x] I have added/updated tests
- [x] New and existing unit tests pass locally with my changes

# 📸 Screenshots / Recordings
N/A

Manual test:
Verified that duplicate-coordinate stories are grouped into a count marker on the mobile map, tapping it shows all stories at that location, and each story remains openable. Also verified that unique-coordinate pins keep the existing single-story behavior and marker taps scroll to the story preview panel.

# ⏱️ Estimated Review Time
- [ ] < 5 min
- [x] 5-15 min
- [ ] > 15 min
