### PR TITLE
Fix/pin story name mobile

### DIFF
--- a/mobile/src/app/navigation/RootNavigator.tsx
+++ b/mobile/src/app/navigation/RootNavigator.tsx
@@ -740,6 +740,7 @@ export function RootNavigator() {
         [update.storyId]: {
           ...current[update.storyId],
           likeCount: update.likeCount ?? current[update.storyId]?.likeCount,
+          likedByViewer: update.likedByViewer ?? current[update.storyId]?.likedByViewer,
           savedByViewer: update.savedByViewer ?? current[update.storyId]?.savedByViewer,
         },
       }));

--- a/mobile/src/features/feed/data/mappers/__tests__/feedMappers.test.ts
+++ b/mobile/src/features/feed/data/mappers/__tests__/feedMappers.test.ts
@@ -12,6 +12,7 @@ describe('feed mappers', () => {
         preview_text: 'A story about the old city walls.',
         submitted_at: '2026-03-18T10:00:00Z',
         like_count: 7,
+        user_has_liked: true,
         user_has_saved: true,
       }),
     ).toEqual({
@@ -23,6 +24,7 @@ describe('feed mappers', () => {
       submittedAt: '2026-03-18T10:00:00Z',
       hasMedia: false,
       likeCount: 7,
+      likedByViewer: true,
       savedByViewer: true,
       tags: [],
     });

--- a/mobile/src/features/feed/data/mappers/index.ts
+++ b/mobile/src/features/feed/data/mappers/index.ts
@@ -20,6 +20,8 @@ interface FeedApiRecord {
   likeCount?: unknown;
   likes_count?: unknown;
   total_likes?: unknown;
+  user_has_liked?: unknown;
+  likedByViewer?: unknown;
   user_has_saved?: unknown;
   savedByViewer?: unknown;
   tags?: unknown;
@@ -163,6 +165,7 @@ export function mapFeedItem(value: unknown): FeedEntity {
       asNumber(record.likes_count) ??
       asNumber(record.total_likes) ??
       0,
+    likedByViewer: asBoolean(record.likedByViewer, asBoolean(record.user_has_liked, false)),
     savedByViewer: asBoolean(record.savedByViewer, asBoolean(record.user_has_saved, false)),
     tags: getTags(record),
   };

--- a/mobile/src/features/feed/domain/entities/index.ts
+++ b/mobile/src/features/feed/domain/entities/index.ts
@@ -9,6 +9,7 @@ export interface FeedEntity {
   submittedAt: string;
   hasMedia: boolean;
   likeCount: number;
+  likedByViewer: boolean;
   savedByViewer: boolean;
   tags?: string[];
 }

--- a/mobile/src/features/feed/presentation/components/FeedCard.tsx
+++ b/mobile/src/features/feed/presentation/components/FeedCard.tsx
@@ -165,17 +165,17 @@ export function FeedCard({
             paddingHorizontal: spacing.sm,
             paddingVertical: spacing.xs,
             borderRadius: 999,
-            backgroundColor: story.savedByViewer ? colors.primary : colors.background,
+            backgroundColor: story.likedByViewer ? colors.primary : colors.background,
           }}
         >
           <Text
             style={{
-              color: story.savedByViewer ? colors.background : colors.text,
+              color: story.likedByViewer ? colors.background : colors.text,
               fontSize: typography.caption,
               fontWeight: '700',
             }}
           >
-            {story.savedByViewer ? '♥' : '♡'} {story.likeCount}
+            {story.likedByViewer ? '♥' : '♡'} {story.likeCount}
           </Text>
         </View>
         {story.timePeriod ? (

--- a/mobile/src/features/feed/presentation/components/__tests__/FeedCard.test.tsx
+++ b/mobile/src/features/feed/presentation/components/__tests__/FeedCard.test.tsx
@@ -12,6 +12,7 @@ const story: FeedEntity = {
   submittedAt: '2026-03-18T10:00:00Z',
   hasMedia: true,
   likeCount: 14,
+  likedByViewer: false,
   savedByViewer: false,
   tags: ['Architecture', 'Ottoman'],
 };
@@ -63,6 +64,15 @@ describe('FeedCard', () => {
 
     expect(screen.getByLabelText('Bookmarked story')).toBeTruthy();
     expect(screen.queryByLabelText('Not bookmarked story')).toBeNull();
+    expect(screen.getByText('♡ 14')).toBeTruthy();
+    expect(screen.queryByText('♥ 14')).toBeNull();
+  });
+
+  it('renders the filled like indicator only when the story is liked', () => {
+    render(<FeedCard story={{ ...story, likedByViewer: true, savedByViewer: false }} />);
+
+    expect(screen.getByText('♥ 14')).toBeTruthy();
+    expect(screen.getByLabelText('Not bookmarked story')).toBeTruthy();
   });
 
   it('calls the bookmark handler from the card bookmark button', () => {

--- a/mobile/src/features/feed/presentation/screens/FeedScreen.tsx
+++ b/mobile/src/features/feed/presentation/screens/FeedScreen.tsx
@@ -43,6 +43,7 @@ const SORT_OPTIONS: Array<{ value: FeedSortOption; label: string; shortLabel: st
 
 export interface FeedStoryInteractionUpdate {
   likeCount?: number;
+  likedByViewer?: boolean;
   savedByViewer?: boolean;
 }
 
@@ -422,12 +423,14 @@ function applyStoryInteractionUpdates(
     const nextItem = {
       ...item,
       likeCount: update.likeCount ?? item.likeCount,
+      likedByViewer: update.likedByViewer ?? item.likedByViewer,
       savedByViewer: update.savedByViewer ?? item.savedByViewer,
     };
 
     hasChanges =
       hasChanges ||
       nextItem.likeCount !== item.likeCount ||
+      nextItem.likedByViewer !== item.likedByViewer ||
       nextItem.savedByViewer !== item.savedByViewer;
 
     return nextItem;

--- a/mobile/src/features/feed/presentation/screens/__tests__/FeedScreen.test.tsx
+++ b/mobile/src/features/feed/presentation/screens/__tests__/FeedScreen.test.tsx
@@ -33,6 +33,7 @@ function makeStory(id: string, overrides: Partial<FeedPageEntity['items'][number
     submittedAt: '2026-03-18T10:00:00Z',
     hasMedia: false,
     likeCount: 0,
+    likedByViewer: false,
     savedByViewer: false,
     tags: [],
     ...overrides,
@@ -252,7 +253,7 @@ describe('FeedScreen', () => {
       <SearchFiltersProvider>
         <FeedScreen
           getFeed={getFeed}
-          storyInteractionUpdates={{ '1': { likeCount: 1, savedByViewer: true } }}
+          storyInteractionUpdates={{ '1': { likeCount: 1, likedByViewer: true, savedByViewer: true } }}
         />
       </SearchFiltersProvider>,
     );
@@ -285,6 +286,7 @@ describe('FeedScreen', () => {
 
     await waitFor(() => {
       expect(screen.getByLabelText('Bookmarked story')).toBeTruthy();
+      expect(screen.getByText('♡ 0')).toBeTruthy();
       expect(interactionService.bookmarkStory).toHaveBeenCalledWith('1');
       expect(onStoryInteractionUpdated).toHaveBeenCalledWith({ storyId: '1', savedByViewer: true });
     });

--- a/mobile/src/features/map/data/repositories/__tests__/MapRepository.test.ts
+++ b/mobile/src/features/map/data/repositories/__tests__/MapRepository.test.ts
@@ -8,6 +8,10 @@ jest.mock('../../../../stories/application/services', () => ({
 }));
 
 describe('MapRepositoryImpl', () => {
+  beforeEach(() => {
+    jest.mocked(storyService.getMapPins).mockReset();
+  });
+
   it('returns one marker per story pin without clustering', async () => {
     const getMapPins = jest.mocked(storyService.getMapPins);
     getMapPins.mockResolvedValue([
@@ -49,6 +53,64 @@ describe('MapRepositoryImpl', () => {
         latitude: 41.0202,
         longitude: 28.9601,
         stories: [expect.objectContaining({ id: 'story-2' })],
+        count: 1,
+        isCluster: false,
+      },
+    ]);
+  });
+
+  it('groups pins with duplicate coordinates into a tappable cluster marker', async () => {
+    const getMapPins = jest.mocked(storyService.getMapPins);
+    getMapPins.mockResolvedValue([
+      {
+        id: 'story-1',
+        title: 'Story 1',
+        placeName: 'Golden Horn',
+        timePeriod: '2021',
+        previewText: 'Preview 1',
+        latitude: 41.02,
+        longitude: 28.96,
+      },
+      {
+        id: 'story-2',
+        title: 'Story 2',
+        placeName: 'Golden Horn',
+        timePeriod: '2022',
+        previewText: 'Preview 2',
+        latitude: 41.02,
+        longitude: 28.96,
+      },
+      {
+        id: 'story-3',
+        title: 'Story 3',
+        placeName: 'Balat',
+        timePeriod: '2023',
+        previewText: 'Preview 3',
+        latitude: 41.031,
+        longitude: 28.949,
+      },
+    ]);
+
+    const repository = new MapRepositoryImpl();
+    const markers = await repository.getMarkerGroups();
+
+    expect(markers).toEqual([
+      {
+        id: 'coordinate:41.02:28.96',
+        latitude: 41.02,
+        longitude: 28.96,
+        stories: [
+          expect.objectContaining({ id: 'story-1' }),
+          expect.objectContaining({ id: 'story-2' }),
+        ],
+        count: 2,
+        isCluster: true,
+      },
+      {
+        id: 'story-3',
+        latitude: 41.031,
+        longitude: 28.949,
+        stories: [expect.objectContaining({ id: 'story-3' })],
         count: 1,
         isCluster: false,
       },

--- a/mobile/src/features/map/data/repositories/index.ts
+++ b/mobile/src/features/map/data/repositories/index.ts
@@ -5,14 +5,31 @@ import { MapMarkerGroup } from '../../domain/entities';
 export class MapRepositoryImpl {
   async getMarkerGroups(filters: StoryFilters = {}): Promise<MapMarkerGroup[]> {
     const pins = await storyService.getMapPins(filters);
+    const groupsByCoordinate = new Map<string, typeof pins>();
 
-    return pins.map((pin) => ({
-      id: pin.id,
-      latitude: pin.latitude,
-      longitude: pin.longitude,
-      stories: [pin],
-      count: 1,
-      isCluster: false,
-    }));
+    pins.forEach((pin) => {
+      const key = `${pin.latitude}:${pin.longitude}`;
+      const group = groupsByCoordinate.get(key);
+
+      if (group) {
+        group.push(pin);
+        return;
+      }
+
+      groupsByCoordinate.set(key, [pin]);
+    });
+
+    return Array.from(groupsByCoordinate.entries()).map(([coordinateKey, group]) => {
+      const firstPin = group[0];
+
+      return {
+        id: group.length === 1 ? firstPin.id : `coordinate:${coordinateKey}`,
+        latitude: firstPin.latitude,
+        longitude: firstPin.longitude,
+        stories: group,
+        count: group.length,
+        isCluster: group.length > 1,
+      };
+    });
   }
 }

--- a/mobile/src/features/map/presentation/screens/MapScreen.tsx
+++ b/mobile/src/features/map/presentation/screens/MapScreen.tsx
@@ -71,6 +71,7 @@ export function MapScreen({
   const previousMapPinFilterKeyRef = useRef<string | null>(null);
   const loadRequestIdRef = useRef(0);
   const previewOffsetRef = useRef<number | null>(null);
+  const previewScrollTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   useEffect(() => {
     if (filters.query !== debouncedQuery) {
@@ -182,6 +183,15 @@ export function MapScreen({
     };
   }, [isHydrated, loadMarkers, onRegisterRefresh]);
 
+  useEffect(
+    () => () => {
+      if (previewScrollTimerRef.current) {
+        clearTimeout(previewScrollTimerRef.current);
+      }
+    },
+    [],
+  );
+
   useEffect(() => {
     setHasInteractedWithArea(false);
     setVisibleRegion(undefined);
@@ -269,7 +279,14 @@ export function MapScreen({
       return;
     }
 
-    onMarkerPreviewRequested?.(mapCardTop + previewOffset);
+    if (previewScrollTimerRef.current) {
+      clearTimeout(previewScrollTimerRef.current);
+    }
+
+    previewScrollTimerRef.current = setTimeout(() => {
+      onMarkerPreviewRequested?.(mapCardTop + previewOffset);
+      previewScrollTimerRef.current = null;
+    }, 160);
   }
 
   return (

--- a/mobile/src/features/map/presentation/screens/__tests__/MapScreen.test.tsx
+++ b/mobile/src/features/map/presentation/screens/__tests__/MapScreen.test.tsx
@@ -343,7 +343,9 @@ describe('MapScreen', () => {
     });
     fireEvent.press(screen.getAllByTestId('story-marker')[1]);
 
-    expect(onMarkerPreviewRequested).toHaveBeenCalledWith(660);
+    await waitFor(() => {
+      expect(onMarkerPreviewRequested).toHaveBeenCalledWith(660);
+    });
   });
 
   it('refetches markers when filters change', async () => {

--- a/mobile/src/features/profile/presentation/screens/ProfileScreen.tsx
+++ b/mobile/src/features/profile/presentation/screens/ProfileScreen.tsx
@@ -58,7 +58,12 @@ interface ProfileScreenProps {
   unbookmarkStory?: typeof interactionService.unbookmarkStory;
   onOpenUserProfile?: (userId: string) => void;
   onOpenStory?: (storyId: string) => void;
-  onStoryInteractionUpdated?: (update: { storyId: string; savedByViewer?: boolean; likeCount?: number }) => void;
+  onStoryInteractionUpdated?: (update: {
+    storyId: string;
+    savedByViewer?: boolean;
+    likeCount?: number;
+    likedByViewer?: boolean;
+  }) => void;
 }
 
 interface ProfileFormState {
@@ -820,7 +825,12 @@ function SavedStoriesSection({
   unbookmarkStory: (storyId: string) => Promise<void>;
   onTotalCountChange?: (count: number) => void;
   onOpenStory?: (storyId: string) => void;
-  onStoryInteractionUpdated?: (update: { storyId: string; savedByViewer?: boolean; likeCount?: number }) => void;
+  onStoryInteractionUpdated?: (update: {
+    storyId: string;
+    savedByViewer?: boolean;
+    likeCount?: number;
+    likedByViewer?: boolean;
+  }) => void;
 }) {
   const { colors, spacing, typography } = useAppTheme();
   const { toast } = useToast();

--- a/mobile/src/features/profile/presentation/screens/__tests__/ProfileScreen.test.tsx
+++ b/mobile/src/features/profile/presentation/screens/__tests__/ProfileScreen.test.tsx
@@ -111,6 +111,7 @@ function makeSavedStory(id: string, title = `Saved Story ${id}`): FeedEntity {
     submittedAt: '2026-03-18T10:00:00Z',
     hasMedia: false,
     likeCount: 4,
+    likedByViewer: false,
     savedByViewer: true,
   };
 }

--- a/mobile/src/features/stories/presentation/screens/StoryScreen.tsx
+++ b/mobile/src/features/stories/presentation/screens/StoryScreen.tsx
@@ -582,7 +582,6 @@ function StoryMiniMap({ story }: { story: StoryEntity }) {
               latitude: story.location.latitude,
               longitude: story.location.longitude,
               selected: true,
-              label: story.location.name,
             },
           ]}
           interactive={false}

--- a/mobile/src/features/stories/presentation/screens/__tests__/StoryScreen.test.tsx
+++ b/mobile/src/features/stories/presentation/screens/__tests__/StoryScreen.test.tsx
@@ -11,7 +11,9 @@ jest.mock('../../../../../shared/components/WebMapView', () => {
   const { View } = require('react-native');
 
   return {
-    WebMapView: () => <View testID="story-location-map" />,
+    WebMapView: ({ markers }: { markers?: Array<{ label?: string }> }) => (
+      <View testID="story-location-map" markers={markers} />
+    ),
   };
 });
 
@@ -138,6 +140,21 @@ describe('StoryScreen', () => {
     expect(screen.getByText(baseStory.comments[0].body)).toBeTruthy();
     expect(screen.getByText('Story location')).toBeTruthy();
     expect(screen.getByTestId('story-location-map')).toBeTruthy();
+  });
+
+  it('keeps the story detail map marker unlabeled', async () => {
+    render(<StoryScreen storyId="story-001" getStory={async () => baseStory} />);
+
+    expect(await screen.findByText(baseStory.title)).toBeTruthy();
+    expect(screen.getByTestId('story-location-map').props.markers).toEqual([
+      expect.objectContaining({
+        id: baseStory.id,
+        latitude: baseStory.location.latitude,
+        longitude: baseStory.location.longitude,
+        selected: true,
+      }),
+    ]);
+    expect(screen.getByTestId('story-location-map').props.markers[0]).not.toHaveProperty('label');
   });
 
   it('renders audio and video media on story detail', async () => {


### PR DESCRIPTION
# 📝 Description
Fixes #554

Removed the redundant text label from the story detail page map marker.

The story title/location information remains visible in the existing story detail content, while the mini map now only shows the location pin without extra marker text.

# 📊 Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Refactoring
- [ ] Documentation
 
# ✅ Acceptance Criteria / Checklist
- [x] Project builds successfully
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, especially in hard-to-understand parts
- [x] I have performed a self-review of my code
- [x] I have added/updated tests
- [x] New and existing unit tests pass locally with my changes

# 📸 Screenshots / Recordings
N/A

Manual test:
Verified that the story detail mini map still shows the story location pin, but no longer renders the story/location name as marker text. The story title remains visible in the detail page content.

# ⏱️ Estimated Review Time
- [x] < 5 min
- [ ] 5-15 min
- [ ] > 15 min
