### PR TITLE
fix: warn on localhost FRONTEND_URL; extend email warnings to Resend backend

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -32,7 +32,9 @@ EMAIL_USE_SSL=True
 DEFAULT_FROM_EMAIL=Local History Story Map <noreply@yourdomain.com>
 
 # Base URL of the frontend — used to build password reset links in emails.
-FRONTEND_URL=http://localhost:3000
+# REQUIRED for production: set this to your deployed frontend URL (https).
+# Leaving this as localhost will produce broken links in reset emails.
+FRONTEND_URL=https://your-frontend-domain.com
 
 # ── Nominatim geocoding proxy ─────────────────────────────────────────────────
 # Nominatim policy requires a real contact address in the User-Agent header.

--- a/.env.example
+++ b/.env.example
@@ -32,8 +32,9 @@ EMAIL_USE_SSL=True
 DEFAULT_FROM_EMAIL=Local History Story Map <noreply@yourdomain.com>
 
 # Base URL of the frontend — used to build password reset links in emails.
-# REQUIRED for production: set this to your deployed frontend URL (https).
-# Leaving this as localhost will produce broken links in reset emails.
+# REQUIRED: replace with your actual deployed frontend URL before going to production.
+# Leaving this unset or pointing to localhost produces broken links in reset emails
+# and triggers a startup warning (when DEBUG=False).
 FRONTEND_URL=https://your-frontend-domain.com
 
 # ── Nominatim geocoding proxy ─────────────────────────────────────────────────

--- a/backend/apps/users/apps.py
+++ b/backend/apps/users/apps.py
@@ -46,7 +46,7 @@ class UsersConfig(AppConfig):
         if getattr(settings, 'DEBUG', True):
             return
         frontend_url = getattr(settings, 'FRONTEND_URL', '')
-        if 'localhost' in frontend_url or '127.0.0.1' in frontend_url:
+        if not frontend_url or 'localhost' in frontend_url or '127.0.0.1' in frontend_url:
             logger.warning(
                 'FRONTEND_URL is set to "%s" — password reset email links will point '
                 'to localhost and will not work in production. '

--- a/backend/apps/users/apps.py
+++ b/backend/apps/users/apps.py
@@ -13,15 +13,25 @@ class UsersConfig(AppConfig):
     def ready(self):
         import apps.users.signals  # noqa: F401
         self._warn_if_email_misconfigured()
+        self._warn_if_frontend_url_misconfigured()
 
     def _warn_if_email_misconfigured(self):
         from django.conf import settings
         backend = getattr(settings, 'EMAIL_BACKEND', '')
-        if 'smtp' not in backend.lower():
+        backend_lower = backend.lower()
+        # Only check real sending backends; console/file/locmem are dev-only.
+        is_smtp = 'smtp' in backend_lower
+        is_resend = 'resend' in backend_lower
+        if not is_smtp and not is_resend:
             return
-        if not getattr(settings, 'EMAIL_HOST_PASSWORD', ''):
+        if is_smtp and not getattr(settings, 'EMAIL_HOST_PASSWORD', ''):
             logger.warning(
                 'EMAIL_HOST_PASSWORD is not set — SMTP email delivery will fail. '
+                'Set it in .env or use EMAIL_BACKEND=django.core.mail.backends.console.EmailBackend for development.'
+            )
+        if is_resend and not getattr(settings, 'RESEND_API_KEY', ''):
+            logger.warning(
+                'RESEND_API_KEY is not set — Resend email delivery will fail. '
                 'Set it in .env or use EMAIL_BACKEND=django.core.mail.backends.console.EmailBackend for development.'
             )
         from_email = getattr(settings, 'DEFAULT_FROM_EMAIL', '')
@@ -29,4 +39,16 @@ class UsersConfig(AppConfig):
             logger.warning(
                 'DEFAULT_FROM_EMAIL contains "example.com" — emails will likely be rejected. '
                 'Set DEFAULT_FROM_EMAIL to a verified sender address in .env.'
+            )
+
+    def _warn_if_frontend_url_misconfigured(self):
+        from django.conf import settings
+        if getattr(settings, 'DEBUG', True):
+            return
+        frontend_url = getattr(settings, 'FRONTEND_URL', '')
+        if 'localhost' in frontend_url or '127.0.0.1' in frontend_url:
+            logger.warning(
+                'FRONTEND_URL is set to "%s" — password reset email links will point '
+                'to localhost and will not work in production. '
+                'Set FRONTEND_URL to your deployed frontend URL in .env.', frontend_url
             )

--- a/backend/apps/users/tests/test_startup_warnings.py
+++ b/backend/apps/users/tests/test_startup_warnings.py
@@ -37,6 +37,9 @@ class TestEmailMisconfigurationWarning:
         assert 'EMAIL_HOST_PASSWORD' not in caplog.text
 
     # ── Resend HTTP backend ─────────────────────────────────────────────────
+    # ResendEmailBackend is introduced by fix/email-verification-delivery.
+    # Django never imports the backend class during these checks, so the
+    # module does not need to exist — only the string 'resend' is matched.
 
     @override_settings(
         EMAIL_BACKEND='common.email_backend.ResendEmailBackend',
@@ -111,6 +114,12 @@ class TestFrontendUrlWarning:
         with caplog.at_level(logging.WARNING, logger='apps.users.apps'):
             _run_frontend_url_check()
         assert 'FRONTEND_URL' not in caplog.text
+
+    @override_settings(DEBUG=False, FRONTEND_URL='')
+    def test_warns_when_frontend_url_is_empty(self, caplog):
+        with caplog.at_level(logging.WARNING, logger='apps.users.apps'):
+            _run_frontend_url_check()
+        assert 'FRONTEND_URL' in caplog.text
 
     @override_settings(DEBUG=True, FRONTEND_URL='http://localhost:3000')
     def test_no_warning_in_debug_mode(self, caplog):

--- a/backend/apps/users/tests/test_startup_warnings.py
+++ b/backend/apps/users/tests/test_startup_warnings.py
@@ -1,0 +1,119 @@
+import logging
+
+import pytest
+from django.apps import apps
+from django.test import override_settings
+
+
+def _run_email_check():
+    apps.get_app_config('users')._warn_if_email_misconfigured()
+
+
+def _run_frontend_url_check():
+    apps.get_app_config('users')._warn_if_frontend_url_misconfigured()
+
+
+class TestEmailMisconfigurationWarning:
+    # ── SMTP backend ────────────────────────────────────────────────────────
+
+    @override_settings(
+        EMAIL_BACKEND='django.core.mail.backends.smtp.EmailBackend',
+        EMAIL_HOST_PASSWORD='',
+        DEFAULT_FROM_EMAIL='Sender <noreply@verified.com>',
+    )
+    def test_smtp_warns_when_password_missing(self, caplog):
+        with caplog.at_level(logging.WARNING, logger='apps.users.apps'):
+            _run_email_check()
+        assert 'EMAIL_HOST_PASSWORD' in caplog.text
+
+    @override_settings(
+        EMAIL_BACKEND='django.core.mail.backends.smtp.EmailBackend',
+        EMAIL_HOST_PASSWORD='secret',
+        DEFAULT_FROM_EMAIL='Sender <noreply@verified.com>',
+    )
+    def test_smtp_no_warning_when_password_set(self, caplog):
+        with caplog.at_level(logging.WARNING, logger='apps.users.apps'):
+            _run_email_check()
+        assert 'EMAIL_HOST_PASSWORD' not in caplog.text
+
+    # ── Resend HTTP backend ─────────────────────────────────────────────────
+
+    @override_settings(
+        EMAIL_BACKEND='common.email_backend.ResendEmailBackend',
+        RESEND_API_KEY='',
+        DEFAULT_FROM_EMAIL='Sender <noreply@verified.com>',
+    )
+    def test_resend_warns_when_api_key_missing(self, caplog):
+        with caplog.at_level(logging.WARNING, logger='apps.users.apps'):
+            _run_email_check()
+        assert 'RESEND_API_KEY' in caplog.text
+
+    @override_settings(
+        EMAIL_BACKEND='common.email_backend.ResendEmailBackend',
+        RESEND_API_KEY='re_abc123',
+        DEFAULT_FROM_EMAIL='Sender <noreply@verified.com>',
+    )
+    def test_resend_no_warning_when_api_key_set(self, caplog):
+        with caplog.at_level(logging.WARNING, logger='apps.users.apps'):
+            _run_email_check()
+        assert 'RESEND_API_KEY' not in caplog.text
+
+    # ── DEFAULT_FROM_EMAIL placeholder ──────────────────────────────────────
+
+    @override_settings(
+        EMAIL_BACKEND='common.email_backend.ResendEmailBackend',
+        RESEND_API_KEY='re_abc123',
+        DEFAULT_FROM_EMAIL='App <noreply@example.com>',
+    )
+    def test_warns_on_example_com_sender_resend(self, caplog):
+        with caplog.at_level(logging.WARNING, logger='apps.users.apps'):
+            _run_email_check()
+        assert 'DEFAULT_FROM_EMAIL' in caplog.text
+
+    @override_settings(
+        EMAIL_BACKEND='django.core.mail.backends.smtp.EmailBackend',
+        EMAIL_HOST_PASSWORD='secret',
+        DEFAULT_FROM_EMAIL='App <noreply@example.com>',
+    )
+    def test_warns_on_example_com_sender_smtp(self, caplog):
+        with caplog.at_level(logging.WARNING, logger='apps.users.apps'):
+            _run_email_check()
+        assert 'DEFAULT_FROM_EMAIL' in caplog.text
+
+    # ── Dev backends are skipped ────────────────────────────────────────────
+
+    @override_settings(
+        EMAIL_BACKEND='django.core.mail.backends.console.EmailBackend',
+        DEFAULT_FROM_EMAIL='App <noreply@example.com>',
+    )
+    def test_console_backend_skips_all_warnings(self, caplog):
+        with caplog.at_level(logging.WARNING, logger='apps.users.apps'):
+            _run_email_check()
+        assert caplog.text == ''
+
+
+class TestFrontendUrlWarning:
+    @override_settings(DEBUG=False, FRONTEND_URL='http://localhost:3000')
+    def test_warns_when_localhost_in_production(self, caplog):
+        with caplog.at_level(logging.WARNING, logger='apps.users.apps'):
+            _run_frontend_url_check()
+        assert 'FRONTEND_URL' in caplog.text
+        assert 'localhost' in caplog.text
+
+    @override_settings(DEBUG=False, FRONTEND_URL='http://127.0.0.1:3000')
+    def test_warns_when_loopback_ip_in_production(self, caplog):
+        with caplog.at_level(logging.WARNING, logger='apps.users.apps'):
+            _run_frontend_url_check()
+        assert 'FRONTEND_URL' in caplog.text
+
+    @override_settings(DEBUG=False, FRONTEND_URL='https://storymap.page')
+    def test_no_warning_for_production_url(self, caplog):
+        with caplog.at_level(logging.WARNING, logger='apps.users.apps'):
+            _run_frontend_url_check()
+        assert 'FRONTEND_URL' not in caplog.text
+
+    @override_settings(DEBUG=True, FRONTEND_URL='http://localhost:3000')
+    def test_no_warning_in_debug_mode(self, caplog):
+        with caplog.at_level(logging.WARNING, logger='apps.users.apps'):
+            _run_frontend_url_check()
+        assert 'FRONTEND_URL' not in caplog.text


### PR DESCRIPTION
# 📝 Description
Fixes #566

Password reset emails were sending links to `http://localhost:3000/reset-password/<token>` because `FRONTEND_URL` defaulted to `http://localhost:3000` with no warning when left unconfigured in production.

**Changes:**
- `apps/users/apps.py` — adds `_warn_if_frontend_url_misconfigured()`: logs a `WARNING` on startup when `FRONTEND_URL` contains `localhost` or `127.0.0.1` and `DEBUG=False`, consistent with existing email misconfiguration warnings.
- `apps/users/apps.py` — extends `_warn_if_email_misconfigured()` to also handle `ResendEmailBackend`: warns when `RESEND_API_KEY` is unset. The previous SMTP-only guard would have silently skipped all email warnings after the pending Resend backend PR merges.
- `.env.example` — replaces `FRONTEND_URL=http://localhost:3000` with `https://your-frontend-domain.com` and adds a comment marking it required for production.
- `tests/test_startup_warnings.py` — 11 new tests covering all warning paths for both backends and both checks.

# 📊 Type of Change
- [x] Bug fix

# ✅ Acceptance Criteria / Checklist
- [x] Project builds successfully
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, especially in hard-to-understand parts
- [x] I have performed a self-review of my code
- [x] I have added/updated tests
- [x] New and existing unit tests pass locally with my changes

# 📸 Screenshots / Recordings
N/A — backend-only warning logic change.

# ⏱️ Estimated Review Time
- [x] < 5 min