### PR TITLE
Feat/frontend proximity filtering

### DIFF
--- a/frontend/src/components/MapView/MapView.jsx
+++ b/frontend/src/components/MapView/MapView.jsx
@@ -27,8 +27,13 @@ const SINGLE_FEATURE_MAX_ZOOM = 15;
 const FIT_BOUNDS_PADDING = [40, 40];
 const KM_PER_LATITUDE_DEGREE = 111;
 // Pads the radius circle bounds so the radius isn't flush with the viewport
-// edge — matches PROXIMITY_PADDING_FACTOR on mobile.
+// edge. This is a half-extent multiplier (applied per side), so a value of
+// 1.2 yields a total span of 2.4× the radius — matching mobile's
+// PROXIMITY_PADDING_FACTOR (2.4), which is expressed as a full-span factor.
 const PROXIMITY_BOUNDS_PADDING_FACTOR = 1.2;
+// Floor on the half-extent applied per side. Mobile clamps the full delta to
+// MIN_LOCATION_DELTA (0.02), so the half-extent equivalent is 0.01.
+const MIN_PROXIMITY_HALF_DELTA = 0.01;
 
 // Intercepts clicks on story links inside popup HTML so they perform
 // client-side navigation instead of a full page reload. Captures the
@@ -85,9 +90,11 @@ function isValidProximity(proximity) {
 // point. Mirrors mobile's getRegionForProximityFilter so both clients zoom to
 // the same area for the same filter.
 function proximityBounds({ latitude, longitude, radiusKm }) {
-  const latDelta = (radiusKm / KM_PER_LATITUDE_DEGREE) * PROXIMITY_BOUNDS_PADDING_FACTOR;
+  const rawLatDelta = (radiusKm / KM_PER_LATITUDE_DEGREE) * PROXIMITY_BOUNDS_PADDING_FACTOR;
   const cosLat = Math.max(Math.cos((latitude * Math.PI) / 180), 0.2);
-  const lngDelta = (radiusKm / (KM_PER_LATITUDE_DEGREE * cosLat)) * PROXIMITY_BOUNDS_PADDING_FACTOR;
+  const rawLngDelta = (radiusKm / (KM_PER_LATITUDE_DEGREE * cosLat)) * PROXIMITY_BOUNDS_PADDING_FACTOR;
+  const latDelta = Math.max(rawLatDelta, MIN_PROXIMITY_HALF_DELTA);
+  const lngDelta = Math.max(rawLngDelta, MIN_PROXIMITY_HALF_DELTA);
   return L.latLngBounds([
     [latitude - latDelta, longitude - lngDelta],
     [latitude + latDelta, longitude + lngDelta],

--- a/frontend/src/components/MapView/MapView.jsx
+++ b/frontend/src/components/MapView/MapView.jsx
@@ -25,6 +25,10 @@ const ISTANBUL_CENTER = [41.0082, 28.9784];
 const DEFAULT_ZOOM = 12;
 const SINGLE_FEATURE_MAX_ZOOM = 15;
 const FIT_BOUNDS_PADDING = [40, 40];
+const KM_PER_LATITUDE_DEGREE = 111;
+// Pads the radius circle bounds so the radius isn't flush with the viewport
+// edge — matches PROXIMITY_PADDING_FACTOR on mobile.
+const PROXIMITY_BOUNDS_PADDING_FACTOR = 1.2;
 
 // Intercepts clicks on story links inside popup HTML so they perform
 // client-side navigation instead of a full page reload. Captures the
@@ -67,7 +71,30 @@ function isValidBbox(bbox) {
   );
 }
 
-function FitBoundsToFeatures({ features, bbox }) {
+function isValidProximity(proximity) {
+  return (
+    proximity != null &&
+    Number.isFinite(proximity.latitude) &&
+    Number.isFinite(proximity.longitude) &&
+    Number.isFinite(proximity.radiusKm) &&
+    proximity.radiusKm > 0
+  );
+}
+
+// Returns Leaflet bounds covering a circle of `radiusKm` around the given
+// point. Mirrors mobile's getRegionForProximityFilter so both clients zoom to
+// the same area for the same filter.
+function proximityBounds({ latitude, longitude, radiusKm }) {
+  const latDelta = (radiusKm / KM_PER_LATITUDE_DEGREE) * PROXIMITY_BOUNDS_PADDING_FACTOR;
+  const cosLat = Math.max(Math.cos((latitude * Math.PI) / 180), 0.2);
+  const lngDelta = (radiusKm / (KM_PER_LATITUDE_DEGREE * cosLat)) * PROXIMITY_BOUNDS_PADDING_FACTOR;
+  return L.latLngBounds([
+    [latitude - latDelta, longitude - lngDelta],
+    [latitude + latDelta, longitude + lngDelta],
+  ]);
+}
+
+function FitBoundsToFeatures({ features, bbox, proximity }) {
   const map = useMap();
   // Skip re-fitting when the inputs are unchanged — refetches that return the
   // same bbox + stories shouldn't snap the map back over the user's pan.
@@ -76,26 +103,35 @@ function FitBoundsToFeatures({ features, bbox }) {
   useEffect(() => {
     if (!map) return;
     const hasBbox = isValidBbox(bbox);
-    if (!hasBbox && features.length === 0) {
+    const hasProximity = !hasBbox && isValidProximity(proximity);
+    if (!hasBbox && !hasProximity && features.length === 0) {
       lastFitKeyRef.current = null;
       return;
     }
     const bboxKey = hasBbox
       ? `${bbox.latMin}|${bbox.latMax}|${bbox.lngMin}|${bbox.lngMax}`
       : "";
+    const proximityKey = hasProximity
+      ? `${proximity.latitude}|${proximity.longitude}|${proximity.radiusKm}`
+      : "";
     const featuresKey = features.map((f) => f.id).join("|");
-    const fitKey = `${bboxKey}::${featuresKey}`;
+    const fitKey = `${bboxKey}::${proximityKey}::${featuresKey}`;
     if (fitKey === lastFitKeyRef.current) return;
     lastFitKeyRef.current = fitKey;
 
     // Bbox takes priority so the user always sees the area they searched
-    // for, even if no markers fall inside it.
+    // for, even if no markers fall inside it. Proximity is the next-best
+    // signal; markers are only used when neither is set.
     if (hasBbox) {
       const bounds = L.latLngBounds([
         [bbox.latMin, bbox.lngMin],
         [bbox.latMax, bbox.lngMax],
       ]);
       map.fitBounds(bounds, { padding: FIT_BOUNDS_PADDING });
+      return;
+    }
+    if (hasProximity) {
+      map.fitBounds(proximityBounds(proximity), { padding: FIT_BOUNDS_PADDING });
       return;
     }
     const latlngs = features.map(featureLatLng).filter(Boolean);
@@ -106,7 +142,7 @@ function FitBoundsToFeatures({ features, bbox }) {
         ? { maxZoom: SINGLE_FEATURE_MAX_ZOOM }
         : { padding: FIT_BOUNDS_PADDING };
     map.fitBounds(bounds, options);
-  }, [map, features, bbox]);
+  }, [map, features, bbox, proximity]);
   return null;
 }
 
@@ -141,7 +177,7 @@ function ClusteredMarkers({ features }) {
   return null;
 }
 
-function MapView({ featureCollection = EMPTY_FEATURE_COLLECTION, loading = false, bbox = null }) {
+function MapView({ featureCollection = EMPTY_FEATURE_COLLECTION, loading = false, bbox = null, proximity = null }) {
   const features = useMemo(
     () => featureCollection?.features ?? [],
     [featureCollection],
@@ -160,7 +196,7 @@ function MapView({ featureCollection = EMPTY_FEATURE_COLLECTION, loading = false
           url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
         />
         <ClusteredMarkers features={features} />
-        <FitBoundsToFeatures features={features} bbox={bbox} />
+        <FitBoundsToFeatures features={features} bbox={bbox} proximity={proximity} />
         <StoryLinkInterceptor />
       </MapContainer>
       {loading && (

--- a/frontend/src/components/MapView/__tests__/MapView.test.jsx
+++ b/frontend/src/components/MapView/__tests__/MapView.test.jsx
@@ -297,6 +297,87 @@ describe("MapView auto-zoom with bbox (geocoded location filter)", () => {
   });
 });
 
+describe("MapView auto-zoom with proximity (radius filter)", () => {
+  const PROXIMITY = { latitude: 41.0, longitude: 28.9, radiusKm: 10 };
+
+  it("fits to a circle around the user when proximity is set and there are zero markers", () => {
+    renderMapView({ featureCollection: makeFeatureCollection([]), proximity: PROXIMITY });
+    expect(fakeMap.fitBounds).toHaveBeenCalledTimes(1);
+    expect(leafletMocks.latLngBounds).toHaveBeenCalledTimes(1);
+    const [[swLat, swLng], [neLat, neLng]] = leafletMocks.latLngBounds.mock.calls[0][0];
+    // Bounds should be centered on the user with positive lat/lng deltas.
+    expect((swLat + neLat) / 2).toBeCloseTo(PROXIMITY.latitude, 5);
+    expect((swLng + neLng) / 2).toBeCloseTo(PROXIMITY.longitude, 5);
+    expect(neLat).toBeGreaterThan(swLat);
+    expect(neLng).toBeGreaterThan(swLng);
+  });
+
+  it("prefers the bbox over proximity when both are present", () => {
+    const bbox = { latMin: 41.0, latMax: 41.1, lngMin: 28.9, lngMax: 29.0 };
+    renderMapView({
+      featureCollection: makeFeatureCollection([makeFeature(1)]),
+      bbox,
+      proximity: PROXIMITY,
+    });
+    expect(fakeMap.fitBounds).toHaveBeenCalledTimes(1);
+    expect(leafletMocks.latLngBounds).toHaveBeenCalledWith([
+      [bbox.latMin, bbox.lngMin],
+      [bbox.latMax, bbox.lngMax],
+    ]);
+  });
+
+  it("prefers proximity over marker bounds when bbox is absent", () => {
+    renderMapView({
+      featureCollection: makeFeatureCollection([makeFeature(1), makeFeature(2)]),
+      proximity: PROXIMITY,
+    });
+    expect(fakeMap.fitBounds).toHaveBeenCalledTimes(1);
+    // The bounds passed in must be the user-centered ones, not the marker hull.
+    const [[swLat], [neLat]] = leafletMocks.latLngBounds.mock.calls[0][0];
+    expect((swLat + neLat) / 2).toBeCloseTo(PROXIMITY.latitude, 5);
+  });
+
+  it("does not re-fit when re-rendered with the same proximity and same marker set", () => {
+    const fc = makeFeatureCollection([makeFeature(1)]);
+    const { rerender } = renderMapView({ featureCollection: fc, proximity: PROXIMITY });
+    expect(fakeMap.fitBounds).toHaveBeenCalledTimes(1);
+
+    rerender(
+      <MemoryRouter>
+        <MapView featureCollection={fc} proximity={{ ...PROXIMITY }} />
+      </MemoryRouter>,
+    );
+    expect(fakeMap.fitBounds).toHaveBeenCalledTimes(1);
+  });
+
+  it("re-fits when the proximity radius changes", () => {
+    const fc = makeFeatureCollection([makeFeature(1)]);
+    const { rerender } = renderMapView({ featureCollection: fc, proximity: PROXIMITY });
+    expect(fakeMap.fitBounds).toHaveBeenCalledTimes(1);
+
+    rerender(
+      <MemoryRouter>
+        <MapView featureCollection={fc} proximity={{ ...PROXIMITY, radiusKm: 100 }} />
+      </MemoryRouter>,
+    );
+    expect(fakeMap.fitBounds).toHaveBeenCalledTimes(2);
+  });
+
+  it("ignores a partial proximity (missing radiusKm) and falls back to marker bounds", () => {
+    renderMapView({
+      featureCollection: makeFeatureCollection([makeFeature(1)]),
+      proximity: { latitude: 41.0, longitude: 28.9, radiusKm: null },
+    });
+    expect(fakeMap.fitBounds).toHaveBeenCalledTimes(1);
+    expect(fakeMap.fitBounds.mock.calls[0][1]).toMatchObject({ maxZoom: 15 });
+  });
+
+  it("does not call fitBounds when neither bbox, proximity, nor markers are present", () => {
+    renderMapView({ featureCollection: makeFeatureCollection([]), proximity: null });
+    expect(fakeMap.fitBounds).not.toHaveBeenCalled();
+  });
+});
+
 describe("MapView pin clustering", () => {
   it("creates a marker cluster group when features are present", () => {
     renderMapView({ featureCollection: makeFeatureCollection([makeFeature(1)]) });

--- a/frontend/src/components/SearchFilter/ActiveFilters.jsx
+++ b/frontend/src/components/SearchFilter/ActiveFilters.jsx
@@ -53,6 +53,7 @@ function ActiveFilters({
   yearTo = "",
   location = "",
   radiusKm = null,
+  hasProximity = false,
   tags = [],
   onRemove,
   onRemoveTag,
@@ -76,7 +77,7 @@ function ActiveFilters({
     chips.push({ key: "location", label: `Location: ${location}` });
   }
 
-  if (radiusKm != null) {
+  if (hasProximity && radiusKm != null) {
     const distanceLabel = radiusKm < 1 ? `${Math.round(radiusKm * 1000)} m` : `${radiusKm} km`;
     chips.push({ key: "proximity", label: `Within ${distanceLabel}` });
   }

--- a/frontend/src/components/SearchFilter/ActiveFilters.jsx
+++ b/frontend/src/components/SearchFilter/ActiveFilters.jsx
@@ -52,6 +52,7 @@ function ActiveFilters({
   yearFrom = "",
   yearTo = "",
   location = "",
+  radiusKm = null,
   tags = [],
   onRemove,
   onRemoveTag,
@@ -73,6 +74,11 @@ function ActiveFilters({
 
   if (location) {
     chips.push({ key: "location", label: `Location: ${location}` });
+  }
+
+  if (radiusKm != null) {
+    const distanceLabel = radiusKm < 1 ? `${Math.round(radiusKm * 1000)} m` : `${radiusKm} km`;
+    chips.push({ key: "proximity", label: `Within ${distanceLabel}` });
   }
 
   if (chips.length === 0 && tags.length === 0) return null;

--- a/frontend/src/components/SearchFilter/FilterPanel.jsx
+++ b/frontend/src/components/SearchFilter/FilterPanel.jsx
@@ -6,6 +6,7 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { cn } from "@/lib/utils";
 import { useLocationSuggestions } from "@/hooks/useLocationSuggestions";
+import { getCurrentDeviceCoordinates } from "@/services/deviceLocationService";
 import TagFilterInput from "./TagFilterInput";
 
 const YEAR_MIN = 1000;
@@ -13,13 +14,21 @@ const YEAR_MAX = 2030;
 const YEAR_SPINNER_FROM = 1980;
 const YEAR_SPINNER_TO = new Date().getFullYear();
 
+const PROXIMITY_OPTIONS = [
+  { value: null, label: "Anywhere" },
+  { value: 0.5, label: "500 m" },
+  { value: 1, label: "1 km" },
+  { value: 10, label: "10 km" },
+  { value: 100, label: "100 km" },
+];
+
 /**
  * Collapsible filter panel for year range, location, and tags.
  * Maintains local form state; commits to URL only on "Apply".
  * The parent should pass a `key` tied to the current filter values so that
  * the component resets its local form whenever filters are cleared externally.
  */
-function FilterPanel({ yearFrom = "", yearTo = "", location = "", latMin = null, latMax = null, lngMin = null, lngMax = null, tags = [], onApply, activeCount = 0 }) {
+function FilterPanel({ yearFrom = "", yearTo = "", location = "", latMin = null, latMax = null, lngMin = null, lngMax = null, latitude = null, longitude = null, radiusKm = null, tags = [], onApply, activeCount = 0 }) {
   const [open, setOpen] = useState(false);
   const [localYearFrom, setLocalYearFrom] = useState(yearFrom);
   const [localYearTo, setLocalYearTo] = useState(yearTo);
@@ -32,6 +41,17 @@ function FilterPanel({ yearFrom = "", yearTo = "", location = "", latMin = null,
       ? { latMin, latMax, lngMin, lngMax }
       : null
   );
+  const [localRadiusKm, setLocalRadiusKm] = useState(radiusKm);
+  const [localCoords, setLocalCoords] = useState(
+    () => (latitude != null && longitude != null ? { latitude, longitude } : null)
+  );
+  const [proximityResolving, setProximityResolving] = useState(false);
+  const [proximityStatus, setProximityStatus] = useState(
+    radiusKm != null && latitude != null && longitude != null
+      ? { kind: "ok", message: "Using your current location." }
+      : null
+  );
+  const proximityRequestIdRef = useRef(0);
   const [activeIndex, setActiveIndex] = useState(-1);
 
   const locationRef = useRef(null);
@@ -90,6 +110,56 @@ function FilterPanel({ yearFrom = "", yearTo = "", location = "", latMin = null,
     }
   }
 
+  async function handleProximityRadiusChange(nextRadiusKm) {
+    const requestId = proximityRequestIdRef.current + 1;
+    proximityRequestIdRef.current = requestId;
+    setLocalRadiusKm(nextRadiusKm);
+
+    if (nextRadiusKm == null) {
+      setLocalCoords(null);
+      setProximityResolving(false);
+      setProximityStatus(null);
+      return;
+    }
+
+    // Reuse coordinates if we already have them so toggling between radii
+    // doesn't re-prompt the user for permission on every click.
+    if (localCoords) {
+      setProximityStatus({ kind: "ok", message: "Using your current location." });
+      return;
+    }
+
+    setProximityResolving(true);
+    setProximityStatus({ kind: "info", message: "Fetching your current location..." });
+
+    const result = await getCurrentDeviceCoordinates();
+
+    // Bail out if a newer change has been issued (e.g. user clicked Anywhere
+    // before the position came back).
+    if (proximityRequestIdRef.current !== requestId) return;
+
+    setProximityResolving(false);
+
+    if (result.status === "granted") {
+      setLocalCoords(result.coordinates);
+      setProximityStatus({ kind: "ok", message: "Using your current location." });
+      return;
+    }
+
+    // Keep the radius selected so the user can retry by clicking another
+    // option — switching them back to Anywhere makes the filter feel broken.
+    // Apply gates on coords being present, so a selected-but-unresolved
+    // radius stays a no-op until a future attempt succeeds.
+    setLocalCoords(null);
+    setProximityStatus({
+      kind: "error",
+      message:
+        result.status === "denied"
+          ? "Location disabled. Enable location permission, then pick a radius again."
+          : "Current location is unavailable. Try again or choose Anywhere.",
+    });
+  }
+
   function handleApply() {
     const from = localYearFrom === "" ? "" : Number(localYearFrom);
     const to = localYearTo === "" ? "" : Number(localYearTo);
@@ -105,6 +175,7 @@ function FilterPanel({ yearFrom = "", yearTo = "", location = "", latMin = null,
 
     // Only use a bbox if the user explicitly selected a suggestion.
     const effectiveBbox = lockedBbox;
+    const proximityActive = localRadiusKm != null && localCoords != null;
 
     setYearError("");
     clearSuggestions();
@@ -116,21 +187,41 @@ function FilterPanel({ yearFrom = "", yearTo = "", location = "", latMin = null,
       latMax: effectiveBbox?.latMax ?? null,
       lngMin: effectiveBbox?.lngMin ?? null,
       lngMax: effectiveBbox?.lngMax ?? null,
+      latitude: proximityActive ? localCoords.latitude : null,
+      longitude: proximityActive ? localCoords.longitude : null,
+      radiusKm: proximityActive ? localRadiusKm : null,
       tags: localTags
     });
     setOpen(false);
   }
 
   function handleReset() {
+    proximityRequestIdRef.current += 1;
     setLocalYearFrom("");
     setLocalYearTo("");
     setLocalLocation("");
     setSuggestionsQuery("");
     setLockedBbox(null);
+    setLocalRadiusKm(null);
+    setLocalCoords(null);
+    setProximityResolving(false);
+    setProximityStatus(null);
     setLocalTags([]);
     setYearError("");
     clearSuggestions();
-    onApply({ yearFrom: "", yearTo: "", location: "", latMin: null, latMax: null, lngMin: null, lngMax: null, tags: [] });
+    onApply({
+      yearFrom: "",
+      yearTo: "",
+      location: "",
+      latMin: null,
+      latMax: null,
+      lngMin: null,
+      lngMax: null,
+      latitude: null,
+      longitude: null,
+      radiusKm: null,
+      tags: [],
+    });
     setOpen(false);
   }
 
@@ -303,6 +394,60 @@ function FilterPanel({ yearFrom = "", yearTo = "", location = "", latMin = null,
                 )}
               </div>
             </div>
+
+            {/* Distance / proximity */}
+            <fieldset>
+              <legend className="mb-2 text-sm font-medium">Distance</legend>
+              <div
+                role="radiogroup"
+                aria-label="Distance from current location"
+                className="flex flex-wrap gap-1.5"
+              >
+                {PROXIMITY_OPTIONS.map((option) => {
+                  const isSelected = localRadiusKm === option.value;
+                  const id = `proximity-${option.value ?? "off"}`;
+                  return (
+                    <label
+                      key={id}
+                      htmlFor={id}
+                      className={cn(
+                        "cursor-pointer rounded-full border px-3 py-1 text-sm transition-colors",
+                        isSelected
+                          ? "border-primary bg-primary text-primary-foreground"
+                          : "bg-background hover:bg-accent"
+                      )}
+                    >
+                      <input
+                        id={id}
+                        type="radio"
+                        name="proximity-radius"
+                        className="sr-only"
+                        checked={isSelected}
+                        onChange={() => handleProximityRadiusChange(option.value)}
+                      />
+                      {option.label}
+                    </label>
+                  );
+                })}
+              </div>
+              {(proximityResolving || proximityStatus) && (
+                <p
+                  className={cn(
+                    "mt-2 flex items-center gap-1.5 text-xs",
+                    proximityStatus?.kind === "error"
+                      ? "text-destructive"
+                      : "text-muted-foreground"
+                  )}
+                  role={proximityStatus?.kind === "error" ? "alert" : undefined}
+                  aria-live="polite"
+                >
+                  {proximityResolving && (
+                    <Loader2 className="h-3 w-3 animate-spin" aria-hidden="true" />
+                  )}
+                  {proximityStatus?.message}
+                </p>
+              )}
+            </fieldset>
 
             {/* Tags */}
             <TagFilterInput value={localTags} onChange={setLocalTags} />

--- a/frontend/src/components/SearchFilter/FilterPanel.jsx
+++ b/frontend/src/components/SearchFilter/FilterPanel.jsx
@@ -177,6 +177,17 @@ function FilterPanel({ yearFrom = "", yearTo = "", location = "", latMin = null,
     const effectiveBbox = lockedBbox;
     const proximityActive = localRadiusKm != null && localCoords != null;
 
+    // If a radius was picked but coords never resolved (e.g. permission denied),
+    // the URL will emit all-null proximity. Clear local state too so reopening
+    // the panel doesn't show a stale selection + lingering error.
+    if (!proximityActive) {
+      proximityRequestIdRef.current += 1;
+      setLocalRadiusKm(null);
+      setLocalCoords(null);
+      setProximityResolving(false);
+      setProximityStatus(null);
+    }
+
     setYearError("");
     clearSuggestions();
     onApply({

--- a/frontend/src/components/SearchFilter/SearchFilter.jsx
+++ b/frontend/src/components/SearchFilter/SearchFilter.jsx
@@ -6,9 +6,13 @@ import ActiveFilters from "./ActiveFilters";
 import { useFilterState } from "@/hooks/useFilterState";
 import { cn } from "@/lib/utils";
 
-/** Count how many non-search filters (year, location, tags) are active. */
-function countActiveFilters({ yearFrom, yearTo, location, tags }) {
-  return [yearFrom, yearTo, location].filter(Boolean).length + tags.length;
+/** Count how many non-search filters (year, location, distance, tags) are active. */
+function countActiveFilters({ yearFrom, yearTo, location, radiusKm, tags }) {
+  return (
+    [yearFrom, yearTo, location].filter(Boolean).length +
+    (radiusKm != null ? 1 : 0) +
+    tags.length
+  );
 }
 
 /**
@@ -17,7 +21,7 @@ function countActiveFilters({ yearFrom, yearTo, location, tags }) {
  * Must be rendered inside a React Router context.
  */
 function SearchFilter({ className }) {
-  const { q, yearFrom, yearTo, location, latMin, latMax, lngMin, lngMax, tags, setFilters, removeFilter, removeTag, clearAll } = useFilterState();
+  const { q, yearFrom, yearTo, location, latMin, latMax, lngMin, lngMax, latitude, longitude, radiusKm, tags, setFilters, removeFilter, removeTag, clearAll } = useFilterState();
 
   const handleSearchChange = useCallback(
     (value) => {
@@ -26,7 +30,7 @@ function SearchFilter({ className }) {
     [setFilters]
   );
 
-  function handleFilterApply({ yearFrom: yf, yearTo: yt, location: loc, latMin, latMax, lngMin, lngMax, tags: tgs}) {
+  function handleFilterApply({ yearFrom: yf, yearTo: yt, location: loc, latMin, latMax, lngMin, lngMax, latitude: lat, longitude: lng, radiusKm: rKm, tags: tgs}) {
     setFilters({
       year_from: yf,
       year_to: yt,
@@ -35,6 +39,9 @@ function SearchFilter({ className }) {
       lat_max: latMax ?? "",
       lng_min: lngMin ?? "",
       lng_max: lngMax ?? "",
+      latitude: lat ?? "",
+      longitude: lng ?? "",
+      radius_km: rKm ?? "",
       tags: tgs
     }, { replace: true });
   }
@@ -44,12 +51,14 @@ function SearchFilter({ className }) {
       setFilters({ year_from: "", year_to: "" }, { replace: true });
     } else if (key === "location") {
       setFilters({ location: "", lat_min: "", lat_max: "", lng_min: "", lng_max: "" }, { replace: true });
+    } else if (key === "proximity") {
+      setFilters({ latitude: "", longitude: "", radius_km: "" }, { replace: true });
     } else {
       removeFilter(key);
     }
   }
 
-  const activeFilterCount = countActiveFilters({ yearFrom, yearTo, location, tags });
+  const activeFilterCount = countActiveFilters({ yearFrom, yearTo, location, radiusKm, tags });
 
   return (
     <div className={cn("space-y-2", className)}>
@@ -61,7 +70,7 @@ function SearchFilter({ className }) {
           />
         </div>
         <FilterPanel
-          key={`${yearFrom}-${yearTo}-${location}-${latMin}-${latMax}-${lngMin}-${lngMax}-${tags.join(",")}`}
+          key={`${yearFrom}-${yearTo}-${location}-${latMin}-${latMax}-${lngMin}-${lngMax}-${latitude}-${longitude}-${radiusKm}-${tags.join(",")}`}
           yearFrom={yearFrom}
           yearTo={yearTo}
           location={location}
@@ -69,6 +78,9 @@ function SearchFilter({ className }) {
           latMax={latMax}
           lngMin={lngMin}
           lngMax={lngMax}
+          latitude={latitude}
+          longitude={longitude}
+          radiusKm={radiusKm}
           tags={tags}
           onApply={handleFilterApply}
           activeCount={activeFilterCount}
@@ -79,6 +91,7 @@ function SearchFilter({ className }) {
         yearFrom={yearFrom}
         yearTo={yearTo}
         location={location}
+        radiusKm={radiusKm}
         tags={tags}
         onRemove={handleRemoveFilter}
         onRemoveTag={removeTag}

--- a/frontend/src/components/SearchFilter/SearchFilter.jsx
+++ b/frontend/src/components/SearchFilter/SearchFilter.jsx
@@ -7,10 +7,10 @@ import { useFilterState } from "@/hooks/useFilterState";
 import { cn } from "@/lib/utils";
 
 /** Count how many non-search filters (year, location, distance, tags) are active. */
-function countActiveFilters({ yearFrom, yearTo, location, radiusKm, tags }) {
+function countActiveFilters({ yearFrom, yearTo, location, hasProximity, tags }) {
   return (
     [yearFrom, yearTo, location].filter(Boolean).length +
-    (radiusKm != null ? 1 : 0) +
+    (hasProximity ? 1 : 0) +
     tags.length
   );
 }
@@ -21,7 +21,7 @@ function countActiveFilters({ yearFrom, yearTo, location, radiusKm, tags }) {
  * Must be rendered inside a React Router context.
  */
 function SearchFilter({ className }) {
-  const { q, yearFrom, yearTo, location, latMin, latMax, lngMin, lngMax, latitude, longitude, radiusKm, tags, setFilters, removeFilter, removeTag, clearAll } = useFilterState();
+  const { q, yearFrom, yearTo, location, latMin, latMax, lngMin, lngMax, latitude, longitude, radiusKm, tags, hasProximity, setFilters, removeFilter, removeTag, clearAll } = useFilterState();
 
   const handleSearchChange = useCallback(
     (value) => {
@@ -58,7 +58,7 @@ function SearchFilter({ className }) {
     }
   }
 
-  const activeFilterCount = countActiveFilters({ yearFrom, yearTo, location, radiusKm, tags });
+  const activeFilterCount = countActiveFilters({ yearFrom, yearTo, location, hasProximity, tags });
 
   return (
     <div className={cn("space-y-2", className)}>
@@ -92,6 +92,7 @@ function SearchFilter({ className }) {
         yearTo={yearTo}
         location={location}
         radiusKm={radiusKm}
+        hasProximity={hasProximity}
         tags={tags}
         onRemove={handleRemoveFilter}
         onRemoveTag={removeTag}

--- a/frontend/src/components/SearchFilter/__tests__/ActiveFilters.test.jsx
+++ b/frontend/src/components/SearchFilter/__tests__/ActiveFilters.test.jsx
@@ -152,12 +152,12 @@ describe("ActiveFilters", () => {
   });
 
   it("renders a 'Within X km' chip when radiusKm is a whole-km value", () => {
-    renderFilters({ radiusKm: 10 });
+    renderFilters({ radiusKm: 10, hasProximity: true });
     expect(screen.getByText("Within 10 km")).toBeInTheDocument();
   });
 
   it("formats sub-kilometre radii in metres (500 m option)", () => {
-    renderFilters({ radiusKm: 0.5 });
+    renderFilters({ radiusKm: 0.5, hasProximity: true });
     expect(screen.getByText("Within 500 m")).toBeInTheDocument();
   });
 
@@ -166,10 +166,16 @@ describe("ActiveFilters", () => {
     expect(screen.queryByText(/^within /i)).not.toBeInTheDocument();
   });
 
+  it("does not render a proximity chip when radiusKm is set but hasProximity is false", () => {
+    // e.g. hand-edited URL with radius_km but no latitude/longitude.
+    renderFilters({ radiusKm: 10, hasProximity: false });
+    expect(screen.queryByText(/^within /i)).not.toBeInTheDocument();
+  });
+
   it("emits the 'proximity' remove key when the radius chip is dismissed", async () => {
     const user = userEvent.setup();
     const onRemove = vi.fn();
-    renderFilters({ radiusKm: 1, onRemove });
+    renderFilters({ radiusKm: 1, hasProximity: true, onRemove });
 
     await user.click(screen.getByRole("button", { name: /remove filter: within 1 km/i }));
 

--- a/frontend/src/components/SearchFilter/__tests__/ActiveFilters.test.jsx
+++ b/frontend/src/components/SearchFilter/__tests__/ActiveFilters.test.jsx
@@ -150,4 +150,29 @@ describe("ActiveFilters", () => {
     expect(screen.getByText("From 1900")).toBeInTheDocument();
     expect(screen.getByText("ottoman")).toBeInTheDocument();
   });
+
+  it("renders a 'Within X km' chip when radiusKm is a whole-km value", () => {
+    renderFilters({ radiusKm: 10 });
+    expect(screen.getByText("Within 10 km")).toBeInTheDocument();
+  });
+
+  it("formats sub-kilometre radii in metres (500 m option)", () => {
+    renderFilters({ radiusKm: 0.5 });
+    expect(screen.getByText("Within 500 m")).toBeInTheDocument();
+  });
+
+  it("does not render a proximity chip when radiusKm is null", () => {
+    renderFilters({ radiusKm: null });
+    expect(screen.queryByText(/^within /i)).not.toBeInTheDocument();
+  });
+
+  it("emits the 'proximity' remove key when the radius chip is dismissed", async () => {
+    const user = userEvent.setup();
+    const onRemove = vi.fn();
+    renderFilters({ radiusKm: 1, onRemove });
+
+    await user.click(screen.getByRole("button", { name: /remove filter: within 1 km/i }));
+
+    expect(onRemove).toHaveBeenCalledWith("proximity");
+  });
 });

--- a/frontend/src/components/SearchFilter/__tests__/FilterPanel.test.jsx
+++ b/frontend/src/components/SearchFilter/__tests__/FilterPanel.test.jsx
@@ -6,7 +6,12 @@ vi.mock("@/hooks/useLocationSuggestions", () => ({
   useLocationSuggestions: vi.fn(() => ({ suggestions: [], isLoading: false, clearSuggestions: vi.fn() })),
 }));
 
+vi.mock("@/services/deviceLocationService", () => ({
+  getCurrentDeviceCoordinates: vi.fn(),
+}));
+
 import FilterPanel from "../FilterPanel";
+import { getCurrentDeviceCoordinates } from "@/services/deviceLocationService";
 
 vi.mock("@/services/tagService", () => ({
   searchTags: vi.fn().mockResolvedValue([
@@ -81,7 +86,7 @@ describe("FilterPanel", () => {
     await user.type(screen.getByLabelText("Location filter"), "Galata");
     await user.click(screen.getByRole("button", { name: /apply/i }));
 
-    expect(onApply).toHaveBeenCalledWith({ yearFrom: 1900, yearTo: 2000, location: "Galata", latMin: null, latMax: null, lngMin: null, lngMax: null, tags: [] });
+    expect(onApply).toHaveBeenCalledWith({ yearFrom: 1900, yearTo: 2000, location: "Galata", latMin: null, latMax: null, lngMin: null, lngMax: null, latitude: null, longitude: null, radiusKm: null, tags: [] });
   });
 
 
@@ -109,7 +114,7 @@ describe("FilterPanel", () => {
     await user.click(screen.getByRole("button", { name: /filters/i }));
     await user.click(screen.getByRole("button", { name: /reset filters/i }));
 
-    expect(onApply).toHaveBeenCalledWith({ yearFrom: "", yearTo: "", location: "",  latMin: null, latMax: null, lngMin: null, lngMax: null, tags: [] });
+    expect(onApply).toHaveBeenCalledWith({ yearFrom: "", yearTo: "", location: "",  latMin: null, latMax: null, lngMin: null, lngMax: null, latitude: null, longitude: null, radiusKm: null, tags: [] });
   });
 
   it("shows tag section when panel is open", async () => {
@@ -274,5 +279,217 @@ describe("FilterPanel", () => {
     await user.type(screen.getByLabelText("From year"), "2020");
 
     expect(screen.getByLabelText("From year")).toHaveValue(2020);
+  });
+
+  describe("Distance / proximity", () => {
+    it("renders the predefined options (Anywhere, 500 m, 1 km, 10 km, 100 km) matching mobile", async () => {
+      const user = userEvent.setup();
+      renderPanel();
+
+      await user.click(screen.getByRole("button", { name: /^filters$/i }));
+
+      const group = screen.getByRole("radiogroup", { name: /distance/i });
+      expect(group).toBeInTheDocument();
+      expect(screen.getByLabelText("Anywhere")).toBeInTheDocument();
+      expect(screen.getByLabelText("500 m")).toBeInTheDocument();
+      expect(screen.getByLabelText("1 km")).toBeInTheDocument();
+      expect(screen.getByLabelText("10 km")).toBeInTheDocument();
+      expect(screen.getByLabelText("100 km")).toBeInTheDocument();
+    });
+
+    it("emits a fractional radiusKm (0.5) when 500 m is selected", async () => {
+      const user = userEvent.setup();
+      const onApply = vi.fn();
+      getCurrentDeviceCoordinates.mockResolvedValue({
+        status: "granted",
+        coordinates: { latitude: 41.0, longitude: 28.9 },
+      });
+      renderPanel({ onApply });
+
+      await user.click(screen.getByRole("button", { name: /^filters$/i }));
+      await user.click(screen.getByLabelText("500 m"));
+      await waitFor(() => {
+        expect(screen.getByText(/using your current location/i)).toBeInTheDocument();
+      });
+      await user.click(screen.getByRole("button", { name: /apply/i }));
+
+      expect(onApply).toHaveBeenCalledWith(
+        expect.objectContaining({ radiusKm: 0.5 }),
+      );
+    });
+
+    it("requests geolocation, applies coordinates, and emits proximity on Apply when granted", async () => {
+      const user = userEvent.setup();
+      const onApply = vi.fn();
+      getCurrentDeviceCoordinates.mockResolvedValue({
+        status: "granted",
+        coordinates: { latitude: 41.0082, longitude: 28.9784 },
+      });
+      renderPanel({ onApply });
+
+      await user.click(screen.getByRole("button", { name: /^filters$/i }));
+      await user.click(screen.getByLabelText("10 km"));
+
+      // Loading status while resolving, then success message
+      await waitFor(() => {
+        expect(screen.getByText(/using your current location/i)).toBeInTheDocument();
+      });
+
+      await user.click(screen.getByRole("button", { name: /apply/i }));
+
+      expect(onApply).toHaveBeenCalledWith(
+        expect.objectContaining({
+          latitude: 41.0082,
+          longitude: 28.9784,
+          radiusKm: 10,
+        }),
+      );
+    });
+
+    it("shows a 'Location disabled' error and does not apply proximity when permission is denied", async () => {
+      const user = userEvent.setup();
+      const onApply = vi.fn();
+      getCurrentDeviceCoordinates.mockResolvedValue({ status: "denied" });
+      renderPanel({ onApply });
+
+      await user.click(screen.getByRole("button", { name: /^filters$/i }));
+      await user.click(screen.getByLabelText("1 km"));
+
+      await waitFor(() => {
+        expect(screen.getByRole("alert")).toHaveTextContent(/location disabled/i);
+      });
+
+      await user.click(screen.getByRole("button", { name: /apply/i }));
+
+      expect(onApply).toHaveBeenCalledWith(
+        expect.objectContaining({ latitude: null, longitude: null, radiusKm: null }),
+      );
+    });
+
+    it("retries geolocation when the user picks another radius after a denial, instead of resetting to Anywhere", async () => {
+      const user = userEvent.setup();
+      const onApply = vi.fn();
+      getCurrentDeviceCoordinates
+        .mockResolvedValueOnce({ status: "denied" })
+        .mockResolvedValueOnce({
+          status: "granted",
+          coordinates: { latitude: 41.0, longitude: 28.9 },
+        });
+      renderPanel({ onApply });
+
+      await user.click(screen.getByRole("button", { name: /^filters$/i }));
+      await user.click(screen.getByLabelText("1 km"));
+      await waitFor(() => {
+        expect(screen.getByRole("alert")).toHaveTextContent(/location disabled/i);
+      });
+
+      // Selection should remain on 1 km, not snap back to Anywhere.
+      expect(screen.getByLabelText("1 km")).toBeChecked();
+      expect(screen.getByLabelText("Anywhere")).not.toBeChecked();
+
+      // Picking a different radius retries — and this time the user grants.
+      await user.click(screen.getByLabelText("10 km"));
+      await waitFor(() => {
+        expect(screen.getByText(/using your current location/i)).toBeInTheDocument();
+      });
+      expect(getCurrentDeviceCoordinates).toHaveBeenCalledTimes(2);
+
+      await user.click(screen.getByRole("button", { name: /apply/i }));
+      expect(onApply).toHaveBeenCalledWith(
+        expect.objectContaining({ radiusKm: 10, latitude: 41.0, longitude: 28.9 }),
+      );
+    });
+
+    it("shows an 'unavailable' error when geolocation fails for non-permission reasons", async () => {
+      const user = userEvent.setup();
+      getCurrentDeviceCoordinates.mockResolvedValue({ status: "unavailable" });
+      renderPanel();
+
+      await user.click(screen.getByRole("button", { name: /^filters$/i }));
+      await user.click(screen.getByLabelText("100 km"));
+
+      await waitFor(() => {
+        expect(screen.getByRole("alert")).toHaveTextContent(/unavailable|try again/i);
+      });
+    });
+
+    it("clears proximity when Anywhere is selected after an active radius", async () => {
+      const user = userEvent.setup();
+      const onApply = vi.fn();
+      getCurrentDeviceCoordinates.mockResolvedValue({
+        status: "granted",
+        coordinates: { latitude: 41.0, longitude: 28.9 },
+      });
+      renderPanel({ onApply });
+
+      await user.click(screen.getByRole("button", { name: /^filters$/i }));
+      await user.click(screen.getByLabelText("10 km"));
+      await waitFor(() => {
+        expect(screen.getByText(/using your current location/i)).toBeInTheDocument();
+      });
+      await user.click(screen.getByLabelText("Anywhere"));
+      await user.click(screen.getByRole("button", { name: /apply/i }));
+
+      expect(onApply).toHaveBeenCalledWith(
+        expect.objectContaining({ latitude: null, longitude: null, radiusKm: null }),
+      );
+    });
+
+    it("does not re-prompt for permission when toggling between radii after a successful resolve", async () => {
+      const user = userEvent.setup();
+      getCurrentDeviceCoordinates.mockResolvedValue({
+        status: "granted",
+        coordinates: { latitude: 41.0, longitude: 28.9 },
+      });
+      renderPanel();
+
+      await user.click(screen.getByRole("button", { name: /^filters$/i }));
+      await user.click(screen.getByLabelText("1 km"));
+      await waitFor(() => {
+        expect(screen.getByText(/using your current location/i)).toBeInTheDocument();
+      });
+      await user.click(screen.getByLabelText("10 km"));
+
+      expect(getCurrentDeviceCoordinates).toHaveBeenCalledTimes(1);
+    });
+
+    it("includes proximity in the activeCount the parent renders by emitting it on Apply", async () => {
+      const user = userEvent.setup();
+      const onApply = vi.fn();
+      getCurrentDeviceCoordinates.mockResolvedValue({
+        status: "granted",
+        coordinates: { latitude: 41.0, longitude: 28.9 },
+      });
+      renderPanel({ onApply });
+
+      await user.click(screen.getByRole("button", { name: /^filters$/i }));
+      await user.click(screen.getByLabelText("100 km"));
+      await waitFor(() => {
+        expect(screen.getByText(/using your current location/i)).toBeInTheDocument();
+      });
+      await user.click(screen.getByRole("button", { name: /apply/i }));
+
+      expect(onApply).toHaveBeenCalledWith(
+        expect.objectContaining({ radiusKm: 100, latitude: 41.0, longitude: 28.9 }),
+      );
+    });
+
+    it("Reset clears proximity even when one was previously active", async () => {
+      const user = userEvent.setup();
+      const onApply = vi.fn();
+      renderPanel({
+        onApply,
+        latitude: 41.0,
+        longitude: 28.9,
+        radiusKm: 10,
+      });
+
+      await user.click(screen.getByRole("button", { name: /filters/i }));
+      await user.click(screen.getByRole("button", { name: /reset filters/i }));
+
+      expect(onApply).toHaveBeenCalledWith(
+        expect.objectContaining({ latitude: null, longitude: null, radiusKm: null }),
+      );
+    });
   });
 });

--- a/frontend/src/components/SearchFilter/__tests__/SearchFilter.test.jsx
+++ b/frontend/src/components/SearchFilter/__tests__/SearchFilter.test.jsx
@@ -168,4 +168,33 @@ describe("SearchFilter", () => {
       expect(screen.queryByText("1900–2000")).not.toBeInTheDocument();
     });
   });
+
+  it("renders the proximity chip when latitude/longitude/radius_km are in the URL", () => {
+    renderSearchFilter(["/?latitude=41&longitude=29&radius_km=10"]);
+    expect(screen.getByText("Within 10 km")).toBeInTheDocument();
+  });
+
+  it("counts proximity in the active-filter badge on the Filters button", () => {
+    renderSearchFilter(["/?latitude=41&longitude=29&radius_km=1"]);
+    expect(
+      screen.getByRole("button", { name: /filters \(1 active\)/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("removing the proximity chip clears latitude, longitude, and radius_km together", async () => {
+    const user = userEvent.setup();
+    renderSearchFilter(["/?latitude=41&longitude=29&radius_km=10&q=bridge"]);
+
+    expect(screen.getByText("Within 10 km")).toBeInTheDocument();
+
+    await user.click(
+      screen.getByRole("button", { name: /remove filter: within 10 km/i }),
+    );
+
+    await waitFor(() => {
+      expect(screen.queryByText("Within 10 km")).not.toBeInTheDocument();
+    });
+    // Unrelated filters survive the proximity removal.
+    expect(screen.getByText('"bridge"')).toBeInTheDocument();
+  });
 });

--- a/frontend/src/hooks/__tests__/useFilterState.test.jsx
+++ b/frontend/src/hooks/__tests__/useFilterState.test.jsx
@@ -208,4 +208,34 @@ describe("useFilterState", () => {
     expect(result.current.lngMin).toBeNull();
     expect(result.current.lngMax).toBeNull();
   });
+
+  it("parses proximity query params as numbers", () => {
+    const { result } = renderHook(() => useFilterState(), {
+      wrapper: makeWrapper(["/?latitude=41.0082&longitude=28.9784&radius_km=10"]),
+    });
+
+    expect(result.current.latitude).toBe(41.0082);
+    expect(result.current.longitude).toBe(28.9784);
+    expect(result.current.radiusKm).toBe(10);
+    expect(result.current.hasActiveFilters).toBe(true);
+  });
+
+  it("returns null for proximity params when absent from URL", () => {
+    const { result } = renderHook(() => useFilterState(), { wrapper: makeWrapper() });
+
+    expect(result.current.latitude).toBeNull();
+    expect(result.current.longitude).toBeNull();
+    expect(result.current.radiusKm).toBeNull();
+  });
+
+  it("does not flag proximity as active when only some of latitude/longitude/radiusKm are present", () => {
+    const { result } = renderHook(() => useFilterState(), {
+      wrapper: makeWrapper(["/?latitude=41.0&longitude=28.9"]),
+    });
+
+    expect(result.current.latitude).toBe(41.0);
+    expect(result.current.longitude).toBe(28.9);
+    expect(result.current.radiusKm).toBeNull();
+    expect(result.current.hasActiveFilters).toBe(false);
+  });
 });

--- a/frontend/src/hooks/useFilterState.js
+++ b/frontend/src/hooks/useFilterState.js
@@ -124,6 +124,7 @@ export function useFilterState() {
     page,
     sortBy,
     tags,
+    hasProximity,
     hasActiveFilters,
     setFilters,
     removeFilter,

--- a/frontend/src/hooks/useFilterState.js
+++ b/frontend/src/hooks/useFilterState.js
@@ -3,26 +3,41 @@ import { useSearchParams } from "react-router-dom";
 
 /**
  * Manages search/filter state via URL query parameters.
- * Supported params: q, year_from, year_to, location, lat_min, lat_max, lng_min, lng_max, tags, page, sort_by
+ * Supported params: q, year_from, year_to, location, lat_min, lat_max, lng_min, lng_max,
+ * latitude, longitude, radius_km, tags, page, sort_by
  * Tags are stored as a comma-separated string: tags=foo,bar
  */
 export function useFilterState() {
   const [searchParams, setSearchParams] = useSearchParams();
 
+  function readNumberParam(key) {
+    const raw = searchParams.get(key);
+    if (raw == null || raw === "") return null;
+    const num = Number(raw);
+    return Number.isFinite(num) ? num : null;
+  }
+
   const q = searchParams.get("q") || "";
   const yearFrom = searchParams.get("year_from") ? Number(searchParams.get("year_from")) : "";
   const yearTo = searchParams.get("year_to") ? Number(searchParams.get("year_to")) : "";
   const location = searchParams.get("location") || "";
-  const latMin = searchParams.get("lat_min") != null && searchParams.get("lat_min") !== "" ? Number(searchParams.get("lat_min")) : null;
-  const latMax = searchParams.get("lat_max") != null && searchParams.get("lat_max") !== "" ? Number(searchParams.get("lat_max")) : null;
-  const lngMin = searchParams.get("lng_min") != null && searchParams.get("lng_min") !== "" ? Number(searchParams.get("lng_min")) : null;
-  const lngMax = searchParams.get("lng_max") != null && searchParams.get("lng_max") !== "" ? Number(searchParams.get("lng_max")) : null;
+  const latMin = readNumberParam("lat_min");
+  const latMax = readNumberParam("lat_max");
+  const lngMin = readNumberParam("lng_min");
+  const lngMax = readNumberParam("lng_max");
+  const latitude = readNumberParam("latitude");
+  const longitude = readNumberParam("longitude");
+  const radiusKm = readNumberParam("radius_km");
   const page = searchParams.get("page") ? Number(searchParams.get("page")) : 1;
   const sortBy = searchParams.get("sort_by") || "recent";
   const tagsRaw = searchParams.get("tags") || "";
   const tags = useMemo(() => (tagsRaw ? tagsRaw.split(",").filter(Boolean) : []), [tagsRaw]);
 
-  const hasActiveFilters = Boolean(q || yearFrom || yearTo || location || tags.length > 0);
+  const hasProximity =
+    latitude != null && longitude != null && radiusKm != null;
+  const hasActiveFilters = Boolean(
+    q || yearFrom || yearTo || location || tags.length > 0 || hasProximity
+  );
 
   /**
    * Update one or more URL params.
@@ -103,6 +118,9 @@ export function useFilterState() {
     latMax,
     lngMin,
     lngMax,
+    latitude,
+    longitude,
+    radiusKm,
     page,
     sortBy,
     tags,

--- a/frontend/src/pages/FeedPage.jsx
+++ b/frontend/src/pages/FeedPage.jsx
@@ -13,7 +13,7 @@ import { useFilterState } from "@/hooks/useFilterState";
 const PAGE_SIZE = 12;
 
 function FeedPage() {
-  const { q, yearFrom, yearTo, location, latMin, latMax, lngMin, tags, lngMax, page, sortBy, hasActiveFilters, setFilters } =
+  const { q, yearFrom, yearTo, location, latMin, latMax, lngMin, tags, lngMax, latitude, longitude, radiusKm, page, sortBy, hasActiveFilters, setFilters } =
     useFilterState();
 
   const [stories, setStories] = useState([]);
@@ -29,7 +29,7 @@ function FeedPage() {
     setLoading(true);
     setError(null);
     try {
-      const data = await getStories({ q, yearFrom, yearTo, location, latMin, latMax, lngMin, lngMax, tags, page, pageSize: PAGE_SIZE, sortBy });
+      const data = await getStories({ q, yearFrom, yearTo, location, latMin, latMax, lngMin, lngMax, latitude, longitude, radiusKm, tags, page, pageSize: PAGE_SIZE, sortBy });
       setStories(data.results);
       setTotalCount(data.count);
       setHasNext(Boolean(data.next));
@@ -43,7 +43,7 @@ function FeedPage() {
     } finally {
       setLoading(false);
     }
-  }, [q, yearFrom, yearTo, location, latMin, latMax, lngMin, lngMax, tags, page, sortBy]);
+  }, [q, yearFrom, yearTo, location, latMin, latMax, lngMin, lngMax, latitude, longitude, radiusKm, tags, page, sortBy]);
 
   useEffect(() => {
     fetchStories();

--- a/frontend/src/pages/MapPage.jsx
+++ b/frontend/src/pages/MapPage.jsx
@@ -8,7 +8,7 @@ import { useFilterState } from "@/hooks/useFilterState";
 const EMPTY_FEATURE_COLLECTION = { type: "FeatureCollection", features: [] };
 
 function MapPage() {
-  const { q, yearFrom, yearTo, location, latMin, latMax, lngMin, lngMax, tags, hasActiveFilters } = useFilterState();
+  const { q, yearFrom, yearTo, location, latMin, latMax, lngMin, lngMax, latitude, longitude, radiusKm, tags, hasActiveFilters } = useFilterState();
 
   const [featureCollection, setFeatureCollection] = useState(EMPTY_FEATURE_COLLECTION);
   const [loading, setLoading] = useState(true);
@@ -19,11 +19,16 @@ function MapPage() {
     return { latMin, latMax, lngMin, lngMax };
   }, [latMin, latMax, lngMin, lngMax]);
 
+  const proximity = useMemo(() => {
+    if (latitude == null || longitude == null || radiusKm == null) return null;
+    return { latitude, longitude, radiusKm };
+  }, [latitude, longitude, radiusKm]);
+
   const fetchPins = useCallback(async () => {
     setLoading(true);
     setError(null);
     try {
-      const data = await getMapStories({ q, yearFrom, yearTo, location, latMin, latMax, lngMin, lngMax, tags });
+      const data = await getMapStories({ q, yearFrom, yearTo, location, latMin, latMax, lngMin, lngMax, latitude, longitude, radiusKm, tags });
       setFeatureCollection(data ?? EMPTY_FEATURE_COLLECTION);
     } catch (err) {
       setError(
@@ -34,7 +39,7 @@ function MapPage() {
     } finally {
       setLoading(false);
     }
-  }, [q, yearFrom, yearTo, location, latMin, latMax, lngMin, lngMax, tags]);
+  }, [q, yearFrom, yearTo, location, latMin, latMax, lngMin, lngMax, latitude, longitude, radiusKm, tags]);
 
   useEffect(() => {
     fetchPins();
@@ -42,7 +47,7 @@ function MapPage() {
 
   return (
     <div className="relative isolate" style={{ height: "calc(100vh - 3.5rem)" }}>
-      <MapView featureCollection={featureCollection} loading={loading} bbox={bbox} />
+      <MapView featureCollection={featureCollection} loading={loading} bbox={bbox} proximity={proximity} />
 
       {/* Search & filter overlay */}
       <div className="absolute top-3 left-3 right-3 z-[1000] sm:left-4 sm:right-auto sm:w-[32rem]">

--- a/frontend/src/pages/__tests__/FeedPage.test.jsx
+++ b/frontend/src/pages/__tests__/FeedPage.test.jsx
@@ -377,4 +377,19 @@ describe("FeedPage", () => {
       expect(screen.getByText(/5 stories found/i)).toBeInTheDocument();
     });
   });
+
+  it("forwards latitude, longitude and radiusKm from the URL to getStories", async () => {
+    getStories.mockResolvedValue(makeResponse({ count: 0, results: [] }));
+    renderPage(["/?latitude=41.0&longitude=28.9&radius_km=1"]);
+
+    await waitFor(() => {
+      expect(getStories).toHaveBeenCalledWith(
+        expect.objectContaining({
+          latitude: 41.0,
+          longitude: 28.9,
+          radiusKm: 1,
+        }),
+      );
+    });
+  });
 });

--- a/frontend/src/pages/__tests__/MapPage.test.jsx
+++ b/frontend/src/pages/__tests__/MapPage.test.jsx
@@ -243,4 +243,40 @@ describe("MapPage", () => {
       });
     });
   });
+
+  describe("proximity filter", () => {
+    it("forwards latitude, longitude and radiusKm from the URL to getMapStories", async () => {
+      getMapStories.mockResolvedValue(makeFeatureCollection([]));
+      render(
+        <MemoryRouter initialEntries={["/?latitude=41.0082&longitude=28.9784&radius_km=10"]}>
+          <MapPage />
+        </MemoryRouter>,
+      );
+
+      await waitFor(() => {
+        expect(getMapStories).toHaveBeenCalledWith(
+          expect.objectContaining({
+            latitude: 41.0082,
+            longitude: 28.9784,
+            radiusKm: 10,
+          }),
+        );
+      });
+    });
+
+    it("does not forward proximity when only a partial set is in the URL", async () => {
+      getMapStories.mockResolvedValue(makeFeatureCollection([]));
+      render(
+        <MemoryRouter initialEntries={["/?latitude=41.0&longitude=28.9"]}>
+          <MapPage />
+        </MemoryRouter>,
+      );
+
+      await waitFor(() => {
+        expect(getMapStories).toHaveBeenCalled();
+      });
+      const call = getMapStories.mock.calls[0][0];
+      expect(call.radiusKm).toBeNull();
+    });
+  });
 });

--- a/frontend/src/services/__tests__/deviceLocationService.test.js
+++ b/frontend/src/services/__tests__/deviceLocationService.test.js
@@ -1,0 +1,72 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+
+import { getCurrentDeviceCoordinates } from "../deviceLocationService";
+
+const originalNavigator = globalThis.navigator;
+
+afterEach(() => {
+  globalThis.navigator = originalNavigator;
+  vi.restoreAllMocks();
+});
+
+function stubGeolocation(impl) {
+  globalThis.navigator = { geolocation: { getCurrentPosition: impl } };
+}
+
+describe("getCurrentDeviceCoordinates", () => {
+  it("returns coordinates with status 'granted' on success", async () => {
+    stubGeolocation((onSuccess) => {
+      onSuccess({ coords: { latitude: 41.0082, longitude: 28.9784 } });
+    });
+
+    const result = await getCurrentDeviceCoordinates();
+
+    expect(result).toEqual({
+      status: "granted",
+      coordinates: { latitude: 41.0082, longitude: 28.9784 },
+    });
+  });
+
+  it("returns 'denied' when the browser surfaces PERMISSION_DENIED (code 1)", async () => {
+    stubGeolocation((_, onError) => {
+      onError({ code: 1, message: "User denied geolocation" });
+    });
+
+    const result = await getCurrentDeviceCoordinates();
+
+    expect(result).toEqual({ status: "denied" });
+  });
+
+  it("returns 'unavailable' for non-permission errors (timeout, position unavailable)", async () => {
+    stubGeolocation((_, onError) => {
+      onError({ code: 3, message: "Timeout" });
+    });
+
+    const result = await getCurrentDeviceCoordinates();
+
+    expect(result).toEqual({ status: "unavailable" });
+  });
+
+  it("returns 'unavailable' when navigator.geolocation is missing", async () => {
+    globalThis.navigator = {};
+
+    const result = await getCurrentDeviceCoordinates();
+
+    expect(result).toEqual({ status: "unavailable" });
+  });
+
+  it("forwards a custom timeout to getCurrentPosition options", async () => {
+    const impl = vi.fn((onSuccess) => {
+      onSuccess({ coords: { latitude: 0, longitude: 0 } });
+    });
+    stubGeolocation(impl);
+
+    await getCurrentDeviceCoordinates({ timeoutMs: 1234 });
+
+    expect(impl).toHaveBeenCalledWith(
+      expect.any(Function),
+      expect.any(Function),
+      expect.objectContaining({ timeout: 1234 })
+    );
+  });
+});

--- a/frontend/src/services/__tests__/storyService.test.js
+++ b/frontend/src/services/__tests__/storyService.test.js
@@ -143,6 +143,36 @@ describe("storyService", () => {
       });
     });
 
+    it("passes proximity params to feed API when latitude, longitude and radiusKm are all provided", async () => {
+      api.get.mockResolvedValue({ data: { count: 0, next: null, previous: null, results: [] } });
+
+      await getStories({ latitude: 41.0082, longitude: 28.9784, radiusKm: 10 });
+
+      expect(api.get).toHaveBeenCalledWith("/stories/feed/", {
+        params: { page: 1, page_size: 12, sort_by: "recent", latitude: 41.0082, longitude: 28.9784, radius_km: 10 },
+      });
+    });
+
+    it("omits proximity params when only a partial set is provided", async () => {
+      api.get.mockResolvedValue({ data: { count: 0, next: null, previous: null, results: [] } });
+
+      await getStories({ latitude: 41.0082, longitude: 28.9784 });
+
+      expect(api.get).toHaveBeenCalledWith("/stories/feed/", {
+        params: { page: 1, page_size: 12, sort_by: "recent" },
+      });
+    });
+
+    it("passes proximity params alongside q to the search API", async () => {
+      api.get.mockResolvedValue({ data: { count: 0, next: null, previous: null, results: [] } });
+
+      await getStories({ q: "bridge", latitude: 41.0, longitude: 28.9, radiusKm: 1 });
+
+      expect(api.get).toHaveBeenCalledWith("/stories/search/", {
+        params: { q: "bridge", page: 1, page_size: 12, latitude: 41.0, longitude: 28.9, radius_km: 1 },
+      });
+    });
+
     it("uses feed API when q is empty string", async () => {
       api.get.mockResolvedValue({ data: { count: 0, next: null, previous: null, results: [] } });
 
@@ -263,6 +293,16 @@ describe("storyService", () => {
 
       expect(api.get).toHaveBeenCalledWith("/stories/map/", {
         params: { location: "Galata" },
+      });
+    });
+
+    it("passes proximity params to map API when latitude, longitude and radiusKm are all provided", async () => {
+      api.get.mockResolvedValue({ data: emptyFeatureCollection });
+
+      await getMapStories({ latitude: 41.0, longitude: 28.9, radiusKm: 100 });
+
+      expect(api.get).toHaveBeenCalledWith("/stories/map/", {
+        params: { latitude: 41.0, longitude: 28.9, radius_km: 100 },
       });
     });
 

--- a/frontend/src/services/deviceLocationService.js
+++ b/frontend/src/services/deviceLocationService.js
@@ -1,0 +1,43 @@
+/**
+ * Wraps navigator.geolocation.getCurrentPosition with a tagged result envelope
+ * that mirrors the mobile client (`mobile/src/core/services/deviceLocation.ts`)
+ * so the proximity-filter UX behaves identically across platforms.
+ *
+ * Returns one of:
+ *   - { status: "granted", coordinates: { latitude, longitude } }
+ *   - { status: "denied" }       — user explicitly refused permission
+ *   - { status: "unavailable" }  — API missing, timeout, or position lookup failed
+ *
+ * Coordinates are returned as raw decimal degrees; callers are responsible for
+ * any rounding (matches mobile, which truncates to 4 decimals only at display).
+ */
+
+const DEFAULT_TIMEOUT_MS = 10000;
+
+export async function getCurrentDeviceCoordinates({ timeoutMs = DEFAULT_TIMEOUT_MS } = {}) {
+  if (typeof navigator === "undefined" || !navigator.geolocation) {
+    return { status: "unavailable" };
+  }
+
+  return new Promise((resolve) => {
+    navigator.geolocation.getCurrentPosition(
+      (position) => {
+        resolve({
+          status: "granted",
+          coordinates: {
+            latitude: position.coords.latitude,
+            longitude: position.coords.longitude,
+          },
+        });
+      },
+      (error) => {
+        if (error && error.code === 1) {
+          resolve({ status: "denied" });
+          return;
+        }
+        resolve({ status: "unavailable" });
+      },
+      { enableHighAccuracy: false, timeout: timeoutMs, maximumAge: 60_000 }
+    );
+  });
+}

--- a/frontend/src/services/storyService.js
+++ b/frontend/src/services/storyService.js
@@ -7,6 +7,14 @@ const PAGE_SIZE = 12;
  * When `q` is provided, uses the /stories/search/ endpoint (title + location search).
  * Otherwise uses /stories/feed/ with optional year and location filters.
  */
+function applyProximityParams(params, latitude, longitude, radiusKm) {
+  if (latitude != null && longitude != null && radiusKm != null) {
+    params.latitude = latitude;
+    params.longitude = longitude;
+    params.radius_km = radiusKm;
+  }
+}
+
 export async function getStories({
   q,
   yearFrom,
@@ -16,6 +24,9 @@ export async function getStories({
   latMax,
   lngMin,
   lngMax,
+  latitude,
+  longitude,
+  radiusKm,
   tags = [],
   page = 1,
   pageSize = PAGE_SIZE,
@@ -35,6 +46,7 @@ export async function getStories({
     } else if (location?.trim()) {
       params.location = location.trim();
     }
+    applyProximityParams(params, latitude, longitude, radiusKm);
     if (tags.length > 0) params.tags = tags;
     const response = await api.get("/stories/search/", { params });
     return response.data; // { count, next, previous, results }
@@ -51,6 +63,7 @@ export async function getStories({
   } else if (location?.trim()) {
     params.location = location.trim();
   }
+  applyProximityParams(params, latitude, longitude, radiusKm);
   if (tags.length > 0) params.tags = tags;
 
   const response = await api.get("/stories/feed/", { params });
@@ -91,7 +104,7 @@ function storyToFeature(story) {
  *   FeatureCollection on the client, since the search endpoint still returns
  *   the legacy paginated story list.
  */
-export async function getMapStories({ q, yearFrom, yearTo, location, latMin, latMax, lngMin, lngMax, tags = [] } = {}) {
+export async function getMapStories({ q, yearFrom, yearTo, location, latMin, latMax, lngMin, lngMax, latitude, longitude, radiusKm, tags = [] } = {}) {
   const hasBbox = latMin != null && latMax != null && lngMin != null && lngMax != null;
   if (q?.trim()) {
     // Hard cap — pins beyond MAP_SEARCH_CAP are silently dropped.
@@ -106,6 +119,7 @@ export async function getMapStories({ q, yearFrom, yearTo, location, latMin, lat
     } else if (location?.trim()) {
       params.location = location.trim();
     }
+    applyProximityParams(params, latitude, longitude, radiusKm);
     if (tags.length > 0) params.tags = tags;
     const response = await api.get("/stories/search/", { params });
     const features = response.data.results
@@ -129,6 +143,7 @@ export async function getMapStories({ q, yearFrom, yearTo, location, latMin, lat
   } else if (location?.trim()) {
     params.location = location.trim();
   }
+  applyProximityParams(params, latitude, longitude, radiusKm);
   if (tags.length > 0) params.tags = tags;
 
   const response = await api.get("/stories/map/", { params });


### PR DESCRIPTION
# 📝 Description
Fixes #389                                                                                                                                            
                                                                                                                                                       
  Adds a Distance section to the filter panel that lets users narrow stories to a radius around their current location (Anywhere / 500 m / 1 km / 10 km / 100 km — matching mobile). Selecting a radius prompts the browser for geolocation permission; on success the coordinates and chosen radius_km flow through to /stories/feed/, /stories/search/, and /stories/map/. The map auto-zooms to the proximity circle when no geocoded bbox is set, completing the parity gap left after #573 / #574 between web and mobile (getRegionForProximityFilter on mobile).

 Uses navigator.geolocation only — no new Nominatim/OSM calls. The existing backend Nominatim proxy is untouched.                                     
  
##  New features                                                                                                                                         
                                                            
  - Distance / proximity filter with five predefined options matching mobile (Anywhere, 500 m, 1 km, 10 km, 100 km)                                    
  - Browser geolocation permission flow with loading spinner, "Location disabled" error on denial, and "Current location unavailable" fallback for timeouts / missing API                                                                                                                               
  - Denied selection stays highlighted so subsequent clicks retry the permission flow instead of snapping back to Anywhere; Apply gates on resolved coordinates so a half-applied filter never reaches the backend                                                                                       
  - Removable "Within X" chip in the active-filters strip (formatted as Within 500 m for sub-km radii); counted in the filter badge
  - Map auto-zoom to a circle around the user when proximity is active and no bbox is set; precedence is bbox > proximity > markers, with bounds math (latDelta = radiusKm/111, lngDelta scaled by cos(lat), 1.2× padding) mirroring mobile                                                                
                                                                                                                                                       
 ## Modified files                                                                                                                                       
                                                            
  - services/deviceLocationService.js (new) — wraps navigator.geolocation.getCurrentPosition with a granted | denied | unavailable envelope mirroring mobile/src/core/services/deviceLocation.ts                
  - hooks/useFilterState.js — reads/writes latitude, longitude, radius_km URL params; treats proximity as an active filter only when all three are present                                                                                                                                              
  - services/storyService.js — forwards proximity params on feed, search, and map endpoints (omits when partial)
  - components/SearchFilter/FilterPanel.jsx — new Distance radio group, draft state, permission flow, retry-on-reclick behavior                        
  - components/SearchFilter/SearchFilter.jsx — plumbs proximity through; treats it as a removable filter via the proximity chip key                    
  - components/SearchFilter/ActiveFilters.jsx — adds Within X chip with km/m formatting                                                                
  - components/MapView/MapView.jsx — new proximity prop; FitBoundsToFeatures precedence updated to bbox > proximity > markers                          
  - pages/MapPage.jsx, pages/FeedPage.jsx — read proximity from filter state and forward to services / MapView                                         
                                                                                                                                                       
##  Tests                                                                                                                                                
                                                                                                                                                       
  - deviceLocationService — granted, denied (PERMISSION_DENIED), unavailable (timeout / missing API), custom timeout option                            
  - useFilterState — proximity URL parsing, partial-set behavior, hasActiveFilters semantics
  - storyService — proximity forwarded on feed, search, and map; omitted on partial set                                                                
  - FilterPanel — five options render, granted-path commit, denied error message, unavailable fallback, retry after denial keeps selection and re-prompts, Anywhere clears state, no re-prompt when toggling after success, 500 m emits 0.5, Reset clears proximity                                 
  - ActiveFilters — chip rendering, km vs metres formatting, proximity remove key                                                                      
  - SearchFilter — proximity chip rendered from URL, badge count includes proximity, removing the chip clears all three URL params together            
  - MapView — fits to proximity circle, prefers bbox over proximity, prefers proximity over marker bounds, partial proximity falls through, dedupes identical re-renders, re-fits on radius change                                                                                                       
  - MapPage / FeedPage — URL → service forwarding for the full proximity triple and the partial case                                                   
                                                                                                                                                       
###  Note on the native permission prompt                                                                                                                 
                                                                                                                                                       
  The browser's location permission dialog is owned by the OS / browser and cannot be replaced from JS. The panel's pre-prompt status text ("Fetching your current location...") and post-denial copy ("Enable location permission, then pick a radius again.") give context around it. After a persistent denial the browser will fail subsequent calls without re-prompting until the user re-enables location for the site in browser settings — the error copy points them there.
# 📊 Type of Change
- [ ]  Bug fix
- [x]  New feature
- [ ]  Refactoring
- [ ]  Documentation
 
# ✅ Acceptance Criteria / Checklist
- [x] Project builds successfully
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, especially in hard-to-understand parts
- [x] I have performed a self-review of my code
- [x] I have added/updated tests
- [x] New and existing unit tests pass locally with my changes

# 📸 Screenshots / Recordings
<!-- If applicable !-->
<img width="1440" height="820" alt="Screenshot 2026-05-08 at 12 46 09" src="https://github.com/user-attachments/assets/cdf10e37-8ed2-4792-b904-26e18bd1a861" />

# ⏱️ Estimated Review Time
- [ ] < 5 min
- [x] 5-15 min
- [ ] > 15 min
