### PR TITLE
feat(frontend): fit map to geocoded bbox with priority over markers

### DIFF
--- a/frontend/src/components/MapView/MapView.jsx
+++ b/frontend/src/components/MapView/MapView.jsx
@@ -57,22 +57,47 @@ function featureLatLng(feature) {
   return [lat, lng];
 }
 
-function FitBoundsToFeatures({ features }) {
+function isValidBbox(bbox) {
+  return (
+    bbox != null &&
+    Number.isFinite(bbox.latMin) &&
+    Number.isFinite(bbox.latMax) &&
+    Number.isFinite(bbox.lngMin) &&
+    Number.isFinite(bbox.lngMax)
+  );
+}
+
+function FitBoundsToFeatures({ features, bbox }) {
   const map = useMap();
-  // Skip re-fitting when the feature set is unchanged — refetches that
-  // return the same stories shouldn't snap the map back over the user's pan.
+  // Skip re-fitting when the inputs are unchanged — refetches that return the
+  // same bbox + stories shouldn't snap the map back over the user's pan.
   const lastFitKeyRef = useRef(null);
 
   useEffect(() => {
     if (!map) return;
-    if (features.length === 0) {
+    const hasBbox = isValidBbox(bbox);
+    if (!hasBbox && features.length === 0) {
       lastFitKeyRef.current = null;
       return;
     }
-    const fitKey = features.map((f) => f.id).join("|");
+    const bboxKey = hasBbox
+      ? `${bbox.latMin}|${bbox.latMax}|${bbox.lngMin}|${bbox.lngMax}`
+      : "";
+    const featuresKey = features.map((f) => f.id).join("|");
+    const fitKey = `${bboxKey}::${featuresKey}`;
     if (fitKey === lastFitKeyRef.current) return;
     lastFitKeyRef.current = fitKey;
 
+    // Bbox takes priority so the user always sees the area they searched
+    // for, even if no markers fall inside it.
+    if (hasBbox) {
+      const bounds = L.latLngBounds([
+        [bbox.latMin, bbox.lngMin],
+        [bbox.latMax, bbox.lngMax],
+      ]);
+      map.fitBounds(bounds, { padding: FIT_BOUNDS_PADDING });
+      return;
+    }
     const latlngs = features.map(featureLatLng).filter(Boolean);
     if (latlngs.length === 0) return;
     const bounds = L.latLngBounds(latlngs);
@@ -81,7 +106,7 @@ function FitBoundsToFeatures({ features }) {
         ? { maxZoom: SINGLE_FEATURE_MAX_ZOOM }
         : { padding: FIT_BOUNDS_PADDING };
     map.fitBounds(bounds, options);
-  }, [map, features]);
+  }, [map, features, bbox]);
   return null;
 }
 
@@ -116,7 +141,7 @@ function ClusteredMarkers({ features }) {
   return null;
 }
 
-function MapView({ featureCollection = EMPTY_FEATURE_COLLECTION, loading = false }) {
+function MapView({ featureCollection = EMPTY_FEATURE_COLLECTION, loading = false, bbox = null }) {
   const features = useMemo(
     () => featureCollection?.features ?? [],
     [featureCollection],
@@ -135,7 +160,7 @@ function MapView({ featureCollection = EMPTY_FEATURE_COLLECTION, loading = false
           url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
         />
         <ClusteredMarkers features={features} />
-        <FitBoundsToFeatures features={features} />
+        <FitBoundsToFeatures features={features} bbox={bbox} />
         <StoryLinkInterceptor />
       </MapContainer>
       {loading && (

--- a/frontend/src/components/MapView/__tests__/MapView.test.jsx
+++ b/frontend/src/components/MapView/__tests__/MapView.test.jsx
@@ -219,6 +219,84 @@ describe("MapView auto-zoom (fit bounds)", () => {
   });
 });
 
+describe("MapView auto-zoom with bbox (geocoded location filter)", () => {
+  const BBOX = { latMin: 41.0, latMax: 41.1, lngMin: 28.9, lngMax: 29.0 };
+
+  it("fits to the bbox when bbox is provided and there are zero markers", () => {
+    renderMapView({ featureCollection: makeFeatureCollection([]), bbox: BBOX });
+    expect(fakeMap.fitBounds).toHaveBeenCalledTimes(1);
+    expect(leafletMocks.latLngBounds).toHaveBeenCalledWith([
+      [BBOX.latMin, BBOX.lngMin],
+      [BBOX.latMax, BBOX.lngMax],
+    ]);
+    expect(fakeMap.fitBounds.mock.calls[0][1]).toMatchObject({ padding: [40, 40] });
+  });
+
+  it("prefers the bbox over marker bounds when both are present", () => {
+    renderMapView({
+      featureCollection: makeFeatureCollection([makeFeature(1), makeFeature(2)]),
+      bbox: BBOX,
+    });
+    expect(fakeMap.fitBounds).toHaveBeenCalledTimes(1);
+    expect(leafletMocks.latLngBounds).toHaveBeenCalledWith([
+      [BBOX.latMin, BBOX.lngMin],
+      [BBOX.latMax, BBOX.lngMax],
+    ]);
+  });
+
+  it("falls back to marker bounds when bbox is not provided", () => {
+    renderMapView({
+      featureCollection: makeFeatureCollection([makeFeature(1), makeFeature(2)]),
+      bbox: null,
+    });
+    expect(fakeMap.fitBounds).toHaveBeenCalledTimes(1);
+    expect(fakeMap.fitBounds.mock.calls[0][1]).toMatchObject({ padding: [40, 40] });
+  });
+
+  it("does not call fitBounds when neither bbox nor markers are present", () => {
+    renderMapView({ featureCollection: makeFeatureCollection([]), bbox: null });
+    expect(fakeMap.fitBounds).not.toHaveBeenCalled();
+  });
+
+  it("does not re-fit when re-rendered with the same bbox and same marker set", () => {
+    const fc = makeFeatureCollection([makeFeature(1), makeFeature(2)]);
+    const { rerender } = renderMapView({ featureCollection: fc, bbox: BBOX });
+    expect(fakeMap.fitBounds).toHaveBeenCalledTimes(1);
+
+    rerender(
+      <MemoryRouter>
+        <MapView featureCollection={fc} bbox={{ ...BBOX }} />
+      </MemoryRouter>,
+    );
+    expect(fakeMap.fitBounds).toHaveBeenCalledTimes(1);
+  });
+
+  it("re-fits when bbox changes even if the marker set is identical", () => {
+    const fc = makeFeatureCollection([makeFeature(1)]);
+    const { rerender } = renderMapView({ featureCollection: fc, bbox: BBOX });
+    expect(fakeMap.fitBounds).toHaveBeenCalledTimes(1);
+
+    rerender(
+      <MemoryRouter>
+        <MapView
+          featureCollection={fc}
+          bbox={{ latMin: 40.0, latMax: 40.5, lngMin: 28.0, lngMax: 28.5 }}
+        />
+      </MemoryRouter>,
+    );
+    expect(fakeMap.fitBounds).toHaveBeenCalledTimes(2);
+  });
+
+  it("ignores a partial bbox and uses marker bounds instead", () => {
+    renderMapView({
+      featureCollection: makeFeatureCollection([makeFeature(1)]),
+      bbox: { latMin: 41.0, latMax: 41.1, lngMin: null, lngMax: null },
+    });
+    expect(fakeMap.fitBounds).toHaveBeenCalledTimes(1);
+    expect(fakeMap.fitBounds.mock.calls[0][1]).toMatchObject({ maxZoom: 15 });
+  });
+});
+
 describe("MapView pin clustering", () => {
   it("creates a marker cluster group when features are present", () => {
     renderMapView({ featureCollection: makeFeatureCollection([makeFeature(1)]) });

--- a/frontend/src/pages/MapPage.jsx
+++ b/frontend/src/pages/MapPage.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from "react";
+import { useState, useEffect, useCallback, useMemo } from "react";
 
 import MapView from "@/components/MapView/MapView";
 import SearchFilter from "@/components/SearchFilter/SearchFilter";
@@ -13,6 +13,11 @@ function MapPage() {
   const [featureCollection, setFeatureCollection] = useState(EMPTY_FEATURE_COLLECTION);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
+
+  const bbox = useMemo(() => {
+    if (latMin == null || latMax == null || lngMin == null || lngMax == null) return null;
+    return { latMin, latMax, lngMin, lngMax };
+  }, [latMin, latMax, lngMin, lngMax]);
 
   const fetchPins = useCallback(async () => {
     setLoading(true);
@@ -37,7 +42,7 @@ function MapPage() {
 
   return (
     <div className="relative isolate" style={{ height: "calc(100vh - 3.5rem)" }}>
-      <MapView featureCollection={featureCollection} loading={loading} />
+      <MapView featureCollection={featureCollection} loading={loading} bbox={bbox} />
 
       {/* Search & filter overlay */}
       <div className="absolute top-3 left-3 right-3 z-[1000] sm:left-4 sm:right-auto sm:w-[32rem]">


### PR DESCRIPTION
# Description
Fixes #574

When a user picks a location from the geocoding autocomplete, the resulting bbox is forwarded to the backend (and stories are filtered geographically), but the web map's auto-zoom previously only saw returned markers. So a remote area with 0 matches gave no visual confirmation, and an area with 1–2 distant matches zoomed to the markers instead of the searched region.

This PR adds bbox-priority auto-zoom on the web, matching the mobile `getRegionForLocationBounds` behavior:

- `MapPage` derives `bbox = { latMin, latMax, lngMin, lngMax }` (or `null`) from existing URL params via `useMemo` and passes it to `<MapView>`.
- `<FitBoundsToFeatures>` now prefers a valid bbox over marker bounds. When neither is present, the default Istanbul view is preserved.
- The `lastFitKeyRef` no-op guard keys on bbox + feature ids together, so identical refetches don't re-fit while a changing bbox does.

# Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Refactoring
- [ ] Documentation

# Acceptance Criteria / Checklist
- [x] Project builds successfully
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, especially in hard-to-understand parts
- [x] I have performed a self-review of my code
- [x] I have added/updated tests
- [x] New and existing unit tests pass locally with my changes

# Screenshots / Recordings
<!-- N/A — behavior is best verified by running the dev server, picking a remote location from the autocomplete, and observing the map fit to the searched area even with zero results. -->

# Estimated Review Time
- [x] < 5 min
- [ ] 5-15 min
- [ ] > 15 min