### PR TITLE
feat: display profile points and badges on mobile

### DIFF
--- a/mobile/src/app/navigation/RootNavigator.tsx
+++ b/mobile/src/app/navigation/RootNavigator.tsx
@@ -402,6 +402,14 @@ export function RootNavigator() {
     [toast],
   );
 
+  const clearPagerDragState = useCallback(() => {
+    isPagerDragActiveRef.current = false;
+    if (pagerDragResetTimerRef.current) {
+      clearTimeout(pagerDragResetTimerRef.current);
+      pagerDragResetTimerRef.current = null;
+    }
+  }, []);
+
   useEffect(() => {
     if (!loading) {
       setHasResolvedInitialSession(true);
@@ -422,6 +430,7 @@ export function RootNavigator() {
         return;
       }
 
+      clearPagerDragState();
       const x = pageIndex * width;
       const animated = Boolean(options?.animated);
 
@@ -437,7 +446,7 @@ export function RootNavigator() {
         pagerRef.current?.scrollTo({ x, y: 0, animated: false });
       });
     },
-    [width],
+    [clearPagerDragState, width],
   );
 
   const navigateToSnapshot = useCallback(
@@ -537,7 +546,7 @@ export function RootNavigator() {
 
   const handleNavigate = (route: AppRoute) => {
     if (MAIN_PAGER_ROUTES.includes(route)) {
-      scrollMainPagerToRoute(route, { animated: true });
+      scrollMainPagerToRoute(route);
       navigateToSnapshot({ route }, { resetStack: true, preserveCurrent: false });
       return;
     }
@@ -723,7 +732,7 @@ export function RootNavigator() {
         },
         { refresh: true },
       );
-      scrollMainPagerToRoute(ROUTES.TIMELINE, { animated: true });
+      scrollMainPagerToRoute(ROUTES.TIMELINE);
       navigateToSnapshot({ route: ROUTES.TIMELINE }, { resetStack: true, preserveCurrent: false });
     },
     [navigateToSnapshot, scrollMainPagerToRoute, updateFilters],

--- a/mobile/src/features/profile/application/services/__tests__/userService.test.ts
+++ b/mobile/src/features/profile/application/services/__tests__/userService.test.ts
@@ -243,6 +243,89 @@ describe('userService', () => {
     });
   });
 
+  it('loads a user point summary from the gamification endpoint', async () => {
+    setApiTransport(async (method: any, config: any) => {
+      if (method === 'GET' && config.url === '/users/12/points/') {
+        return {
+          status: 200,
+          data: {
+            user_id: 12,
+            total_points: 1250,
+          } as never,
+          config,
+        };
+      }
+
+      throw new Error(`Unexpected request: ${method} ${config.url}`);
+    });
+
+    await expect(userService.getUserPoints('12')).resolves.toEqual({
+      userId: '12',
+      totalPoints: 1250,
+    });
+  });
+
+  it('loads earned badges from the paginated user badges endpoint', async () => {
+    setApiTransport(async (method: any, config: any) => {
+      if (method === 'GET' && config.url === '/users/12/badges/?page=1&page_size=50') {
+        return {
+          status: 200,
+          data: {
+            count: 2,
+            next: null,
+            previous: null,
+            results: [
+              {
+                id: 22,
+                badge: {
+                  id: 1,
+                  name: 'First Story',
+                  description: 'Published one story.',
+                  criteria_type: 'stories_published',
+                  criteria_threshold: 1,
+                },
+                awarded_at: '2026-05-01T12:00:00Z',
+              },
+              {
+                id: 23,
+                badge: {
+                  id: 2,
+                  name: 'Point Collector',
+                  description: 'Reached 50 points.',
+                  criteria_type: 'points_total',
+                  criteria_threshold: 50,
+                },
+                awarded_at: null,
+              },
+            ],
+          } as never,
+          config,
+        };
+      }
+
+      throw new Error(`Unexpected request: ${method} ${config.url}`);
+    });
+
+    await expect(userService.getUserBadges('12')).resolves.toEqual([
+      {
+        id: '1',
+        name: 'First Story',
+        description: 'Published one story.',
+        criteriaType: 'stories_published',
+        criteriaThreshold: 1,
+        awardedAt: '2026-05-01T12:00:00Z',
+      },
+      {
+        id: '2',
+        name: 'Point Collector',
+        description: 'Reached 50 points.',
+        criteriaType: 'points_total',
+        criteriaThreshold: 50,
+        awardedAt: null,
+      },
+    ]);
+  });
+
   it('updates the authenticated profile via PATCH /users/me/', async () => {
     setApiTransport(async (method: any, config: any) => {
       if (method === 'PATCH' && config.url === '/users/me/') {

--- a/mobile/src/features/profile/application/services/index.ts
+++ b/mobile/src/features/profile/application/services/index.ts
@@ -1,5 +1,12 @@
 import { ProfileRepositoryImpl } from '../../data/repositories';
-import { FollowListResult, ProfileEntity, ProfilePhotoUploadInput, UpdateProfileInput } from '../../domain/entities';
+import {
+  BadgeEntity,
+  FollowListResult,
+  PointsSummaryEntity,
+  ProfileEntity,
+  ProfilePhotoUploadInput,
+  UpdateProfileInput,
+} from '../../domain/entities';
 import { FeedPageEntity } from '../../../feed/domain/entities';
 
 const repository = new ProfileRepositoryImpl();
@@ -40,5 +47,11 @@ export const userService = {
   },
   async getSavedStories(userId: string, page = 1): Promise<FeedPageEntity> {
     return repository.getSavedStories(userId, page);
+  },
+  async getUserPoints(userId: string): Promise<PointsSummaryEntity> {
+    return repository.getUserPoints(userId);
+  },
+  async getUserBadges(userId: string): Promise<BadgeEntity[]> {
+    return repository.getUserBadges(userId);
   },
 };

--- a/mobile/src/features/profile/data/mappers/index.ts
+++ b/mobile/src/features/profile/data/mappers/index.ts
@@ -1,4 +1,10 @@
-import { FollowListResult, FollowUserEntity, ProfileEntity } from '../../domain/entities';
+import {
+  BadgeEntity,
+  FollowListResult,
+  FollowUserEntity,
+  PointsSummaryEntity,
+  ProfileEntity,
+} from '../../domain/entities';
 
 function asString(value: unknown) {
   if (typeof value === 'string') {
@@ -193,4 +199,36 @@ export function mapFollowList(payload: Record<string, unknown>): FollowListResul
     previous: asNullableString(payload.previous),
     count: asNumber(payload.count),
   };
+}
+
+export function mapPointsSummary(payload: Record<string, unknown>): PointsSummaryEntity {
+  return {
+    userId: asString(payload.user_id ?? payload.userId),
+    totalPoints: asNumber(payload.total_points ?? payload.totalPoints),
+  };
+}
+
+export function mapUserBadge(payload: Record<string, unknown>): BadgeEntity {
+  const nestedBadge =
+    payload.badge && typeof payload.badge === 'object'
+      ? (payload.badge as Record<string, unknown>)
+      : payload;
+
+  return {
+    id: asString(nestedBadge.id ?? payload.id),
+    name: asString(nestedBadge.name),
+    description: asNullableString(nestedBadge.description),
+    criteriaType: asNullableString(nestedBadge.criteria_type ?? nestedBadge.criteriaType),
+    criteriaThreshold: asNullableNumber(nestedBadge.criteria_threshold ?? nestedBadge.criteriaThreshold),
+    awardedAt: asNullableString(payload.awarded_at ?? payload.awardedAt),
+  };
+}
+
+export function mapUserBadges(payload: Record<string, unknown>): BadgeEntity[] {
+  const results = Array.isArray(payload.results) ? payload.results : [];
+
+  return results
+    .filter((item): item is Record<string, unknown> => Boolean(item) && typeof item === 'object')
+    .map(mapUserBadge)
+    .filter((badge) => badge.id && badge.name);
 }

--- a/mobile/src/features/profile/data/repositories/index.ts
+++ b/mobile/src/features/profile/data/repositories/index.ts
@@ -1,11 +1,20 @@
 import {
+  BadgeEntity,
   FollowListResult,
+  PointsSummaryEntity,
   ProfileEntity,
   ProfilePhotoUploadInput,
   UpdateProfileInput,
 } from '../../domain/entities';
 import { ProfileRepository } from '../../domain/repositories';
-import { mapCurrentProfile, mapFollowList, mapPublicProfile, mergePublicProfileSummary } from '../mappers';
+import {
+  mapCurrentProfile,
+  mapFollowList,
+  mapPointsSummary,
+  mapPublicProfile,
+  mapUserBadges,
+  mergePublicProfileSummary,
+} from '../mappers';
 import { profileRemoteSource } from '../sources';
 import { mapFeedPage } from '../../../feed/data/mappers';
 
@@ -74,5 +83,15 @@ export class ProfileRepositoryImpl implements ProfileRepository {
   async getSavedStories(userId: string, page = 1) {
     const payload = await profileRemoteSource.getSavedStories(userId, page);
     return mapFeedPage(payload, page, 10);
+  }
+
+  async getUserPoints(userId: string): Promise<PointsSummaryEntity> {
+    const payload = await profileRemoteSource.getUserPoints(userId);
+    return mapPointsSummary(payload);
+  }
+
+  async getUserBadges(userId: string): Promise<BadgeEntity[]> {
+    const payload = await profileRemoteSource.getUserBadges(userId);
+    return mapUserBadges(payload);
   }
 }

--- a/mobile/src/features/profile/data/sources/index.ts
+++ b/mobile/src/features/profile/data/sources/index.ts
@@ -165,6 +165,24 @@ export const profileRemoteSource = {
       results: [],
     };
   },
+
+  async getUserPoints(userId: string) {
+    return (await apiClient.get<Record<string, unknown>>(`/users/${userId}/points/`)) ?? {
+      user_id: userId,
+      total_points: 0,
+    };
+  },
+
+  async getUserBadges(userId: string) {
+    return (await apiClient.get<Record<string, unknown>>(
+      `/users/${userId}/badges/${buildQueryString({ page: 1, page_size: 50 })}`,
+    )) ?? {
+      count: 0,
+      next: null,
+      previous: null,
+      results: [],
+    };
+  },
 };
 
 export const profileLocalSource = {};

--- a/mobile/src/features/profile/domain/entities/index.ts
+++ b/mobile/src/features/profile/domain/entities/index.ts
@@ -55,3 +55,17 @@ export interface FollowListResult {
   previous: string | null;
   count: number;
 }
+
+export interface PointsSummaryEntity {
+  userId: string;
+  totalPoints: number;
+}
+
+export interface BadgeEntity {
+  id: string;
+  name: string;
+  description: string | null;
+  criteriaType: string | null;
+  criteriaThreshold: number | null;
+  awardedAt: string | null;
+}

--- a/mobile/src/features/profile/domain/repositories/index.ts
+++ b/mobile/src/features/profile/domain/repositories/index.ts
@@ -1,4 +1,11 @@
-import { FollowListResult, ProfileEntity, ProfilePhotoUploadInput, UpdateProfileInput } from '../entities';
+import {
+  BadgeEntity,
+  FollowListResult,
+  PointsSummaryEntity,
+  ProfileEntity,
+  ProfilePhotoUploadInput,
+  UpdateProfileInput,
+} from '../entities';
 import { FeedPageEntity } from '../../../feed/domain/entities';
 
 export interface ProfileRepository {
@@ -13,4 +20,6 @@ export interface ProfileRepository {
   getFollowers(userId: string, page?: number): Promise<FollowListResult>;
   getFollowing(userId: string, page?: number): Promise<FollowListResult>;
   getSavedStories(userId: string, page?: number): Promise<FeedPageEntity>;
+  getUserPoints(userId: string): Promise<PointsSummaryEntity>;
+  getUserBadges(userId: string): Promise<BadgeEntity[]>;
 }

--- a/mobile/src/features/profile/presentation/screens/ProfileScreen.tsx
+++ b/mobile/src/features/profile/presentation/screens/ProfileScreen.tsx
@@ -209,7 +209,7 @@ function describeBadgeCondition(badge: BadgeEntity) {
 
 function getBadgeInitial(badge: BadgeEntity) {
   if (badge.criteriaType === 'registration') {
-    return 'R';
+    return '01';
   }
 
   if (badge.criteriaType === 'story_count' || badge.criteriaType === 'stories_published') {
@@ -221,6 +221,42 @@ function getBadgeInitial(badge: BadgeEntity) {
   }
 
   return badge.name.slice(0, 1).toUpperCase();
+}
+
+function getBadgePalette(badge: BadgeEntity) {
+  if (badge.criteriaType === 'registration') {
+    return {
+      background: '#FEF3C7',
+      border: '#F59E0B',
+      text: '#92400E',
+      shine: '#FFFBEB',
+    };
+  }
+
+  if (badge.criteriaType === 'story_count' || badge.criteriaType === 'stories_published') {
+    return {
+      background: '#DBEAFE',
+      border: '#2563EB',
+      text: '#1E3A8A',
+      shine: '#EFF6FF',
+    };
+  }
+
+  if (badge.criteriaType === 'points' || badge.criteriaType === 'points_total') {
+    return {
+      background: '#DCFCE7',
+      border: '#16A34A',
+      text: '#166534',
+      shine: '#F0FDF4',
+    };
+  }
+
+  return {
+    background: '#F3E8FF',
+    border: '#9333EA',
+    text: '#581C87',
+    shine: '#FAF5FF',
+  };
 }
 
 function formatBirthDateLabel(value: string) {
@@ -643,46 +679,71 @@ function BadgesSection({
           showsHorizontalScrollIndicator={false}
           contentContainerStyle={{ gap: spacing.sm, paddingRight: spacing.sm }}
         >
-          {badges.map((badge) => (
-            <Pressable
-              key={badge.id}
-              accessibilityRole="button"
-              accessibilityLabel={`Open badge details: ${badge.name}`}
-              onPress={() => onSelectBadge(badge)}
-              style={({ pressed }) => ({
-                width: 156,
-                minHeight: 148,
-                padding: spacing.md,
-                borderRadius: 16,
-                borderWidth: 1,
-                borderColor: colors.border,
-                backgroundColor: colors.background,
-                gap: spacing.sm,
-                opacity: pressed ? 0.82 : 1,
-              })}
-            >
-              <View
-                style={{
-                  width: 46,
-                  height: 46,
-                  borderRadius: 23,
+          {badges.map((badge) => {
+            const badgePalette = getBadgePalette(badge);
+
+            return (
+              <Pressable
+                key={badge.id}
+                accessibilityRole="button"
+                accessibilityLabel={`Open badge details: ${badge.name}`}
+                onPress={() => onSelectBadge(badge)}
+                style={({ pressed }) => ({
+                  width: 82,
                   alignItems: 'center',
-                  justifyContent: 'center',
-                  backgroundColor: colors.infoSurface,
-                }}
+                  gap: spacing.xs,
+                  opacity: pressed ? 0.76 : 1,
+                  transform: [{ scale: pressed ? 0.96 : 1 }],
+                })}
               >
-                <Text style={{ color: colors.primary, fontSize: typography.subtitle, fontWeight: '800' }}>
-                  {getBadgeInitial(badge)}
+                <View
+                  style={{
+                    width: 58,
+                    height: 58,
+                    borderRadius: 29,
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                    borderWidth: 2,
+                    borderColor: badgePalette.border,
+                    backgroundColor: badgePalette.background,
+                    shadowColor: badgePalette.border,
+                    shadowOpacity: 0.2,
+                    shadowRadius: 8,
+                    shadowOffset: { width: 0, height: 3 },
+                    elevation: 2,
+                  }}
+                >
+                  <View
+                    style={{
+                      position: 'absolute',
+                      top: 8,
+                      left: 10,
+                      width: 17,
+                      height: 9,
+                      borderRadius: 9,
+                      backgroundColor: badgePalette.shine,
+                      opacity: 0.9,
+                    }}
+                  />
+                  <Text style={{ color: badgePalette.text, fontSize: 18, fontWeight: '900' }}>
+                    {getBadgeInitial(badge)}
+                  </Text>
+                </View>
+                <Text
+                  numberOfLines={2}
+                  style={{
+                    minHeight: 34,
+                    color: colors.text,
+                    fontSize: typography.caption,
+                    fontWeight: '800',
+                    textAlign: 'center',
+                  }}
+                >
+                  {badge.name}
                 </Text>
-              </View>
-              <Text numberOfLines={2} style={{ color: colors.text, fontWeight: '800' }}>
-                {badge.name}
-              </Text>
-              <Text numberOfLines={3} style={{ color: colors.muted, fontSize: typography.caption }}>
-                {describeBadgeCondition(badge)}
-              </Text>
-            </Pressable>
-          ))}
+              </Pressable>
+            );
+          })}
         </ScrollView>
       ) : null}
     </View>
@@ -698,49 +759,73 @@ function BadgeDetailsModal({
 }) {
   const { colors, spacing, typography } = useAppTheme();
   const awardedDate = formatAwardedDate(badge?.awardedAt);
+  const badgePalette = badge ? getBadgePalette(badge) : null;
 
   return (
-    <Modal animationType="slide" transparent visible={Boolean(badge)} onRequestClose={onClose}>
+    <Modal animationType="fade" transparent visible={Boolean(badge)} onRequestClose={onClose}>
       <View
         style={{
           flex: 1,
-          backgroundColor: 'rgba(10, 10, 10, 0.35)',
-          justifyContent: 'flex-end',
+          padding: spacing.lg,
+          backgroundColor: 'rgba(10, 10, 10, 0.34)',
+          justifyContent: 'center',
         }}
       >
-        <Pressable style={{ flex: 1 }} onPress={onClose} />
+        <Pressable
+          style={{ position: 'absolute', top: 0, right: 0, bottom: 0, left: 0 }}
+          onPress={onClose}
+        />
         <View
           style={{
-            paddingHorizontal: spacing.lg,
-            paddingTop: spacing.lg,
-            paddingBottom: spacing.xl,
-            borderTopLeftRadius: 24,
-            borderTopRightRadius: 24,
+            padding: spacing.lg,
+            borderRadius: 22,
+            borderWidth: 1,
+            borderColor: colors.border,
             backgroundColor: colors.background,
             gap: spacing.md,
+            shadowColor: '#000000',
+            shadowOpacity: 0.18,
+            shadowRadius: 22,
+            shadowOffset: { width: 0, height: 10 },
+            elevation: 6,
           }}
         >
-          {badge ? (
+          {badge && badgePalette ? (
             <>
               <View
                 style={{
-                  width: 54,
-                  height: 54,
-                  borderRadius: 27,
+                  alignSelf: 'center',
+                  width: 76,
+                  height: 76,
+                  borderRadius: 38,
                   alignItems: 'center',
                   justifyContent: 'center',
-                  backgroundColor: colors.infoSurface,
+                  borderWidth: 2,
+                  borderColor: badgePalette.border,
+                  backgroundColor: badgePalette.background,
                 }}
               >
-                <Text style={{ color: colors.primary, fontSize: typography.title, fontWeight: '800' }}>
+                <View
+                  style={{
+                    position: 'absolute',
+                    top: 11,
+                    left: 14,
+                    width: 23,
+                    height: 12,
+                    borderRadius: 12,
+                    backgroundColor: badgePalette.shine,
+                    opacity: 0.9,
+                  }}
+                />
+                <Text style={{ color: badgePalette.text, fontSize: 24, fontWeight: '900' }}>
                   {getBadgeInitial(badge)}
                 </Text>
               </View>
-              <View style={{ gap: spacing.xs }}>
-                <Text style={{ color: colors.text, fontSize: typography.title, fontWeight: '800' }}>
+              <View style={{ alignItems: 'center', gap: spacing.xs }}>
+                <Text style={{ color: colors.text, fontSize: typography.title, fontWeight: '800', textAlign: 'center' }}>
                   {badge.name}
                 </Text>
-                <Text style={{ color: colors.text }}>
+                <Text style={{ color: colors.text, textAlign: 'center' }}>
                   {badge.description ?? describeBadgeCondition(badge)}
                 </Text>
               </View>

--- a/mobile/src/features/profile/presentation/screens/ProfileScreen.tsx
+++ b/mobile/src/features/profile/presentation/screens/ProfileScreen.tsx
@@ -15,7 +15,14 @@ import { interactionService } from '../../../interactions/application/services';
 import { FeedCard } from '../../../feed/presentation/components/FeedCard';
 import { FeedEntity, FeedPageEntity } from '../../../feed/domain/entities';
 import { userService } from '../../application/services';
-import { FollowListResult, FollowUserEntity, ProfileEntity, ProfilePhotoUploadInput, UpdateProfileInput } from '../../domain/entities';
+import {
+  BadgeEntity,
+  FollowListResult,
+  FollowUserEntity,
+  ProfileEntity,
+  ProfilePhotoUploadInput,
+  UpdateProfileInput,
+} from '../../domain/entities';
 import { AuthUser } from '../../../../core/auth/session';
 
 type ProfileMode = 'self' | 'public';
@@ -55,6 +62,8 @@ interface ProfileScreenProps {
   getFollowers?: typeof userService.getFollowers;
   getFollowing?: typeof userService.getFollowing;
   getSavedStories?: typeof userService.getSavedStories;
+  getUserPoints?: typeof userService.getUserPoints;
+  getUserBadges?: typeof userService.getUserBadges;
   unbookmarkStory?: typeof interactionService.unbookmarkStory;
   onOpenUserProfile?: (userId: string) => void;
   onOpenStory?: (storyId: string) => void;
@@ -147,6 +156,70 @@ function formatJoinedDate(value?: string) {
     month: 'long',
     year: 'numeric',
   });
+}
+
+function formatPoints(value: number) {
+  return Math.max(0, value).toLocaleString('en-US');
+}
+
+function formatAwardedDate(value?: string | null) {
+  if (!value) {
+    return undefined;
+  }
+
+  const parsedDate = new Date(value);
+
+  if (Number.isNaN(parsedDate.getTime())) {
+    return undefined;
+  }
+
+  return parsedDate.toLocaleDateString('en-US', {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+  });
+}
+
+function describeBadgeCondition(badge: BadgeEntity) {
+  const threshold = badge.criteriaThreshold;
+
+  if (badge.criteriaType === 'registration') {
+    return 'Awarded for completing registration.';
+  }
+
+  if (badge.criteriaType === 'story_count' || badge.criteriaType === 'stories_published') {
+    if (threshold === 1) {
+      return 'Awarded for publishing your first story.';
+    }
+
+    if (threshold) {
+      return `Awarded for publishing ${threshold} stories.`;
+    }
+  }
+
+  if (badge.criteriaType === 'points' || badge.criteriaType === 'points_total') {
+    if (threshold) {
+      return `Awarded for reaching ${formatPoints(threshold)} points.`;
+    }
+  }
+
+  return badge.description ?? 'Earned through profile activity.';
+}
+
+function getBadgeInitial(badge: BadgeEntity) {
+  if (badge.criteriaType === 'registration') {
+    return 'R';
+  }
+
+  if (badge.criteriaType === 'story_count' || badge.criteriaType === 'stories_published') {
+    return 'S';
+  }
+
+  if (badge.criteriaType === 'points' || badge.criteriaType === 'points_total') {
+    return 'P';
+  }
+
+  return badge.name.slice(0, 1).toUpperCase();
 }
 
 function formatBirthDateLabel(value: string) {
@@ -497,6 +570,203 @@ function StatButton({
       </Text>
       <Text style={{ color: selected ? colors.primary : colors.text, fontSize: typography.subtitle, fontWeight: '800' }}>{value}</Text>
     </Pressable>
+  );
+}
+
+function BadgesSection({
+  badges,
+  isLoading,
+  error,
+  onSelectBadge,
+}: {
+  badges: BadgeEntity[];
+  isLoading: boolean;
+  error?: string | null;
+  onSelectBadge: (badge: BadgeEntity) => void;
+}) {
+  const { colors, spacing, typography } = useAppTheme();
+
+  return (
+    <View
+      accessibilityLabel="Earned badges section"
+      style={{
+        padding: spacing.lg,
+        borderRadius: 20,
+        borderWidth: 1,
+        borderColor: colors.border,
+        backgroundColor: colors.surface,
+        gap: spacing.md,
+      }}
+    >
+      <View style={{ flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between', gap: spacing.md }}>
+        <View style={{ flex: 1, gap: spacing.xs }}>
+          <Text style={{ color: colors.text, fontSize: typography.subtitle, fontWeight: '800' }}>
+            Earned badges
+          </Text>
+          <Text style={{ color: colors.muted }}>
+            {badges.length === 1 ? '1 badge earned' : `${badges.length} badges earned`}
+          </Text>
+        </View>
+      </View>
+
+      {isLoading && badges.length === 0 ? <Loader message="Loading badges..." /> : null}
+
+      {error && badges.length === 0 ? (
+        <Text style={{ color: colors.danger }}>{error}</Text>
+      ) : null}
+
+      {!isLoading && !error && badges.length === 0 ? (
+        <View
+          style={{
+            padding: spacing.md,
+            borderRadius: 16,
+            borderWidth: 1,
+            borderColor: colors.border,
+            backgroundColor: colors.background,
+          }}
+        >
+          <Text style={{ color: colors.text, fontWeight: '700' }}>No badges earned yet</Text>
+          <Text style={{ marginTop: spacing.xs, color: colors.muted }}>
+            Publish stories and collect points to unlock badges.
+          </Text>
+        </View>
+      ) : null}
+
+      {badges.length > 0 ? (
+        <ScrollView
+          horizontal
+          showsHorizontalScrollIndicator={false}
+          contentContainerStyle={{ gap: spacing.sm, paddingRight: spacing.sm }}
+        >
+          {badges.map((badge) => (
+            <Pressable
+              key={badge.id}
+              accessibilityRole="button"
+              accessibilityLabel={`Open badge details: ${badge.name}`}
+              onPress={() => onSelectBadge(badge)}
+              style={({ pressed }) => ({
+                width: 156,
+                minHeight: 148,
+                padding: spacing.md,
+                borderRadius: 16,
+                borderWidth: 1,
+                borderColor: colors.border,
+                backgroundColor: colors.background,
+                gap: spacing.sm,
+                opacity: pressed ? 0.82 : 1,
+              })}
+            >
+              <View
+                style={{
+                  width: 46,
+                  height: 46,
+                  borderRadius: 23,
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                  backgroundColor: colors.infoSurface,
+                }}
+              >
+                <Text style={{ color: colors.primary, fontSize: typography.subtitle, fontWeight: '800' }}>
+                  {getBadgeInitial(badge)}
+                </Text>
+              </View>
+              <Text numberOfLines={2} style={{ color: colors.text, fontWeight: '800' }}>
+                {badge.name}
+              </Text>
+              <Text numberOfLines={3} style={{ color: colors.muted, fontSize: typography.caption }}>
+                {describeBadgeCondition(badge)}
+              </Text>
+            </Pressable>
+          ))}
+        </ScrollView>
+      ) : null}
+    </View>
+  );
+}
+
+function BadgeDetailsModal({
+  badge,
+  onClose,
+}: {
+  badge: BadgeEntity | null;
+  onClose: () => void;
+}) {
+  const { colors, spacing, typography } = useAppTheme();
+  const awardedDate = formatAwardedDate(badge?.awardedAt);
+
+  return (
+    <Modal animationType="slide" transparent visible={Boolean(badge)} onRequestClose={onClose}>
+      <View
+        style={{
+          flex: 1,
+          backgroundColor: 'rgba(10, 10, 10, 0.35)',
+          justifyContent: 'flex-end',
+        }}
+      >
+        <Pressable style={{ flex: 1 }} onPress={onClose} />
+        <View
+          style={{
+            paddingHorizontal: spacing.lg,
+            paddingTop: spacing.lg,
+            paddingBottom: spacing.xl,
+            borderTopLeftRadius: 24,
+            borderTopRightRadius: 24,
+            backgroundColor: colors.background,
+            gap: spacing.md,
+          }}
+        >
+          {badge ? (
+            <>
+              <View
+                style={{
+                  width: 54,
+                  height: 54,
+                  borderRadius: 27,
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                  backgroundColor: colors.infoSurface,
+                }}
+              >
+                <Text style={{ color: colors.primary, fontSize: typography.title, fontWeight: '800' }}>
+                  {getBadgeInitial(badge)}
+                </Text>
+              </View>
+              <View style={{ gap: spacing.xs }}>
+                <Text style={{ color: colors.text, fontSize: typography.title, fontWeight: '800' }}>
+                  {badge.name}
+                </Text>
+                <Text style={{ color: colors.text }}>
+                  {badge.description ?? describeBadgeCondition(badge)}
+                </Text>
+              </View>
+              <View
+                style={{
+                  padding: spacing.md,
+                  borderRadius: 16,
+                  borderWidth: 1,
+                  borderColor: colors.border,
+                  backgroundColor: colors.surface,
+                  gap: spacing.xs,
+                }}
+              >
+                <Text style={{ color: colors.muted, fontSize: typography.caption, textTransform: 'uppercase' }}>
+                  Requirement
+                </Text>
+                <Text style={{ color: colors.text, fontWeight: '700' }}>
+                  {describeBadgeCondition(badge)}
+                </Text>
+                {awardedDate ? (
+                  <Text style={{ color: colors.muted }}>Earned on {awardedDate}</Text>
+                ) : null}
+              </View>
+            </>
+          ) : null}
+          <Button variant="outline" onPress={onClose} fullWidth>
+            Close
+          </Button>
+        </View>
+      </View>
+    </Modal>
   );
 }
 
@@ -998,6 +1268,8 @@ export function ProfileScreen({
   getFollowers = userService.getFollowers,
   getFollowing = userService.getFollowing,
   getSavedStories = userService.getSavedStories,
+  getUserPoints = userService.getUserPoints,
+  getUserBadges = userService.getUserBadges,
   unbookmarkStory = interactionService.unbookmarkStory,
   onOpenUserProfile,
   onOpenStory,
@@ -1034,6 +1306,11 @@ export function ProfileScreen({
   const [isFollowListVisible, setIsFollowListVisible] = useState(false);
   const [activeSelfTab, setActiveSelfTab] = useState<SelfProfileTab>('profile');
   const [savedStoriesCount, setSavedStoriesCount] = useState<number | null>(null);
+  const [pointsTotal, setPointsTotal] = useState<number | null>(null);
+  const [badges, setBadges] = useState<BadgeEntity[]>([]);
+  const [isGamificationLoading, setIsGamificationLoading] = useState(false);
+  const [gamificationError, setGamificationError] = useState<string | null>(null);
+  const [selectedBadge, setSelectedBadge] = useState<BadgeEntity | null>(null);
   const scrollViewRef = useRef<ScrollView>(null);
   const savedStoriesSectionYRef = useRef(0);
   const shouldScrollToSavedStoriesRef = useRef(false);
@@ -1120,6 +1397,51 @@ export function ProfileScreen({
       isActive = false;
     };
   }, [getSavedStories, isSelfMode, profile?.id]);
+
+  useEffect(() => {
+    if (!profile?.id) {
+      setPointsTotal(null);
+      setBadges([]);
+      setGamificationError(null);
+      return;
+    }
+
+    let isActive = true;
+
+    setPointsTotal(profile.totalPoints);
+    setBadges([]);
+    setGamificationError(null);
+    setIsGamificationLoading(true);
+
+    Promise.all([
+      getUserPoints(profile.id),
+      getUserBadges(profile.id),
+    ])
+      .then(([pointsSummary, earnedBadges]) => {
+        if (!isActive) {
+          return;
+        }
+
+        setPointsTotal(pointsSummary.totalPoints);
+        setBadges(earnedBadges);
+      })
+      .catch(() => {
+        if (!isActive) {
+          return;
+        }
+
+        setGamificationError('Unable to load badges right now.');
+      })
+      .finally(() => {
+        if (isActive) {
+          setIsGamificationLoading(false);
+        }
+      });
+
+    return () => {
+      isActive = false;
+    };
+  }, [getUserBadges, getUserPoints, profile?.id, profile?.totalPoints]);
 
   const validateForm = useCallback(() => {
     const nextErrors: FormErrors = {};
@@ -1499,7 +1821,7 @@ export function ProfileScreen({
 
           <View style={{ flexDirection: 'row', flexWrap: 'wrap', gap: spacing.md }}>
             {joinedDate ? <StatChip label="Joined" value={joinedDate} /> : null}
-            {isSelfMode ? <StatChip label="Points" value={String(profile.totalPoints)} /> : null}
+            <StatChip label="Points" value={formatPoints(pointsTotal ?? profile.totalPoints)} />
             <StatChip label="Stories" value={String(profile.publishedStoryCount ?? 0)} />
             <StatButton
               label={followersCount === 1 ? 'Follower' : 'Followers'}
@@ -1547,6 +1869,13 @@ export function ProfileScreen({
             </FieldCard>
           ) : null}
         </View>
+
+        <BadgesSection
+          badges={badges}
+          isLoading={isGamificationLoading}
+          error={gamificationError}
+          onSelectBadge={setSelectedBadge}
+        />
 
         {isSelfMode && activeSelfTab === 'saved' ? (
           <View
@@ -1856,6 +2185,11 @@ export function ProfileScreen({
         showCurrentUserAtTop={isFollowing}
         onClose={() => setIsFollowListVisible(false)}
         onOpenUserProfile={handleOpenFollowUserProfile}
+      />
+
+      <BadgeDetailsModal
+        badge={selectedBadge}
+        onClose={() => setSelectedBadge(null)}
       />
 
       <Modal

--- a/mobile/src/features/profile/presentation/screens/ProfileScreen.tsx
+++ b/mobile/src/features/profile/presentation/screens/ProfileScreen.tsx
@@ -177,6 +177,7 @@ function formatAwardedDate(value?: string | null) {
     month: 'short',
     day: 'numeric',
     year: 'numeric',
+    timeZone: 'UTC',
   });
 }
 
@@ -604,7 +605,11 @@ function BadgesSection({
             Earned badges
           </Text>
           <Text style={{ color: colors.muted }}>
-            {badges.length === 1 ? '1 badge earned' : `${badges.length} badges earned`}
+            {isLoading && badges.length === 0
+              ? 'Loading badges...'
+              : badges.length === 1
+                ? '1 badge earned'
+                : `${badges.length} badges earned`}
           </Text>
         </View>
       </View>
@@ -1308,7 +1313,7 @@ export function ProfileScreen({
   const [savedStoriesCount, setSavedStoriesCount] = useState<number | null>(null);
   const [pointsTotal, setPointsTotal] = useState<number | null>(null);
   const [badges, setBadges] = useState<BadgeEntity[]>([]);
-  const [isGamificationLoading, setIsGamificationLoading] = useState(false);
+  const [isGamificationLoading, setIsGamificationLoading] = useState(true);
   const [gamificationError, setGamificationError] = useState<string | null>(null);
   const [selectedBadge, setSelectedBadge] = useState<BadgeEntity | null>(null);
   const scrollViewRef = useRef<ScrollView>(null);
@@ -1348,6 +1353,11 @@ export function ProfileScreen({
         });
       }
 
+      setPointsTotal(nextProfile.totalPoints);
+      setBadges([]);
+      setGamificationError(null);
+      setSelectedBadge(null);
+      setIsGamificationLoading(true);
       setProfile(nextProfile);
       setFollowersCount(nextProfile.followersCount ?? 0);
       setFollowingCount(nextProfile.followingCount ?? 0);
@@ -1413,24 +1423,28 @@ export function ProfileScreen({
     setGamificationError(null);
     setIsGamificationLoading(true);
 
-    Promise.all([
+    Promise.allSettled([
       getUserPoints(profile.id),
       getUserBadges(profile.id),
     ])
-      .then(([pointsSummary, earnedBadges]) => {
+      .then(([pointsResult, badgesResult]) => {
         if (!isActive) {
           return;
         }
 
-        setPointsTotal(pointsSummary.totalPoints);
-        setBadges(earnedBadges);
-      })
-      .catch(() => {
-        if (!isActive) {
-          return;
+        if (pointsResult.status === 'fulfilled') {
+          setPointsTotal(pointsResult.value.totalPoints);
+        } else {
+          setPointsTotal(profile.totalPoints);
         }
 
-        setGamificationError('Unable to load badges right now.');
+        if (badgesResult.status === 'fulfilled') {
+          setBadges(badgesResult.value);
+          setGamificationError(null);
+        } else {
+          setBadges([]);
+          setGamificationError('Unable to load badges right now.');
+        }
       })
       .finally(() => {
         if (isActive) {

--- a/mobile/src/features/profile/presentation/screens/ProfileScreen.tsx
+++ b/mobile/src/features/profile/presentation/screens/ProfileScreen.tsx
@@ -228,6 +228,9 @@ function getBadgePalette(badge: BadgeEntity) {
     return {
       background: '#FEF3C7',
       border: '#F59E0B',
+      inner: '#FDE68A',
+      ribbon: '#D97706',
+      ribbonEdge: '#B45309',
       text: '#92400E',
       shine: '#FFFBEB',
     };
@@ -237,6 +240,9 @@ function getBadgePalette(badge: BadgeEntity) {
     return {
       background: '#DBEAFE',
       border: '#2563EB',
+      inner: '#BFDBFE',
+      ribbon: '#1D4ED8',
+      ribbonEdge: '#1E40AF',
       text: '#1E3A8A',
       shine: '#EFF6FF',
     };
@@ -246,6 +252,9 @@ function getBadgePalette(badge: BadgeEntity) {
     return {
       background: '#DCFCE7',
       border: '#16A34A',
+      inner: '#BBF7D0',
+      ribbon: '#15803D',
+      ribbonEdge: '#166534',
       text: '#166534',
       shine: '#F0FDF4',
     };
@@ -254,6 +263,9 @@ function getBadgePalette(badge: BadgeEntity) {
   return {
     background: '#F3E8FF',
     border: '#9333EA',
+    inner: '#E9D5FF',
+    ribbon: '#7E22CE',
+    ribbonEdge: '#6B21A8',
     text: '#581C87',
     shine: '#FAF5FF',
   };
@@ -689,7 +701,7 @@ function BadgesSection({
                 accessibilityLabel={`Open badge details: ${badge.name}`}
                 onPress={() => onSelectBadge(badge)}
                 style={({ pressed }) => ({
-                  width: 82,
+                  width: 88,
                   alignItems: 'center',
                   gap: spacing.xs,
                   opacity: pressed ? 0.76 : 1,
@@ -698,36 +710,94 @@ function BadgesSection({
               >
                 <View
                   style={{
-                    width: 58,
-                    height: 58,
-                    borderRadius: 29,
+                    width: 72,
+                    height: 78,
                     alignItems: 'center',
-                    justifyContent: 'center',
-                    borderWidth: 2,
-                    borderColor: badgePalette.border,
-                    backgroundColor: badgePalette.background,
-                    shadowColor: badgePalette.border,
-                    shadowOpacity: 0.2,
-                    shadowRadius: 8,
-                    shadowOffset: { width: 0, height: 3 },
-                    elevation: 2,
+                    justifyContent: 'flex-start',
                   }}
                 >
                   <View
                     style={{
                       position: 'absolute',
-                      top: 8,
-                      left: 10,
-                      width: 17,
-                      height: 9,
-                      borderRadius: 9,
-                      backgroundColor: badgePalette.shine,
-                      opacity: 0.9,
+                      top: 42,
+                      left: 18,
+                      flexDirection: 'row',
+                      zIndex: 0,
                     }}
-                  />
-                  <Text style={{ color: badgePalette.text, fontSize: 18, fontWeight: '900' }}>
-                    {getBadgeInitial(badge)}
-                  </Text>
+                  >
+                    <View
+                      style={{
+                        width: 16,
+                        height: 30,
+                        borderBottomLeftRadius: 4,
+                        borderBottomRightRadius: 4,
+                        borderWidth: 1,
+                        borderColor: badgePalette.ribbonEdge,
+                        backgroundColor: badgePalette.ribbon,
+                        transform: [{ rotate: '10deg' }],
+                      }}
+                    />
+                    <View
+                      style={{
+                        width: 16,
+                        height: 30,
+                        marginLeft: -2,
+                        borderBottomLeftRadius: 4,
+                        borderBottomRightRadius: 4,
+                        borderWidth: 1,
+                        borderColor: badgePalette.ribbonEdge,
+                        backgroundColor: badgePalette.ribbon,
+                        transform: [{ rotate: '-10deg' }],
+                      }}
+                    />
+                  </View>
+                  <View
+                    style={{
+                      width: 58,
+                      height: 58,
+                      borderRadius: 29,
+                      alignItems: 'center',
+                      justifyContent: 'center',
+                      borderWidth: 2,
+                      borderColor: badgePalette.border,
+                      backgroundColor: badgePalette.background,
+                      shadowColor: badgePalette.border,
+                      shadowOpacity: 0.24,
+                      shadowRadius: 9,
+                      shadowOffset: { width: 0, height: 3 },
+                      elevation: 3,
+                      zIndex: 1,
+                    }}
+                  >
+                    <View
+                      style={{
+                        position: 'absolute',
+                        top: 8,
+                        left: 10,
+                        width: 17,
+                        height: 9,
+                        borderRadius: 9,
+                        backgroundColor: badgePalette.shine,
+                        opacity: 0.9,
+                      }}
+                    />
+                    <View
+                      style={{
+                        width: 42,
+                        height: 42,
+                        borderRadius: 21,
+                        alignItems: 'center',
+                        justifyContent: 'center',
+                        borderWidth: 1,
+                        borderColor: badgePalette.border,
+                        backgroundColor: badgePalette.inner,
+                      }}
+                    >
+                      <Text style={{ color: badgePalette.text, fontSize: 17, fontWeight: '900' }}>
+                        {getBadgeInitial(badge)}
+                      </Text>
+                    </View>
+                  </View>
                 </View>
                 <Text
                   numberOfLines={2}
@@ -795,31 +865,94 @@ function BadgeDetailsModal({
               <View
                 style={{
                   alignSelf: 'center',
-                  width: 76,
-                  height: 76,
-                  borderRadius: 38,
+                  width: 106,
+                  height: 122,
                   alignItems: 'center',
-                  justifyContent: 'center',
-                  borderWidth: 2,
-                  borderColor: badgePalette.border,
-                  backgroundColor: badgePalette.background,
+                  justifyContent: 'flex-start',
                 }}
               >
                 <View
                   style={{
                     position: 'absolute',
-                    top: 11,
-                    left: 14,
-                    width: 23,
-                    height: 12,
-                    borderRadius: 12,
-                    backgroundColor: badgePalette.shine,
-                    opacity: 0.9,
+                    top: 66,
+                    left: 28,
+                    flexDirection: 'row',
+                    zIndex: 0,
                   }}
-                />
-                <Text style={{ color: badgePalette.text, fontSize: 24, fontWeight: '900' }}>
-                  {getBadgeInitial(badge)}
-                </Text>
+                >
+                  <View
+                    style={{
+                      width: 24,
+                      height: 44,
+                      borderBottomLeftRadius: 6,
+                      borderBottomRightRadius: 6,
+                      borderWidth: 1,
+                      borderColor: badgePalette.ribbonEdge,
+                      backgroundColor: badgePalette.ribbon,
+                      transform: [{ rotate: '10deg' }],
+                    }}
+                  />
+                  <View
+                    style={{
+                      width: 24,
+                      height: 44,
+                      marginLeft: -3,
+                      borderBottomLeftRadius: 6,
+                      borderBottomRightRadius: 6,
+                      borderWidth: 1,
+                      borderColor: badgePalette.ribbonEdge,
+                      backgroundColor: badgePalette.ribbon,
+                      transform: [{ rotate: '-10deg' }],
+                    }}
+                  />
+                </View>
+                <View
+                  style={{
+                    width: 84,
+                    height: 84,
+                    borderRadius: 42,
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                    borderWidth: 3,
+                    borderColor: badgePalette.border,
+                    backgroundColor: badgePalette.background,
+                    shadowColor: badgePalette.border,
+                    shadowOpacity: 0.28,
+                    shadowRadius: 14,
+                    shadowOffset: { width: 0, height: 6 },
+                    elevation: 5,
+                    zIndex: 1,
+                  }}
+                >
+                  <View
+                    style={{
+                      position: 'absolute',
+                      top: 12,
+                      left: 15,
+                      width: 26,
+                      height: 13,
+                      borderRadius: 13,
+                      backgroundColor: badgePalette.shine,
+                      opacity: 0.92,
+                    }}
+                  />
+                  <View
+                    style={{
+                      width: 60,
+                      height: 60,
+                      borderRadius: 30,
+                      alignItems: 'center',
+                      justifyContent: 'center',
+                      borderWidth: 1,
+                      borderColor: badgePalette.border,
+                      backgroundColor: badgePalette.inner,
+                    }}
+                  >
+                    <Text style={{ color: badgePalette.text, fontSize: 25, fontWeight: '900' }}>
+                      {getBadgeInitial(badge)}
+                    </Text>
+                  </View>
+                </View>
               </View>
               <View style={{ alignItems: 'center', gap: spacing.xs }}>
                 <Text style={{ color: colors.text, fontSize: typography.title, fontWeight: '800', textAlign: 'center' }}>

--- a/mobile/src/features/profile/presentation/screens/__tests__/ProfileScreen.test.tsx
+++ b/mobile/src/features/profile/presentation/screens/__tests__/ProfileScreen.test.tsx
@@ -279,7 +279,29 @@ describe('ProfileScreen', () => {
     );
 
     expect(await screen.findByText('Traveler')).toBeTruthy();
-    expect(screen.getByText('Loading badges...')).toBeTruthy();
+    expect(screen.getAllByText('Loading badges...').length).toBeGreaterThan(0);
+  });
+
+  it('keeps profile points visible and shows a badge error when badge loading fails', async () => {
+    render(
+      <ProfileScreen
+        mode="self"
+        getCurrentProfile={async () => ({
+          ...selfProfile,
+          totalPoints: 42,
+        })}
+        getUserPoints={async () => {
+          throw new Error('Points unavailable');
+        }}
+        getUserBadges={async () => {
+          throw new Error('Badges unavailable');
+        }}
+      />,
+    );
+
+    expect(await screen.findByText('Traveler')).toBeTruthy();
+    expect(screen.getByText('42')).toBeTruthy();
+    expect(await screen.findByText('Unable to load badges right now.')).toBeTruthy();
   });
 
   it('renders saved stories on the signed-in user profile', async () => {

--- a/mobile/src/features/profile/presentation/screens/__tests__/ProfileScreen.test.tsx
+++ b/mobile/src/features/profile/presentation/screens/__tests__/ProfileScreen.test.tsx
@@ -134,6 +134,11 @@ describe('ProfileScreen', () => {
       items: [],
       totalCount: 0,
     }));
+    jest.spyOn(userService, 'getUserPoints').mockImplementation(async (userId) => ({
+      userId,
+      totalPoints: userId === publicProfile.id ? publicProfile.totalPoints : selfProfile.totalPoints,
+    }));
+    jest.spyOn(userService, 'getUserBadges').mockResolvedValue([]);
     mockAuthUser = {
       id: 7,
       email: 'traveler@example.com',
@@ -200,6 +205,81 @@ describe('ProfileScreen', () => {
 
     expect(await screen.findByText('Traveler')).toBeTruthy();
     expect(screen.getByText('May 20, 1995')).toBeTruthy();
+  });
+
+  it('renders points and earned badges with a badge detail modal', async () => {
+    render(
+      <ProfileScreen
+        mode="self"
+        getCurrentProfile={async () => ({
+          ...selfProfile,
+          totalPoints: 100,
+        })}
+        getUserPoints={async () => ({
+          userId: '7',
+          totalPoints: 1250,
+        })}
+        getUserBadges={async () => [
+          {
+            id: 'badge-1',
+            name: 'First Story',
+            description: 'Published one story.',
+            criteriaType: 'stories_published',
+            criteriaThreshold: 1,
+            awardedAt: '2026-05-01T12:00:00Z',
+          },
+        ]}
+      />,
+    );
+
+    expect(await screen.findByText('Traveler')).toBeTruthy();
+    expect(await screen.findByText('1,250')).toBeTruthy();
+    expect(await screen.findByText('First Story')).toBeTruthy();
+
+    fireEvent.press(screen.getByLabelText('Open badge details: First Story'));
+
+    expect(await screen.findByText('Published one story.')).toBeTruthy();
+    expect(screen.getAllByText('Awarded for publishing your first story.').length).toBeGreaterThan(0);
+    expect(screen.getByText('Earned on May 1, 2026')).toBeTruthy();
+  });
+
+  it('shows points and the badge empty state on public profiles', async () => {
+    render(
+      <ProfileScreen
+        mode="public"
+        userId="45"
+        getPublicProfile={async () => ({
+          ...publicProfile,
+          id: '45',
+          totalPoints: 300,
+          followersCount: 2,
+          followingCount: 1,
+        })}
+        getUserPoints={async () => ({
+          userId: '45',
+          totalPoints: 500,
+        })}
+        getUserBadges={async () => []}
+      />,
+    );
+
+    expect(await screen.findByText('Aylin')).toBeTruthy();
+    expect(await screen.findByText('500')).toBeTruthy();
+    expect(await screen.findByText('No badges earned yet')).toBeTruthy();
+    expect(screen.queryByText('Saved Stories')).toBeNull();
+  });
+
+  it('shows a loading state while badges are being fetched', async () => {
+    render(
+      <ProfileScreen
+        mode="self"
+        getCurrentProfile={async () => selfProfile}
+        getUserBadges={() => new Promise<never>(() => undefined)}
+      />,
+    );
+
+    expect(await screen.findByText('Traveler')).toBeTruthy();
+    expect(screen.getByText('Loading badges...')).toBeTruthy();
   });
 
   it('renders saved stories on the signed-in user profile', async () => {


### PR DESCRIPTION
# 📝 Description
Fixes #192

Implements mobile profile gamification display for both own and public profiles. Profiles now show the user's total points, load earned badges from the gamification endpoints, render badges in a mobile-friendly horizontal section, and open a badge detail modal with requirements and earned date information.

Also wires the mobile profile API/service layer to the shared gamification contract:
- `userService.getUserPoints()`
- `userService.getUserBadges()`

# 📊 Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Refactoring
- [ ] Documentation

# ✅ Acceptance Criteria / Checklist
- [x] Points are displayed on the authenticated user's profile header
- [x] Points are visible on public profiles
- [x] Earned badges are displayed in a mobile-friendly horizontal layout
- [x] Badge details are shown when a badge is tapped
- [x] Registration, story-count, and points-threshold badge criteria render with readable descriptions
- [x] Empty badge state is shown when the user has no earned badges
- [x] Loading state is shown while badges are being fetched
- [x] API service methods added for points and badges
- [x] Unit tests cover points rendering, badge display, badge interaction, empty state, and loading state

# 🧪 Tests
- [x] `npm run typecheck`
- [x] `npm test -- --runTestsByPath src/features/profile/application/services/__tests__/userService.test.ts src/features/profile/presentation/screens/__tests__/ProfileScreen.test.tsx`
- [x] `npm test -- --runInBand`

# ⏱️ Estimated Review Time
- [ ] < 5 min
- [ ] 5-15 min
- [x] > 15 min
