### PR TITLE
fix: stabilize mobile bottom tab routing

### DIFF
--- a/mobile/src/app/navigation/RootNavigator.tsx
+++ b/mobile/src/app/navigation/RootNavigator.tsx
@@ -402,6 +402,14 @@ export function RootNavigator() {
     [toast],
   );
 
+  const clearPagerDragState = useCallback(() => {
+    isPagerDragActiveRef.current = false;
+    if (pagerDragResetTimerRef.current) {
+      clearTimeout(pagerDragResetTimerRef.current);
+      pagerDragResetTimerRef.current = null;
+    }
+  }, []);
+
   useEffect(() => {
     if (!loading) {
       setHasResolvedInitialSession(true);
@@ -422,6 +430,7 @@ export function RootNavigator() {
         return;
       }
 
+      clearPagerDragState();
       const x = pageIndex * width;
       const animated = Boolean(options?.animated);
 
@@ -437,7 +446,7 @@ export function RootNavigator() {
         pagerRef.current?.scrollTo({ x, y: 0, animated: false });
       });
     },
-    [width],
+    [clearPagerDragState, width],
   );
 
   const navigateToSnapshot = useCallback(
@@ -537,7 +546,7 @@ export function RootNavigator() {
 
   const handleNavigate = (route: AppRoute) => {
     if (MAIN_PAGER_ROUTES.includes(route)) {
-      scrollMainPagerToRoute(route, { animated: true });
+      scrollMainPagerToRoute(route);
       navigateToSnapshot({ route }, { resetStack: true, preserveCurrent: false });
       return;
     }

--- a/mobile/src/app/navigation/RootNavigator.tsx
+++ b/mobile/src/app/navigation/RootNavigator.tsx
@@ -732,7 +732,7 @@ export function RootNavigator() {
         },
         { refresh: true },
       );
-      scrollMainPagerToRoute(ROUTES.TIMELINE, { animated: true });
+      scrollMainPagerToRoute(ROUTES.TIMELINE);
       navigateToSnapshot({ route: ROUTES.TIMELINE }, { resetStack: true, preserveCurrent: false });
     },
     [navigateToSnapshot, scrollMainPagerToRoute, updateFilters],

--- a/mobile/src/app/navigation/__tests__/RootNavigator.test.tsx
+++ b/mobile/src/app/navigation/__tests__/RootNavigator.test.tsx
@@ -453,6 +453,40 @@ describe('RootNavigator auth flow', () => {
     });
   });
 
+  it('opens the timeline tab on the first press even when stale pager momentum fires', async () => {
+    renderNavigator();
+
+    await screen.findByLabelText('Timeline');
+    expect(screen.getByLabelText('Feed').props.accessibilityState.selected).toBe(true);
+
+    fireEvent(screen.getByTestId('main-route-pager'), 'scrollBeginDrag');
+    fireEvent.press(screen.getByLabelText('Timeline'));
+    fireEvent(screen.getByTestId('main-route-pager'), 'momentumScrollEnd', {
+      nativeEvent: {
+        contentOffset: { x: 0, y: 0 },
+      },
+    });
+
+    expect(screen.getByLabelText('Timeline').props.accessibilityState.selected).toBe(true);
+    expect(screen.getByLabelText('Map').props.accessibilityState.selected).toBe(false);
+    expect(screen.getByLabelText('Feed').props.accessibilityState.selected).toBe(false);
+
+    fireEvent.press(screen.getByLabelText('Map'));
+    expect(screen.getByLabelText('Map').props.accessibilityState.selected).toBe(true);
+
+    fireEvent(screen.getByTestId('main-route-pager'), 'scrollBeginDrag');
+    fireEvent.press(screen.getByLabelText('Timeline'));
+    fireEvent(screen.getByTestId('main-route-pager'), 'momentumScrollEnd', {
+      nativeEvent: {
+        contentOffset: { x: 999999, y: 0 },
+      },
+    });
+
+    expect(screen.getByLabelText('Timeline').props.accessibilityState.selected).toBe(true);
+    expect(screen.getByLabelText('Map').props.accessibilityState.selected).toBe(false);
+    expect(screen.getByLabelText('Feed').props.accessibilityState.selected).toBe(false);
+  });
+
   it('keeps pull-to-refresh available away from the map and suppresses it during map gestures', async () => {
     renderNavigator();
 

--- a/mobile/src/app/navigation/__tests__/RootNavigator.test.tsx
+++ b/mobile/src/app/navigation/__tests__/RootNavigator.test.tsx
@@ -1064,6 +1064,15 @@ describe('RootNavigator auth flow', () => {
     });
     fireEvent.press(screen.getAllByTestId('story-marker')[0]);
     fireEvent.press(await screen.findByLabelText('View timeline near Harbor Memory'));
+    fireEvent(screen.getByTestId('main-route-pager'), 'momentumScrollEnd', {
+      nativeEvent: {
+        contentOffset: { x: 999999, y: 0 },
+      },
+    });
+
+    expect(screen.getByLabelText('Timeline').props.accessibilityState.selected).toBe(true);
+    expect(screen.getByLabelText('Feed').props.accessibilityState.selected).toBe(false);
+    expect(screen.getByLabelText('Map').props.accessibilityState.selected).toBe(false);
 
     await waitFor(() => {
       expect(apiRequests).toContain(


### PR DESCRIPTION
# 📝 Description
Fixes #557

Stabilizes mobile bottom navigation between **Map**, **Timeline**, and **Feed**.

The bottom tab press path was still sharing state with the horizontal pager drag/momentum flow. If stale pager momentum fired after a tab press, the visible route could be overwritten by a neighboring page, causing Timeline to require a second tap.

This PR clears pending pager drag state before programmatic pager movement and makes bottom tab presses jump directly to the selected route, keeping the selected tab and visible screen synchronized on the first tap.

# 📊 Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Refactoring
- [ ] Documentation

# ✅ Acceptance Criteria / Checklist
- [x] Bottom navigation tabs open the correct screen on the first tap
- [x] Timeline, Feed, and Map tab states stay synchronized with the visible screen
- [x] Stale pager momentum does not override a tab press
- [x] Existing back/navigation behavior is not changed
- [x] Regression test added for Feed -> Timeline and Map -> Timeline stale momentum cases

# 🧪 Tests
- [x] npm run typecheck
- [x] npm test -- RootNavigator.test.tsx --runInBand --silent
- [x] npm test -- --runInBand --silent

# ⏱️ Estimated Review Time
- [x] < 5 min
- [ ] 5-15 min
- [ ] > 15 min