### PR TITLE
feat(frontend): add map auto-zoom and pin clustering

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -13,6 +13,7 @@
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "leaflet": "^1.9.4",
+        "leaflet.markercluster": "^1.5.3",
         "lucide-react": "^0.577.0",
         "radix-ui": "^1.4.3",
         "react": "^19.2.4",
@@ -4648,6 +4649,15 @@
       "integrity": "sha512-nxS1ynzJOmOlHp+iL3FyWqK89GtNL8U8rvlMOsQdTTssxZwCXh8N2NB3GDQOL+YR3XnWyZAxwQixURb+FA74PA==",
       "license": "BSD-2-Clause",
       "peer": true
+    },
+    "node_modules/leaflet.markercluster": {
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/leaflet.markercluster/-/leaflet.markercluster-1.5.3.tgz",
+      "integrity": "sha512-vPTw/Bndq7eQHjLBVlWpnGeLa3t+3zGiuM7fJwCkiMFq+nmRuG3RI3f7f4N4TDX7T4NpbAXpR2+NTRSEGfCSeA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "leaflet": "^1.3.1"
+      }
     },
     "node_modules/levn": {
       "version": "0.4.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -17,6 +17,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "leaflet": "^1.9.4",
+    "leaflet.markercluster": "^1.5.3",
     "lucide-react": "^0.577.0",
     "radix-ui": "^1.4.3",
     "react": "^19.2.4",

--- a/frontend/src/components/MapView/MapView.jsx
+++ b/frontend/src/components/MapView/MapView.jsx
@@ -1,14 +1,17 @@
-import { useEffect, useMemo } from "react";
-import { MapContainer, TileLayer, GeoJSON, useMap } from "react-leaflet";
+import { useEffect, useMemo, useRef } from "react";
+import { MapContainer, TileLayer, useMap } from "react-leaflet";
 import { useNavigate, useLocation } from "react-router-dom";
 import L from "leaflet";
 import "leaflet/dist/leaflet.css";
+import "leaflet.markercluster";
+import "leaflet.markercluster/dist/MarkerCluster.css";
+import "leaflet.markercluster/dist/MarkerCluster.Default.css";
 import markerIcon2x from "leaflet/dist/images/marker-icon-2x.png";
 import markerIcon from "leaflet/dist/images/marker-icon.png";
 import markerShadow from "leaflet/dist/images/marker-shadow.png";
 
 import { EMPTY_FEATURE_COLLECTION } from "@/services/storyService";
-import { pointToLayer, onEachFeature } from "./mapFeatureUtils";
+import { featurePopupHtml } from "./mapFeatureUtils";
 
 // Fix Leaflet default marker icon paths for Vite bundler
 delete L.Icon.Default.prototype._getIconUrl;
@@ -20,6 +23,8 @@ L.Icon.Default.mergeOptions({
 
 const ISTANBUL_CENTER = [41.0082, 28.9784];
 const DEFAULT_ZOOM = 12;
+const SINGLE_FEATURE_MAX_ZOOM = 15;
+const FIT_BOUNDS_PADDING = [40, 40];
 
 // Intercepts clicks on story links inside popup HTML so they perform
 // client-side navigation instead of a full page reload. Captures the
@@ -45,16 +50,64 @@ function StoryLinkInterceptor() {
   return null;
 }
 
+function featureLatLng(feature) {
+  const coords = feature?.geometry?.coordinates;
+  if (!Array.isArray(coords) || coords.length < 2) return null;
+  const [lng, lat] = coords;
+  return [lat, lng];
+}
+
+function FitBoundsToFeatures({ features }) {
+  const map = useMap();
+  useEffect(() => {
+    if (!map || features.length === 0) return;
+    const latlngs = features.map(featureLatLng).filter(Boolean);
+    if (latlngs.length === 0) return;
+    const bounds = L.latLngBounds(latlngs);
+    const options =
+      latlngs.length === 1
+        ? { maxZoom: SINGLE_FEATURE_MAX_ZOOM }
+        : { padding: FIT_BOUNDS_PADDING };
+    map.fitBounds(bounds, options);
+  }, [map, features]);
+  return null;
+}
+
+function ClusteredMarkers({ features }) {
+  const map = useMap();
+  const groupRef = useRef(null);
+
+  useEffect(() => {
+    if (!map) return undefined;
+    const group = L.markerClusterGroup();
+    groupRef.current = group;
+    map.addLayer(group);
+    return () => {
+      map.removeLayer(group);
+      groupRef.current = null;
+    };
+  }, [map]);
+
+  useEffect(() => {
+    const group = groupRef.current;
+    if (!group) return;
+    group.clearLayers();
+    features.forEach((feature) => {
+      const latlng = featureLatLng(feature);
+      if (!latlng) return;
+      const marker = L.marker(latlng);
+      marker.bindPopup(featurePopupHtml(feature));
+      group.addLayer(marker);
+    });
+  }, [features]);
+
+  return null;
+}
+
 function MapView({ featureCollection = EMPTY_FEATURE_COLLECTION, loading = false }) {
   const features = useMemo(
     () => featureCollection?.features ?? [],
     [featureCollection],
-  );
-  // react-leaflet's <GeoJSON> only initializes the layer once, so force a
-  // remount whenever the feature set changes (filter/search results).
-  const geoJSONKey = useMemo(
-    () => features.map((f) => f.id).join("|"),
-    [features],
   );
 
   return (
@@ -69,14 +122,8 @@ function MapView({ featureCollection = EMPTY_FEATURE_COLLECTION, loading = false
           attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
           url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
         />
-        {features.length > 0 && (
-          <GeoJSON
-            key={geoJSONKey}
-            data={featureCollection}
-            pointToLayer={pointToLayer}
-            onEachFeature={onEachFeature}
-          />
-        )}
+        <ClusteredMarkers features={features} />
+        <FitBoundsToFeatures features={features} />
         <StoryLinkInterceptor />
       </MapContainer>
       {loading && (

--- a/frontend/src/components/MapView/MapView.jsx
+++ b/frontend/src/components/MapView/MapView.jsx
@@ -96,7 +96,7 @@ function ClusteredMarkers({ features }) {
       const latlng = featureLatLng(feature);
       if (!latlng) return;
       const marker = L.marker(latlng);
-      marker.bindPopup(featurePopupHtml(feature));
+      marker.bindPopup(() => featurePopupHtml(feature));
       group.addLayer(marker);
     });
   }, [features]);

--- a/frontend/src/components/MapView/MapView.jsx
+++ b/frontend/src/components/MapView/MapView.jsx
@@ -59,8 +59,20 @@ function featureLatLng(feature) {
 
 function FitBoundsToFeatures({ features }) {
   const map = useMap();
+  // Skip re-fitting when the feature set is unchanged — refetches that
+  // return the same stories shouldn't snap the map back over the user's pan.
+  const lastFitKeyRef = useRef(null);
+
   useEffect(() => {
-    if (!map || features.length === 0) return;
+    if (!map) return;
+    if (features.length === 0) {
+      lastFitKeyRef.current = null;
+      return;
+    }
+    const fitKey = features.map((f) => f.id).join("|");
+    if (fitKey === lastFitKeyRef.current) return;
+    lastFitKeyRef.current = fitKey;
+
     const latlngs = features.map(featureLatLng).filter(Boolean);
     if (latlngs.length === 0) return;
     const bounds = L.latLngBounds(latlngs);

--- a/frontend/src/components/MapView/__tests__/MapView.test.jsx
+++ b/frontend/src/components/MapView/__tests__/MapView.test.jsx
@@ -3,27 +3,20 @@ import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { MemoryRouter, Route, Routes, useLocation } from "react-router-dom";
 
-// Hoisted references shared between the test file and the mocked modules.
-// fakeMapContainer is the DOM node StoryLinkInterceptor binds its click
-// handler on. fakeMap exposes the leaflet methods MapView's child components
-// invoke (fitBounds / addLayer / removeLayer) so tests can assert call args.
 const { fakeMapContainer, fakeMap, leafletMocks } = vi.hoisted(() => {
   const container = document.createElement("div");
-  const map = {
-    fitBounds: undefined,
-    addLayer: undefined,
-    removeLayer: undefined,
-    getContainer: () => container,
-  };
   return {
     fakeMapContainer: container,
-    fakeMap: map,
+    fakeMap: {
+      fitBounds: undefined,
+      addLayer: undefined,
+      removeLayer: undefined,
+      getContainer: () => container,
+    },
     leafletMocks: {
       marker: undefined,
       markerClusterGroup: undefined,
-      featureGroup: undefined,
       latLngBounds: undefined,
-      latLng: undefined,
     },
   };
 });
@@ -36,76 +29,32 @@ vi.mock("react-leaflet", () => ({
     </div>
   ),
   TileLayer: () => null,
-  GeoJSON: ({ data, pointToLayer, onEachFeature }) => {
-    const features = data?.features ?? [];
-    // Invoke the callbacks the same way L.geoJSON would so that bindPopup
-    // and marker creation are exercised under test.
-    features.forEach((feature) => {
-      const fakeLayer = {
-        bindPopup: vi.fn(),
-        on: vi.fn(),
-      };
-      pointToLayer?.(feature, [0, 0]);
-      onEachFeature?.(feature, fakeLayer);
-    });
-    return (
-      <div
-        data-testid="map-geojson"
-        data-feature-count={features.length}
-      >
-        {features.map((f) => (
-          <div key={f.id} data-testid="map-marker">
-            {f.properties?.title}
-          </div>
-        ))}
-      </div>
-    );
-  },
   useMap: () => fakeMap,
 }));
 
 vi.mock("leaflet", () => {
-  const marker = vi.fn((latlng) => {
-    const layer = { bindPopup: vi.fn(), latlng };
-    return layer;
-  });
-  const featureGroup = vi.fn((markers) => ({
-    getBounds: () => ({ markers, kind: "feature-group-bounds" }),
-  }));
-  const latLngBounds = vi.fn((latlngs) => ({
-    latlngs,
-    kind: "latlng-bounds",
-  }));
-  const latLng = vi.fn((lat, lng) => ({ lat, lng }));
+  const marker = vi.fn((latlng) => ({ bindPopup: vi.fn(), latlng }));
+  const latLngBounds = vi.fn((latlngs) => ({ latlngs }));
   const markerClusterGroup = vi.fn(() => ({
     addLayer: vi.fn(),
     addLayers: vi.fn(),
     clearLayers: vi.fn(),
     removeLayer: vi.fn(),
-    kind: "cluster-group",
   }));
   leafletMocks.marker = marker;
   leafletMocks.markerClusterGroup = markerClusterGroup;
-  leafletMocks.featureGroup = featureGroup;
   leafletMocks.latLngBounds = latLngBounds;
-  leafletMocks.latLng = latLng;
   const L = {
     Icon: { Default: { prototype: { _getIconUrl: "" }, mergeOptions: vi.fn() } },
     marker,
     markerClusterGroup,
-    featureGroup,
     latLngBounds,
-    latLng,
   };
   return { default: L };
 });
 
-vi.mock("leaflet.markercluster", () => ({}));
-vi.mock("leaflet.markercluster/dist/MarkerCluster.css", () => ({}));
-vi.mock("leaflet.markercluster/dist/MarkerCluster.Default.css", () => ({}));
-
 import MapView from "../MapView";
-import { onEachFeature } from "../mapFeatureUtils";
+import { featurePopupHtml } from "../mapFeatureUtils";
 
 function makeFeature(id, overrides = {}) {
   return {
@@ -139,21 +88,19 @@ function renderMapView(props = {}, { initialEntries = ["/map"] } = {}) {
   );
 }
 
-describe("MapView", () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
-    // Reset the shared fake container so event listeners from a prior test
-    // don't leak into the next one.
-    while (fakeMapContainer.firstChild) {
-      fakeMapContainer.removeChild(fakeMapContainer.firstChild);
-    }
-    fakeMapContainer.replaceWith(fakeMapContainer.cloneNode(false));
-    fakeMap.fitBounds = vi.fn();
-    fakeMap.addLayer = vi.fn();
-    fakeMap.removeLayer = vi.fn();
-    fakeMap.getContainer = () => fakeMapContainer;
-  });
+beforeEach(() => {
+  vi.clearAllMocks();
+  while (fakeMapContainer.firstChild) {
+    fakeMapContainer.removeChild(fakeMapContainer.firstChild);
+  }
+  fakeMapContainer.replaceWith(fakeMapContainer.cloneNode(false));
+  fakeMap.fitBounds = vi.fn();
+  fakeMap.addLayer = vi.fn();
+  fakeMap.removeLayer = vi.fn();
+  fakeMap.getContainer = () => fakeMapContainer;
+});
 
+describe("MapView", () => {
   it("renders the map container", () => {
     renderMapView();
     expect(screen.getByTestId("map-container")).toBeInTheDocument();
@@ -168,7 +115,6 @@ describe("MapView", () => {
   it("creates markers using [lat, lng] order from feature [lng, lat] coordinates", () => {
     const fc = makeFeatureCollection([makeFeature(1)]);
     renderMapView({ featureCollection: fc });
-    // makeFeature(1).geometry.coordinates = [28.91, 41.01]
     const firstCallArg = leafletMocks.marker.mock.calls[0][0];
     expect(firstCallArg[0]).toBeCloseTo(41.01);
     expect(firstCallArg[1]).toBeCloseTo(28.91);
@@ -197,18 +143,6 @@ describe("MapView", () => {
 });
 
 describe("MapView auto-zoom (fit bounds)", () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
-    while (fakeMapContainer.firstChild) {
-      fakeMapContainer.removeChild(fakeMapContainer.firstChild);
-    }
-    fakeMapContainer.replaceWith(fakeMapContainer.cloneNode(false));
-    fakeMap.fitBounds = vi.fn();
-    fakeMap.addLayer = vi.fn();
-    fakeMap.removeLayer = vi.fn();
-    fakeMap.getContainer = () => fakeMapContainer;
-  });
-
   it("does not call fitBounds when there are zero features", () => {
     renderMapView({ featureCollection: makeFeatureCollection([]) });
     expect(fakeMap.fitBounds).not.toHaveBeenCalled();
@@ -251,18 +185,6 @@ describe("MapView auto-zoom (fit bounds)", () => {
 });
 
 describe("MapView pin clustering", () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
-    while (fakeMapContainer.firstChild) {
-      fakeMapContainer.removeChild(fakeMapContainer.firstChild);
-    }
-    fakeMapContainer.replaceWith(fakeMapContainer.cloneNode(false));
-    fakeMap.fitBounds = vi.fn();
-    fakeMap.addLayer = vi.fn();
-    fakeMap.removeLayer = vi.fn();
-    fakeMap.getContainer = () => fakeMapContainer;
-  });
-
   it("creates a marker cluster group when features are present", () => {
     renderMapView({ featureCollection: makeFeatureCollection([makeFeature(1)]) });
     expect(leafletMocks.markerClusterGroup).toHaveBeenCalled();
@@ -302,7 +224,7 @@ describe("MapView pin clustering", () => {
     expect(fakeMap.removeLayer).toHaveBeenCalledWith(clusterGroup);
   });
 
-  it("binds a popup containing the feature title for each marker", () => {
+  it("binds a popup whose lazy callback returns HTML containing the feature title", () => {
     renderMapView({
       featureCollection: makeFeatureCollection([
         makeFeature(1, { title: "Castle Story" }),
@@ -310,23 +232,20 @@ describe("MapView pin clustering", () => {
     });
     const markerInstance = leafletMocks.marker.mock.results[0].value;
     expect(markerInstance.bindPopup).toHaveBeenCalledTimes(1);
-    const html = markerInstance.bindPopup.mock.calls[0][0];
-    expect(html).toContain("Castle Story");
+    const popupArg = markerInstance.bindPopup.mock.calls[0][0];
+    expect(typeof popupArg).toBe("function");
+    expect(popupArg()).toContain("Castle Story");
   });
 });
 
-describe("onEachFeature", () => {
-  it("binds a popup whose HTML contains title, location, time period, and a Read more link", () => {
+describe("featurePopupHtml", () => {
+  it("returns HTML containing title, location, time period, and a Read more link", () => {
     const feature = makeFeature(42, {
       title: "The Old Bridge",
       location_name: "Galata",
       year: 1920,
     });
-    const bindPopup = vi.fn();
-    onEachFeature(feature, { bindPopup });
-
-    expect(bindPopup).toHaveBeenCalledTimes(1);
-    const html = bindPopup.mock.calls[0][0];
+    const html = featurePopupHtml(feature);
     expect(html).toContain("The Old Bridge");
     expect(html).toContain("Galata");
     expect(html).toContain("1920");
@@ -336,10 +255,7 @@ describe("onEachFeature", () => {
 
   it("omits the location line when location_name is missing", () => {
     const feature = makeFeature(7, { location_name: undefined });
-    const bindPopup = vi.fn();
-    onEachFeature(feature, { bindPopup });
-
-    const html = bindPopup.mock.calls[0][0];
+    const html = featurePopupHtml(feature);
     expect(html).toContain("Story 7");
     expect(html).not.toContain("Location 7");
   });
@@ -379,7 +295,6 @@ describe("StoryLinkInterceptor", () => {
     const user = userEvent.setup();
     render(<Harness initialEntries={["/map?category=nature"]} />);
 
-    // Simulate the popup HTML Leaflet would have injected into the map container.
     const anchor = document.createElement("a");
     anchor.setAttribute("href", "/stories/99");
     anchor.textContent = "Read more";
@@ -390,8 +305,8 @@ describe("StoryLinkInterceptor", () => {
     await user.click(anchor);
 
     expect(screen.getByTestId("current-pathname").textContent).toBe("/stories/99");
-    // Filter state must survive the SPA navigation so the Back navigation
-    // returns the user to the filtered map.
+    // Filter state must survive the SPA navigation so Back returns the user
+    // to the filtered map.
     expect(screen.getByTestId("current-state-from").textContent).toBe(
       "/map?category=nature",
     );

--- a/frontend/src/components/MapView/__tests__/MapView.test.jsx
+++ b/frontend/src/components/MapView/__tests__/MapView.test.jsx
@@ -3,12 +3,30 @@ import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { MemoryRouter, Route, Routes, useLocation } from "react-router-dom";
 
-// Hoisted reference to the fake Leaflet container so the StoryLinkInterceptor
-// in MapView registers its click handler on an element we can dispatch events
-// against from tests.
-const { fakeMapContainer } = vi.hoisted(() => ({
-  fakeMapContainer: document.createElement("div"),
-}));
+// Hoisted references shared between the test file and the mocked modules.
+// fakeMapContainer is the DOM node StoryLinkInterceptor binds its click
+// handler on. fakeMap exposes the leaflet methods MapView's child components
+// invoke (fitBounds / addLayer / removeLayer) so tests can assert call args.
+const { fakeMapContainer, fakeMap, leafletMocks } = vi.hoisted(() => {
+  const container = document.createElement("div");
+  const map = {
+    fitBounds: undefined,
+    addLayer: undefined,
+    removeLayer: undefined,
+    getContainer: () => container,
+  };
+  return {
+    fakeMapContainer: container,
+    fakeMap: map,
+    leafletMocks: {
+      marker: undefined,
+      markerClusterGroup: undefined,
+      featureGroup: undefined,
+      latLngBounds: undefined,
+      latLng: undefined,
+    },
+  };
+});
 
 vi.mock("react-leaflet", () => ({
   MapContainer: ({ children, ...props }) => (
@@ -43,17 +61,48 @@ vi.mock("react-leaflet", () => ({
       </div>
     );
   },
-  useMap: () => ({ getContainer: () => fakeMapContainer }),
+  useMap: () => fakeMap,
 }));
 
 vi.mock("leaflet", () => {
-  const marker = vi.fn(() => ({ bindPopup: vi.fn() }));
+  const marker = vi.fn((latlng) => {
+    const layer = { bindPopup: vi.fn(), latlng };
+    return layer;
+  });
+  const featureGroup = vi.fn((markers) => ({
+    getBounds: () => ({ markers, kind: "feature-group-bounds" }),
+  }));
+  const latLngBounds = vi.fn((latlngs) => ({
+    latlngs,
+    kind: "latlng-bounds",
+  }));
+  const latLng = vi.fn((lat, lng) => ({ lat, lng }));
+  const markerClusterGroup = vi.fn(() => ({
+    addLayer: vi.fn(),
+    addLayers: vi.fn(),
+    clearLayers: vi.fn(),
+    removeLayer: vi.fn(),
+    kind: "cluster-group",
+  }));
+  leafletMocks.marker = marker;
+  leafletMocks.markerClusterGroup = markerClusterGroup;
+  leafletMocks.featureGroup = featureGroup;
+  leafletMocks.latLngBounds = latLngBounds;
+  leafletMocks.latLng = latLng;
   const L = {
     Icon: { Default: { prototype: { _getIconUrl: "" }, mergeOptions: vi.fn() } },
     marker,
+    markerClusterGroup,
+    featureGroup,
+    latLngBounds,
+    latLng,
   };
   return { default: L };
 });
+
+vi.mock("leaflet.markercluster", () => ({}));
+vi.mock("leaflet.markercluster/dist/MarkerCluster.css", () => ({}));
+vi.mock("leaflet.markercluster/dist/MarkerCluster.Default.css", () => ({}));
 
 import MapView from "../MapView";
 import { onEachFeature } from "../mapFeatureUtils";
@@ -99,6 +148,10 @@ describe("MapView", () => {
       fakeMapContainer.removeChild(fakeMapContainer.firstChild);
     }
     fakeMapContainer.replaceWith(fakeMapContainer.cloneNode(false));
+    fakeMap.fitBounds = vi.fn();
+    fakeMap.addLayer = vi.fn();
+    fakeMap.removeLayer = vi.fn();
+    fakeMap.getContainer = () => fakeMapContainer;
   });
 
   it("renders the map container", () => {
@@ -106,28 +159,29 @@ describe("MapView", () => {
     expect(screen.getByTestId("map-container")).toBeInTheDocument();
   });
 
-  it("renders a marker for each feature in the FeatureCollection", () => {
+  it("creates a leaflet marker for each feature in the FeatureCollection", () => {
     const fc = makeFeatureCollection([makeFeature(1), makeFeature(2), makeFeature(3)]);
     renderMapView({ featureCollection: fc });
-    expect(screen.getAllByTestId("map-marker")).toHaveLength(3);
+    expect(leafletMocks.marker).toHaveBeenCalledTimes(3);
   });
 
-  it("passes the FeatureCollection as-is to the GeoJSON layer", () => {
+  it("creates markers using [lat, lng] order from feature [lng, lat] coordinates", () => {
     const fc = makeFeatureCollection([makeFeature(1)]);
     renderMapView({ featureCollection: fc });
-    const layer = screen.getByTestId("map-geojson");
-    expect(layer).toHaveAttribute("data-feature-count", "1");
+    // makeFeature(1).geometry.coordinates = [28.91, 41.01]
+    const firstCallArg = leafletMocks.marker.mock.calls[0][0];
+    expect(firstCallArg[0]).toBeCloseTo(41.01);
+    expect(firstCallArg[1]).toBeCloseTo(28.91);
   });
 
-  it("does not render a GeoJSON layer when the FeatureCollection is empty", () => {
+  it("does not create any markers when the FeatureCollection is empty", () => {
     renderMapView({ featureCollection: makeFeatureCollection([]) });
-    expect(screen.queryByTestId("map-geojson")).not.toBeInTheDocument();
-    expect(screen.queryByTestId("map-marker")).not.toBeInTheDocument();
+    expect(leafletMocks.marker).not.toHaveBeenCalled();
   });
 
   it("handles a missing featureCollection prop without crashing", () => {
     renderMapView();
-    expect(screen.queryByTestId("map-marker")).not.toBeInTheDocument();
+    expect(leafletMocks.marker).not.toHaveBeenCalled();
   });
 
   it("shows loading overlay when loading is true", () => {
@@ -140,11 +194,124 @@ describe("MapView", () => {
     renderMapView({ loading: false });
     expect(screen.queryByLabelText("Loading map pins")).not.toBeInTheDocument();
   });
+});
 
-  it("exposes the feature title in the marker element", () => {
-    const fc = makeFeatureCollection([makeFeature(1)]);
+describe("MapView auto-zoom (fit bounds)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    while (fakeMapContainer.firstChild) {
+      fakeMapContainer.removeChild(fakeMapContainer.firstChild);
+    }
+    fakeMapContainer.replaceWith(fakeMapContainer.cloneNode(false));
+    fakeMap.fitBounds = vi.fn();
+    fakeMap.addLayer = vi.fn();
+    fakeMap.removeLayer = vi.fn();
+    fakeMap.getContainer = () => fakeMapContainer;
+  });
+
+  it("does not call fitBounds when there are zero features", () => {
+    renderMapView({ featureCollection: makeFeatureCollection([]) });
+    expect(fakeMap.fitBounds).not.toHaveBeenCalled();
+  });
+
+  it("calls fitBounds with maxZoom 15 when there is exactly one feature", () => {
+    renderMapView({ featureCollection: makeFeatureCollection([makeFeature(1)]) });
+    expect(fakeMap.fitBounds).toHaveBeenCalledTimes(1);
+    const options = fakeMap.fitBounds.mock.calls[0][1];
+    expect(options).toMatchObject({ maxZoom: 15 });
+  });
+
+  it("calls fitBounds with bounds covering all features when there are multiple", () => {
+    const fc = makeFeatureCollection([
+      makeFeature(1),
+      makeFeature(2),
+      makeFeature(3),
+    ]);
     renderMapView({ featureCollection: fc });
-    expect(screen.getByText("Story 1")).toBeInTheDocument();
+    expect(fakeMap.fitBounds).toHaveBeenCalledTimes(1);
+    const options = fakeMap.fitBounds.mock.calls[0][1];
+    expect(options).toMatchObject({ padding: [40, 40] });
+  });
+
+  it("re-fits bounds when the feature set changes", () => {
+    const { rerender } = renderMapView({
+      featureCollection: makeFeatureCollection([makeFeature(1)]),
+    });
+    expect(fakeMap.fitBounds).toHaveBeenCalledTimes(1);
+
+    rerender(
+      <MemoryRouter>
+        <MapView
+          featureCollection={makeFeatureCollection([makeFeature(2), makeFeature(3)])}
+        />
+      </MemoryRouter>,
+    );
+    expect(fakeMap.fitBounds).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe("MapView pin clustering", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    while (fakeMapContainer.firstChild) {
+      fakeMapContainer.removeChild(fakeMapContainer.firstChild);
+    }
+    fakeMapContainer.replaceWith(fakeMapContainer.cloneNode(false));
+    fakeMap.fitBounds = vi.fn();
+    fakeMap.addLayer = vi.fn();
+    fakeMap.removeLayer = vi.fn();
+    fakeMap.getContainer = () => fakeMapContainer;
+  });
+
+  it("creates a marker cluster group when features are present", () => {
+    renderMapView({ featureCollection: makeFeatureCollection([makeFeature(1)]) });
+    expect(leafletMocks.markerClusterGroup).toHaveBeenCalled();
+  });
+
+  it("adds the cluster group to the map", () => {
+    renderMapView({ featureCollection: makeFeatureCollection([makeFeature(1)]) });
+    const clusterGroup = leafletMocks.markerClusterGroup.mock.results[0].value;
+    expect(fakeMap.addLayer).toHaveBeenCalledWith(clusterGroup);
+  });
+
+  it("clears and repopulates the cluster group when features change", () => {
+    const { rerender } = renderMapView({
+      featureCollection: makeFeatureCollection([makeFeature(1)]),
+    });
+    const clusterGroup = leafletMocks.markerClusterGroup.mock.results[0].value;
+    const initialMarkerCalls = leafletMocks.marker.mock.calls.length;
+
+    rerender(
+      <MemoryRouter>
+        <MapView
+          featureCollection={makeFeatureCollection([makeFeature(2), makeFeature(3)])}
+        />
+      </MemoryRouter>,
+    );
+
+    expect(clusterGroup.clearLayers).toHaveBeenCalled();
+    expect(leafletMocks.marker.mock.calls.length).toBeGreaterThan(initialMarkerCalls);
+  });
+
+  it("removes the cluster group from the map on unmount", () => {
+    const { unmount } = renderMapView({
+      featureCollection: makeFeatureCollection([makeFeature(1)]),
+    });
+    const clusterGroup = leafletMocks.markerClusterGroup.mock.results[0].value;
+    unmount();
+    expect(fakeMap.removeLayer).toHaveBeenCalledWith(clusterGroup);
+  });
+
+  it("binds a popup containing the feature title for each marker", () => {
+    renderMapView({
+      featureCollection: makeFeatureCollection([
+        makeFeature(1, { title: "Castle Story" }),
+      ]),
+    });
+    const markerInstance = leafletMocks.marker.mock.results[0].value;
+    expect(markerInstance.bindPopup).toHaveBeenCalledTimes(1);
+    const html = markerInstance.bindPopup.mock.calls[0][0];
+    expect(html).toContain("Castle Story");
   });
 });
 

--- a/frontend/src/components/MapView/__tests__/MapView.test.jsx
+++ b/frontend/src/components/MapView/__tests__/MapView.test.jsx
@@ -182,6 +182,41 @@ describe("MapView auto-zoom (fit bounds)", () => {
     );
     expect(fakeMap.fitBounds).toHaveBeenCalledTimes(2);
   });
+
+  it("does not re-fit when re-rendered with the same feature ids", () => {
+    const { rerender } = renderMapView({
+      featureCollection: makeFeatureCollection([makeFeature(1), makeFeature(2)]),
+    });
+    expect(fakeMap.fitBounds).toHaveBeenCalledTimes(1);
+
+    rerender(
+      <MemoryRouter>
+        <MapView
+          featureCollection={makeFeatureCollection([makeFeature(1), makeFeature(2)])}
+        />
+      </MemoryRouter>,
+    );
+    expect(fakeMap.fitBounds).toHaveBeenCalledTimes(1);
+  });
+
+  it("re-fits again after the feature set empties and repopulates", () => {
+    const { rerender } = renderMapView({
+      featureCollection: makeFeatureCollection([makeFeature(1)]),
+    });
+    expect(fakeMap.fitBounds).toHaveBeenCalledTimes(1);
+
+    rerender(
+      <MemoryRouter>
+        <MapView featureCollection={makeFeatureCollection([])} />
+      </MemoryRouter>,
+    );
+    rerender(
+      <MemoryRouter>
+        <MapView featureCollection={makeFeatureCollection([makeFeature(1)])} />
+      </MemoryRouter>,
+    );
+    expect(fakeMap.fitBounds).toHaveBeenCalledTimes(2);
+  });
 });
 
 describe("MapView pin clustering", () => {

--- a/frontend/src/components/MapView/mapFeatureUtils.jsx
+++ b/frontend/src/components/MapView/mapFeatureUtils.jsx
@@ -1,4 +1,3 @@
-import L from "leaflet";
 import { renderToStaticMarkup } from "react-dom/server";
 
 import StoryPopup from "./StoryPopup";
@@ -23,9 +22,3 @@ function featureToStory(feature) {
 // in place (or sanitize explicitly) to prevent XSS at this seam.
 export const featurePopupHtml = (feature) =>
   renderToStaticMarkup(<StoryPopup story={featureToStory(feature)} />);
-
-export const pointToLayer = (_feature, latlng) => L.marker(latlng);
-
-export const onEachFeature = (feature, layer) => {
-  layer.bindPopup(featurePopupHtml(feature));
-};

--- a/frontend/src/components/MapView/mapFeatureUtils.jsx
+++ b/frontend/src/components/MapView/mapFeatureUtils.jsx
@@ -16,16 +16,16 @@ function featureToStory(feature) {
   };
 }
 
-export const pointToLayer = (_feature, latlng) => L.marker(latlng);
-
 // XSS trust boundary: Leaflet's bindPopup treats this string as innerHTML.
 // renderToStaticMarkup escapes every React child/attribute, so feature
 // properties coming from our trusted API render safely. Any future change
 // that embeds user-controlled HTML into StoryPopup must keep that escaping
 // in place (or sanitize explicitly) to prevent XSS at this seam.
+export const featurePopupHtml = (feature) =>
+  renderToStaticMarkup(<StoryPopup story={featureToStory(feature)} />);
+
+export const pointToLayer = (_feature, latlng) => L.marker(latlng);
+
 export const onEachFeature = (feature, layer) => {
-  const html = renderToStaticMarkup(
-    <StoryPopup story={featureToStory(feature)} />,
-  );
-  layer.bindPopup(html);
+  layer.bindPopup(featurePopupHtml(feature));
 };

--- a/frontend/src/pages/__tests__/MapPage.test.jsx
+++ b/frontend/src/pages/__tests__/MapPage.test.jsx
@@ -36,16 +36,10 @@ vi.mock("leaflet", () => {
       addLayer: vi.fn(),
       clearLayers: vi.fn(),
     })),
-    featureGroup: vi.fn(() => ({ getBounds: () => ({}) })),
     latLngBounds: vi.fn(() => ({})),
-    latLng: vi.fn((lat, lng) => ({ lat, lng })),
   };
   return { default: L };
 });
-
-vi.mock("leaflet.markercluster", () => ({}));
-vi.mock("leaflet.markercluster/dist/MarkerCluster.css", () => ({}));
-vi.mock("leaflet.markercluster/dist/MarkerCluster.Default.css", () => ({}));
 
 vi.mock("@/services/storyService", () => ({
   getMapStories: vi.fn(),

--- a/frontend/src/pages/__tests__/MapPage.test.jsx
+++ b/frontend/src/pages/__tests__/MapPage.test.jsx
@@ -20,16 +20,32 @@ vi.mock("react-leaflet", () => ({
       </div>
     );
   },
-  useMap: () => ({ getContainer: () => document.createElement("div") }),
+  useMap: () => ({
+    getContainer: () => document.createElement("div"),
+    addLayer: vi.fn(),
+    removeLayer: vi.fn(),
+    fitBounds: vi.fn(),
+  }),
 }));
 
 vi.mock("leaflet", () => {
   const L = {
     Icon: { Default: { prototype: { _getIconUrl: "" }, mergeOptions: vi.fn() } },
     marker: vi.fn(() => ({ bindPopup: vi.fn() })),
+    markerClusterGroup: vi.fn(() => ({
+      addLayer: vi.fn(),
+      clearLayers: vi.fn(),
+    })),
+    featureGroup: vi.fn(() => ({ getBounds: () => ({}) })),
+    latLngBounds: vi.fn(() => ({})),
+    latLng: vi.fn((lat, lng) => ({ lat, lng })),
   };
   return { default: L };
 });
+
+vi.mock("leaflet.markercluster", () => ({}));
+vi.mock("leaflet.markercluster/dist/MarkerCluster.css", () => ({}));
+vi.mock("leaflet.markercluster/dist/MarkerCluster.Default.css", () => ({}));
 
 vi.mock("@/services/storyService", () => ({
   getMapStories: vi.fn(),
@@ -42,6 +58,7 @@ vi.mock("react-router-dom", async () => {
 });
 
 import { getMapStories } from "@/services/storyService";
+import L from "leaflet";
 import MapPage from "../MapPage";
 
 function makeFeature(id, overrides = {}) {
@@ -100,7 +117,7 @@ describe("MapPage", () => {
     renderPage();
 
     await waitFor(() => {
-      expect(screen.getAllByTestId("map-marker")).toHaveLength(2);
+      expect(L.marker).toHaveBeenCalledTimes(2);
     });
   });
 
@@ -128,7 +145,7 @@ describe("MapPage", () => {
     await user.click(screen.getByRole("button", { name: /retry/i }));
 
     await waitFor(() => {
-      expect(screen.getByTestId("map-marker")).toBeInTheDocument();
+      expect(L.marker).toHaveBeenCalled();
     });
 
     expect(getMapStories).toHaveBeenCalledTimes(2);
@@ -139,8 +156,9 @@ describe("MapPage", () => {
     renderPage();
 
     await waitFor(() => {
-      expect(screen.queryByTestId("map-marker")).not.toBeInTheDocument();
+      expect(getMapStories).toHaveBeenCalled();
     });
+    expect(L.marker).not.toHaveBeenCalled();
   });
 
   describe("search status indicator", () => {

--- a/frontend/src/test/setup.js
+++ b/frontend/src/test/setup.js
@@ -1,1 +1,6 @@
 import "@testing-library/jest-dom";
+import { vi } from "vitest";
+
+vi.mock("leaflet.markercluster", () => ({}));
+vi.mock("leaflet.markercluster/dist/MarkerCluster.css", () => ({}));
+vi.mock("leaflet.markercluster/dist/MarkerCluster.Default.css", () => ({}));


### PR DESCRIPTION
# Description
Fixes #458

Adds auto-zoom (fit bounds) and pin clustering to the story map.

- **Auto-zoom**: when ≥ 1 stories load, the map fits to the bounds of all visible markers. Single-marker case caps `maxZoom: 15` to avoid street-level zoom; multi-marker case applies `padding: [40, 40]`. Empty case keeps the Istanbul default. Re-fits when the feature set changes.
- **Clustering**: replaces the bare GeoJSON layer with `leaflet.markercluster` integrated imperatively via `useMap()` — the React wrapper's peer-dep with `react-leaflet 5` is unreliable, so the library is wired directly.
- **Lazy popup rendering**: `bindPopup(() => featurePopupHtml(feature))` so popup HTML is only computed when a marker is actually opened, not for every marker on every feature change.
- Removes dead `pointToLayer` / `onEachFeature` helpers (no longer used by production code) and the matching dead test branches.
- Hoists `leaflet.markercluster*` mocks to the shared `src/test/setup.js` so they're declared once.

New dependency: `leaflet.markercluster ^1.5.3`.

# Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Refactoring
- [ ] Documentation

# Acceptance Criteria / Checklist
- [x] Project builds successfully
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, especially in hard-to-understand parts
- [x] I have performed a self-review of my code
- [x] I have added/updated tests
- [x] New and existing unit tests pass locally with my changes

# Screenshots / Recordings
<!-- TBD -->

# Estimated Review Time
- [ ] < 5 min
- [x] 5-15 min
- [ ] > 15 min