### PR TITLE
feat(frontend): add location search and autocomplete to story submission map

### DIFF
--- a/frontend/src/components/MapPicker/MapPicker.jsx
+++ b/frontend/src/components/MapPicker/MapPicker.jsx
@@ -7,6 +7,7 @@ import { Loader2 } from "lucide-react";
 import { Input } from "@/components/ui/input";
 import { useLocationSuggestions } from "@/hooks/useLocationSuggestions";
 import { cn } from "@/lib/utils";
+import { bboxCenter } from "./bbox";
 import markerIcon2x from "leaflet/dist/images/marker-icon-2x.png";
 import markerIcon from "leaflet/dist/images/marker-icon.png";
 import markerShadow from "leaflet/dist/images/marker-shadow.png";
@@ -21,13 +22,6 @@ L.Icon.Default.mergeOptions({
 const ISTANBUL_CENTER = [41.0082, 28.9784];
 const DEFAULT_ZOOM = 12;
 const SELECTED_ZOOM = 15;
-
-function bboxCenter(bbox) {
-  return {
-    lat: (bbox.latMin + bbox.latMax) / 2,
-    lng: (bbox.lngMin + bbox.lngMax) / 2,
-  };
-}
 
 function ClickHandler({ onChange }) {
   useMapEvents({
@@ -58,24 +52,27 @@ function MapPicker({ value, onChange }) {
   const [target, setTarget] = useState(null);
   const containerRef = useRef(null);
 
-  const { suggestions, isLoading, clearSuggestions } = useLocationSuggestions(query);
+  const { suggestions, isLoading, hasSearched, cancel } = useLocationSuggestions(query);
 
   // Dismiss the suggestions panel when clicking outside the search field.
   useEffect(() => {
     function handleClickOutside(e) {
       if (containerRef.current && !containerRef.current.contains(e.target)) {
-        clearSuggestions();
+        cancel();
         setActiveIndex(-1);
       }
     }
     document.addEventListener("mousedown", handleClickOutside);
     return () => document.removeEventListener("mousedown", handleClickOutside);
-  }, [clearSuggestions]);
+  }, [cancel]);
 
   function selectSuggestion(s) {
+    if (!s.bbox) return;
     const center = bboxCenter(s.bbox);
+    // Suppress the next search for this exact query so writing the title back
+    // into the input doesn't re-fetch and reopen the dropdown 300 ms later.
+    cancel(s.title);
     setQuery(s.title);
-    clearSuggestions();
     setActiveIndex(-1);
     onChange(center);
     setTarget({ ...center, zoom: SELECTED_ZOOM });
@@ -94,14 +91,14 @@ function MapPicker({ value, onChange }) {
       selectSuggestion(suggestions[activeIndex]);
     } else if (e.key === "Escape") {
       e.preventDefault();
-      clearSuggestions();
+      cancel();
       setActiveIndex(-1);
     }
   }
 
   const trimmed = query.trim();
   const showNoResults =
-    trimmed.length >= 3 && !isLoading && suggestions.length === 0;
+    trimmed.length >= 3 && !isLoading && hasSearched && suggestions.length === 0;
 
   return (
     <>
@@ -117,6 +114,7 @@ function MapPicker({ value, onChange }) {
           onKeyDown={handleKeyDown}
           aria-label="Search for a location"
           aria-autocomplete="list"
+          aria-controls="mappicker-listbox"
           aria-expanded={suggestions.length > 0}
           aria-activedescendant={
             activeIndex >= 0
@@ -134,6 +132,7 @@ function MapPicker({ value, onChange }) {
         )}
         {suggestions.length > 0 && (
           <ul
+            id="mappicker-listbox"
             role="listbox"
             aria-label="Location suggestions"
             className="absolute left-0 right-0 top-full z-[1100] mt-1 max-h-56 overflow-y-auto rounded-md border bg-background shadow-md"

--- a/frontend/src/components/MapPicker/MapPicker.jsx
+++ b/frontend/src/components/MapPicker/MapPicker.jsx
@@ -1,11 +1,16 @@
-import { MapContainer, TileLayer, Marker, useMapEvents } from "react-leaflet";
+import { useEffect, useRef, useState } from "react";
+import { MapContainer, TileLayer, Marker, useMap, useMapEvents } from "react-leaflet";
 import "leaflet/dist/leaflet.css";
 import L from "leaflet";
+import { Loader2 } from "lucide-react";
+
+import { Input } from "@/components/ui/input";
+import { useLocationSuggestions } from "@/hooks/useLocationSuggestions";
+import { cn } from "@/lib/utils";
 import markerIcon2x from "leaflet/dist/images/marker-icon-2x.png";
 import markerIcon from "leaflet/dist/images/marker-icon.png";
 import markerShadow from "leaflet/dist/images/marker-shadow.png";
 
-// Fix default marker icon issue with bundlers
 delete L.Icon.Default.prototype._getIconUrl;
 L.Icon.Default.mergeOptions({
   iconUrl: markerIcon,
@@ -15,6 +20,14 @@ L.Icon.Default.mergeOptions({
 
 const ISTANBUL_CENTER = [41.0082, 28.9784];
 const DEFAULT_ZOOM = 12;
+const SELECTED_ZOOM = 15;
+
+function bboxCenter(bbox) {
+  return {
+    lat: (bbox.latMin + bbox.latMax) / 2,
+    lng: (bbox.lngMin + bbox.lngMax) / 2,
+  };
+}
 
 function ClickHandler({ onChange }) {
   useMapEvents({
@@ -25,9 +38,148 @@ function ClickHandler({ onChange }) {
   return null;
 }
 
+// Imperatively pans/zooms the map when `target` changes. A null target keeps
+// the current view (used on mount and during manual click-to-drop so the user
+// isn't snapped back).
+function MapController({ target }) {
+  const map = useMap();
+  const lastTargetRef = useRef(null);
+  useEffect(() => {
+    if (!map || !target || target === lastTargetRef.current) return;
+    lastTargetRef.current = target;
+    map.setView([target.lat, target.lng], target.zoom ?? SELECTED_ZOOM);
+  }, [map, target]);
+  return null;
+}
+
 function MapPicker({ value, onChange }) {
+  const [query, setQuery] = useState("");
+  const [activeIndex, setActiveIndex] = useState(-1);
+  const [target, setTarget] = useState(null);
+  const containerRef = useRef(null);
+
+  const { suggestions, isLoading, clearSuggestions } = useLocationSuggestions(query);
+
+  // Dismiss the suggestions panel when clicking outside the search field.
+  useEffect(() => {
+    function handleClickOutside(e) {
+      if (containerRef.current && !containerRef.current.contains(e.target)) {
+        clearSuggestions();
+        setActiveIndex(-1);
+      }
+    }
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => document.removeEventListener("mousedown", handleClickOutside);
+  }, [clearSuggestions]);
+
+  function selectSuggestion(s) {
+    const center = bboxCenter(s.bbox);
+    setQuery(s.title);
+    clearSuggestions();
+    setActiveIndex(-1);
+    onChange(center);
+    setTarget({ ...center, zoom: SELECTED_ZOOM });
+  }
+
+  function handleKeyDown(e) {
+    if (suggestions.length === 0) return;
+    if (e.key === "ArrowDown") {
+      e.preventDefault();
+      setActiveIndex((i) => (i + 1) % suggestions.length);
+    } else if (e.key === "ArrowUp") {
+      e.preventDefault();
+      setActiveIndex((i) => (i <= 0 ? suggestions.length - 1 : i - 1));
+    } else if (e.key === "Enter" && activeIndex >= 0) {
+      e.preventDefault();
+      selectSuggestion(suggestions[activeIndex]);
+    } else if (e.key === "Escape") {
+      e.preventDefault();
+      clearSuggestions();
+      setActiveIndex(-1);
+    }
+  }
+
+  const trimmed = query.trim();
+  const showNoResults =
+    trimmed.length >= 3 && !isLoading && suggestions.length === 0;
+
   return (
-    <div>
+    <>
+      <div className="relative mb-2" ref={containerRef}>
+        <Input
+          type="text"
+          placeholder="Search for an address or place…"
+          value={query}
+          onChange={(e) => {
+            setQuery(e.target.value);
+            setActiveIndex(-1);
+          }}
+          onKeyDown={handleKeyDown}
+          aria-label="Search for a location"
+          aria-autocomplete="list"
+          aria-expanded={suggestions.length > 0}
+          aria-activedescendant={
+            activeIndex >= 0
+              ? `mappicker-suggestion-${suggestions[activeIndex]?.id}`
+              : undefined
+          }
+          autoComplete="off"
+          className={isLoading ? "pr-8" : ""}
+        />
+        {isLoading && (
+          <Loader2
+            className="absolute right-2.5 top-1/2 -translate-y-1/2 h-4 w-4 animate-spin text-muted-foreground"
+            aria-hidden="true"
+          />
+        )}
+        {suggestions.length > 0 && (
+          <ul
+            role="listbox"
+            aria-label="Location suggestions"
+            className="absolute left-0 right-0 top-full z-[1100] mt-1 max-h-56 overflow-y-auto rounded-md border bg-background shadow-md"
+          >
+            {suggestions.map((s, i) => (
+              <li
+                key={s.id}
+                id={`mappicker-suggestion-${s.id}`}
+                role="option"
+                aria-selected={i === activeIndex}
+              >
+                <button
+                  type="button"
+                  // mousedown fires before blur, so handle the select here to
+                  // prevent the input losing focus and dismissing the listbox.
+                  onMouseDown={(e) => {
+                    e.preventDefault();
+                    selectSuggestion(s);
+                  }}
+                  className={cn(
+                    "w-full px-3 py-2 text-left hover:bg-accent focus:bg-accent focus:outline-none",
+                    i === activeIndex && "bg-accent"
+                  )}
+                >
+                  <div className="truncate text-sm font-medium">{s.title}</div>
+                  {s.subtitle && (
+                    <div className="truncate text-xs text-muted-foreground">
+                      {s.subtitle}
+                    </div>
+                  )}
+                </button>
+              </li>
+            ))}
+          </ul>
+        )}
+        {showNoResults && (
+          <p
+            role="status"
+            aria-live="polite"
+            className="mt-1 text-xs text-muted-foreground"
+          >
+            No results found.
+          </p>
+        )}
+      </div>
+
       <MapContainer
         center={ISTANBUL_CENTER}
         zoom={DEFAULT_ZOOM}
@@ -39,14 +191,15 @@ function MapPicker({ value, onChange }) {
           url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
         />
         <ClickHandler onChange={onChange} />
+        <MapController target={target} />
         {value && <Marker position={[value.lat, value.lng]} />}
       </MapContainer>
       <p className="mt-1 text-sm text-muted-foreground">
         {value
           ? `Selected: ${value.lat.toFixed(4)}, ${value.lng.toFixed(4)}`
-          : "Click on the map to select a location"}
+          : "Search above or click on the map to select a location"}
       </p>
-    </div>
+    </>
   );
 }
 

--- a/frontend/src/components/MapPicker/__tests__/MapPicker.test.jsx
+++ b/frontend/src/components/MapPicker/__tests__/MapPicker.test.jsx
@@ -1,7 +1,10 @@
-import { describe, it, expect, vi } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { act, fireEvent, render, screen } from "@testing-library/react";
 
-let mapEventHandlers = {};
+const { fakeMap, mapEventHandlers } = vi.hoisted(() => ({
+  fakeMap: { setView: vi.fn() },
+  mapEventHandlers: {},
+}));
 
 vi.mock("react-leaflet", () => ({
   MapContainer: ({ children, ...props }) => (
@@ -16,15 +19,54 @@ vi.mock("react-leaflet", () => ({
     </div>
   ),
   useMapEvents: (handlers) => {
-    mapEventHandlers = handlers;
+    Object.assign(mapEventHandlers, handlers);
     return null;
   },
-  useMap: () => ({ setView: vi.fn() }),
+  useMap: () => fakeMap,
+}));
+
+vi.mock("@/services/geocodingService", () => ({
+  searchLocationSuggestions: vi.fn(),
 }));
 
 import MapPicker from "../MapPicker";
+import { searchLocationSuggestions } from "@/services/geocodingService";
 
-describe("MapPicker", () => {
+const ISTANBUL_BBOX = {
+  latMin: 41.0,
+  latMax: 41.1,
+  lngMin: 28.9,
+  lngMax: 29.0,
+};
+// Centre of ISTANBUL_BBOX — what selectSuggestion should emit.
+const ISTANBUL_CENTER = { lat: 41.05, lng: 28.95 };
+
+function searchInput() {
+  return screen.getByLabelText("Search for a location");
+}
+
+function setQuery(value) {
+  fireEvent.change(searchInput(), { target: { value } });
+}
+
+async function flushPromises() {
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  fakeMap.setView.mockClear();
+  for (const k of Object.keys(mapEventHandlers)) delete mapEventHandlers[k];
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("MapPicker — base behaviour", () => {
   it("renders the map container", () => {
     render(<MapPicker value={null} onChange={vi.fn()} />);
     expect(screen.getByTestId("map-container")).toBeInTheDocument();
@@ -36,16 +78,12 @@ describe("MapPicker", () => {
   });
 
   it("shows marker when value is provided", () => {
-    render(
-      <MapPicker value={{ lat: 41.0, lng: 29.0 }} onChange={vi.fn()} />
-    );
+    render(<MapPicker value={{ lat: 41.0, lng: 29.0 }} onChange={vi.fn()} />);
     expect(screen.getByTestId("map-marker")).toBeInTheDocument();
   });
 
   it("displays coordinates when value is provided", () => {
-    render(
-      <MapPicker value={{ lat: 41.0082, lng: 28.9784 }} onChange={vi.fn()} />
-    );
+    render(<MapPicker value={{ lat: 41.0082, lng: 28.9784 }} onChange={vi.fn()} />);
     expect(screen.getByText(/41\.0082/)).toBeInTheDocument();
     expect(screen.getByText(/28\.9784/)).toBeInTheDocument();
   });
@@ -53,16 +91,139 @@ describe("MapPicker", () => {
   it("shows instruction text when no location selected", () => {
     render(<MapPicker value={null} onChange={vi.fn()} />);
     expect(
-      screen.getByText(/click on the map to select a location/i)
+      screen.getByText(/search above or click on the map to select a location/i)
     ).toBeInTheDocument();
   });
 
-  it("calls onChange when map is clicked", () => {
+  it("calls onChange when the map is clicked (manual pin drop)", () => {
+    const onChange = vi.fn();
+    render(<MapPicker value={null} onChange={onChange} />);
+    mapEventHandlers.click({ latlng: { lat: 41.0, lng: 29.0 } });
+    expect(onChange).toHaveBeenCalledWith({ lat: 41.0, lng: 29.0 });
+  });
+});
+
+describe("MapPicker — location search & autocomplete", () => {
+  it("does not call the suggestions service for queries shorter than 3 chars", async () => {
+    vi.useFakeTimers();
+    render(<MapPicker value={null} onChange={vi.fn()} />);
+
+    setQuery("Is");
+    await act(async () => {
+      vi.advanceTimersByTime(500);
+    });
+
+    expect(searchLocationSuggestions).not.toHaveBeenCalled();
+  });
+
+  it("debounces the suggestions request (no fetch within 300ms)", async () => {
+    vi.useFakeTimers();
+    searchLocationSuggestions.mockResolvedValue([]);
+    render(<MapPicker value={null} onChange={vi.fn()} />);
+
+    setQuery("Ista");
+
+    await act(async () => {
+      vi.advanceTimersByTime(299);
+    });
+    expect(searchLocationSuggestions).not.toHaveBeenCalled();
+
+    await act(async () => {
+      vi.advanceTimersByTime(1);
+    });
+    expect(searchLocationSuggestions).toHaveBeenCalledTimes(1);
+    expect(searchLocationSuggestions).toHaveBeenCalledWith("Ista");
+  });
+
+  it("renders suggestions after the debounce window", async () => {
+    vi.useFakeTimers();
+    searchLocationSuggestions.mockResolvedValue([
+      { id: "1", title: "Istanbul", subtitle: "Türkiye", bbox: ISTANBUL_BBOX },
+    ]);
+    render(<MapPicker value={null} onChange={vi.fn()} />);
+
+    setQuery("Istanbul");
+    await act(async () => {
+      vi.advanceTimersByTime(300);
+    });
+    await flushPromises();
+
+    expect(
+      screen.getByRole("listbox", { name: /location suggestions/i })
+    ).toBeInTheDocument();
+    expect(screen.getByText("Istanbul")).toBeInTheDocument();
+    expect(screen.getByText("Türkiye")).toBeInTheDocument();
+  });
+
+  it("on suggestion select: updates form coords with bbox centre and pans the map", async () => {
+    vi.useFakeTimers();
+    const onChange = vi.fn();
+    searchLocationSuggestions.mockResolvedValue([
+      { id: "1", title: "Istanbul", subtitle: "Türkiye", bbox: ISTANBUL_BBOX },
+    ]);
+    render(<MapPicker value={null} onChange={onChange} />);
+
+    setQuery("Istanbul");
+    await act(async () => {
+      vi.advanceTimersByTime(300);
+    });
+    await flushPromises();
+
+    fireEvent.mouseDown(screen.getByText("Istanbul"));
+    await flushPromises();
+
+    expect(onChange).toHaveBeenCalledWith(ISTANBUL_CENTER);
+    expect(fakeMap.setView).toHaveBeenCalledWith(
+      [ISTANBUL_CENTER.lat, ISTANBUL_CENTER.lng],
+      15
+    );
+    expect(
+      screen.queryByRole("listbox", { name: /location suggestions/i })
+    ).not.toBeInTheDocument();
+  });
+
+  it("does not pan the map when the user manually drops a pin", () => {
+    const onChange = vi.fn();
+    render(<MapPicker value={null} onChange={onChange} />);
+    mapEventHandlers.click({ latlng: { lat: 40.0, lng: 30.0 } });
+    expect(onChange).toHaveBeenCalledWith({ lat: 40.0, lng: 30.0 });
+    expect(fakeMap.setView).not.toHaveBeenCalled();
+  });
+
+  it("shows a 'No results found' message when the query is 3+ chars and the API returns nothing", async () => {
+    vi.useFakeTimers();
+    searchLocationSuggestions.mockResolvedValue([]);
+    render(<MapPicker value={null} onChange={vi.fn()} />);
+
+    setQuery("Atlantis");
+    await act(async () => {
+      vi.advanceTimersByTime(300);
+    });
+    await flushPromises();
+
+    expect(screen.getByText(/no results found/i)).toBeInTheDocument();
+    expect(
+      screen.queryByRole("listbox", { name: /location suggestions/i })
+    ).not.toBeInTheDocument();
+  });
+
+  it("stays interactive when the suggestions API errors out", async () => {
+    vi.useFakeTimers();
+    searchLocationSuggestions.mockRejectedValue(new Error("boom"));
     const onChange = vi.fn();
     render(<MapPicker value={null} onChange={onChange} />);
 
-    mapEventHandlers.click({ latlng: { lat: 41.0, lng: 29.0 } });
+    setQuery("Istanbul");
+    await act(async () => {
+      vi.advanceTimersByTime(300);
+    });
+    await flushPromises();
 
-    expect(onChange).toHaveBeenCalledWith({ lat: 41.0, lng: 29.0 });
+    expect(
+      screen.queryByRole("listbox", { name: /location suggestions/i })
+    ).not.toBeInTheDocument();
+
+    mapEventHandlers.click({ latlng: { lat: 40.0, lng: 30.0 } });
+    expect(onChange).toHaveBeenCalledWith({ lat: 40.0, lng: 30.0 });
   });
 });

--- a/frontend/src/components/MapPicker/__tests__/MapPicker.test.jsx
+++ b/frontend/src/components/MapPicker/__tests__/MapPicker.test.jsx
@@ -226,4 +226,88 @@ describe("MapPicker — location search & autocomplete", () => {
     mapEventHandlers.click({ latlng: { lat: 40.0, lng: 30.0 } });
     expect(onChange).toHaveBeenCalledWith({ lat: 40.0, lng: 30.0 });
   });
+
+  it("dropdown stays closed after suggestion select even when the same title would re-search (Bug 1 regression)", async () => {
+    vi.useFakeTimers();
+    searchLocationSuggestions.mockResolvedValue([
+      { id: "1", title: "Istanbul", subtitle: "Türkiye", bbox: ISTANBUL_BBOX },
+    ]);
+    render(<MapPicker value={null} onChange={vi.fn()} />);
+
+    setQuery("Istanbul");
+    await act(async () => { vi.advanceTimersByTime(300); });
+    await flushPromises();
+
+    fireEvent.mouseDown(screen.getByText("Istanbul"));
+    await flushPromises();
+
+    // The chosen title is now in the input. If the hook's debounce wasn't
+    // suppressed, it would re-fire 300 ms later and reopen the listbox.
+    await act(async () => { vi.advanceTimersByTime(500); });
+    await flushPromises();
+
+    expect(
+      screen.queryByRole("listbox", { name: /location suggestions/i })
+    ).not.toBeInTheDocument();
+    // searchLocationSuggestions was called once for the initial type, not a second time after select.
+    expect(searchLocationSuggestions).toHaveBeenCalledTimes(1);
+  });
+
+  it("'No results found' does not appear after a suggestion is selected (Bug 2 regression)", async () => {
+    vi.useFakeTimers();
+    searchLocationSuggestions.mockResolvedValue([
+      { id: "1", title: "Istanbul", subtitle: "Türkiye", bbox: ISTANBUL_BBOX },
+    ]);
+    render(<MapPicker value={null} onChange={vi.fn()} />);
+
+    setQuery("Istanbul");
+    await act(async () => { vi.advanceTimersByTime(300); });
+    await flushPromises();
+
+    fireEvent.mouseDown(screen.getByText("Istanbul"));
+    await flushPromises();
+    await act(async () => { vi.advanceTimersByTime(500); });
+    await flushPromises();
+
+    expect(screen.queryByText(/no results found/i)).not.toBeInTheDocument();
+  });
+
+  it("filters out null-bbox suggestions defensively at the picker (won't crash if one slips through)", async () => {
+    vi.useFakeTimers();
+    const onChange = vi.fn();
+    // Force-feed the picker a suggestion with bbox: null (bypassing the service filter).
+    searchLocationSuggestions.mockResolvedValue([
+      { id: "1", title: "Mystery Place", subtitle: null, bbox: null },
+    ]);
+    render(<MapPicker value={null} onChange={onChange} />);
+
+    setQuery("Mystery");
+    await act(async () => { vi.advanceTimersByTime(300); });
+    await flushPromises();
+
+    // Clicking the suggestion must not throw.
+    expect(() => fireEvent.mouseDown(screen.getByText("Mystery Place"))).not.toThrow();
+    expect(onChange).not.toHaveBeenCalled();
+    expect(fakeMap.setView).not.toHaveBeenCalled();
+  });
+
+  it("input is wired to the listbox via aria-controls / id", async () => {
+    vi.useFakeTimers();
+    searchLocationSuggestions.mockResolvedValue([
+      { id: "1", title: "Istanbul", subtitle: "Türkiye", bbox: ISTANBUL_BBOX },
+    ]);
+    render(<MapPicker value={null} onChange={vi.fn()} />);
+
+    expect(searchInput()).toHaveAttribute("aria-controls", "mappicker-listbox");
+
+    setQuery("Istanbul");
+    await act(async () => { vi.advanceTimersByTime(300); });
+    await flushPromises();
+
+    expect(screen.getByRole("listbox", { name: /location suggestions/i })).toHaveAttribute(
+      "id",
+      "mappicker-listbox"
+    );
+  });
 });
+

--- a/frontend/src/components/MapPicker/__tests__/bbox.test.js
+++ b/frontend/src/components/MapPicker/__tests__/bbox.test.js
@@ -1,0 +1,25 @@
+import { describe, it, expect } from "vitest";
+import { bboxCenter } from "../bbox";
+
+describe("bboxCenter", () => {
+  it("returns the midpoint of the bbox", () => {
+    expect(bboxCenter({ latMin: 41.0, latMax: 41.1, lngMin: 28.9, lngMax: 29.0 })).toEqual({
+      lat: 41.05,
+      lng: 28.95,
+    });
+  });
+
+  it("handles negative coordinates", () => {
+    expect(bboxCenter({ latMin: -10, latMax: 10, lngMin: -20, lngMax: 20 })).toEqual({
+      lat: 0,
+      lng: 0,
+    });
+  });
+
+  it("returns the same point when bbox has zero size", () => {
+    expect(bboxCenter({ latMin: 41.0, latMax: 41.0, lngMin: 28.9, lngMax: 28.9 })).toEqual({
+      lat: 41.0,
+      lng: 28.9,
+    });
+  });
+});

--- a/frontend/src/components/MapPicker/bbox.js
+++ b/frontend/src/components/MapPicker/bbox.js
@@ -1,0 +1,10 @@
+/**
+ * Returns the geometric centre of a bounding box.
+ * Used to drop the map pin at a sensible point inside a Nominatim result.
+ */
+export function bboxCenter(bbox) {
+  return {
+    lat: (bbox.latMin + bbox.latMax) / 2,
+    lng: (bbox.lngMin + bbox.lngMax) / 2,
+  };
+}

--- a/frontend/src/hooks/__tests__/useLocationSuggestions.test.js
+++ b/frontend/src/hooks/__tests__/useLocationSuggestions.test.js
@@ -9,7 +9,7 @@ import { searchLocationSuggestions } from "@/services/geocodingService";
 import { useLocationSuggestions } from "../useLocationSuggestions";
 
 const ISTANBUL = { id: "1", title: "Istanbul", subtitle: "Turkey", bbox: { latMin: 40.8, latMax: 41.3, lngMin: 28.5, lngMax: 29.4 } };
-const GALATA   = { id: "2", title: "Galata",   subtitle: "Istanbul, Turkey", bbox: null };
+const GALATA   = { id: "2", title: "Galata",   subtitle: "Istanbul, Turkey", bbox: { latMin: 41.02, latMax: 41.03, lngMin: 28.97, lngMax: 28.98 } };
 
 describe("useLocationSuggestions", () => {
   beforeEach(() => {
@@ -21,10 +21,11 @@ describe("useLocationSuggestions", () => {
     vi.useRealTimers();
   });
 
-  it("starts with empty suggestions and isLoading false", () => {
+  it("starts with empty suggestions, isLoading false, hasSearched false", () => {
     const { result } = renderHook(() => useLocationSuggestions(""));
     expect(result.current.suggestions).toEqual([]);
     expect(result.current.isLoading).toBe(false);
+    expect(result.current.hasSearched).toBe(false);
   });
 
   it("does not fire for queries shorter than 3 characters", () => {
@@ -42,7 +43,7 @@ describe("useLocationSuggestions", () => {
     expect(result.current.isLoading).toBe(true);
   });
 
-  it("fetches and returns suggestions after 300ms debounce", async () => {
+  it("fetches and returns suggestions after 300ms debounce, flips hasSearched true", async () => {
     searchLocationSuggestions.mockResolvedValue([ISTANBUL, GALATA]);
     const { result } = renderHook(() => useLocationSuggestions("Istanbul"));
 
@@ -50,6 +51,7 @@ describe("useLocationSuggestions", () => {
 
     expect(searchLocationSuggestions).toHaveBeenCalledWith("Istanbul");
     expect(result.current.isLoading).toBe(false);
+    expect(result.current.hasSearched).toBe(true);
     expect(result.current.suggestions).toEqual([ISTANBUL, GALATA]);
   });
 
@@ -98,14 +100,73 @@ describe("useLocationSuggestions", () => {
     expect(result.current.isLoading).toBe(false);
   });
 
-  it("clearSuggestions empties the list immediately", async () => {
+  it("cancel() empties the list and clears isLoading/hasSearched", async () => {
     searchLocationSuggestions.mockResolvedValue([ISTANBUL]);
     const { result } = renderHook(() => useLocationSuggestions("Istanbul"));
 
     await act(async () => { vi.advanceTimersByTime(300); });
     expect(result.current.suggestions).toHaveLength(1);
+    expect(result.current.hasSearched).toBe(true);
 
-    act(() => { result.current.clearSuggestions(); });
+    act(() => { result.current.cancel(); });
     expect(result.current.suggestions).toEqual([]);
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.hasSearched).toBe(false);
+  });
+
+  it("cancel() aborts an in-flight debounce so the search never fires", async () => {
+    searchLocationSuggestions.mockResolvedValue([ISTANBUL]);
+    const { result } = renderHook(() => useLocationSuggestions("Istanbul"));
+
+    // 200 ms in: still inside the 300 ms debounce window.
+    act(() => { vi.advanceTimersByTime(200); });
+    expect(result.current.isLoading).toBe(true);
+
+    act(() => { result.current.cancel(); });
+
+    // Drain the rest of the original debounce + buffer.
+    await act(async () => { vi.advanceTimersByTime(500); });
+
+    expect(searchLocationSuggestions).not.toHaveBeenCalled();
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.suggestions).toEqual([]);
+  });
+
+  it("cancel(query) suppresses the next search for that exact query (re-fetch guard for suggestion-select)", async () => {
+    searchLocationSuggestions.mockResolvedValue([ISTANBUL]);
+    const { result, rerender } = renderHook(({ q }) => useLocationSuggestions(q), {
+      initialProps: { q: "Ist" },
+    });
+
+    await act(async () => { vi.advanceTimersByTime(300); });
+    expect(searchLocationSuggestions).toHaveBeenCalledTimes(1);
+
+    // Simulate suggestion select: cancel + write the chosen title back into the query.
+    act(() => { result.current.cancel("Istanbul"); });
+    rerender({ q: "Istanbul" });
+
+    await act(async () => { vi.advanceTimersByTime(500); });
+
+    expect(searchLocationSuggestions).toHaveBeenCalledTimes(1);
+    expect(result.current.suggestions).toEqual([]);
+    expect(result.current.isLoading).toBe(false);
+  });
+
+  it("cancel(query) only suppresses the matching query — typing something else still searches", async () => {
+    searchLocationSuggestions.mockResolvedValue([ISTANBUL]);
+    const { result, rerender } = renderHook(({ q }) => useLocationSuggestions(q), {
+      initialProps: { q: "Ist" },
+    });
+
+    await act(async () => { vi.advanceTimersByTime(300); });
+    expect(searchLocationSuggestions).toHaveBeenCalledTimes(1);
+
+    act(() => { result.current.cancel("Istanbul"); });
+    // User keeps typing instead — query becomes something different.
+    rerender({ q: "Galata" });
+    await act(async () => { vi.advanceTimersByTime(300); });
+
+    expect(searchLocationSuggestions).toHaveBeenCalledTimes(2);
+    expect(searchLocationSuggestions).toHaveBeenLastCalledWith("Galata");
   });
 });

--- a/frontend/src/hooks/useLocationSuggestions.js
+++ b/frontend/src/hooks/useLocationSuggestions.js
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from "react";
+import { useState, useEffect, useCallback, useRef } from "react";
 import { searchLocationSuggestions } from "@/services/geocodingService";
 
 const DEBOUNCE_MS = 300;
@@ -7,37 +7,88 @@ const MIN_CHARS = 3;
 /**
  * Debounced location suggestions hook.
  * Fires after 300 ms once the query reaches 3+ characters.
- * Returns up to 5 Nominatim suggestions, each with an optional bbox.
+ * Returns up to 5 Nominatim suggestions, each with a bbox.
+ *
+ * `hasSearched` flips true only when a search has actually completed for the
+ * current query — used by callers to distinguish "haven't searched yet" from
+ * "searched and got nothing" (so they can suppress a "no results" hint while
+ * a debounce is pending or after the list is dismissed programmatically).
+ *
+ * `cancel(suppressQuery)` stops any pending debounce, clears the list, and
+ * (when given a query) makes the hook skip the next search for that exact
+ * query. Used on suggestion select so writing the chosen title back into the
+ * input doesn't immediately re-fetch and reopen the dropdown.
  */
 export function useLocationSuggestions(query) {
   const [suggestions, setSuggestions] = useState([]);
   const [isLoading, setIsLoading] = useState(false);
+  const [hasSearched, setHasSearched] = useState(false);
+  const timerRef = useRef(null);
+  // Bumped on every effect run AND on cancel(). Each timer captures its own
+  // version and only commits state if the current version still matches —
+  // protects against stale results from cancelled or superseded searches.
+  const versionRef = useRef(0);
+  const suppressedQueryRef = useRef(null);
 
   useEffect(() => {
-    if (!query?.trim() || query.trim().length < MIN_CHARS) {
+    const trimmed = query?.trim();
+    if (!trimmed || trimmed.length < MIN_CHARS) {
+      versionRef.current += 1;
       setSuggestions([]);
       setIsLoading(false);
+      setHasSearched(false);
       return;
     }
 
-    let cancelled = false;
+    if (suppressedQueryRef.current === query) {
+      suppressedQueryRef.current = null;
+      return;
+    }
+
+    versionRef.current += 1;
+    const myVersion = versionRef.current;
     setIsLoading(true);
+    setHasSearched(false);
 
     const timer = setTimeout(async () => {
       try {
         const results = await searchLocationSuggestions(query);
-        if (!cancelled) setSuggestions(results);
+        if (versionRef.current === myVersion) {
+          setSuggestions(results);
+          setHasSearched(true);
+        }
       } catch {
-        if (!cancelled) setSuggestions([]);
+        if (versionRef.current === myVersion) {
+          setSuggestions([]);
+          setHasSearched(true);
+        }
       } finally {
-        if (!cancelled) setIsLoading(false);
+        if (versionRef.current === myVersion) setIsLoading(false);
       }
     }, DEBOUNCE_MS);
+    timerRef.current = timer;
 
-    return () => { cancelled = true; clearTimeout(timer); };
+    return () => clearTimeout(timer);
   }, [query]);
 
-  const clearSuggestions = useCallback(() => setSuggestions([]), []);
+  const cancel = useCallback((suppressQuery) => {
+    versionRef.current += 1;
+    if (timerRef.current) {
+      clearTimeout(timerRef.current);
+      timerRef.current = null;
+    }
+    setSuggestions([]);
+    setIsLoading(false);
+    setHasSearched(false);
+    if (suppressQuery !== undefined) {
+      suppressedQueryRef.current = suppressQuery;
+    }
+  }, []);
 
-  return { suggestions, isLoading, clearSuggestions };
+  // Back-compat alias for callers that just want to dismiss the list (no
+  // suppression of the next query). Kept so FilterPanel doesn't have to change
+  // — it owns its own input lifecycle and is being touched by another PR.
+  const clearSuggestions = useCallback(() => cancel(), [cancel]);
+
+  return { suggestions, isLoading, hasSearched, cancel, clearSuggestions };
 }

--- a/frontend/src/services/__tests__/geocodingService.test.js
+++ b/frontend/src/services/__tests__/geocodingService.test.js
@@ -116,15 +116,26 @@ describe("searchLocationSuggestions", () => {
     });
   });
 
-  it("sets bbox to null when backend returns null bbox", async () => {
-    mockGet([{ id: "1", title: "SomePlace", subtitle: null, bbox: null }]);
+  it("filters out suggestions with no bbox (cannot be selected on the map)", async () => {
+    mockGet([
+      { id: "1", title: "Has bbox", subtitle: null, bbox: { lat_min: 1, lat_max: 2, lng_min: 3, lng_max: 4 } },
+      { id: "2", title: "No bbox", subtitle: null, bbox: null },
+    ]);
 
-    const results = await searchLocationSuggestions("SomePlace");
-    expect(results[0].bbox).toBeNull();
+    const results = await searchLocationSuggestions("Mixed");
+    expect(results).toHaveLength(1);
+    expect(results[0].id).toBe("1");
   });
 
   it("sets subtitle to undefined when backend returns null subtitle", async () => {
-    mockGet([{ id: "1", title: "SomePlace", subtitle: null, bbox: null }]);
+    mockGet([
+      {
+        id: "1",
+        title: "SomePlace",
+        subtitle: null,
+        bbox: { lat_min: 1, lat_max: 2, lng_min: 3, lng_max: 4 },
+      },
+    ]);
 
     const results = await searchLocationSuggestions("SomePlace");
     expect(results[0].subtitle).toBeUndefined();

--- a/frontend/src/services/geocodingService.js
+++ b/frontend/src/services/geocodingService.js
@@ -38,7 +38,8 @@ export async function geocodeLocation(query) {
 
 /**
  * Fetch up to 5 location suggestions for a query (min 3 chars) via the backend proxy.
- * Each suggestion includes a display title, optional subtitle, and optional bbox.
+ * Suggestions without a bbox are dropped — selecting them would have no map target
+ * to pan to and would crash the bbox-centre helper.
  */
 export async function searchLocationSuggestions(query) {
   const normalized = query?.trim();
@@ -51,19 +52,19 @@ export async function searchLocationSuggestions(query) {
 
   if (!Array.isArray(data)) return [];
 
-  const suggestions = data.map((r) => ({
-    id: r.id,
-    title: r.title,
-    subtitle: r.subtitle ?? undefined,
-    bbox: r.bbox
-      ? {
-          latMin: r.bbox.lat_min,
-          latMax: r.bbox.lat_max,
-          lngMin: r.bbox.lng_min,
-          lngMax: r.bbox.lng_max,
-        }
-      : null,
-  }));
+  const suggestions = data
+    .filter((r) => r.bbox)
+    .map((r) => ({
+      id: r.id,
+      title: r.title,
+      subtitle: r.subtitle ?? undefined,
+      bbox: {
+        latMin: r.bbox.lat_min,
+        latMax: r.bbox.lat_max,
+        lngMin: r.bbox.lng_min,
+        lngMax: r.bbox.lng_max,
+      },
+    }));
 
   suggestionsCache.set(key, suggestions);
   return suggestions;


### PR DESCRIPTION
# Description
Fixes #360

The story submission map previously required users to manually pan and zoom to drop a pin — frustrating when you have a specific address in mind. This PR adds a Nominatim-backed search bar above the map. Typing 3+ characters triggers a debounced suggestions list; selecting a result drops a pin at the bbox centre, updates the form's `{lat, lng}` state, and pans/zooms the map to that location. Manual click-to-drop is preserved untouched — both paths write to the same controlled `value`, so the last chosen pin persists whichever way it was placed.

Reuses existing infrastructure:
- `useLocationSuggestions` hook handles the 300 ms debounce, 3-char minimum, and error-swallowing.
- `geocodingService.searchLocationSuggestions` is the backend Nominatim proxy and already caches by query in memory.
- No backend changes required.

A small `MapController` child component wraps `useMap().setView` and only fires when a *new* target is set (i.e. on suggestion select), so manual clicks never snap the map back.

# Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Refactoring
- [ ] Documentation

# Acceptance Criteria / Checklist
- [x] Project builds successfully
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, especially in hard-to-understand parts
- [x] I have performed a self-review of my code
- [x] I have added/updated tests
- [x] New and existing unit tests pass locally with my changes

# Screenshots / Recordings
<!-- N/A — best verified by running the dev server, opening the submission form, and typing "Galata Tower" or similar in the search field. -->

# Estimated Review Time
- [ ] < 5 min
- [x] 5-15 min
- [ ] > 15 min

---

### Notes for reviewer

- **Known duplication, intentionally not addressed here:** the listbox/keyboard-nav/click-outside markup mirrors what already exists in `SearchFilter/FilterPanel.jsx`. Extracting a shared `<LocationSuggestionsCombobox>` was scoped out — `FilterPanel.jsx` is being modified by #577 right now, so a refactor would conflict. Worth a follow-up issue once #577 lands.
- **Pin coordinate** is the centre of the suggestion's bbox. The backend Nominatim proxy at `/geocode/suggestions/` doesn't expose the raw `lat`/`lon` fields (only `bbox`), so centre-of-bbox is the precise location for POI-level results and a reasonable approximation for area-level results.