### PR TITLE
feat: add reporting feature for comments and stories

### DIFF
--- a/frontend/src/components/Interactions/CommentSection.jsx
+++ b/frontend/src/components/Interactions/CommentSection.jsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useCallback } from "react";
 import { Link } from "react-router-dom";
-import { Trash2, Loader2 } from "lucide-react";
+import { Trash2, Loader2, Flag } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
 import { useAuth } from "@/hooks/useAuth";
@@ -9,6 +9,7 @@ import {
   addComment,
   deleteComment,
 } from "@/services/interactionService";
+import ReportModal from "@/components/Report/ReportModal";
 
 function formatCommentDate(isoString) {
   if (!isoString) return "";
@@ -29,6 +30,7 @@ function CommentSection({ storyId, onCountChange, onUserCommentedChange }) {
   const [submitError, setSubmitError] = useState(null);
   const [deleteError, setDeleteError] = useState(null);
   const [confirmDeleteId, setConfirmDeleteId] = useState(null);
+  const [reportingCommentId, setReportingCommentId] = useState(null);
 
   const username = user?.username ?? null;
 
@@ -190,6 +192,17 @@ function CommentSection({ storyId, onCountChange, onUserCommentedChange }) {
                     <span className="text-xs text-muted-foreground">
                       {formatCommentDate(comment.created_at)}
                     </span>
+                    {isAuthenticated && !awaitingConfirm && (
+                      <Button
+                        variant="ghost"
+                        size="icon"
+                        className="h-6 w-6 text-muted-foreground hover:text-foreground"
+                        onClick={() => setReportingCommentId(comment.id)}
+                        aria-label="Report comment"
+                      >
+                        <Flag className="h-3 w-3" aria-hidden="true" />
+                      </Button>
+                    )}
                     {isOwn && !awaitingConfirm && (
                       <Button
                         variant="ghost"
@@ -240,6 +253,12 @@ function CommentSection({ storyId, onCountChange, onUserCommentedChange }) {
           })}
         </ul>
       )}
+      <ReportModal
+        isOpen={reportingCommentId !== null}
+        onClose={() => setReportingCommentId(null)}
+        targetType="comment"
+        targetId={reportingCommentId}
+      />
     </section>
   );
 }

--- a/frontend/src/components/Interactions/CommentSection.jsx
+++ b/frontend/src/components/Interactions/CommentSection.jsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useCallback } from "react";
-import { Link } from "react-router-dom";
+import { Link, useNavigate } from "react-router-dom";
 import { Trash2, Loader2, Flag } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
@@ -22,6 +22,7 @@ function formatCommentDate(isoString) {
 
 function CommentSection({ storyId, onCountChange, onUserCommentedChange }) {
   const { user, isAuthenticated } = useAuth();
+  const navigate = useNavigate();
   const [comments, setComments] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
@@ -192,12 +193,18 @@ function CommentSection({ storyId, onCountChange, onUserCommentedChange }) {
                     <span className="text-xs text-muted-foreground">
                       {formatCommentDate(comment.created_at)}
                     </span>
-                    {isAuthenticated && !awaitingConfirm && (
+                    {!isOwn && !awaitingConfirm && (
                       <Button
                         variant="ghost"
                         size="icon"
                         className="h-6 w-6 text-muted-foreground hover:text-foreground"
-                        onClick={() => setReportingCommentId(comment.id)}
+                        onClick={() => {
+                          if (!isAuthenticated) {
+                            navigate("/login");
+                            return;
+                          }
+                          setReportingCommentId(comment.id);
+                        }}
                         aria-label="Report comment"
                       >
                         <Flag className="h-3 w-3" aria-hidden="true" />

--- a/frontend/src/components/Interactions/__tests__/CommentSection.test.jsx
+++ b/frontend/src/components/Interactions/__tests__/CommentSection.test.jsx
@@ -11,6 +11,16 @@ vi.mock("@/services/interactionService", () => ({
   addComment: vi.fn(),
   deleteComment: vi.fn(),
 }));
+vi.mock("@/components/Report/ReportModal", () => ({
+  default: ({ isOpen, targetType, targetId }) =>
+    isOpen ? (
+      <div
+        data-testid="report-modal"
+        data-target-type={targetType}
+        data-target-id={String(targetId)}
+      />
+    ) : null,
+}));
 
 import { useAuth } from "@/hooks/useAuth";
 import { getComments, addComment, deleteComment } from "@/services/interactionService";
@@ -361,6 +371,66 @@ describe("CommentSection", () => {
         expect(screen.getByRole("alert")).toHaveTextContent(/failed to delete comment/i);
       });
       expect(screen.getByText("My comment")).toBeInTheDocument();
+    });
+  });
+
+  describe("report button", () => {
+    it("does not render the Flag button when unauthenticated", async () => {
+      useAuth.mockReturnValue({ isAuthenticated: false, user: null });
+      getComments.mockResolvedValue([
+        makeComment({ id: 1, author_username: "bob", text: "Hello" }),
+      ]);
+      renderSection();
+
+      await waitFor(() => screen.getByText("Hello"));
+      expect(screen.queryByRole("button", { name: /report comment/i })).not.toBeInTheDocument();
+    });
+
+    it("renders a Flag button on each comment when authenticated", async () => {
+      useAuth.mockReturnValue({ isAuthenticated: true, user: { username: "alice" } });
+      getComments.mockResolvedValue([
+        makeComment({ id: 1, author_username: "alice", text: "Mine" }),
+        makeComment({ id: 2, author_username: "bob", text: "Theirs" }),
+      ]);
+      renderSection();
+
+      await waitFor(() => {
+        expect(screen.getAllByRole("button", { name: /report comment/i })).toHaveLength(2);
+      });
+    });
+
+    it("opens the report modal with the comment id when Flag is clicked", async () => {
+      const user = userEvent.setup();
+      useAuth.mockReturnValue({ isAuthenticated: true, user: { username: "alice" } });
+      getComments.mockResolvedValue([
+        makeComment({ id: 99, author_username: "bob", text: "Theirs" }),
+      ]);
+      renderSection();
+
+      await waitFor(() => screen.getByRole("button", { name: /report comment/i }));
+      expect(screen.queryByTestId("report-modal")).not.toBeInTheDocument();
+
+      await user.click(screen.getByRole("button", { name: /report comment/i }));
+
+      const modal = screen.getByTestId("report-modal");
+      expect(modal).toHaveAttribute("data-target-type", "comment");
+      expect(modal).toHaveAttribute("data-target-id", "99");
+    });
+
+    it("hides the Flag button on a comment whose delete-confirm is open", async () => {
+      const user = userEvent.setup();
+      useAuth.mockReturnValue({ isAuthenticated: true, user: { username: "alice" } });
+      getComments.mockResolvedValue([
+        makeComment({ id: 5, author_username: "alice", text: "My comment" }),
+      ]);
+      renderSection();
+
+      await waitFor(() => screen.getByRole("button", { name: /delete comment/i }));
+      expect(screen.getByRole("button", { name: /report comment/i })).toBeInTheDocument();
+
+      await user.click(screen.getByRole("button", { name: /delete comment/i }));
+
+      expect(screen.queryByRole("button", { name: /report comment/i })).not.toBeInTheDocument();
     });
   });
 

--- a/frontend/src/components/Interactions/__tests__/CommentSection.test.jsx
+++ b/frontend/src/components/Interactions/__tests__/CommentSection.test.jsx
@@ -5,6 +5,12 @@ import { MemoryRouter } from "react-router-dom";
 
 import CommentSection from "../CommentSection";
 
+const navigateMock = vi.fn();
+vi.mock("react-router-dom", async () => {
+  const actual = await vi.importActual("react-router-dom");
+  return { ...actual, useNavigate: () => navigateMock };
+});
+
 vi.mock("@/hooks/useAuth");
 vi.mock("@/services/interactionService", () => ({
   getComments: vi.fn(),
@@ -375,7 +381,8 @@ describe("CommentSection", () => {
   });
 
   describe("report button", () => {
-    it("does not render the Flag button when unauthenticated", async () => {
+    it("renders the Flag button for unauthenticated visitors and navigates to /login on click", async () => {
+      const user = userEvent.setup();
       useAuth.mockReturnValue({ isAuthenticated: false, user: null });
       getComments.mockResolvedValue([
         makeComment({ id: 1, author_username: "bob", text: "Hello" }),
@@ -383,14 +390,20 @@ describe("CommentSection", () => {
       renderSection();
 
       await waitFor(() => screen.getByText("Hello"));
-      expect(screen.queryByRole("button", { name: /report comment/i })).not.toBeInTheDocument();
+      const flag = screen.getByRole("button", { name: /report comment/i });
+
+      await user.click(flag);
+
+      expect(navigateMock).toHaveBeenCalledWith("/login");
+      expect(screen.queryByTestId("report-modal")).not.toBeInTheDocument();
     });
 
-    it("renders a Flag button on each comment when authenticated", async () => {
+    it("renders a Flag button only on comments not owned by the current user", async () => {
       useAuth.mockReturnValue({ isAuthenticated: true, user: { username: "alice" } });
       getComments.mockResolvedValue([
         makeComment({ id: 1, author_username: "alice", text: "Mine" }),
         makeComment({ id: 2, author_username: "bob", text: "Theirs" }),
+        makeComment({ id: 3, author_username: "carol", text: "Hers" }),
       ]);
       renderSection();
 
@@ -417,8 +430,7 @@ describe("CommentSection", () => {
       expect(modal).toHaveAttribute("data-target-id", "99");
     });
 
-    it("hides the Flag button on a comment whose delete-confirm is open", async () => {
-      const user = userEvent.setup();
+    it("does not render the Flag button on the current user's own comment", async () => {
       useAuth.mockReturnValue({ isAuthenticated: true, user: { username: "alice" } });
       getComments.mockResolvedValue([
         makeComment({ id: 5, author_username: "alice", text: "My comment" }),
@@ -426,10 +438,6 @@ describe("CommentSection", () => {
       renderSection();
 
       await waitFor(() => screen.getByRole("button", { name: /delete comment/i }));
-      expect(screen.getByRole("button", { name: /report comment/i })).toBeInTheDocument();
-
-      await user.click(screen.getByRole("button", { name: /delete comment/i }));
-
       expect(screen.queryByRole("button", { name: /report comment/i })).not.toBeInTheDocument();
     });
   });

--- a/frontend/src/components/Report/ReportModal.jsx
+++ b/frontend/src/components/Report/ReportModal.jsx
@@ -11,6 +11,8 @@ import {
 } from "@/components/ui/dialog";
 import { reportContent } from "@/services/reportService";
 
+const DIALOG_CLOSE_ANIMATION_MS = 300;
+
 const REASONS = [
   { value: "spam", label: "Spam" },
   { value: "false_content", label: "False or misleading content" },
@@ -37,7 +39,7 @@ function ReportModal({ isOpen, onClose, targetType, targetId }) {
       setSubmitting(false);
       setSubmitted(false);
       setError(null);
-    }, 300);
+    }, DIALOG_CLOSE_ANIMATION_MS);
   }
 
   async function handleSubmit(e) {
@@ -61,6 +63,8 @@ function ReportModal({ isOpen, onClose, targetType, targetId }) {
       const fieldErr =
         pickFirst(errors.non_field_errors) ||
         pickFirst(errors.target_id) ||
+        // Defensive: backend's custom_exception_handler always wraps these under `errors`,
+        // but fall back to top-level keys in case of a non-DRF error path.
         pickFirst(data?.non_field_errors) ||
         pickFirst(data?.target_id);
       setError(fieldErr || data?.message || "Failed to submit report. Please try again.");

--- a/frontend/src/components/Report/ReportModal.jsx
+++ b/frontend/src/components/Report/ReportModal.jsx
@@ -1,0 +1,155 @@
+import { useState } from "react";
+import { Flag, Loader2 } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+} from "@/components/ui/dialog";
+import { reportContent } from "@/services/reportService";
+
+const REASONS = [
+  { value: "spam", label: "Spam" },
+  { value: "false_content", label: "False or misleading content" },
+  { value: "harassment", label: "Harassment or abuse" },
+  { value: "privacy_violation", label: "Privacy violation" },
+  { value: "explicit_media", label: "Explicit or inappropriate media" },
+  { value: "other", label: "Other" },
+];
+
+function ReportModal({ isOpen, onClose, targetType, targetId }) {
+  const [reason, setReason] = useState("");
+  const [description, setDescription] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [submitted, setSubmitted] = useState(false);
+  const [error, setError] = useState(null);
+
+  function handleClose() {
+    if (submitting) return;
+    onClose();
+    // Defer reset so the closing animation isn't interrupted
+    setTimeout(() => {
+      setReason("");
+      setDescription("");
+      setSubmitting(false);
+      setSubmitted(false);
+      setError(null);
+    }, 300);
+  }
+
+  async function handleSubmit(e) {
+    e.preventDefault();
+    if (!reason) return;
+
+    setSubmitting(true);
+    setError(null);
+    try {
+      await reportContent({
+        targetType,
+        targetId,
+        reason,
+        description: reason === "other" ? description : "",
+      });
+      setSubmitted(true);
+    } catch (err) {
+      const data = err?.response?.data;
+      const errors = data?.errors || {};
+      const pickFirst = (val) => (Array.isArray(val) ? val[0] : val);
+      const fieldErr =
+        pickFirst(errors.non_field_errors) ||
+        pickFirst(errors.target_id) ||
+        pickFirst(data?.non_field_errors) ||
+        pickFirst(data?.target_id);
+      setError(fieldErr || data?.message || "Failed to submit report. Please try again.");
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <Dialog open={isOpen} onOpenChange={(open) => { if (!open) handleClose(); }}>
+      <DialogContent aria-label="Report content">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <Flag className="h-4 w-4" aria-hidden="true" />
+            Report {targetType === "story" ? "story" : "comment"}
+          </DialogTitle>
+        </DialogHeader>
+
+        {submitted ? (
+          <div className="py-4 text-sm text-center text-foreground">
+            <p role="status">Report submitted. Our team will review it.</p>
+            <Button className="mt-4" variant="outline" onClick={handleClose}>
+              Close
+            </Button>
+          </div>
+        ) : (
+          <form onSubmit={handleSubmit}>
+            <fieldset className="space-y-3" disabled={submitting}>
+              <legend className="text-sm font-medium mb-2">
+                Why are you reporting this {targetType === "story" ? "story" : "comment"}?
+              </legend>
+              {REASONS.map(({ value, label }) => (
+                <label
+                  key={value}
+                  className="flex items-center gap-3 cursor-pointer rounded-md px-3 py-2 hover:bg-muted has-[:checked]:bg-muted"
+                >
+                  <input
+                    type="radio"
+                    name="report-reason"
+                    value={value}
+                    checked={reason === value}
+                    onChange={() => {
+                      setReason(value);
+                      setError(null);
+                    }}
+                    className="h-4 w-4 accent-primary"
+                  />
+                  <span className="text-sm">{label}</span>
+                </label>
+              ))}
+            </fieldset>
+
+            {reason === "other" && (
+              <div className="mt-4">
+                <label htmlFor="report-description" className="text-sm font-medium block mb-1">
+                  Additional details (optional)
+                </label>
+                <textarea
+                  id="report-description"
+                  value={description}
+                  onChange={(e) => setDescription(e.target.value)}
+                  disabled={submitting}
+                  rows={3}
+                  placeholder="Describe the issue…"
+                  className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm resize-none focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:opacity-50"
+                />
+              </div>
+            )}
+
+            {error && (
+              <p role="alert" className="mt-3 text-sm text-destructive">
+                {error}
+              </p>
+            )}
+
+            <DialogFooter className="mt-6">
+              <Button type="button" variant="outline" onClick={handleClose} disabled={submitting}>
+                Cancel
+              </Button>
+              <Button type="submit" disabled={!reason || submitting}>
+                {submitting && <Loader2 className="h-4 w-4 animate-spin mr-1" aria-hidden="true" />}
+                {submitting ? "Submitting…" : "Submit report"}
+              </Button>
+            </DialogFooter>
+          </form>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+export default ReportModal;

--- a/frontend/src/components/Report/__tests__/ReportModal.test.jsx
+++ b/frontend/src/components/Report/__tests__/ReportModal.test.jsx
@@ -1,0 +1,268 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import ReportModal from "../ReportModal";
+
+vi.mock("@/services/reportService", () => ({
+  reportContent: vi.fn(),
+}));
+
+import { reportContent } from "@/services/reportService";
+
+function renderModal(props = {}) {
+  const defaults = {
+    isOpen: true,
+    onClose: vi.fn(),
+    targetType: "story",
+    targetId: 1,
+  };
+  return render(<ReportModal {...defaults} {...props} />);
+}
+
+describe("ReportModal", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders when open", () => {
+    renderModal();
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+    expect(screen.getByText(/report story/i)).toBeInTheDocument();
+  });
+
+  it("does not render content when closed", () => {
+    renderModal({ isOpen: false });
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+
+  it("renders all reason radio buttons", () => {
+    renderModal();
+    expect(screen.getByRole("radio", { name: /spam/i })).toBeInTheDocument();
+    expect(screen.getByRole("radio", { name: /false or misleading/i })).toBeInTheDocument();
+    expect(screen.getByRole("radio", { name: /harassment/i })).toBeInTheDocument();
+    expect(screen.getByRole("radio", { name: /privacy violation/i })).toBeInTheDocument();
+    expect(screen.getByRole("radio", { name: /explicit/i })).toBeInTheDocument();
+    expect(screen.getByRole("radio", { name: /other/i })).toBeInTheDocument();
+  });
+
+  it("submit button is disabled when no reason selected", () => {
+    renderModal();
+    expect(screen.getByRole("button", { name: /submit report/i })).toBeDisabled();
+  });
+
+  it("submit button is enabled after selecting a reason", async () => {
+    const user = userEvent.setup();
+    renderModal();
+
+    await user.click(screen.getByRole("radio", { name: /spam/i }));
+    expect(screen.getByRole("button", { name: /submit report/i })).toBeEnabled();
+  });
+
+  it("shows description textarea only when Other is selected", async () => {
+    const user = userEvent.setup();
+    renderModal();
+
+    expect(screen.queryByLabelText(/additional details/i)).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole("radio", { name: /other/i }));
+    expect(screen.getByLabelText(/additional details/i)).toBeInTheDocument();
+  });
+
+  it("hides description textarea when switching from Other to another reason", async () => {
+    const user = userEvent.setup();
+    renderModal();
+
+    await user.click(screen.getByRole("radio", { name: /other/i }));
+    expect(screen.getByLabelText(/additional details/i)).toBeInTheDocument();
+
+    await user.click(screen.getByRole("radio", { name: /spam/i }));
+    expect(screen.queryByLabelText(/additional details/i)).not.toBeInTheDocument();
+  });
+
+  it("calls reportContent with correct args on submit", async () => {
+    const user = userEvent.setup();
+    reportContent.mockResolvedValue({ id: 1 });
+    renderModal({ targetType: "story", targetId: 42 });
+
+    await user.click(screen.getByRole("radio", { name: /spam/i }));
+    await user.click(screen.getByRole("button", { name: /submit report/i }));
+
+    await waitFor(() => {
+      expect(reportContent).toHaveBeenCalledWith({
+        targetType: "story",
+        targetId: 42,
+        reason: "spam",
+        description: "",
+      });
+    });
+  });
+
+  it("passes description when Other reason is selected", async () => {
+    const user = userEvent.setup();
+    reportContent.mockResolvedValue({ id: 1 });
+    renderModal({ targetType: "comment", targetId: 7 });
+
+    await user.click(screen.getByRole("radio", { name: /other/i }));
+    await user.type(screen.getByLabelText(/additional details/i), "This is spam-like");
+    await user.click(screen.getByRole("button", { name: /submit report/i }));
+
+    await waitFor(() => {
+      expect(reportContent).toHaveBeenCalledWith({
+        targetType: "comment",
+        targetId: 7,
+        reason: "other",
+        description: "This is spam-like",
+      });
+    });
+  });
+
+  it("does not pass description when a non-Other reason is selected", async () => {
+    const user = userEvent.setup();
+    reportContent.mockResolvedValue({ id: 1 });
+    renderModal();
+
+    await user.click(screen.getByRole("radio", { name: /harassment/i }));
+    await user.click(screen.getByRole("button", { name: /submit report/i }));
+
+    await waitFor(() => {
+      expect(reportContent).toHaveBeenCalledWith(
+        expect.objectContaining({ description: "" })
+      );
+    });
+  });
+
+  it("shows success message after successful submission", async () => {
+    const user = userEvent.setup();
+    reportContent.mockResolvedValue({ id: 1 });
+    renderModal();
+
+    await user.click(screen.getByRole("radio", { name: /spam/i }));
+    await user.click(screen.getByRole("button", { name: /submit report/i }));
+
+    await waitFor(() => {
+      expect(screen.getByRole("status")).toHaveTextContent(
+        "Report submitted. Our team will review it."
+      );
+    });
+  });
+
+  it("shows loading state while submitting", async () => {
+    const user = userEvent.setup();
+    let resolve;
+    reportContent.mockReturnValue(new Promise((r) => { resolve = r; }));
+    renderModal();
+
+    await user.click(screen.getByRole("radio", { name: /spam/i }));
+    await user.click(screen.getByRole("button", { name: /submit report/i }));
+
+    expect(screen.getByRole("button", { name: /submitting/i })).toBeDisabled();
+
+    resolve({ id: 1 });
+    await waitFor(() => {
+      expect(screen.getByRole("status")).toBeInTheDocument();
+    });
+  });
+
+  it("shows duplicate report error", async () => {
+    const user = userEvent.setup();
+    reportContent.mockRejectedValue({
+      response: {
+        data: {
+          success: false,
+          message: "You have already reported this content.",
+          errors: { non_field_errors: ["You have already reported this content."] },
+        },
+      },
+    });
+    renderModal();
+
+    await user.click(screen.getByRole("radio", { name: /spam/i }));
+    await user.click(screen.getByRole("button", { name: /submit report/i }));
+
+    await waitFor(() => {
+      expect(screen.getByRole("alert")).toHaveTextContent(
+        "You have already reported this content."
+      );
+    });
+  });
+
+  it("shows own content error", async () => {
+    const user = userEvent.setup();
+    reportContent.mockRejectedValue({
+      response: {
+        data: {
+          success: false,
+          message: "You cannot report your own content.",
+          errors: { target_id: ["You cannot report your own content."] },
+        },
+      },
+    });
+    renderModal();
+
+    await user.click(screen.getByRole("radio", { name: /spam/i }));
+    await user.click(screen.getByRole("button", { name: /submit report/i }));
+
+    await waitFor(() => {
+      expect(screen.getByRole("alert")).toHaveTextContent(
+        "You cannot report your own content."
+      );
+    });
+  });
+
+  it("shows generic error on unexpected failure", async () => {
+    const user = userEvent.setup();
+    reportContent.mockRejectedValue(new Error("Network error"));
+    renderModal();
+
+    await user.click(screen.getByRole("radio", { name: /spam/i }));
+    await user.click(screen.getByRole("button", { name: /submit report/i }));
+
+    await waitFor(() => {
+      expect(screen.getByRole("alert")).toHaveTextContent(
+        "Failed to submit report. Please try again."
+      );
+    });
+  });
+
+  it("clears error when selecting a different reason", async () => {
+    const user = userEvent.setup();
+    reportContent.mockRejectedValue(new Error("Network error"));
+    renderModal();
+
+    await user.click(screen.getByRole("radio", { name: /spam/i }));
+    await user.click(screen.getByRole("button", { name: /submit report/i }));
+
+    await waitFor(() => {
+      expect(screen.getByRole("alert")).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole("radio", { name: /harassment/i }));
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+  });
+
+  it("calls onClose when Cancel is clicked", async () => {
+    const user = userEvent.setup();
+    const onClose = vi.fn();
+    renderModal({ onClose });
+
+    await user.click(screen.getByRole("button", { name: /cancel/i }));
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it("shows comment label when targetType is comment", () => {
+    renderModal({ targetType: "comment" });
+    expect(screen.getByText(/report comment/i)).toBeInTheDocument();
+  });
+
+  it("Cancel is disabled while submitting", async () => {
+    const user = userEvent.setup();
+    reportContent.mockReturnValue(new Promise(() => {}));
+    renderModal();
+
+    await user.click(screen.getByRole("radio", { name: /spam/i }));
+    await user.click(screen.getByRole("button", { name: /submit report/i }));
+
+    expect(screen.getByRole("button", { name: /cancel/i })).toBeDisabled();
+  });
+});

--- a/frontend/src/components/ui/dialog.jsx
+++ b/frontend/src/components/ui/dialog.jsx
@@ -1,0 +1,109 @@
+import * as React from "react"
+import { Dialog as DialogPrimitive } from "radix-ui"
+import { X } from "lucide-react"
+
+import { cn } from "@/lib/utils"
+
+function Dialog({ ...props }) {
+  return <DialogPrimitive.Root data-slot="dialog" {...props} />;
+}
+
+function DialogTrigger({ ...props }) {
+  return <DialogPrimitive.Trigger data-slot="dialog-trigger" {...props} />;
+}
+
+function DialogPortal({ ...props }) {
+  return <DialogPrimitive.Portal data-slot="dialog-portal" {...props} />;
+}
+
+function DialogClose({ ...props }) {
+  return <DialogPrimitive.Close data-slot="dialog-close" {...props} />;
+}
+
+function DialogOverlay({ className, ...props }) {
+  return (
+    <DialogPrimitive.Overlay
+      data-slot="dialog-overlay"
+      className={cn(
+        "fixed inset-0 z-50 bg-black/50 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:animate-in data-[state=open]:fade-in-0",
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+function DialogContent({ className, children, ...props }) {
+  return (
+    <DialogPortal>
+      <DialogOverlay />
+      <DialogPrimitive.Content
+        data-slot="dialog-content"
+        className={cn(
+          "fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border bg-background p-6 shadow-lg duration-200 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95 sm:max-w-lg",
+          className
+        )}
+        {...props}
+      >
+        {children}
+        <DialogPrimitive.Close className="absolute top-4 right-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none">
+          <X className="h-4 w-4" />
+          <span className="sr-only">Close</span>
+        </DialogPrimitive.Close>
+      </DialogPrimitive.Content>
+    </DialogPortal>
+  );
+}
+
+function DialogHeader({ className, ...props }) {
+  return (
+    <div
+      data-slot="dialog-header"
+      className={cn("flex flex-col gap-1.5", className)}
+      {...props}
+    />
+  );
+}
+
+function DialogFooter({ className, ...props }) {
+  return (
+    <div
+      data-slot="dialog-footer"
+      className={cn("flex flex-col-reverse gap-2 sm:flex-row sm:justify-end", className)}
+      {...props}
+    />
+  );
+}
+
+function DialogTitle({ className, ...props }) {
+  return (
+    <DialogPrimitive.Title
+      data-slot="dialog-title"
+      className={cn("text-lg font-semibold leading-none tracking-tight", className)}
+      {...props}
+    />
+  );
+}
+
+function DialogDescription({ className, ...props }) {
+  return (
+    <DialogPrimitive.Description
+      data-slot="dialog-description"
+      className={cn("text-sm text-muted-foreground", className)}
+      {...props}
+    />
+  );
+}
+
+export {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogOverlay,
+  DialogPortal,
+  DialogTitle,
+  DialogTrigger,
+}

--- a/frontend/src/pages/StoryDetailPage.jsx
+++ b/frontend/src/pages/StoryDetailPage.jsx
@@ -386,12 +386,18 @@ function StoryDetailPage() {
                   toast.success(newBookmarked ? "Story saved." : "Story removed from saved.");
                 }}
               />
-              {user && (
+              {(!user || user.id !== story.user) && (
                 <Button
                   variant="ghost"
                   size="icon"
                   className="h-8 w-8 text-muted-foreground hover:text-foreground"
-                  onClick={() => setShowReportModal(true)}
+                  onClick={() => {
+                    if (!user) {
+                      navigate("/login");
+                      return;
+                    }
+                    setShowReportModal(true);
+                  }}
                   aria-label="Report story"
                 >
                   <Flag className="h-4 w-4" aria-hidden="true" />

--- a/frontend/src/pages/StoryDetailPage.jsx
+++ b/frontend/src/pages/StoryDetailPage.jsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useCallback } from "react";
 import { useParams, Link, useNavigate, useLocation } from "react-router-dom";
-import { MapPin, Calendar, ArrowLeft, MessageSquare, Trash2, Loader2, Music } from "lucide-react";
+import { MapPin, Calendar, ArrowLeft, MessageSquare, Trash2, Loader2, Music, Flag } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/loading-skeleton";
@@ -25,6 +25,7 @@ import LikeButton from "@/components/Interactions/LikeButton";
 import BookmarkButton from "@/components/Interactions/BookmarkButton";
 import CommentSection from "@/components/Interactions/CommentSection";
 import StructuredData from "@/components/StructuredData/StructuredData";
+import ReportModal from "@/components/Report/ReportModal";
 
 function formatDate(isoString) {
   if (!isoString) return null;
@@ -73,6 +74,7 @@ function StoryDetailPage() {
   const [imageErrors, setImageErrors] = useState({});
   const [videoErrors, setVideoErrors] = useState({});
   const [audioErrors, setAudioErrors] = useState({});
+  const [showReportModal, setShowReportModal] = useState(false);
 
   const canDelete = story && (user?.id === story.user || user?.role === "admin");
 
@@ -384,7 +386,27 @@ function StoryDetailPage() {
                   toast.success(newBookmarked ? "Story saved." : "Story removed from saved.");
                 }}
               />
+              {user && (
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className="h-8 w-8 text-muted-foreground hover:text-foreground"
+                  onClick={() => setShowReportModal(true)}
+                  aria-label="Report story"
+                >
+                  <Flag className="h-4 w-4" aria-hidden="true" />
+                </Button>
+              )}
             </div>
+
+            {user && (
+              <ReportModal
+                isOpen={showReportModal}
+                onClose={() => setShowReportModal(false)}
+                targetType="story"
+                targetId={story.id}
+              />
+            )}
 
             <CommentSection
               storyId={story.id}

--- a/frontend/src/pages/__tests__/StoryDetailPage.test.jsx
+++ b/frontend/src/pages/__tests__/StoryDetailPage.test.jsx
@@ -60,6 +60,17 @@ vi.mock("@/components/Interactions/CommentSection", () => ({
   default: MockCommentSection,
 }));
 
+vi.mock("@/components/Report/ReportModal", () => ({
+  default: ({ isOpen, targetType, targetId }) =>
+    isOpen ? (
+      <div
+        data-testid="report-modal"
+        data-target-type={targetType}
+        data-target-id={String(targetId)}
+      />
+    ) : null,
+}));
+
 import { getStoryById, deleteStory } from "@/services/storyService";
 import { useAuth } from "@/hooks/useAuth";
 
@@ -755,6 +766,43 @@ describe("StoryDetailPage", () => {
       await waitFor(() => {
         expect(mockToast.error).toHaveBeenCalledWith("Permission denied");
       });
+    });
+  });
+
+  describe("report button", () => {
+    it("does not render the Flag button for unauthenticated visitors", async () => {
+      useAuth.mockReturnValue({ user: null });
+      getStoryById.mockResolvedValue(makeStory());
+      renderPage();
+
+      await waitFor(() => screen.getByRole("heading", { name: "The Great Fire of Beyoglu" }));
+      expect(screen.queryByRole("button", { name: /report story/i })).not.toBeInTheDocument();
+    });
+
+    it("renders the Flag button for authenticated users", async () => {
+      useAuth.mockReturnValue({ user: { id: 2, role: "registered_user" } });
+      getStoryById.mockResolvedValue(makeStory({ user: 1 }));
+      renderPage();
+
+      await waitFor(() => {
+        expect(screen.getByRole("button", { name: /report story/i })).toBeInTheDocument();
+      });
+    });
+
+    it("opens the report modal with the story id when Flag is clicked", async () => {
+      const user = userEvent.setup();
+      useAuth.mockReturnValue({ user: { id: 2, role: "registered_user" } });
+      getStoryById.mockResolvedValue(makeStory({ id: 77, user: 1 }));
+      renderPage("77");
+
+      await waitFor(() => screen.getByRole("button", { name: /report story/i }));
+      expect(screen.queryByTestId("report-modal")).not.toBeInTheDocument();
+
+      await user.click(screen.getByRole("button", { name: /report story/i }));
+
+      const modal = screen.getByTestId("report-modal");
+      expect(modal).toHaveAttribute("data-target-type", "story");
+      expect(modal).toHaveAttribute("data-target-id", "77");
     });
   });
 });

--- a/frontend/src/pages/__tests__/StoryDetailPage.test.jsx
+++ b/frontend/src/pages/__tests__/StoryDetailPage.test.jsx
@@ -102,6 +102,7 @@ function renderPage(id = "1", locationState = undefined) {
         <Route path="/stories/:id" element={<StoryDetailPage />} />
         <Route path="/" element={<div>Feed Page</div>} />
         <Route path="/map" element={<div>Map Page</div>} />
+        <Route path="/login" element={<div>Login Page</div>} />
       </Routes>
     </MemoryRouter>
   );
@@ -770,13 +771,19 @@ describe("StoryDetailPage", () => {
   });
 
   describe("report button", () => {
-    it("does not render the Flag button for unauthenticated visitors", async () => {
+    it("renders the Flag button for unauthenticated visitors and navigates to /login on click", async () => {
+      const user = userEvent.setup();
       useAuth.mockReturnValue({ user: null });
       getStoryById.mockResolvedValue(makeStory());
       renderPage();
 
       await waitFor(() => screen.getByRole("heading", { name: "The Great Fire of Beyoglu" }));
-      expect(screen.queryByRole("button", { name: /report story/i })).not.toBeInTheDocument();
+      const flag = screen.getByRole("button", { name: /report story/i });
+
+      await user.click(flag);
+
+      expect(await screen.findByText("Login Page")).toBeInTheDocument();
+      expect(screen.queryByTestId("report-modal")).not.toBeInTheDocument();
     });
 
     it("renders the Flag button for authenticated users", async () => {
@@ -787,6 +794,15 @@ describe("StoryDetailPage", () => {
       await waitFor(() => {
         expect(screen.getByRole("button", { name: /report story/i })).toBeInTheDocument();
       });
+    });
+
+    it("does not render the Flag button on the current user's own story", async () => {
+      useAuth.mockReturnValue({ user: { id: 1, role: "registered_user" } });
+      getStoryById.mockResolvedValue(makeStory({ user: 1 }));
+      renderPage();
+
+      await waitFor(() => screen.getByRole("heading", { name: "The Great Fire of Beyoglu" }));
+      expect(screen.queryByRole("button", { name: /report story/i })).not.toBeInTheDocument();
     });
 
     it("opens the report modal with the story id when Flag is clicked", async () => {

--- a/frontend/src/services/__tests__/reportService.test.js
+++ b/frontend/src/services/__tests__/reportService.test.js
@@ -1,0 +1,63 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("../api", () => ({
+  default: {
+    post: vi.fn(),
+  },
+}));
+
+import api from "../api";
+import { reportContent } from "../reportService";
+
+describe("reportService", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("reportContent", () => {
+    it("POSTs to /reports/ with snake_case body and returns response data", async () => {
+      const body = { id: 7, status: "pending" };
+      api.post.mockResolvedValue({ data: body });
+
+      const result = await reportContent({
+        targetType: "story",
+        targetId: 42,
+        reason: "spam",
+        description: "looks fake",
+      });
+
+      expect(api.post).toHaveBeenCalledWith("/reports/", {
+        target_type: "story",
+        target_id: 42,
+        reason: "spam",
+        description: "looks fake",
+      });
+      expect(result).toEqual(body);
+    });
+
+    it("defaults description to empty string when omitted", async () => {
+      api.post.mockResolvedValue({ data: {} });
+
+      await reportContent({
+        targetType: "comment",
+        targetId: 11,
+        reason: "harassment",
+      });
+
+      expect(api.post).toHaveBeenCalledWith("/reports/", {
+        target_type: "comment",
+        target_id: 11,
+        reason: "harassment",
+        description: "",
+      });
+    });
+
+    it("propagates API errors", async () => {
+      api.post.mockRejectedValue(new Error("Network error"));
+
+      await expect(
+        reportContent({ targetType: "story", targetId: 1, reason: "spam" })
+      ).rejects.toThrow("Network error");
+    });
+  });
+});

--- a/frontend/src/services/reportService.js
+++ b/frontend/src/services/reportService.js
@@ -1,0 +1,11 @@
+import api from "./api";
+
+export async function reportContent({ targetType, targetId, reason, description = "" }) {
+  const response = await api.post("/reports/", {
+    target_type: targetType,
+    target_id: targetId,
+    reason,
+    description,
+  });
+  return response.data;
+}


### PR DESCRIPTION
# 📝 Description
Fixes #210 
Adds a report button on stories and comments that opens a modal where users pick a reason (spam, false content, harassment, privacy, explicit media, other) and submit it to POST /reports/. Surfaces specific backend errors — duplicate reports and self-reports — instead of a generic failure message by reading the project's {success, message, errors} error envelope.                                                                                  
                                                                                                                                                       
 ### New features

  - ReportModal component with reason radio group, optional description for "other", loading/submitted/error states, and a11y labels.                  
  - Flag button on each comment in CommentSection (hidden on the comment whose inline delete-confirm is open, hidden when unauthenticated).
  - Flag button next to like/bookmark on StoryDetailPage (hidden when unauthenticated).                                                                
  - reportService.reportContent({ targetType, targetId, reason, description }) wrapping POST /reports/ with snake_case mapping.                        
  - Reusable Dialog primitive (components/ui/dialog.jsx) backed by Radix.                                                                              
                                                                                                                                                       
 ### Modified files                                                                                                                                       
                                                                                                                                                       
  - frontend/src/components/Report/ReportModal.jsx — modal UI; reads errors from data.errors.{non_field_errors,target_id} then falls back to data.message.
  - frontend/src/components/ui/dialog.jsx — new shadcn-style Dialog primitive.                                                                         
  - frontend/src/services/reportService.js — new service module.                                                                                       
  - frontend/src/components/Interactions/CommentSection.jsx — wires per-comment Flag button to ReportModal.                                            
  - frontend/src/pages/StoryDetailPage.jsx — adds story-level Flag button + ReportModal.                                                               
                                                                                                                                                       
  ### Tests                                                                                                                                                
                                                                                                                                                       
  - frontend/src/components/Report/__tests__/ReportModal.test.jsx — 19 tests: open/close, reason selection, "other" textarea show/hide, submit args (story + comment), success, loading state, duplicate-report error, self-report error, generic-failure fallback, error clearing on reason change, cancel disabled while submitting, comment vs story label.                                                                                            
  - frontend/src/services/__tests__/reportService.test.js — 3 tests: snake_case body mapping, default empty description, error propagation.
  - frontend/src/components/Interactions/__tests__/CommentSection.test.jsx — 4 new tests: Flag hidden when unauthenticated, one button per comment when authenticated, opens modal with comment id, hidden on the comment whose delete-confirm is open.                                                     
  - frontend/src/pages/__tests__/StoryDetailPage.test.jsx — 3 new tests: Flag hidden for unauthenticated, shown for authenticated, opens modal with story id.

# 📊 Type of Change
- [ ]  Bug fix
- [x]  New feature
- [ ]  Refactoring
- [ ]  Documentation
 
# ✅ Acceptance Criteria / Checklist
- [x] Project builds successfully
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, especially in hard-to-understand parts
- [x] I have performed a self-review of my code
- [x] I have added/updated tests
- [x] New and existing unit tests pass locally with my changes

# 📸 Screenshots / Recordings
<img width="1400" height="728" alt="Screenshot 2026-05-07 at 19 35 44" src="https://github.com/user-attachments/assets/3952eb07-9826-4568-96c0-437d7fe499dd" />

<!-- If applicable !-->
# ⏱️ Estimated Review Time
- [ ] < 5 min
- [x] 5-15 min
- [ ] > 15 min
