### PR TITLE
fix: restore mobile map preview scrolling

### DIFF
--- a/mobile/src/app/navigation/RootNavigator.tsx
+++ b/mobile/src/app/navigation/RootNavigator.tsx
@@ -970,7 +970,6 @@ export function RootNavigator() {
               scrollable
               hideHeader
               active={currentRoute === ROUTES.MAP}
-              canCancelContentTouches={false}
               refreshSuppressed={isMapTouchActive}
               testID="map-route-scroll"
               preservedScrollY={mapScrollOffsetRef.current}

--- a/mobile/src/app/navigation/__tests__/RootNavigator.test.tsx
+++ b/mobile/src/app/navigation/__tests__/RootNavigator.test.tsx
@@ -468,7 +468,7 @@ describe('RootNavigator auth flow', () => {
     expect(screen.getByTestId('main-route-pager').props.scrollEnabled).not.toBe(false);
     expect(screen.getByTestId('main-route-pager').props.canCancelContentTouches).toBe(false);
     expect(screen.getByTestId('map-route-scroll').props.scrollEnabled).toBe(true);
-    expect(screen.getByTestId('map-route-scroll').props.canCancelContentTouches).toBe(false);
+    expect(screen.getByTestId('map-route-scroll').props.canCancelContentTouches).toBe(true);
     await waitFor(() => {
       expect(screen.getByTestId('map-route-scroll').props.refreshControl).toBeTruthy();
       expect(screen.getByTestId('map-route-scroll').props.refreshControl.props.enabled).toBe(true);


### PR DESCRIPTION
# 📝 Description
Fixes #556

Restores normal vertical scrolling from the mobile map story preview area. The map page was applying non-cancelable child touch behavior to the entire map route, which prevented the parent vertical ScrollView from taking over drags that start on story preview content.

This change keeps map gesture suppression for the actual map area, while allowing the preview area to behave like normal scrollable page content so users can reach preview actions such as **Read full story**.

# 📊 Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Refactoring
- [ ] Documentation

# ✅ Acceptance Criteria / Checklist
- [x] Dragging vertically on the story preview area can scroll the map page
- [x] Map pan and pinch behavior remains scoped to the actual map area
- [x] Existing map gesture suppression remains in place during map interaction
- [x] Tests updated for the corrected ScrollView behavior
- [x] Typecheck passes
- [x] Mobile test suite passes

# 🧪 Tests
- [x] npm run typecheck
- [x] npm test -- RootNavigator.test.tsx MapScreen.test.tsx --runInBand --silent
- [x] npm test -- --runInBand --silent

# ⏱️ Estimated Review Time
- [x] < 5 min
- [ ] 5-15 min
- [ ] > 15 min