### PR TITLE
feat: mobile add forgot and reset password flows

### DIFF
--- a/mobile/app.json
+++ b/mobile/app.json
@@ -2,6 +2,7 @@
   "expo": {
     "name": "StoryMap",
     "slug": "local-history-story-map",
+    "scheme": "storymap",
     "version": "1.0.0",
     "orientation": "portrait",
     "userInterfaceStyle": "automatic",

--- a/mobile/src/app/navigation/RootNavigator.tsx
+++ b/mobile/src/app/navigation/RootNavigator.tsx
@@ -1,9 +1,9 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { BackHandler, NativeScrollEvent, NativeSyntheticEvent, Pressable, RefreshControl, ScrollView, StatusBar, Text, useWindowDimensions, View } from 'react-native';
+import { BackHandler, Linking, NativeScrollEvent, NativeSyntheticEvent, Pressable, RefreshControl, ScrollView, StatusBar, Text, useWindowDimensions, View } from 'react-native';
 import { Bell, MapPin, Plus } from 'lucide-react-native';
 import { Loader, Screen } from '../../shared';
 import { ROUTES } from './routes';
-import { AuthScreen, useAuth, VerifyEmailScreen } from '../../features/auth';
+import { AuthScreen, ForgotPasswordScreen, ResetPasswordScreen, useAuth, VerifyEmailScreen } from '../../features/auth';
 import { useAppTheme } from '../../core/hooks/useAppTheme';
 import { ProtectedScreen } from './ProtectedScreen';
 import { FeedScreen, FeedStoryInteractionUpdate } from '../../features/feed';
@@ -20,12 +20,14 @@ import { useToast } from '../../shared/hooks/useToast';
 import { APP_NAME } from '../../core/constants/app';
 import { NotificationScreen, notificationService } from '../../features/notifications';
 import { NotificationEntity } from '../../features/notifications/domain/entities';
+import { getResetPasswordTokenFromPath, isForgotPasswordPath } from './linking';
 
 type AppRoute = (typeof ROUTES)[keyof typeof ROUTES];
 interface RouteSnapshot {
   route: AppRoute;
   storyId?: string | null;
   userId?: string | null;
+  resetToken?: string | null;
 }
 
 const protectedRoutes: AppRoute[] = [ROUTES.PROFILE, ROUTES.SUBMISSION, ROUTES.NOTIFICATIONS];
@@ -361,6 +363,7 @@ export function RootNavigator() {
   const [currentRoute, setCurrentRoute] = useState<AppRoute>(ROUTES.FEED);
   const [activeStoryId, setActiveStoryId] = useState<string | null>(null);
   const [activeUserId, setActiveUserId] = useState<string | null>(null);
+  const [activeResetToken, setActiveResetToken] = useState<string | null>(null);
   const [pendingVerification, setPendingVerification] = useState<{ email: string; password: string } | null>(null);
   const [shouldCompleteProfileAfterLogin, setShouldCompleteProfileAfterLogin] = useState(false);
   const [feedSort, setFeedSort] = useState<FeedSortOption>('recent');
@@ -374,21 +377,28 @@ export function RootNavigator() {
   const isPagerDragActiveRef = useRef(false);
   const pagerDragResetTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const mapScrollOffsetRef = useRef(0);
+  const hasHandledInitialLinkRef = useRef(false);
 
   const currentSnapshot = useMemo<RouteSnapshot>(
     () => ({
       route: currentRoute,
       storyId: currentRoute === ROUTES.STORY_DETAIL ? activeStoryId : null,
       userId: currentRoute === ROUTES.USER_PROFILE ? activeUserId : null,
+      resetToken: currentRoute === ROUTES.RESET_PASSWORD ? activeResetToken : null,
     }),
-    [activeStoryId, activeUserId, currentRoute],
+    [activeResetToken, activeStoryId, activeUserId, currentRoute],
   );
   const [redirectTarget, setRedirectTarget] = useState<RouteSnapshot>({ route: ROUTES.PROFILE });
   const canGoBack = backStack.length > 0;
   const isMainRoute = MAIN_PAGER_ROUTES.includes(currentRoute);
   const isProfileCompletionRoute = currentRoute === ROUTES.PROFILE_COMPLETION;
   const resolvedRedirectTarget = useMemo<RouteSnapshot>(() => {
-    if (redirectTarget.route === ROUTES.AUTH || redirectTarget.route === ROUTES.PROFILE_COMPLETION) {
+    if (
+      redirectTarget.route === ROUTES.AUTH ||
+      redirectTarget.route === ROUTES.FORGOT_PASSWORD ||
+      redirectTarget.route === ROUTES.RESET_PASSWORD ||
+      redirectTarget.route === ROUTES.PROFILE_COMPLETION
+    ) {
       return { route: ROUTES.FEED };
     }
 
@@ -420,6 +430,7 @@ export function RootNavigator() {
     setCurrentRoute(snapshot.route);
     setActiveStoryId(snapshot.route === ROUTES.STORY_DETAIL ? snapshot.storyId ?? null : null);
     setActiveUserId(snapshot.route === ROUTES.USER_PROFILE ? snapshot.userId ?? null : null);
+    setActiveResetToken(snapshot.route === ROUTES.RESET_PASSWORD ? snapshot.resetToken ?? null : null);
   }, []);
 
   const scrollMainPagerToRoute = useCallback(
@@ -455,7 +466,8 @@ export function RootNavigator() {
         !options?.resetStack &&
         snapshot.route === currentSnapshot.route &&
         snapshot.storyId === currentSnapshot.storyId &&
-        snapshot.userId === currentSnapshot.userId
+        snapshot.userId === currentSnapshot.userId &&
+        snapshot.resetToken === currentSnapshot.resetToken
       ) {
         return;
       }
@@ -469,7 +481,8 @@ export function RootNavigator() {
           if (
             previous?.route === currentSnapshot.route &&
             previous?.storyId === currentSnapshot.storyId &&
-            previous?.userId === currentSnapshot.userId
+            previous?.userId === currentSnapshot.userId &&
+            previous?.resetToken === currentSnapshot.resetToken
           ) {
             return current;
           }
@@ -569,6 +582,41 @@ export function RootNavigator() {
     navigateToSnapshot({ route });
   };
 
+  const handleDeepLink = useCallback(
+    (url: string | null) => {
+      if (!url) {
+        return;
+      }
+
+      const resetToken = getResetPasswordTokenFromPath(url);
+
+      if (resetToken) {
+        navigateToSnapshot({ route: ROUTES.RESET_PASSWORD, resetToken });
+        return;
+      }
+
+      if (isForgotPasswordPath(url)) {
+        navigateToSnapshot({ route: ROUTES.FORGOT_PASSWORD });
+      }
+    },
+    [navigateToSnapshot],
+  );
+
+  useEffect(() => {
+    if (!hasHandledInitialLinkRef.current) {
+      hasHandledInitialLinkRef.current = true;
+      void Linking.getInitialURL().then(handleDeepLink).catch(() => undefined);
+    }
+
+    const subscription = Linking.addEventListener('url', (event) => {
+      handleDeepLink(event.url);
+    });
+
+    return () => {
+      subscription.remove();
+    };
+  }, [handleDeepLink]);
+
   useEffect(() => {
     if (!isMainRoute) {
       setIsMapTouchActive(false);
@@ -627,7 +675,8 @@ export function RootNavigator() {
       if (
         previousSnapshot?.route === resolvedRedirectTarget.route &&
         previousSnapshot?.storyId === resolvedRedirectTarget.storyId &&
-        previousSnapshot?.userId === resolvedRedirectTarget.userId
+        previousSnapshot?.userId === resolvedRedirectTarget.userId &&
+        previousSnapshot?.resetToken === resolvedRedirectTarget.resetToken
       ) {
         nextStack.pop();
       }
@@ -808,7 +857,27 @@ export function RootNavigator() {
   let content: React.ReactNode;
 
   if (currentRoute === ROUTES.AUTH) {
-    content = <AuthScreen onAuthenticated={handleLoginComplete} onRegistrationPending={handleRegistrationPending} />;
+    content = (
+      <AuthScreen
+        onAuthenticated={handleLoginComplete}
+        onRegistrationPending={handleRegistrationPending}
+        onForgotPassword={() => navigateToSnapshot({ route: ROUTES.FORGOT_PASSWORD })}
+      />
+    );
+  } else if (currentRoute === ROUTES.FORGOT_PASSWORD) {
+    content = (
+      <ForgotPasswordScreen
+        onBackToLogin={() => navigateToSnapshot({ route: ROUTES.AUTH }, { resetStack: true, preserveCurrent: false })}
+      />
+    );
+  } else if (currentRoute === ROUTES.RESET_PASSWORD) {
+    content = (
+      <ResetPasswordScreen
+        token={activeResetToken}
+        onResetSuccess={() => navigateToSnapshot({ route: ROUTES.AUTH }, { resetStack: true, preserveCurrent: false })}
+        onRequestNewLink={() => navigateToSnapshot({ route: ROUTES.FORGOT_PASSWORD })}
+      />
+    );
   } else if (currentRoute === ROUTES.VERIFY_EMAIL && pendingVerification) {
     content = (
       <VerifyEmailScreen

--- a/mobile/src/app/navigation/__tests__/linking.test.ts
+++ b/mobile/src/app/navigation/__tests__/linking.test.ts
@@ -1,15 +1,21 @@
 import {
   getProfilePath,
+  getForgotPasswordPath,
+  getResetPasswordPath,
+  getResetPasswordTokenFromPath,
   getStoryIdFromPath,
   getStoryPath,
   getUserIdFromProfilePath,
   getUserProfilePath,
+  isForgotPasswordPath,
   linking,
 } from '../linking';
 
 describe('linking', () => {
   it('defines the profile and story route patterns', () => {
     expect(linking.config.screens.Profile).toBe('profile');
+    expect(linking.config.screens.ForgotPassword).toBe('forgot-password');
+    expect(linking.config.screens.ResetPassword).toBe('reset-password');
     expect(linking.config.screens.UserProfile).toBe('users/:id');
     expect(linking.config.screens.StoryDetail).toBe('stories/:id');
   });
@@ -22,5 +28,17 @@ describe('linking', () => {
     expect(getStoryPath('story-001')).toBe('/stories/story-001');
     expect(getStoryIdFromPath('/stories/story-001')).toBe('story-001');
     expect(getStoryIdFromPath('/feed/story-001')).toBeNull();
+  });
+
+  it('builds and parses password reset paths', () => {
+    expect(getForgotPasswordPath()).toBe('/forgot-password');
+    expect(isForgotPasswordPath('/forgot-password')).toBe(true);
+    expect(isForgotPasswordPath('https://app.example.com/forgot-password')).toBe(true);
+    expect(getResetPasswordPath('token 123')).toBe('/reset-password?token=token%20123');
+    expect(getResetPasswordTokenFromPath('/reset-password?token=abc-123')).toBe('abc-123');
+    expect(getResetPasswordTokenFromPath('/reset-password/abc-123')).toBe('abc-123');
+    expect(getResetPasswordTokenFromPath('https://app.example.com/reset-password?token=abc-123')).toBe('abc-123');
+    expect(getResetPasswordTokenFromPath('storymap://reset-password?token=abc-123')).toBe('abc-123');
+    expect(getResetPasswordTokenFromPath('/profile')).toBeNull();
   });
 });

--- a/mobile/src/app/navigation/linking.ts
+++ b/mobile/src/app/navigation/linking.ts
@@ -1,8 +1,10 @@
 export const linking = {
-  prefixes: [],
+  prefixes: ['storymap://'],
   config: {
     screens: {
       Profile: 'profile',
+      ForgotPassword: 'forgot-password',
+      ResetPassword: 'reset-password',
       UserProfile: 'users/:id',
       StoryDetail: 'stories/:id',
       Timeline: 'timeline',
@@ -12,6 +14,14 @@ export const linking = {
 
 export function getProfilePath() {
   return '/profile';
+}
+
+export function getForgotPasswordPath() {
+  return '/forgot-password';
+}
+
+export function getResetPasswordPath(token: string) {
+  return `/reset-password?token=${encodeURIComponent(token)}`;
 }
 
 export function getUserProfilePath(userId: string) {
@@ -32,4 +42,47 @@ export function getStoryIdFromPath(path: string) {
   const match = path.match(/^\/stories\/([^/]+)$/);
 
   return match?.[1] ?? null;
+}
+
+function normalizePath(value: string) {
+  if (!value) {
+    return '/';
+  }
+
+  try {
+    const parsedUrl = new URL(value);
+    const pathname = parsedUrl.pathname || (parsedUrl.hostname ? `/${parsedUrl.hostname}` : '/');
+
+    return `${pathname}${parsedUrl.search}`;
+  } catch {
+    return value.startsWith('/') ? value : `/${value}`;
+  }
+}
+
+export function isForgotPasswordPath(pathOrUrl: string) {
+  const normalizedPath = normalizePath(pathOrUrl).split('?')[0];
+
+  return normalizedPath === '/forgot-password';
+}
+
+export function getResetPasswordTokenFromPath(pathOrUrl: string) {
+  const normalizedPath = normalizePath(pathOrUrl);
+  const [pathname, queryString = ''] = normalizedPath.split('?');
+
+  if (pathname !== '/reset-password' && !pathname.startsWith('/reset-password/')) {
+    return null;
+  }
+
+  const tokenFromQuery = queryString
+    .split('&')
+    .map((part) => part.split('='))
+    .find(([key]) => key === 'token')?.[1];
+
+  if (tokenFromQuery) {
+    return decodeURIComponent(tokenFromQuery);
+  }
+
+  const tokenFromPath = pathname.match(/^\/reset-password\/([^/]+)$/)?.[1];
+
+  return tokenFromPath ? decodeURIComponent(tokenFromPath) : null;
 }

--- a/mobile/src/app/navigation/routes.ts
+++ b/mobile/src/app/navigation/routes.ts
@@ -1,5 +1,7 @@
 export const ROUTES = {
   AUTH: 'Auth',
+  FORGOT_PASSWORD: 'ForgotPassword',
+  RESET_PASSWORD: 'ResetPassword',
   VERIFY_EMAIL: 'VerifyEmail',
   GUEST_HOME: 'GuestHome',
   USER_HOME: 'UserHome',
@@ -64,6 +66,18 @@ export const AUTH_ACTION_ROUTES = [
     key: ROUTES.AUTH,
     label: 'Login',
     tabLabel: 'Login',
+    requiresAuth: false,
+  },
+  {
+    key: ROUTES.FORGOT_PASSWORD,
+    label: 'Forgot Password',
+    tabLabel: 'Forgot Password',
+    requiresAuth: false,
+  },
+  {
+    key: ROUTES.RESET_PASSWORD,
+    label: 'Reset Password',
+    tabLabel: 'Reset Password',
     requiresAuth: false,
   },
   {

--- a/mobile/src/app/navigation/types.ts
+++ b/mobile/src/app/navigation/types.ts
@@ -1,5 +1,7 @@
 export type RootStackParamList = {
   Auth: undefined;
+  ForgotPassword: undefined;
+  ResetPassword: { token?: string };
   VerifyEmail: { email: string };
   GuestHome: undefined;
   UserHome: undefined;

--- a/mobile/src/features/auth/application/services/__tests__/authService.test.ts
+++ b/mobile/src/features/auth/application/services/__tests__/authService.test.ts
@@ -49,4 +49,46 @@ describe('authService email verification', () => {
       },
     ]);
   });
+
+  it('requests a password reset through /auth/password-reset/', async () => {
+    const requests: Array<{ method: string; url?: string; data?: unknown }> = [];
+
+    setApiTransport(async (method: any, config: any) => {
+      requests.push({ method, url: config.url, data: config.data });
+      return { status: 200, data: { message: 'ok' } as never, config };
+    });
+
+    await authService.forgotPassword(' Traveler@Example.COM ');
+
+    expect(requests).toEqual([
+      {
+        method: 'POST',
+        url: '/auth/password-reset/',
+        data: { email: 'traveler@example.com' },
+      },
+    ]);
+  });
+
+  it('resets a password through /auth/password-reset/confirm/', async () => {
+    const requests: Array<{ method: string; url?: string; data?: unknown }> = [];
+
+    setApiTransport(async (method: any, config: any) => {
+      requests.push({ method, url: config.url, data: config.data });
+      return { status: 200, data: { message: 'ok' } as never, config };
+    });
+
+    await authService.resetPassword(' reset-token ', 'NewPassword1');
+
+    expect(requests).toEqual([
+      {
+        method: 'POST',
+        url: '/auth/password-reset/confirm/',
+        data: {
+          token: 'reset-token',
+          new_password: 'NewPassword1',
+          new_password_confirmation: 'NewPassword1',
+        },
+      },
+    ]);
+  });
 });

--- a/mobile/src/features/auth/application/services/index.ts
+++ b/mobile/src/features/auth/application/services/index.ts
@@ -17,6 +17,12 @@ export const authService = {
   async resendVerificationCode(email: string): Promise<void> {
     return repository.resendVerificationCode(email);
   },
+  async forgotPassword(email: string): Promise<void> {
+    return repository.forgotPassword(email);
+  },
+  async resetPassword(token: string, newPassword: string): Promise<void> {
+    return repository.resetPassword(token, newPassword);
+  },
   async restore(): Promise<AuthSessionEntity | null> {
     return repository.restore();
   },

--- a/mobile/src/features/auth/context/AuthContext.tsx
+++ b/mobile/src/features/auth/context/AuthContext.tsx
@@ -28,6 +28,8 @@ const AUTH_ENDPOINTS = [
   '/auth/logout/',
   '/auth/verify-email/',
   '/auth/resend-verification/',
+  '/auth/password-reset/',
+  '/auth/password-reset/confirm/',
 ];
 
 interface AuthContextValue {

--- a/mobile/src/features/auth/data/repositories/index.ts
+++ b/mobile/src/features/auth/data/repositories/index.ts
@@ -37,6 +37,18 @@ export class AuthRepositoryImpl implements AuthRepository {
     await authRemoteSource.resendVerificationCode(email.trim().toLowerCase());
   }
 
+  async forgotPassword(email: string): Promise<void> {
+    await authRemoteSource.forgotPassword(email.trim().toLowerCase());
+  }
+
+  async resetPassword(token: string, newPassword: string): Promise<void> {
+    await authRemoteSource.resetPassword({
+      token: token.trim(),
+      new_password: newPassword,
+      new_password_confirmation: newPassword,
+    });
+  }
+
   async restore(): Promise<AuthSessionEntity | null> {
     const storedSession = await authLocalSource.getSession();
 

--- a/mobile/src/features/auth/data/sources/index.ts
+++ b/mobile/src/features/auth/data/sources/index.ts
@@ -16,6 +16,12 @@ export interface RegisterPayload {
   password_confirmation: string;
 }
 
+export interface ResetPasswordPayload {
+  token: string;
+  new_password: string;
+  new_password_confirmation: string;
+}
+
 interface BackendUser {
   id: number;
   email: string;
@@ -84,6 +90,12 @@ export const authRemoteSource = {
   },
   async resendVerificationCode(email: string): Promise<void> {
     await apiClient.post<void>(`${endpoints.auth}/resend-verification/`, { email });
+  },
+  async forgotPassword(email: string): Promise<void> {
+    await apiClient.post<void>(`${endpoints.auth}/password-reset/`, { email });
+  },
+  async resetPassword(payload: ResetPasswordPayload): Promise<void> {
+    await apiClient.post<void>(`${endpoints.auth}/password-reset/confirm/`, payload);
   },
   async refresh(session: Session): Promise<Pick<Session, 'accessToken' | 'refreshToken'>> {
     const response = await apiClient.post<RefreshResponse>(

--- a/mobile/src/features/auth/domain/repositories/index.ts
+++ b/mobile/src/features/auth/domain/repositories/index.ts
@@ -16,6 +16,8 @@ export interface AuthRepository {
   register(input: RegisterUserInput): Promise<RegisterUserResult>;
   verifyEmail(email: string, code: string): Promise<void>;
   resendVerificationCode(email: string): Promise<void>;
+  forgotPassword(email: string): Promise<void>;
+  resetPassword(token: string, newPassword: string): Promise<void>;
   restore(): Promise<AuthSessionEntity | null>;
   refresh(session: AuthSessionEntity): Promise<AuthSessionEntity>;
   logout(session?: AuthSessionEntity | null): Promise<void>;

--- a/mobile/src/features/auth/index.ts
+++ b/mobile/src/features/auth/index.ts
@@ -1,3 +1,5 @@
 export * from './presentation/screens/AuthScreen';
+export * from './presentation/screens/ForgotPasswordScreen';
+export * from './presentation/screens/ResetPasswordScreen';
 export * from './presentation/screens/VerifyEmailScreen';
 export * from './context/AuthContext';

--- a/mobile/src/features/auth/presentation/components/AuthFormCard.tsx
+++ b/mobile/src/features/auth/presentation/components/AuthFormCard.tsx
@@ -37,6 +37,7 @@ interface AuthFormCardProps {
   onConfirmPasswordChange: (value: string) => void;
   onSubmit: () => void;
   onToggleMode: () => void;
+  onForgotPassword?: () => void;
   passwordInputRef?: RefObject<TextInput | null>;
 }
 
@@ -57,6 +58,7 @@ export function AuthFormCard({
   onConfirmPasswordChange,
   onSubmit,
   onToggleMode,
+  onForgotPassword,
   passwordInputRef,
 }: AuthFormCardProps) {
   const { colors, spacing, typography } = useAppTheme();
@@ -192,6 +194,14 @@ export function AuthFormCard({
       <Button onPress={onSubmit} disabled={isLoading}>
         {isLoading ? (isRegister ? 'Creating account...' : 'Signing in...') : isRegister ? 'Create account' : 'Sign in'}
       </Button>
+
+      {!isRegister && onForgotPassword ? (
+        <Pressable disabled={isLoading} onPress={onForgotPassword} accessibilityRole="button">
+          <Text style={{ color: colors.primary, textAlign: 'center', fontWeight: '700' }}>
+            Forgot your password?
+          </Text>
+        </Pressable>
+      ) : null}
 
       <Pressable disabled={isLoading} onPress={onToggleMode}>
         <Text style={{ color: colors.muted, textAlign: 'center' }}>

--- a/mobile/src/features/auth/presentation/components/__tests__/AuthFormCard.test.tsx
+++ b/mobile/src/features/auth/presentation/components/__tests__/AuthFormCard.test.tsx
@@ -4,6 +4,8 @@ import { ThemeProvider } from '../../../../../app/providers/ThemeProvider';
 import { AuthFormCard } from '../AuthFormCard';
 
 function renderCard(mode: 'signIn' | 'register' = 'signIn') {
+  const onForgotPassword = jest.fn();
+
   return render(
     <ThemeProvider>
       <AuthFormCard
@@ -24,6 +26,7 @@ function renderCard(mode: 'signIn' | 'register' = 'signIn') {
         onConfirmPasswordChange={() => undefined}
         onSubmit={() => undefined}
         onToggleMode={() => undefined}
+        onForgotPassword={onForgotPassword}
       />
     </ThemeProvider>,
   );
@@ -53,5 +56,55 @@ describe('AuthFormCard', () => {
 
     fireEvent.press(screen.getByLabelText('Show confirm password'));
     expect(screen.getByLabelText('Confirm password').props.secureTextEntry).toBe(false);
+  });
+
+  it('shows the forgot password action on sign in only', () => {
+    const { rerender } = render(
+      <ThemeProvider>
+        <AuthFormCard
+          mode="signIn"
+          username=""
+          email="traveler@example.com"
+          password="Password1"
+          confirmPassword="Password1"
+          fieldErrors={{}}
+          isLoading={false}
+          passwordRules={[]}
+          onUsernameChange={() => undefined}
+          onEmailChange={() => undefined}
+          onPasswordChange={() => undefined}
+          onConfirmPasswordChange={() => undefined}
+          onSubmit={() => undefined}
+          onToggleMode={() => undefined}
+          onForgotPassword={() => undefined}
+        />
+      </ThemeProvider>,
+    );
+
+    expect(screen.getByText('Forgot your password?')).toBeTruthy();
+
+    rerender(
+      <ThemeProvider>
+        <AuthFormCard
+          mode="register"
+          username=""
+          email="traveler@example.com"
+          password="Password1"
+          confirmPassword="Password1"
+          fieldErrors={{}}
+          isLoading={false}
+          passwordRules={[]}
+          onUsernameChange={() => undefined}
+          onEmailChange={() => undefined}
+          onPasswordChange={() => undefined}
+          onConfirmPasswordChange={() => undefined}
+          onSubmit={() => undefined}
+          onToggleMode={() => undefined}
+          onForgotPassword={() => undefined}
+        />
+      </ThemeProvider>,
+    );
+
+    expect(screen.queryByText('Forgot your password?')).toBeNull();
   });
 });

--- a/mobile/src/features/auth/presentation/screens/AuthScreen.tsx
+++ b/mobile/src/features/auth/presentation/screens/AuthScreen.tsx
@@ -6,10 +6,12 @@ import { useToast } from '../../../../shared/hooks/useToast';
 import { useAuth } from '../../context/AuthContext';
 import { AuthFieldErrors, AuthFormCard, AuthMode, PasswordRule } from '../components/AuthFormCard';
 import { AuthUiState } from '../state/authUiState';
+import { getPasswordError, passwordRules } from '../utils/passwordRules';
 
 interface AuthScreenProps {
   onAuthenticated?: (context: { source: 'signIn' | 'register' }) => void;
   onRegistrationPending?: (context: { email: string; password: string }) => void;
+  onForgotPassword?: () => void;
 }
 
 const initialState: AuthUiState = {
@@ -25,29 +27,6 @@ const initialFieldErrors: AuthFieldErrors = {
   confirmPassword: undefined,
 };
 
-const passwordRules = [
-  {
-    id: 'length',
-    label: 'At least 8 characters',
-    test: (password: string) => password.length >= 8,
-  },
-  {
-    id: 'uppercase',
-    label: 'One uppercase letter',
-    test: (password: string) => /[A-Z]/.test(password),
-  },
-  {
-    id: 'lowercase',
-    label: 'One lowercase letter',
-    test: (password: string) => /[a-z]/.test(password),
-  },
-  {
-    id: 'number',
-    label: 'One number',
-    test: (password: string) => /[0-9]/.test(password),
-  },
-];
-
 interface AuthFormState extends AuthUiState {
   username: string;
   confirmPassword: string;
@@ -62,26 +41,6 @@ const initialFormState: AuthFormState = {
   successMessage: undefined,
   fieldErrors: initialFieldErrors,
 };
-
-function getPasswordError(password: string) {
-  if (password.length < 8) {
-    return 'Password must be at least 8 characters long.';
-  }
-
-  if (!/[A-Z]/.test(password)) {
-    return 'Password must contain at least one uppercase letter.';
-  }
-
-  if (!/[a-z]/.test(password)) {
-    return 'Password must contain at least one lowercase letter.';
-  }
-
-  if (!/[0-9]/.test(password)) {
-    return 'Password must contain at least one number.';
-  }
-
-  return undefined;
-}
 
 function extractRegisterErrors(error: unknown): {
   error?: string;
@@ -131,7 +90,7 @@ function extractRegisterErrors(error: unknown): {
   };
 }
 
-export function AuthScreen({ onAuthenticated, onRegistrationPending }: AuthScreenProps) {
+export function AuthScreen({ onAuthenticated, onRegistrationPending, onForgotPassword }: AuthScreenProps) {
   const { login, register, loading } = useAuth();
   const { colors, spacing, typography } = useAppTheme();
   const { toast } = useToast();
@@ -366,6 +325,7 @@ export function AuthScreen({ onAuthenticated, onRegistrationPending }: AuthScree
             onSubmit={submit}
             passwordInputRef={passwordInputRef}
             onToggleMode={toggleMode}
+            onForgotPassword={onForgotPassword}
           />
         </View>
       </ScrollView>

--- a/mobile/src/features/auth/presentation/screens/ForgotPasswordScreen.tsx
+++ b/mobile/src/features/auth/presentation/screens/ForgotPasswordScreen.tsx
@@ -1,0 +1,147 @@
+import React, { useState } from 'react';
+import { KeyboardAvoidingView, Platform, Pressable, ScrollView, Text, View } from 'react-native';
+import { useAppTheme } from '../../../../core/hooks/useAppTheme';
+import { validators } from '../../../../shared/forms/validators';
+import { useToast } from '../../../../shared/hooks/useToast';
+import { Button } from '../../../../shared/ui/Button';
+import { Input } from '../../../../shared/ui/Input';
+import { authService } from '../../application/services';
+
+const confirmationMessage =
+  "If an account exists with this email, we've sent a password reset link. Check your inbox.";
+
+interface ForgotPasswordScreenProps {
+  initialEmail?: string;
+  onBackToLogin?: () => void;
+}
+
+export function ForgotPasswordScreen({ initialEmail = '', onBackToLogin }: ForgotPasswordScreenProps) {
+  const { colors, spacing, typography } = useAppTheme();
+  const { toast } = useToast();
+  const [email, setEmail] = useState(initialEmail);
+  const [emailError, setEmailError] = useState<string | undefined>();
+  const [error, setError] = useState<string | undefined>();
+  const [isLoading, setIsLoading] = useState(false);
+  const [isSubmitted, setIsSubmitted] = useState(false);
+
+  const submit = async () => {
+    const trimmedEmail = email.trim();
+
+    if (!validators.required(trimmedEmail)) {
+      setEmailError('Email is required.');
+      setError(undefined);
+      return;
+    }
+
+    if (!validators.email(trimmedEmail)) {
+      setEmailError('Please enter a valid email address.');
+      setError(undefined);
+      return;
+    }
+
+    setIsLoading(true);
+    setEmailError(undefined);
+    setError(undefined);
+
+    try {
+      await authService.forgotPassword(trimmedEmail);
+      setIsSubmitted(true);
+      toast.success('Password reset email sent.');
+    } catch (submitError) {
+      const message = submitError instanceof Error ? submitError.message : 'Unable to request a reset link right now.';
+      setError(message);
+      toast.error(message);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return (
+    <KeyboardAvoidingView
+      style={{ flex: 1, backgroundColor: colors.background }}
+      behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
+      keyboardVerticalOffset={spacing.md}
+    >
+      <ScrollView
+        keyboardShouldPersistTaps="handled"
+        keyboardDismissMode={Platform.OS === 'ios' ? 'interactive' : 'on-drag'}
+        automaticallyAdjustKeyboardInsets
+        contentInsetAdjustmentBehavior="always"
+        contentContainerStyle={{ flexGrow: 1, padding: spacing.lg, justifyContent: 'flex-start' }}
+      >
+        <View style={{ gap: spacing.lg, paddingTop: spacing.md, paddingBottom: spacing.xl }}>
+          <View style={{ gap: spacing.xs }}>
+            <Text style={{ color: colors.text, fontSize: typography.title, fontWeight: '800' }}>
+              Forgot password
+            </Text>
+            <Text style={{ color: colors.muted }}>
+              Enter the email address for your account.
+            </Text>
+          </View>
+
+          <View
+            style={{
+              padding: spacing.lg,
+              borderRadius: 20,
+              backgroundColor: colors.surface,
+              borderWidth: 1,
+              borderColor: colors.border,
+              gap: spacing.md,
+            }}
+          >
+            {isSubmitted ? (
+              <View
+                style={{
+                  borderWidth: 1,
+                  borderColor: colors.primary,
+                  backgroundColor: colors.infoSurface,
+                  borderRadius: 12,
+                  padding: spacing.md,
+                }}
+              >
+                <Text style={{ color: colors.primary, fontWeight: '600' }}>{confirmationMessage}</Text>
+              </View>
+            ) : (
+              <>
+                <View style={{ gap: spacing.sm }}>
+                  <Text style={{ color: colors.text, fontWeight: '600' }}>Email</Text>
+                  <Input
+                    value={email}
+                    onChangeText={(value) => {
+                      setEmail(value);
+                      setEmailError(undefined);
+                      setError(undefined);
+                    }}
+                    placeholder="you@example.com"
+                    keyboardType="email-address"
+                    textContentType="emailAddress"
+                    autoComplete="email"
+                    accessibilityLabel="Email address"
+                    editable={!isLoading}
+                    returnKeyType="done"
+                    onSubmitEditing={submit}
+                  />
+                  {emailError ? <Text style={{ color: colors.danger }}>{emailError}</Text> : null}
+                </View>
+
+                {error ? <Text style={{ color: colors.danger }}>{error}</Text> : null}
+
+                <Button onPress={submit} disabled={isLoading}>
+                  {isLoading ? 'Sending reset link...' : 'Send reset link'}
+                </Button>
+              </>
+            )}
+
+            {onBackToLogin ? (
+              <Pressable disabled={isLoading} onPress={onBackToLogin} accessibilityRole="button">
+                <Text style={{ color: colors.muted, textAlign: 'center' }}>
+                  Back to <Text style={{ color: colors.primary, fontWeight: '700' }}>Sign in</Text>
+                </Text>
+              </Pressable>
+            ) : null}
+          </View>
+        </View>
+      </ScrollView>
+    </KeyboardAvoidingView>
+  );
+}

--- a/mobile/src/features/auth/presentation/screens/ResetPasswordScreen.tsx
+++ b/mobile/src/features/auth/presentation/screens/ResetPasswordScreen.tsx
@@ -1,0 +1,188 @@
+import React, { useState } from 'react';
+import { KeyboardAvoidingView, Platform, Pressable, ScrollView, Text, View } from 'react-native';
+import { useAppTheme } from '../../../../core/hooks/useAppTheme';
+import { useToast } from '../../../../shared/hooks/useToast';
+import { Button } from '../../../../shared/ui/Button';
+import { Input } from '../../../../shared/ui/Input';
+import { authService } from '../../application/services';
+import { getPasswordError, passwordRules } from '../utils/passwordRules';
+
+interface ResetPasswordScreenProps {
+  token?: string | null;
+  onResetSuccess?: () => void;
+  onRequestNewLink?: () => void;
+}
+
+export function ResetPasswordScreen({ token, onResetSuccess, onRequestNewLink }: ResetPasswordScreenProps) {
+  const { colors, spacing, typography } = useAppTheme();
+  const { toast } = useToast();
+  const [password, setPassword] = useState('');
+  const [confirmPassword, setConfirmPassword] = useState('');
+  const [passwordError, setPasswordError] = useState<string | undefined>();
+  const [confirmPasswordError, setConfirmPasswordError] = useState<string | undefined>();
+  const [error, setError] = useState<string | undefined>(
+    token ? undefined : 'This reset link is missing a token.',
+  );
+  const [isLoading, setIsLoading] = useState(false);
+  const [isPasswordVisible, setIsPasswordVisible] = useState(false);
+  const [isConfirmPasswordVisible, setIsConfirmPasswordVisible] = useState(false);
+
+  const visiblePasswordRules = passwordRules.map((rule) => ({
+    id: rule.id,
+    label: rule.label,
+    passed: rule.test(password),
+  }));
+
+  const validate = () => {
+    const nextPasswordError = getPasswordError(password);
+    const nextConfirmPasswordError =
+      !confirmPassword ? 'Please confirm your password.' : password !== confirmPassword ? 'Passwords do not match.' : undefined;
+
+    setPasswordError(nextPasswordError);
+    setConfirmPasswordError(nextConfirmPasswordError);
+    setError(undefined);
+
+    return !nextPasswordError && !nextConfirmPasswordError;
+  };
+
+  const submit = async () => {
+    if (!token) {
+      setError('This reset link is missing a token.');
+      return;
+    }
+
+    if (!validate()) {
+      return;
+    }
+
+    setIsLoading(true);
+    setError(undefined);
+
+    try {
+      await authService.resetPassword(token, password);
+      toast.success('Password reset successfully. Please log in with your new password.');
+      onResetSuccess?.();
+    } catch {
+      setError('This reset link is invalid or expired.');
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return (
+    <KeyboardAvoidingView
+      style={{ flex: 1, backgroundColor: colors.background }}
+      behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
+      keyboardVerticalOffset={spacing.md}
+    >
+      <ScrollView
+        keyboardShouldPersistTaps="handled"
+        keyboardDismissMode={Platform.OS === 'ios' ? 'interactive' : 'on-drag'}
+        automaticallyAdjustKeyboardInsets
+        contentInsetAdjustmentBehavior="always"
+        contentContainerStyle={{ flexGrow: 1, padding: spacing.lg, justifyContent: 'flex-start' }}
+      >
+        <View style={{ gap: spacing.lg, paddingTop: spacing.md, paddingBottom: spacing.xl }}>
+          <View style={{ gap: spacing.xs }}>
+            <Text style={{ color: colors.text, fontSize: typography.title, fontWeight: '800' }}>
+              Reset password
+            </Text>
+            <Text style={{ color: colors.muted }}>
+              Choose a new password for your account.
+            </Text>
+          </View>
+
+          <View
+            style={{
+              padding: spacing.lg,
+              borderRadius: 20,
+              backgroundColor: colors.surface,
+              borderWidth: 1,
+              borderColor: colors.border,
+              gap: spacing.md,
+            }}
+          >
+            <View style={{ gap: spacing.sm }}>
+              <Text style={{ color: colors.text, fontWeight: '600' }}>New password</Text>
+              <Input
+                value={password}
+                onChangeText={(value) => {
+                  setPassword(value);
+                  setPasswordError(undefined);
+                  setConfirmPasswordError(undefined);
+                  setError(undefined);
+                }}
+                placeholder="Create a password"
+                secureTextEntry={!isPasswordVisible}
+                textContentType="newPassword"
+                autoComplete="new-password"
+                accessibilityLabel="New password"
+                editable={!isLoading}
+                returnKeyType="next"
+                trailingActionLabel={isPasswordVisible ? 'Hide' : 'Show'}
+                trailingActionAccessibilityLabel={isPasswordVisible ? 'Hide new password' : 'Show new password'}
+                onTrailingActionPress={() => setIsPasswordVisible((current) => !current)}
+              />
+              {passwordError ? <Text style={{ color: colors.danger }}>{passwordError}</Text> : null}
+            </View>
+
+            <View style={{ gap: spacing.sm }}>
+              <Text style={{ color: colors.text, fontWeight: '600' }}>Confirm password</Text>
+              <Input
+                value={confirmPassword}
+                onChangeText={(value) => {
+                  setConfirmPassword(value);
+                  setConfirmPasswordError(undefined);
+                  setError(undefined);
+                }}
+                placeholder="Repeat your password"
+                secureTextEntry={!isConfirmPasswordVisible}
+                textContentType="newPassword"
+                autoComplete="new-password"
+                accessibilityLabel="Confirm password"
+                editable={!isLoading}
+                returnKeyType="done"
+                onSubmitEditing={submit}
+                trailingActionLabel={isConfirmPasswordVisible ? 'Hide' : 'Show'}
+                trailingActionAccessibilityLabel={
+                  isConfirmPasswordVisible ? 'Hide confirm password' : 'Show confirm password'
+                }
+                onTrailingActionPress={() => setIsConfirmPasswordVisible((current) => !current)}
+              />
+              {confirmPasswordError ? <Text style={{ color: colors.danger }}>{confirmPasswordError}</Text> : null}
+            </View>
+
+            <View style={{ gap: spacing.xs }}>
+              {visiblePasswordRules.map((rule) => (
+                <Text
+                  key={rule.id}
+                  style={{
+                    color: rule.passed ? colors.primary : colors.muted,
+                    fontSize: typography.caption,
+                  }}
+                >
+                  {rule.passed ? '[x]' : '[ ]'} {rule.label}
+                </Text>
+              ))}
+            </View>
+
+            {error ? (
+              <View style={{ gap: spacing.sm }}>
+                <Text style={{ color: colors.danger }}>{error}</Text>
+                {onRequestNewLink ? (
+                  <Pressable disabled={isLoading} onPress={onRequestNewLink} accessibilityRole="button">
+                    <Text style={{ color: colors.primary, fontWeight: '700' }}>Request a new reset link</Text>
+                  </Pressable>
+                ) : null}
+              </View>
+            ) : null}
+
+            <Button onPress={submit} disabled={isLoading || !token}>
+              {isLoading ? 'Resetting password...' : 'Reset password'}
+            </Button>
+          </View>
+        </View>
+      </ScrollView>
+    </KeyboardAvoidingView>
+  );
+}

--- a/mobile/src/features/auth/presentation/screens/__tests__/ForgotPasswordScreen.test.tsx
+++ b/mobile/src/features/auth/presentation/screens/__tests__/ForgotPasswordScreen.test.tsx
@@ -1,0 +1,56 @@
+import React from 'react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react-native';
+import { ThemeProvider } from '../../../../../app/providers/ThemeProvider';
+import { ToastProvider } from '../../../../../shared/toast/ToastProvider';
+import { authService } from '../../../application/services';
+import { ForgotPasswordScreen } from '../ForgotPasswordScreen';
+
+function renderScreen(props: Partial<React.ComponentProps<typeof ForgotPasswordScreen>> = {}) {
+  return render(
+    <ThemeProvider>
+      <ToastProvider>
+        <ForgotPasswordScreen {...props} />
+      </ToastProvider>
+    </ThemeProvider>,
+  );
+}
+
+describe('ForgotPasswordScreen', () => {
+  beforeEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('renders the email form', () => {
+    renderScreen();
+
+    expect(screen.getByText('Forgot password')).toBeTruthy();
+    expect(screen.getByLabelText('Email address')).toBeTruthy();
+    expect(screen.getByText('Send reset link')).toBeTruthy();
+  });
+
+  it('validates email before submitting', () => {
+    const forgotPassword = jest.spyOn(authService, 'forgotPassword').mockResolvedValueOnce(undefined);
+    renderScreen();
+
+    fireEvent.changeText(screen.getByLabelText('Email address'), 'not-an-email');
+    fireEvent.press(screen.getByText('Send reset link'));
+
+    expect(screen.getByText('Please enter a valid email address.')).toBeTruthy();
+    expect(forgotPassword).not.toHaveBeenCalled();
+  });
+
+  it('submits the email and shows the vague confirmation message', async () => {
+    const forgotPassword = jest.spyOn(authService, 'forgotPassword').mockResolvedValueOnce(undefined);
+    renderScreen();
+
+    fireEvent.changeText(screen.getByLabelText('Email address'), ' Traveler@Example.COM ');
+    fireEvent.press(screen.getByText('Send reset link'));
+
+    await waitFor(() => {
+      expect(forgotPassword).toHaveBeenCalledWith('Traveler@Example.COM');
+    });
+    expect(
+      screen.getByText("If an account exists with this email, we've sent a password reset link. Check your inbox."),
+    ).toBeTruthy();
+  });
+});

--- a/mobile/src/features/auth/presentation/screens/__tests__/ResetPasswordScreen.test.tsx
+++ b/mobile/src/features/auth/presentation/screens/__tests__/ResetPasswordScreen.test.tsx
@@ -1,0 +1,89 @@
+import React from 'react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react-native';
+import { ThemeProvider } from '../../../../../app/providers/ThemeProvider';
+import { ToastProvider } from '../../../../../shared/toast/ToastProvider';
+import { authService } from '../../../application/services';
+import { ResetPasswordScreen } from '../ResetPasswordScreen';
+
+function renderScreen(props: Partial<React.ComponentProps<typeof ResetPasswordScreen>> = {}) {
+  return render(
+    <ThemeProvider>
+      <ToastProvider>
+        <ResetPasswordScreen token="reset-token" {...props} />
+      </ToastProvider>
+    </ThemeProvider>,
+  );
+}
+
+function resetPasswordButtonText() {
+  const matches = screen.getAllByText('Reset password');
+
+  return matches[matches.length - 1];
+}
+
+describe('ResetPasswordScreen', () => {
+  beforeEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('renders password fields and rules', () => {
+    renderScreen();
+
+    expect(screen.getAllByText('Reset password').length).toBeGreaterThan(0);
+    expect(screen.getByLabelText('New password')).toBeTruthy();
+    expect(screen.getByLabelText('Confirm password')).toBeTruthy();
+    expect(screen.getByText('[ ] At least 8 characters')).toBeTruthy();
+  });
+
+  it('shows inline password validation errors', () => {
+    const resetPassword = jest.spyOn(authService, 'resetPassword').mockResolvedValueOnce(undefined);
+    renderScreen();
+
+    fireEvent.changeText(screen.getByLabelText('New password'), 'short');
+    fireEvent.changeText(screen.getByLabelText('Confirm password'), 'different');
+    fireEvent.press(resetPasswordButtonText());
+
+    expect(screen.getByText('Password must be at least 8 characters long.')).toBeTruthy();
+    expect(screen.getByText('Passwords do not match.')).toBeTruthy();
+    expect(resetPassword).not.toHaveBeenCalled();
+  });
+
+  it('submits the token and matching new password', async () => {
+    const resetPassword = jest.spyOn(authService, 'resetPassword').mockResolvedValueOnce(undefined);
+    const onResetSuccess = jest.fn();
+    renderScreen({ onResetSuccess });
+
+    fireEvent.changeText(screen.getByLabelText('New password'), 'NewPassword1');
+    fireEvent.changeText(screen.getByLabelText('Confirm password'), 'NewPassword1');
+    fireEvent.press(resetPasswordButtonText());
+
+    await waitFor(() => {
+      expect(resetPassword).toHaveBeenCalledWith('reset-token', 'NewPassword1');
+    });
+    expect(onResetSuccess).toHaveBeenCalledTimes(1);
+  });
+
+  it('shows invalid token errors with a link to request a new reset link', async () => {
+    jest.spyOn(authService, 'resetPassword').mockRejectedValueOnce(new Error('Invalid token'));
+    const onRequestNewLink = jest.fn();
+    renderScreen({ onRequestNewLink });
+
+    fireEvent.changeText(screen.getByLabelText('New password'), 'NewPassword1');
+    fireEvent.changeText(screen.getByLabelText('Confirm password'), 'NewPassword1');
+    fireEvent.press(resetPasswordButtonText());
+
+    expect(await screen.findByText('This reset link is invalid or expired.')).toBeTruthy();
+
+    fireEvent.press(screen.getByText('Request a new reset link'));
+    expect(onRequestNewLink).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not submit when the token is missing', () => {
+    const resetPassword = jest.spyOn(authService, 'resetPassword').mockResolvedValueOnce(undefined);
+    renderScreen({ token: null });
+
+    expect(screen.getByText('This reset link is missing a token.')).toBeTruthy();
+    fireEvent.press(resetPasswordButtonText());
+    expect(resetPassword).not.toHaveBeenCalled();
+  });
+});

--- a/mobile/src/features/auth/presentation/utils/passwordRules.ts
+++ b/mobile/src/features/auth/presentation/utils/passwordRules.ts
@@ -1,0 +1,43 @@
+export const passwordRules = [
+  {
+    id: 'length',
+    label: 'At least 8 characters',
+    test: (password: string) => password.length >= 8,
+  },
+  {
+    id: 'uppercase',
+    label: 'One uppercase letter',
+    test: (password: string) => /[A-Z]/.test(password),
+  },
+  {
+    id: 'lowercase',
+    label: 'One lowercase letter',
+    test: (password: string) => /[a-z]/.test(password),
+  },
+  {
+    id: 'number',
+    label: 'One number',
+    test: (password: string) => /[0-9]/.test(password),
+  },
+] as const;
+
+export function getPasswordError(password: string) {
+  const failedRule = passwordRules.find((rule) => !rule.test(password));
+
+  if (!failedRule) {
+    return undefined;
+  }
+
+  switch (failedRule.id) {
+    case 'length':
+      return 'Password must be at least 8 characters long.';
+    case 'uppercase':
+      return 'Password must contain at least one uppercase letter.';
+    case 'lowercase':
+      return 'Password must contain at least one lowercase letter.';
+    case 'number':
+      return 'Password must contain at least one number.';
+    default:
+      return 'Password does not meet the requirements.';
+  }
+}

--- a/mobile/src/features/profile/presentation/screens/ProfileScreen.tsx
+++ b/mobile/src/features/profile/presentation/screens/ProfileScreen.tsx
@@ -57,6 +57,7 @@ interface ProfileScreenProps {
   uploadProfilePhoto?: typeof userService.uploadProfilePhoto;
   removeProfilePhoto?: typeof userService.removeProfilePhoto;
   deleteAccount?: typeof userService.deleteAccount;
+  requestPasswordReset?: typeof authService.forgotPassword;
   followUser?: typeof userService.followUser;
   unfollowUser?: typeof userService.unfollowUser;
   getFollowers?: typeof userService.getFollowers;
@@ -1486,6 +1487,7 @@ export function ProfileScreen({
   uploadProfilePhoto = userService.uploadProfilePhoto,
   removeProfilePhoto = userService.removeProfilePhoto,
   deleteAccount = userService.deleteAccount,
+  requestPasswordReset = authService.forgotPassword,
   followUser = userService.followUser,
   unfollowUser = userService.unfollowUser,
   getFollowers = userService.getFollowers,
@@ -1519,6 +1521,7 @@ export function ProfileScreen({
   const deletePasswordRef = useRef('');
   const [deleteError, setDeleteError] = useState<string>();
   const [isDeleting, setIsDeleting] = useState(false);
+  const [isRequestingPasswordReset, setIsRequestingPasswordReset] = useState(false);
   const [error, setError] = useState<string>();
   const [formErrors, setFormErrors] = useState<FormErrors>({});
   const [followersCount, setFollowersCount] = useState(0);
@@ -1851,6 +1854,29 @@ export function ProfileScreen({
       setIsDeleting(false);
     }
   }, [deleteAccount, toast]);
+
+  const handleRequestPasswordReset = useCallback(async () => {
+    const resetEmail = profile?.email ?? user?.email;
+
+    if (!resetEmail || isRequestingPasswordReset) {
+      return;
+    }
+
+    setIsRequestingPasswordReset(true);
+
+    try {
+      await requestPasswordReset(resetEmail);
+      toast.success('Password reset link sent. Check your inbox.');
+    } catch (passwordResetError) {
+      const message =
+        passwordResetError instanceof Error
+          ? passwordResetError.message
+          : 'Unable to send a password reset link right now.';
+      toast.error(message);
+    } finally {
+      setIsRequestingPasswordReset(false);
+    }
+  }, [isRequestingPasswordReset, profile?.email, requestPasswordReset, toast, user?.email]);
 
   const handleRequestLoginForFollow = useCallback(() => {
     toast.info('Please sign in to follow users.');
@@ -2361,6 +2387,14 @@ export function ProfileScreen({
             ) : (
               <>
                 <NotificationPreferencesSection />
+                <Button
+                  variant="outline"
+                  accessibilityLabel="Send password reset link"
+                  onPress={() => void handleRequestPasswordReset()}
+                  disabled={isRequestingPasswordReset || !(profile.email ?? user?.email)}
+                >
+                  {isRequestingPasswordReset ? 'Sending reset link...' : 'Reset password'}
+                </Button>
                 <Button variant="outline" onPress={() => void logout()}>
                   Sign out
                 </Button>

--- a/mobile/src/features/profile/presentation/screens/__tests__/ProfileScreen.test.tsx
+++ b/mobile/src/features/profile/presentation/screens/__tests__/ProfileScreen.test.tsx
@@ -31,6 +31,7 @@ let mockIsAuthenticated = true;
 jest.mock('../../../../auth/application/services', () => ({
   authService: {
     clear: mockAuthClear,
+    forgotPassword: jest.fn(async () => undefined),
   },
 }));
 
@@ -1087,6 +1088,26 @@ describe('ProfileScreen', () => {
 
     expect(await screen.findByText('Re-enter your password to continue.')).toBeTruthy();
     expect(deleteAccount).not.toHaveBeenCalled();
+  });
+
+  it('sends a password reset link from the signed-in profile', async () => {
+    const requestPasswordReset = jest.fn(async () => undefined);
+
+    render(
+      <ProfileScreen
+        mode="self"
+        getCurrentProfile={async () => selfProfile}
+        requestPasswordReset={requestPasswordReset}
+      />,
+    );
+
+    await screen.findByText('Traveler');
+    fireEvent.press(screen.getByLabelText('Send password reset link'));
+
+    await waitFor(() => {
+      expect(requestPasswordReset).toHaveBeenCalledWith('traveler@example.com');
+    });
+    expect(mockToastSuccess).toHaveBeenCalledWith('Password reset link sent. Check your inbox.');
   });
 
   it('can dismiss the delete account modal without triggering deletion', async () => {


### PR DESCRIPTION
# 📝 Description
Fixes #191

Adds the complete mobile forgot-password and reset-password flow. The login screen now links to a forgot-password screen, reset links route into a reset-password screen with token parsing, and authenticated users can request a password reset link from their profile. The auth service layer now exposes password reset request/confirm methods wired to the existing backend endpoints.

# 📊 Type of Change
- [ ]  Bug fix
- [x]  New feature
- [ ]  Refactoring
- [ ]  Documentation
 
# ✅ Acceptance Criteria / Checklist
- [x] Project builds successfully
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, especially in hard-to-understand parts
- [x] I have performed a self-review of my code
- [x] I have added/updated tests
- [x] New and existing unit tests pass locally with my changes

# 📸 Screenshots / Recordings
Not captured.

# ⏱️ Estimated Review Time
- [ ] < 5 min
- [ ] 5-15 min
- [x] > 15 min
