### PR TITLE
feat: integrate public profile stories on mobile

### DIFF
--- a/backend/apps/users/tests/test_views.py
+++ b/backend/apps/users/tests/test_views.py
@@ -1097,7 +1097,7 @@ class TestUserBookmarksView:
 class TestUserStoriesView:
     url = '/users/{user_id}/stories/'
 
-    def _make_story(self, user, title='Story', status=Story.STATUS_PUBLISHED):
+    def _make_story(self, user, title='Story', status=Story.STATUS_PUBLISHED, contributor_visible=True):
         return Story.objects.create(
             user=user,
             title=title,
@@ -1108,6 +1108,7 @@ class TestUserStoriesView:
             location_name='Istanbul',
             time_type=Story.TIME_EXACT,
             year=2000,
+            contributor_visible=contributor_visible,
         )
 
     def test_unauthenticated_returns_200(self, client, user):
@@ -1121,6 +1122,28 @@ class TestUserStoriesView:
         response = client.get(self.url.format(user_id=user.pk))
         assert response.data['count'] == 1
         assert response.data['results'][0]['title'] == 'Published'
+
+    def test_public_profile_hides_anonymous_stories_from_other_viewers(self, client, user, second_user):
+        self._make_story(user, title='Visible Story')
+        self._make_story(user, title='Anonymous Story', contributor_visible=False)
+        client.force_authenticate(user=second_user)
+
+        response = client.get(self.url.format(user_id=user.pk))
+
+        assert response.status_code == 200
+        assert response.data['count'] == 1
+        assert response.data['results'][0]['title'] == 'Visible Story'
+
+    def test_owner_profile_includes_own_anonymous_stories(self, client, user):
+        self._make_story(user, title='Visible Story')
+        self._make_story(user, title='Anonymous Story', contributor_visible=False)
+        client.force_authenticate(user=user)
+
+        response = client.get(self.url.format(user_id=user.pk))
+
+        assert response.status_code == 200
+        assert response.data['count'] == 2
+        assert {story['title'] for story in response.data['results']} == {'Visible Story', 'Anonymous Story'}
 
     def test_response_is_paginated(self, client, user):
         response = client.get(self.url.format(user_id=user.pk))

--- a/backend/apps/users/views.py
+++ b/backend/apps/users/views.py
@@ -255,6 +255,9 @@ class UserStoriesView(APIView):
 
     def get(self, request, user_id):
         qs = get_user_published_stories(user_id)
+        is_owner = request.user.is_authenticated and request.user.pk == user_id
+        if not is_owner:
+            qs = qs.filter(contributor_visible=True)
         if request.user.is_authenticated:
             qs = annotate_user_interactions(qs, request.user)
         paginator = StoryPagination()

--- a/mobile/src/app/navigation/RootNavigator.tsx
+++ b/mobile/src/app/navigation/RootNavigator.tsx
@@ -854,6 +854,7 @@ export function RootNavigator() {
           mode="public"
           userId={activeUserId}
           onOpenUserProfile={(targetUserId) => navigationRef.navigateToUserProfile?.(targetUserId)}
+          onOpenStory={handleOpenStoryDetail}
         />
       </ScreenShell>
     );

--- a/mobile/src/app/navigation/__tests__/RootNavigator.test.tsx
+++ b/mobile/src/app/navigation/__tests__/RootNavigator.test.tsx
@@ -264,6 +264,23 @@ function installAuthTransport() {
       };
     }
 
+    if (
+      method === 'GET' &&
+      (config.url === '/users/12/stories/?page=1&page_size=10' ||
+        config.url === '/users/1/stories/?page=1&page_size=10')
+    ) {
+      return {
+        status: 200,
+        data: {
+          count: feedResults.length,
+          next: null,
+          previous: null,
+          results: feedResults,
+        } as never,
+        config,
+      };
+    }
+
     if (method === 'GET' && config.url?.startsWith('/notifications/')) {
       if (config.url === '/notifications/preferences/') {
         return {
@@ -1190,6 +1207,25 @@ describe('RootNavigator auth flow', () => {
     });
   });
 
+  it('opens story detail from a public profile published story card', async () => {
+    render(
+      <AppProviders>
+        <RootNavigator />
+      </AppProviders>,
+    );
+
+    await screen.findByLabelText('Read story: Harbor Memory');
+    fireEvent.press(screen.getByLabelText('Read story: Harbor Memory'));
+    expect(await screen.findByText('Harbor Memory')).toBeTruthy();
+
+    fireEvent.press(screen.getByLabelText('Open profile: Aylin'));
+    expect(await screen.findByText('Published Stories')).toBeTruthy();
+
+    fireEvent.press(screen.getByLabelText('Read story: Harbor Memory'));
+
+    expect(await screen.findByText('It still lives in local memory.')).toBeTruthy();
+  });
+
   it('opens the signed-in user profile when the contributor is the current user', async () => {
     setApiTransport(async (method, config) => {
       if (method === 'GET' && (config.url?.startsWith('/stories/feed/') || config.url?.startsWith('/stories/search/'))) {
@@ -1255,6 +1291,27 @@ describe('RootNavigator auth flow', () => {
         return {
           status: 200,
           data: profileDetail as never,
+          config,
+        };
+      }
+
+      if (method === 'GET' && config.url === '/users/1/') {
+        return {
+          status: 200,
+          data: ownPublicProfileDetail as never,
+          config,
+        };
+      }
+
+      if (method === 'GET' && config.url === '/users/1/stories/?page=1&page_size=10') {
+        return {
+          status: 200,
+          data: {
+            count: feedResults.length,
+            next: null,
+            previous: null,
+            results: feedResults,
+          } as never,
           config,
         };
       }

--- a/mobile/src/features/profile/application/services/__tests__/userService.test.ts
+++ b/mobile/src/features/profile/application/services/__tests__/userService.test.ts
@@ -243,6 +243,57 @@ describe('userService', () => {
     });
   });
 
+  it('loads public user stories from the published stories endpoint', async () => {
+    setApiTransport(async (method: any, config: any) => {
+      if (method === 'GET' && config.url === '/users/12/stories/?page=3&page_size=10') {
+        return {
+          status: 200,
+          data: {
+            count: 21,
+            next: 'next-page',
+            previous: 'previous-page',
+            results: [
+              {
+                id: 'story-9',
+                title: 'Published Harbor',
+                location_name: 'Golden Horn',
+                time_type: 'exact_year',
+                year: 1980,
+                preview_text: 'A public profile story.',
+                submitted_at: '2026-04-12T09:00:00Z',
+                like_count: 6,
+                user_has_liked: true,
+                user_has_saved: true,
+                tags: [{ name: 'Culture' }],
+              },
+            ],
+          } as never,
+          config,
+        };
+      }
+
+      throw new Error(`Unexpected request: ${method} ${config.url}`);
+    });
+
+    await expect(userService.getUserStories('12', 3)).resolves.toMatchObject({
+      page: 3,
+      totalCount: 21,
+      hasNextPage: true,
+      items: [
+        {
+          id: 'story-9',
+          title: 'Published Harbor',
+          locationName: 'Golden Horn',
+          timePeriod: '1980',
+          likeCount: 6,
+          likedByViewer: true,
+          savedByViewer: true,
+          tags: ['Culture'],
+        },
+      ],
+    });
+  });
+
   it('updates the authenticated profile via PATCH /users/me/', async () => {
     setApiTransport(async (method: any, config: any) => {
       if (method === 'PATCH' && config.url === '/users/me/') {

--- a/mobile/src/features/profile/application/services/index.ts
+++ b/mobile/src/features/profile/application/services/index.ts
@@ -41,4 +41,7 @@ export const userService = {
   async getSavedStories(userId: string, page = 1): Promise<FeedPageEntity> {
     return repository.getSavedStories(userId, page);
   },
+  async getUserStories(userId: string, page = 1): Promise<FeedPageEntity> {
+    return repository.getUserStories(userId, page);
+  },
 };

--- a/mobile/src/features/profile/data/repositories/index.ts
+++ b/mobile/src/features/profile/data/repositories/index.ts
@@ -75,4 +75,9 @@ export class ProfileRepositoryImpl implements ProfileRepository {
     const payload = await profileRemoteSource.getSavedStories(userId, page);
     return mapFeedPage(payload, page, 10);
   }
+
+  async getUserStories(userId: string, page = 1) {
+    const payload = await profileRemoteSource.getUserStories(userId, page);
+    return mapFeedPage(payload, page, 10);
+  }
 }

--- a/mobile/src/features/profile/data/sources/index.ts
+++ b/mobile/src/features/profile/data/sources/index.ts
@@ -165,6 +165,17 @@ export const profileRemoteSource = {
       results: [],
     };
   },
+
+  async getUserStories(userId: string, page = 1) {
+    return (await apiClient.get<Record<string, unknown>>(
+      `/users/${userId}/stories/${buildQueryString({ page, page_size: 10 })}`,
+    )) ?? {
+      count: 0,
+      next: null,
+      previous: null,
+      results: [],
+    };
+  },
 };
 
 export const profileLocalSource = {};

--- a/mobile/src/features/profile/domain/repositories/index.ts
+++ b/mobile/src/features/profile/domain/repositories/index.ts
@@ -13,4 +13,5 @@ export interface ProfileRepository {
   getFollowers(userId: string, page?: number): Promise<FollowListResult>;
   getFollowing(userId: string, page?: number): Promise<FollowListResult>;
   getSavedStories(userId: string, page?: number): Promise<FeedPageEntity>;
+  getUserStories(userId: string, page?: number): Promise<FeedPageEntity>;
 }

--- a/mobile/src/features/profile/presentation/screens/ProfileScreen.tsx
+++ b/mobile/src/features/profile/presentation/screens/ProfileScreen.tsx
@@ -370,10 +370,14 @@ function validatePendingPhoto(photo: PendingPhotoState | null) {
 }
 
 function getPublishedStoriesErrorMessage(error: unknown) {
+  const responseStatus =
+    error && typeof error === 'object' && 'response' in error
+      ? (error as { response?: { status?: unknown } }).response?.status
+      : undefined;
   const message = error instanceof Error ? error.message : '';
   const normalizedMessage = message.toLowerCase();
 
-  if (normalizedMessage.includes('404') || normalizedMessage.includes('not found')) {
+  if (responseStatus === 404 || normalizedMessage.includes('404') || normalizedMessage.includes('not found')) {
     return 'This profile is unavailable or no longer active.';
   }
 
@@ -841,9 +845,13 @@ function PublishedStoriesSection({
   const [isLoadingMore, setIsLoadingMore] = useState(false);
   const [error, setError] = useState<string>();
   const [totalCount, setTotalCount] = useState(0);
+  const storyRequestIdRef = useRef(0);
 
   const loadPage = useCallback(
     async (nextPage: number, append: boolean) => {
+      const requestId = storyRequestIdRef.current + 1;
+      storyRequestIdRef.current = requestId;
+
       if (append) {
         setIsLoadingMore(true);
       } else {
@@ -855,15 +863,25 @@ function PublishedStoriesSection({
       try {
         const result = await getUserStories(userId, nextPage);
 
+        if (storyRequestIdRef.current !== requestId) {
+          return;
+        }
+
         setStories((current) => (append ? [...current, ...result.items] : result.items));
         setPage(nextPage);
         setHasMore(result.hasNextPage);
         setTotalCount(result.totalCount);
       } catch (loadError) {
+        if (storyRequestIdRef.current !== requestId) {
+          return;
+        }
+
         setError(getPublishedStoriesErrorMessage(loadError));
       } finally {
-        setIsLoading(false);
-        setIsLoadingMore(false);
+        if (storyRequestIdRef.current === requestId) {
+          setIsLoading(false);
+          setIsLoadingMore(false);
+        }
       }
     },
     [getUserStories, userId],
@@ -875,6 +893,10 @@ function PublishedStoriesSection({
     setHasMore(false);
     setTotalCount(0);
     void loadPage(1, false);
+
+    return () => {
+      storyRequestIdRef.current += 1;
+    };
   }, [loadPage]);
 
   return (

--- a/mobile/src/features/profile/presentation/screens/ProfileScreen.tsx
+++ b/mobile/src/features/profile/presentation/screens/ProfileScreen.tsx
@@ -55,6 +55,7 @@ interface ProfileScreenProps {
   getFollowers?: typeof userService.getFollowers;
   getFollowing?: typeof userService.getFollowing;
   getSavedStories?: typeof userService.getSavedStories;
+  getUserStories?: typeof userService.getUserStories;
   unbookmarkStory?: typeof interactionService.unbookmarkStory;
   onOpenUserProfile?: (userId: string) => void;
   onOpenStory?: (storyId: string) => void;
@@ -366,6 +367,17 @@ function validatePendingPhoto(photo: PendingPhotoState | null) {
   }
 
   return undefined;
+}
+
+function getPublishedStoriesErrorMessage(error: unknown) {
+  const message = error instanceof Error ? error.message : '';
+  const normalizedMessage = message.toLowerCase();
+
+  if (normalizedMessage.includes('404') || normalizedMessage.includes('not found')) {
+    return 'This profile is unavailable or no longer active.';
+  }
+
+  return message || 'Unable to load published stories.';
 }
 
 function LoadingState() {
@@ -812,6 +824,129 @@ function FieldCard({
   );
 }
 
+function PublishedStoriesSection({
+  userId,
+  getUserStories,
+  onOpenStory,
+}: {
+  userId: string;
+  getUserStories: (userId: string, page?: number) => Promise<FeedPageEntity>;
+  onOpenStory?: (storyId: string) => void;
+}) {
+  const { colors, spacing, typography } = useAppTheme();
+  const [stories, setStories] = useState<FeedEntity[]>([]);
+  const [page, setPage] = useState(1);
+  const [hasMore, setHasMore] = useState(false);
+  const [isLoading, setIsLoading] = useState(true);
+  const [isLoadingMore, setIsLoadingMore] = useState(false);
+  const [error, setError] = useState<string>();
+  const [totalCount, setTotalCount] = useState(0);
+
+  const loadPage = useCallback(
+    async (nextPage: number, append: boolean) => {
+      if (append) {
+        setIsLoadingMore(true);
+      } else {
+        setIsLoading(true);
+      }
+
+      setError(undefined);
+
+      try {
+        const result = await getUserStories(userId, nextPage);
+
+        setStories((current) => (append ? [...current, ...result.items] : result.items));
+        setPage(nextPage);
+        setHasMore(result.hasNextPage);
+        setTotalCount(result.totalCount);
+      } catch (loadError) {
+        setError(getPublishedStoriesErrorMessage(loadError));
+      } finally {
+        setIsLoading(false);
+        setIsLoadingMore(false);
+      }
+    },
+    [getUserStories, userId],
+  );
+
+  useEffect(() => {
+    setStories([]);
+    setPage(1);
+    setHasMore(false);
+    setTotalCount(0);
+    void loadPage(1, false);
+  }, [loadPage]);
+
+  return (
+    <View
+      accessibilityLabel="Published stories section"
+      style={{
+        padding: spacing.lg,
+        borderRadius: 20,
+        borderWidth: 1,
+        borderColor: colors.border,
+        backgroundColor: colors.surface,
+        gap: spacing.md,
+      }}
+    >
+      <View style={{ gap: spacing.xs }}>
+        <Text style={{ color: colors.text, fontSize: typography.subtitle, fontWeight: '800' }}>
+          Published Stories
+        </Text>
+        <Text style={{ color: colors.muted }}>
+          {totalCount > 0
+            ? `${totalCount} ${totalCount === 1 ? 'story' : 'stories'} published by this user.`
+            : 'Stories published by this user.'}
+        </Text>
+      </View>
+
+      {isLoading && stories.length === 0 ? <Loader message="Loading published stories..." /> : null}
+
+      {error && stories.length === 0 ? (
+        <ErrorState
+          title="Published stories unavailable"
+          message={error}
+          retryLabel="Try again"
+          onRetry={() => {
+            void loadPage(1, false);
+          }}
+        />
+      ) : null}
+
+      {!isLoading && !error && stories.length === 0 ? (
+        <EmptyState
+          title="No published stories yet"
+          message="This user has not published any stories yet."
+        />
+      ) : null}
+
+      {stories.length > 0 ? (
+        <View style={{ gap: spacing.md }}>
+          {stories.map((story) => (
+            <FeedCard
+              key={story.id}
+              story={story}
+              onPress={onOpenStory}
+            />
+          ))}
+          {error ? <Text style={{ color: colors.danger }}>{error}</Text> : null}
+          {hasMore ? (
+            <Button
+              variant="outline"
+              onPress={() => {
+                void loadPage(page + 1, true);
+              }}
+              disabled={isLoadingMore}
+            >
+              {isLoadingMore ? 'Loading...' : 'Load more stories'}
+            </Button>
+          ) : null}
+        </View>
+      ) : null}
+    </View>
+  );
+}
+
 function SavedStoriesSection({
   userId,
   getSavedStories,
@@ -998,6 +1133,7 @@ export function ProfileScreen({
   getFollowers = userService.getFollowers,
   getFollowing = userService.getFollowing,
   getSavedStories = userService.getSavedStories,
+  getUserStories = userService.getUserStories,
   unbookmarkStory = interactionService.unbookmarkStory,
   onOpenUserProfile,
   onOpenStory,
@@ -1826,23 +1962,11 @@ export function ProfileScreen({
         ) : null}
 
         {!isSelfMode ? (
-          <View
-            style={{
-              padding: spacing.lg,
-              borderRadius: 20,
-              borderWidth: 1,
-              borderColor: colors.border,
-              backgroundColor: colors.surface,
-              gap: spacing.sm,
-            }}
-          >
-            <Text style={{ color: colors.text, fontSize: typography.subtitle, fontWeight: '800' }}>
-              Stories
-            </Text>
-            <Text style={{ color: colors.muted }}>
-              Stories are intentionally out of scope for this profile version and will be added later.
-            </Text>
-          </View>
+          <PublishedStoriesSection
+            userId={profile.id}
+            getUserStories={getUserStories}
+            onOpenStory={onOpenStory}
+          />
         ) : null}
       </ScrollView>
 

--- a/mobile/src/features/profile/presentation/screens/ProfileScreen.tsx
+++ b/mobile/src/features/profile/presentation/screens/ProfileScreen.tsx
@@ -1983,6 +1983,14 @@ export function ProfileScreen({
           </View>
         ) : null}
 
+        {isSelfMode && activeSelfTab === 'profile' ? (
+          <PublishedStoriesSection
+            userId={profile.id}
+            getUserStories={getUserStories}
+            onOpenStory={onOpenStory}
+          />
+        ) : null}
+
         {!isSelfMode ? (
           <PublishedStoriesSection
             userId={profile.id}

--- a/mobile/src/features/profile/presentation/screens/ProfileScreen.tsx
+++ b/mobile/src/features/profile/presentation/screens/ProfileScreen.tsx
@@ -25,6 +25,7 @@ const BIO_MAX_LENGTH = 280;
 const MIN_BIRTH_YEAR = 1900;
 const FOLLOW_STATE_LOOKUP_MAX_PAGES = 10;
 const FOLLOW_LIST_DRAG_THRESHOLD = 8;
+const PUBLISHED_STORIES_COLLAPSED_LIMIT = 3;
 const followStateOverrides = new Map<string, boolean>();
 const MONTH_OPTIONS = [
   'January',
@@ -845,6 +846,7 @@ function PublishedStoriesSection({
   const [isLoadingMore, setIsLoadingMore] = useState(false);
   const [error, setError] = useState<string>();
   const [totalCount, setTotalCount] = useState(0);
+  const [isExpanded, setIsExpanded] = useState(false);
   const storyRequestIdRef = useRef(0);
 
   const loadPage = useCallback(
@@ -892,12 +894,21 @@ function PublishedStoriesSection({
     setPage(1);
     setHasMore(false);
     setTotalCount(0);
+    setIsExpanded(false);
     void loadPage(1, false);
 
     return () => {
       storyRequestIdRef.current += 1;
     };
   }, [loadPage]);
+
+  const hasHiddenPublishedStories = stories.length > PUBLISHED_STORIES_COLLAPSED_LIMIT;
+  const shouldShowPublishedStoryToggle =
+    hasHiddenPublishedStories || totalCount > PUBLISHED_STORIES_COLLAPSED_LIMIT;
+  const displayedStories =
+    hasHiddenPublishedStories && !isExpanded
+      ? stories.slice(0, PUBLISHED_STORIES_COLLAPSED_LIMIT)
+      : stories;
 
   return (
     <View
@@ -944,7 +955,7 @@ function PublishedStoriesSection({
 
       {stories.length > 0 ? (
         <View style={{ gap: spacing.md }}>
-          {stories.map((story) => (
+          {displayedStories.map((story) => (
             <FeedCard
               key={story.id}
               story={story}
@@ -952,7 +963,15 @@ function PublishedStoriesSection({
             />
           ))}
           {error ? <Text style={{ color: colors.danger }}>{error}</Text> : null}
-          {hasMore ? (
+          {shouldShowPublishedStoryToggle ? (
+            <Button
+              variant="outline"
+              onPress={() => setIsExpanded((current) => !current)}
+            >
+              {isExpanded ? 'Show less stories' : 'Show more stories'}
+            </Button>
+          ) : null}
+          {hasMore && (!shouldShowPublishedStoryToggle || isExpanded) ? (
             <Button
               variant="outline"
               onPress={() => {

--- a/mobile/src/features/profile/presentation/screens/__tests__/ProfileScreen.test.tsx
+++ b/mobile/src/features/profile/presentation/screens/__tests__/ProfileScreen.test.tsx
@@ -313,6 +313,33 @@ describe('ProfileScreen', () => {
     expect(onOpenStory).toHaveBeenCalledWith('saved-1');
   });
 
+  it('renders published stories on the signed-in user profile and opens one', async () => {
+    const getUserStories = jest.fn(async () => makePublishedStoriesPage({
+      items: [makePublishedStory('published-own-1', 'My Published Harbor')],
+      totalCount: 2,
+    }));
+    const onOpenStory = jest.fn();
+
+    render(
+      <ProfileScreen
+        mode="self"
+        getCurrentProfile={async () => selfProfile}
+        getUserStories={getUserStories}
+        onOpenStory={onOpenStory}
+      />,
+    );
+
+    expect(await screen.findByText('Traveler')).toBeTruthy();
+    expect(await screen.findByText('Published Stories')).toBeTruthy();
+    expect(await screen.findByText('My Published Harbor')).toBeTruthy();
+    expect(screen.getByText('2 stories published by this user.')).toBeTruthy();
+
+    fireEvent.press(screen.getByLabelText('Read story: My Published Harbor'));
+
+    expect(getUserStories).toHaveBeenCalledWith('7', 1);
+    expect(onOpenStory).toHaveBeenCalledWith('published-own-1');
+  });
+
   it('removes a saved story with an optimistic update and confirmation toast', async () => {
     const unbookmarkStory = jest.fn(async () => undefined);
     const onStoryInteractionUpdated = jest.fn();

--- a/mobile/src/features/profile/presentation/screens/__tests__/ProfileScreen.test.tsx
+++ b/mobile/src/features/profile/presentation/screens/__tests__/ProfileScreen.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { fireEvent, render, screen, waitFor } from '@testing-library/react-native';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react-native';
 import * as ImagePicker from 'expo-image-picker';
 import { ScrollView } from 'react-native';
 import { ProfileScreen } from '../ProfileScreen';
@@ -779,7 +779,9 @@ describe('ProfileScreen', () => {
         userId="12"
         getPublicProfile={async () => publicProfile}
         getUserStories={async () => {
-          throw new Error('Not found');
+          throw Object.assign(new Error('No User matches the given query.'), {
+            response: { status: 404 },
+          });
         }}
       />,
     );
@@ -788,6 +790,59 @@ describe('ProfileScreen', () => {
     expect(await screen.findByText('Published stories unavailable')).toBeTruthy();
     expect(screen.getByText('This profile is unavailable or no longer active.')).toBeTruthy();
     expect(screen.getByText('I write about harbor neighborhoods.')).toBeTruthy();
+  });
+
+  it('ignores stale public story responses after switching profiles', async () => {
+    let resolveFirstStories: (value: FeedPageEntity) => void = () => undefined;
+    const firstStoriesPromise = new Promise<FeedPageEntity>((resolve) => {
+      resolveFirstStories = resolve;
+    });
+    const getUserStories = jest.fn((loadedUserId: string) => {
+      if (loadedUserId === '12') {
+        return firstStoriesPromise;
+      }
+
+      return Promise.resolve(makePublishedStoriesPage({
+        items: [makePublishedStory('published-2', 'Second User Story')],
+      }));
+    });
+    const getPublicProfile = jest.fn(async (loadedUserId: string) => ({
+      ...publicProfile,
+      id: loadedUserId,
+      username: loadedUserId === '12' ? 'Aylin' : 'Deniz',
+    }));
+
+    const { rerender } = render(
+      <ProfileScreen
+        mode="public"
+        userId="12"
+        getPublicProfile={getPublicProfile}
+        getUserStories={getUserStories}
+      />,
+    );
+
+    expect(await screen.findByText('Aylin')).toBeTruthy();
+
+    rerender(
+      <ProfileScreen
+        mode="public"
+        userId="13"
+        getPublicProfile={getPublicProfile}
+        getUserStories={getUserStories}
+      />,
+    );
+
+    expect(await screen.findByText('Deniz')).toBeTruthy();
+    expect(await screen.findByText('Second User Story')).toBeTruthy();
+
+    await act(async () => {
+      resolveFirstStories(makePublishedStoriesPage({
+        items: [makePublishedStory('published-1', 'First User Story')],
+      }));
+    });
+
+    expect(screen.queryByText('First User Story')).toBeNull();
+    expect(screen.getByText('Second User Story')).toBeTruthy();
   });
 
   it('does not render a follow button on the user own profile', async () => {

--- a/mobile/src/features/profile/presentation/screens/__tests__/ProfileScreen.test.tsx
+++ b/mobile/src/features/profile/presentation/screens/__tests__/ProfileScreen.test.tsx
@@ -748,6 +748,38 @@ describe('ProfileScreen', () => {
     expect(onOpenStory).toHaveBeenCalledWith('published-1');
   });
 
+  it('collapses long public profile story lists behind show more and show less controls', async () => {
+    const stories = Array.from({ length: 5 }, (_, index) =>
+      makePublishedStory(`published-${index + 1}`, `Published Story ${index + 1}`),
+    );
+
+    render(
+      <ProfileScreen
+        mode="public"
+        userId="12"
+        getPublicProfile={async () => publicProfile}
+        getUserStories={async () => makePublishedStoriesPage({
+          items: stories,
+          totalCount: stories.length,
+        })}
+      />,
+    );
+
+    expect(await screen.findByText('Published Story 1')).toBeTruthy();
+    expect(screen.getByText('Published Story 3')).toBeTruthy();
+    expect(screen.queryByText('Published Story 4')).toBeNull();
+
+    fireEvent.press(screen.getByText('Show more stories'));
+
+    expect(screen.getByText('Published Story 4')).toBeTruthy();
+    expect(screen.getByText('Published Story 5')).toBeTruthy();
+
+    fireEvent.press(screen.getByText('Show less stories'));
+
+    expect(screen.queryByText('Published Story 4')).toBeNull();
+    expect(screen.getByText('Published Story 3')).toBeTruthy();
+  });
+
   it('shows the public profile published stories empty state', async () => {
     render(
       <ProfileScreen

--- a/mobile/src/features/profile/presentation/screens/__tests__/ProfileScreen.test.tsx
+++ b/mobile/src/features/profile/presentation/screens/__tests__/ProfileScreen.test.tsx
@@ -127,10 +127,41 @@ function makeSavedStoriesPage(overrides: Partial<FeedPageEntity> = {}): FeedPage
   };
 }
 
+function makePublishedStory(id: string, title = `Published Story ${id}`): FeedEntity {
+  return {
+    id,
+    title,
+    locationName: 'Kadikoy',
+    timePeriod: '1980',
+    previewText: 'A published story about local history.',
+    submittedAt: '2026-04-12T09:00:00Z',
+    hasMedia: false,
+    likeCount: 6,
+    likedByViewer: true,
+    savedByViewer: true,
+    tags: ['Culture'],
+  };
+}
+
+function makePublishedStoriesPage(overrides: Partial<FeedPageEntity> = {}): FeedPageEntity {
+  return {
+    items: [makePublishedStory('published-1', 'Published Harbor')],
+    page: 1,
+    pageSize: 10,
+    totalCount: 1,
+    hasNextPage: false,
+    ...overrides,
+  };
+}
+
 describe('ProfileScreen', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     jest.spyOn(userService, 'getSavedStories').mockResolvedValue(makeSavedStoriesPage({
+      items: [],
+      totalCount: 0,
+    }));
+    jest.spyOn(userService, 'getUserStories').mockResolvedValue(makePublishedStoriesPage({
       items: [],
       totalCount: 0,
     }));
@@ -661,6 +692,102 @@ describe('ProfileScreen', () => {
     expect(await screen.findByText('Anonymous user')).toBeTruthy();
     expect(screen.queryByText('Izmir')).toBeNull();
     expect(screen.queryByText('1988')).toBeNull();
+  });
+
+  it('renders published stories on a public profile and opens a story', async () => {
+    const getUserStories = jest.fn(async () => makePublishedStoriesPage());
+    const onOpenStory = jest.fn();
+
+    render(
+      <ProfileScreen
+        mode="public"
+        userId="12"
+        getPublicProfile={async () => publicProfile}
+        getUserStories={getUserStories}
+        onOpenStory={onOpenStory}
+      />,
+    );
+
+    expect(await screen.findByText('Aylin')).toBeTruthy();
+    expect(await screen.findByText('Published Stories')).toBeTruthy();
+    expect(await screen.findByText('Published Harbor')).toBeTruthy();
+    expect(screen.getByText('Kadikoy')).toBeTruthy();
+    expect(screen.getByText('1 story published by this user.')).toBeTruthy();
+    expect(screen.getByLabelText('Bookmarked story')).toBeTruthy();
+
+    fireEvent.press(screen.getByLabelText('Read story: Published Harbor'));
+
+    expect(getUserStories).toHaveBeenCalledWith('12', 1);
+    expect(onOpenStory).toHaveBeenCalledWith('published-1');
+  });
+
+  it('shows the public profile published stories empty state', async () => {
+    render(
+      <ProfileScreen
+        mode="public"
+        userId="12"
+        getPublicProfile={async () => publicProfile}
+        getUserStories={async () => makePublishedStoriesPage({
+          items: [],
+          totalCount: 0,
+        })}
+      />,
+    );
+
+    expect(await screen.findByText('Aylin')).toBeTruthy();
+    expect(await screen.findByText('No published stories yet')).toBeTruthy();
+    expect(screen.getByText('This user has not published any stories yet.')).toBeTruthy();
+  });
+
+  it('loads more public profile stories when additional pages exist', async () => {
+    const getUserStories = jest
+      .fn()
+      .mockResolvedValueOnce(makePublishedStoriesPage({
+        items: [makePublishedStory('published-1', 'First Published Story')],
+        totalCount: 2,
+        hasNextPage: true,
+      }))
+      .mockResolvedValueOnce(makePublishedStoriesPage({
+        items: [makePublishedStory('published-2', 'Second Published Story')],
+        page: 2,
+        totalCount: 2,
+        hasNextPage: false,
+      }));
+
+    render(
+      <ProfileScreen
+        mode="public"
+        userId="12"
+        getPublicProfile={async () => publicProfile}
+        getUserStories={getUserStories}
+      />,
+    );
+
+    expect(await screen.findByText('Aylin')).toBeTruthy();
+    expect(await screen.findByText('First Published Story')).toBeTruthy();
+
+    fireEvent.press(screen.getByText('Load more stories'));
+
+    expect(await screen.findByText('Second Published Story')).toBeTruthy();
+    expect(getUserStories).toHaveBeenCalledWith('12', 2);
+  });
+
+  it('shows a graceful public stories error without hiding profile details', async () => {
+    render(
+      <ProfileScreen
+        mode="public"
+        userId="12"
+        getPublicProfile={async () => publicProfile}
+        getUserStories={async () => {
+          throw new Error('Not found');
+        }}
+      />,
+    );
+
+    expect(await screen.findByText('Aylin')).toBeTruthy();
+    expect(await screen.findByText('Published stories unavailable')).toBeTruthy();
+    expect(screen.getByText('This profile is unavailable or no longer active.')).toBeTruthy();
+    expect(screen.getByText('I write about harbor neighborhoods.')).toBeTruthy();
   });
 
   it('does not render a follow button on the user own profile', async () => {


### PR DESCRIPTION
# 📝 Description
Fixes #551

Integrates the mobile profile screens with the paginated published-stories endpoint: `GET /users/<user_id>/stories/`.

Public profiles now load and render the target user's published stories using the existing mobile feed card layout. The signed-in user's own profile also shows their published stories on the profile tab, while the existing saved-stories section remains separate under the Saved stat.

This update also fixes profile story navigation and privacy behavior:
- published story cards on public profiles open the story detail screen
- self-profile published stories open the story detail screen
- long published-story lists are collapsed after the first 3 cards with Show more / Show less controls
- anonymous/contributor-hidden stories are hidden from other users' public profile views
- the story owner can still see their own anonymous published stories on their own profile

# 📊 Type of Change
- [x] Bug fix
- [x] New feature
- [ ] Refactoring
- [ ] Documentation

# ✅ Acceptance Criteria / Checklist
- [x] Public profile fetches published stories from `/users/<user_id>/stories/`
- [x] Own profile displays the signed-in user's published stories
- [x] Published stories render with existing mobile story card/feed UI
- [x] Published story cards navigate to story detail
- [x] Long published story lists support Show more / Show less
- [x] Pagination/incremental loading is supported
- [x] Loading, empty, and error states are handled
- [x] 404/inactive profile story-list errors are handled gracefully
- [x] `user_has_liked` and `user_has_saved` are mapped into card interaction state
- [x] Anonymous/contributor-hidden stories are not exposed on other users' public profiles
- [x] Existing saved-stories and follow behavior remains unchanged
- [x] Unit tests added/updated

# 🧪 Tests
- [x] `npm test -- --runTestsByPath src/features/profile/presentation/screens/__tests__/ProfileScreen.test.tsx`
- [x] `npm test -- --runTestsByPath src/features/profile/presentation/screens/__tests__/ProfileScreen.test.tsx src/app/navigation/__tests__/RootNavigator.test.tsx`
- [x] `npm run typecheck`
- [x] `npm test -- --runInBand`
- [ ] Backend targeted test could not be run locally because Docker daemon is not running and the local venv is missing `corsheaders`; CI should run it.

# ⏱️ Estimated Review Time
- [ ] < 5 min
- [x] 5-15 min
- [ ] > 15 min
