### PR TITLE
feat: mobile add reporting flow for stories and comments

### DIFF
--- a/mobile/src/features/reports/application/services/__tests__/reportService.test.ts
+++ b/mobile/src/features/reports/application/services/__tests__/reportService.test.ts
@@ -1,0 +1,62 @@
+import { resetApiTransport, setApiTransport } from '../../../../../core/api/client';
+import { reportService } from '..';
+
+describe('reportService', () => {
+  const requests: Array<{ method: string; url?: string; data?: unknown }> = [];
+
+  beforeEach(() => {
+    requests.length = 0;
+    setApiTransport(async (method, config) => {
+      requests.push({ method, url: config.url, data: config.data });
+      const data = config.data as { target_id?: unknown; reason?: unknown } | undefined;
+
+      if (method === 'POST' && config.url === '/reports/') {
+        return {
+          status: 201,
+          data: {
+            id: 7,
+            target_type: 'story',
+            target_id: data?.target_id,
+            reason: data?.reason,
+            status: 'pending',
+            created_at: '2026-05-08T12:00:00Z',
+          } as never,
+          config,
+        };
+      }
+
+      throw new Error(`Unexpected request ${method} ${config.url}`);
+    });
+  });
+
+  afterEach(() => {
+    resetApiTransport();
+  });
+
+  it('posts a content report to the reports endpoint and maps the response', async () => {
+    const report = await reportService.reportContent({
+      targetType: 'story',
+      targetId: '42',
+      reason: 'privacy_violation',
+      description: 'Contains a private address.',
+    });
+
+    expect(requests[0]).toEqual({
+      method: 'POST',
+      url: '/reports/',
+      data: {
+        target_type: 'story',
+        target_id: 42,
+        reason: 'privacy_violation',
+        description: 'Contains a private address.',
+      },
+    });
+    expect(report).toMatchObject({
+      id: '7',
+      targetType: 'story',
+      targetId: '42',
+      reason: 'privacy_violation',
+      status: 'pending',
+    });
+  });
+});

--- a/mobile/src/features/reports/application/services/index.ts
+++ b/mobile/src/features/reports/application/services/index.ts
@@ -1,1 +1,12 @@
-export const reportsService = {};
+import { ReportRepositoryImpl } from '../../data/repositories';
+import { ReportContentInput, ReportEntity } from '../../domain/entities';
+
+const repository = new ReportRepositoryImpl();
+
+export const reportService = {
+  async reportContent(input: ReportContentInput): Promise<ReportEntity> {
+    return repository.reportContent(input);
+  },
+};
+
+export const reportsService = reportService;

--- a/mobile/src/features/reports/data/mappers/index.ts
+++ b/mobile/src/features/reports/data/mappers/index.ts
@@ -1,3 +1,53 @@
-export function mapReport(value: unknown) {
-  return value;
+import { ReportEntity, ReportReason, ReportTargetType } from '../../domain/entities';
+
+function asString(value: unknown) {
+  if (typeof value === 'string') {
+    return value;
+  }
+
+  if (typeof value === 'number') {
+    return String(value);
+  }
+
+  return '';
+}
+
+function isReportReason(value: unknown): value is ReportReason {
+  return (
+    value === 'spam' ||
+    value === 'false_content' ||
+    value === 'harassment' ||
+    value === 'privacy_violation' ||
+    value === 'explicit_media' ||
+    value === 'other'
+  );
+}
+
+function isReportTargetType(value: unknown): value is ReportTargetType {
+  return value === 'story' || value === 'comment';
+}
+
+export function mapReport(value: unknown): ReportEntity {
+  if (!value || typeof value !== 'object') {
+    throw new Error('Invalid report payload.');
+  }
+
+  const report = value as Record<string, unknown>;
+  const id = asString(report.id);
+  const targetType = isReportTargetType(report.target_type) ? report.target_type : undefined;
+  const targetId = asString(report.target_id);
+  const reason = isReportReason(report.reason) ? report.reason : undefined;
+
+  if (!id || !targetType || !targetId || !reason) {
+    throw new Error('Invalid report payload.');
+  }
+
+  return {
+    id,
+    targetType,
+    targetId,
+    reason,
+    status: asString(report.status) || undefined,
+    createdAt: asString(report.created_at) || undefined,
+  };
 }

--- a/mobile/src/features/reports/data/repositories/index.ts
+++ b/mobile/src/features/reports/data/repositories/index.ts
@@ -1,1 +1,10 @@
-export class ReportRepositoryImpl {}
+import { mapReport } from '../mappers';
+import { reportsRemoteSource } from '../sources';
+import { ReportContentInput, ReportEntity } from '../../domain/entities';
+import { ReportRepository } from '../../domain/repositories';
+
+export class ReportRepositoryImpl implements ReportRepository {
+  async reportContent(input: ReportContentInput): Promise<ReportEntity> {
+    return mapReport(await reportsRemoteSource.reportContent(input));
+  }
+}

--- a/mobile/src/features/reports/data/sources/index.ts
+++ b/mobile/src/features/reports/data/sources/index.ts
@@ -1,2 +1,21 @@
-export const reportsRemoteSource = {};
+import { apiClient } from '../../../../core/api/client';
+import { ReportContentInput } from '../../domain/entities';
+
+function getTargetIdPayload(targetId: string) {
+  const parsed = Number(targetId);
+
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : targetId;
+}
+
+export const reportsRemoteSource = {
+  async reportContent(input: ReportContentInput) {
+    return apiClient.post('/reports/', {
+      target_type: input.targetType,
+      target_id: getTargetIdPayload(input.targetId),
+      reason: input.reason,
+      description: input.description?.trim() ?? '',
+    });
+  },
+};
+
 export const reportsLocalSource = {};

--- a/mobile/src/features/reports/domain/entities/ReportReason.ts
+++ b/mobile/src/features/reports/domain/entities/ReportReason.ts
@@ -1,7 +1,7 @@
 export type ReportReason =
   | 'spam'
-  | 'false-misleading'
-  | 'harassment-abuse'
-  | 'privacy-violation'
-  | 'explicit-inappropriate-media'
+  | 'false_content'
+  | 'harassment'
+  | 'privacy_violation'
+  | 'explicit_media'
   | 'other';

--- a/mobile/src/features/reports/domain/entities/index.ts
+++ b/mobile/src/features/reports/domain/entities/index.ts
@@ -1,3 +1,21 @@
+import { ReportReason } from './ReportReason';
+
+export type ReportTargetType = 'story' | 'comment';
+
 export interface ReportEntity {
   id: string;
+  targetType: ReportTargetType;
+  targetId: string;
+  reason: ReportReason;
+  status?: string;
+  createdAt?: string;
 }
+
+export interface ReportContentInput {
+  targetType: ReportTargetType;
+  targetId: string;
+  reason: ReportReason;
+  description?: string;
+}
+
+export * from './ReportReason';

--- a/mobile/src/features/reports/domain/repositories/index.ts
+++ b/mobile/src/features/reports/domain/repositories/index.ts
@@ -1,3 +1,5 @@
+import { ReportContentInput, ReportEntity } from '../entities';
+
 export interface ReportRepository {
-  placeholder(): Promise<void>;
+  reportContent(input: ReportContentInput): Promise<ReportEntity>;
 }

--- a/mobile/src/features/reports/index.ts
+++ b/mobile/src/features/reports/index.ts
@@ -1,1 +1,4 @@
 export * from './presentation/screens/ReportScreen';
+export * from './presentation/components/ReportSheet';
+export * from './application/services';
+export * from './domain/entities';

--- a/mobile/src/features/reports/presentation/components/ReportSheet.tsx
+++ b/mobile/src/features/reports/presentation/components/ReportSheet.tsx
@@ -1,0 +1,166 @@
+import React, { useMemo, useState } from 'react';
+import { Modal, Pressable, Text, View } from 'react-native';
+import { X } from 'lucide-react-native';
+import { useAppTheme } from '../../../../core/hooks/useAppTheme';
+import { Button } from '../../../../shared/ui/Button';
+import { Input } from '../../../../shared/ui/Input';
+import { ReportReason, ReportTargetType } from '../../domain/entities';
+
+const reportReasonOptions: Array<{ value: ReportReason; label: string }> = [
+  { value: 'spam', label: 'Spam' },
+  { value: 'false_content', label: 'False/misleading' },
+  { value: 'harassment', label: 'Harassment' },
+  { value: 'privacy_violation', label: 'Privacy violation' },
+  { value: 'explicit_media', label: 'Explicit media' },
+  { value: 'other', label: 'Other' },
+];
+
+interface ReportSheetProps {
+  visible: boolean;
+  targetType?: ReportTargetType;
+  isSubmitting?: boolean;
+  error?: string;
+  onClose: () => void;
+  onSubmit: (input: { reason: ReportReason; description?: string }) => void;
+}
+
+function getTitle(targetType?: ReportTargetType) {
+  return targetType === 'comment' ? 'Report comment' : 'Report story';
+}
+
+export function ReportSheet({
+  visible,
+  targetType,
+  isSubmitting = false,
+  error,
+  onClose,
+  onSubmit,
+}: ReportSheetProps) {
+  const { colors, spacing, typography } = useAppTheme();
+  const [selectedReason, setSelectedReason] = useState<ReportReason>();
+  const [description, setDescription] = useState('');
+  const title = useMemo(() => getTitle(targetType), [targetType]);
+
+  const canSubmit = Boolean(selectedReason) && !isSubmitting;
+
+  return (
+    <Modal visible={visible} animationType="slide" transparent onRequestClose={onClose}>
+      <View
+        style={{
+          flex: 1,
+          justifyContent: 'flex-end',
+          backgroundColor: 'rgba(10, 10, 10, 0.4)',
+        }}
+      >
+        <Pressable
+          accessibilityRole="button"
+          accessibilityLabel="Close report sheet"
+          onPress={onClose}
+          style={{ flex: 1 }}
+        />
+        <View
+          style={{
+            padding: spacing.lg,
+            borderTopLeftRadius: 24,
+            borderTopRightRadius: 24,
+            backgroundColor: colors.background,
+            borderWidth: 1,
+            borderColor: colors.border,
+          }}
+        >
+          <View style={{ flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between' }}>
+            <Text style={{ color: colors.text, fontSize: typography.subtitle, fontWeight: '800' }}>
+              {title}
+            </Text>
+            <Pressable
+              accessibilityRole="button"
+              accessibilityLabel="Close report modal"
+              disabled={isSubmitting}
+              onPress={onClose}
+              style={({ pressed }) => ({
+                width: 44,
+                height: 44,
+                borderRadius: 999,
+                alignItems: 'center',
+                justifyContent: 'center',
+                backgroundColor: colors.surface,
+                borderWidth: 1,
+                borderColor: colors.border,
+                opacity: pressed || isSubmitting ? 0.7 : 1,
+              })}
+            >
+              <X size={19} color={colors.text} strokeWidth={2.4} />
+            </Pressable>
+          </View>
+
+          <View style={{ marginTop: spacing.md, gap: spacing.sm }}>
+            {reportReasonOptions.map((option) => {
+              const selected = selectedReason === option.value;
+
+              return (
+                <Pressable
+                  key={option.value}
+                  accessibilityRole="button"
+                  accessibilityLabel={`Report reason: ${option.label}`}
+                  accessibilityState={{ selected }}
+                  disabled={isSubmitting}
+                  onPress={() => setSelectedReason(option.value)}
+                  style={({ pressed }) => ({
+                    minHeight: 48,
+                    paddingHorizontal: spacing.md,
+                    paddingVertical: spacing.sm,
+                    borderRadius: 12,
+                    borderWidth: 1,
+                    borderColor: selected ? colors.primary : colors.border,
+                    backgroundColor: selected ? colors.infoSurface : colors.surface,
+                    justifyContent: 'center',
+                    opacity: pressed || isSubmitting ? 0.75 : 1,
+                  })}
+                >
+                  <Text style={{ color: colors.text, fontWeight: selected ? '800' : '600' }}>
+                    {option.label}
+                  </Text>
+                </Pressable>
+              );
+            })}
+          </View>
+
+          {selectedReason === 'other' ? (
+            <View style={{ marginTop: spacing.md }}>
+              <Input
+                value={description}
+                onChangeText={setDescription}
+                placeholder="Add details (optional)"
+                accessibilityLabel="Report details"
+                editable={!isSubmitting}
+                multiline
+                numberOfLines={3}
+                style={{ minHeight: 96, alignItems: 'stretch' }}
+              />
+            </View>
+          ) : null}
+
+          {error ? (
+            <Text style={{ marginTop: spacing.md, color: colors.danger, fontWeight: '600' }}>
+              {error}
+            </Text>
+          ) : null}
+
+          <View style={{ marginTop: spacing.lg }}>
+            <Button
+              fullWidth
+              disabled={!canSubmit}
+              onPress={() => {
+                if (selectedReason) {
+                  onSubmit({ reason: selectedReason, description });
+                }
+              }}
+            >
+              {isSubmitting ? 'Submitting...' : 'Submit report'}
+            </Button>
+          </View>
+        </View>
+      </View>
+    </Modal>
+  );
+}

--- a/mobile/src/features/stories/presentation/screens/StoryScreen.tsx
+++ b/mobile/src/features/stories/presentation/screens/StoryScreen.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { Alert, Image, LayoutChangeEvent, Pressable, ScrollView, Text, View } from 'react-native';
 import Slider from '@react-native-community/slider';
-import { Bookmark, Calendar, Clock, MapPin, Pause, Play, Trash2, Volume2 } from 'lucide-react-native';
+import { Bookmark, Calendar, Clock, Flag, MapPin, Pause, Play, Trash2, Volume2 } from 'lucide-react-native';
 import { useAudioPlayer, useAudioPlayerStatus } from 'expo-audio';
 import { VideoView, useVideoPlayer } from 'expo-video';
 import { roles } from '../../../../core/auth/roles';
@@ -9,6 +9,9 @@ import { Session } from '../../../../core/auth/session';
 import { useAppTheme } from '../../../../core/hooks/useAppTheme';
 import { interactionService } from '../../../interactions/application/services';
 import { StoryCommentEntity } from '../../../interactions/domain/entities';
+import { reportService } from '../../../reports/application/services';
+import { ReportReason, ReportTargetType } from '../../../reports/domain/entities';
+import { ReportSheet } from '../../../reports/presentation/components/ReportSheet';
 import { storyService } from '../../application/services';
 import { StoryEntity, StoryMediaItem } from '../../domain/entities';
 import { ErrorState } from '../../../../shared/ui/ErrorState';
@@ -18,6 +21,7 @@ import { Loader } from '../../../../shared/ui/Loader';
 import { NotFoundPage } from '../../../../shared/ui/NotFoundPage';
 import { WebMapView } from '../../../../shared/components/WebMapView';
 import { TagChip } from '../../../../shared/components/TagChip';
+import { useToast } from '../../../../shared/hooks/useToast';
 import { userService } from '../../../profile/application/services';
 import { createInitialStoryDetailUiState } from '../state/storiesUiState';
 import { loadStoryDetail } from '../state/storyDetailController';
@@ -39,6 +43,11 @@ interface StoryScreenProps {
   getStory?: typeof storyService.getStory;
   deleteStory?: typeof storyService.deleteStory;
   getPublicProfile?: typeof userService.getPublicProfile;
+}
+
+interface ReportTarget {
+  targetType: ReportTargetType;
+  targetId: string;
 }
 
 function formatDate(dateString: string) {
@@ -639,6 +648,7 @@ interface CommentsSectionProps {
   onDeleteRequest: (commentId: string) => void;
   onDeleteCancel: () => void;
   onDeleteConfirm: (commentId: string) => void;
+  onReportRequest: (commentId: string) => void;
 }
 
 function CommentsSection({
@@ -657,6 +667,7 @@ function CommentsSection({
   onDeleteRequest,
   onDeleteCancel,
   onDeleteConfirm,
+  onReportRequest,
 }: CommentsSectionProps) {
   const { colors, spacing, typography } = useAppTheme();
   const displayedComments = useMemo(() => sortCommentsNewestFirst(comments), [comments]);
@@ -728,11 +739,38 @@ function CommentsSection({
             {formatDate(comment.createdAt)}
           </Text>
           <Text style={{ marginTop: spacing.sm, color: colors.text }}>{comment.body}</Text>
-          {isOwnComment && !awaitingConfirm ? (
-            <View style={{ marginTop: spacing.md, alignItems: 'flex-end' }}>
-              <Pressable onPress={() => onDeleteRequest(comment.id)} accessibilityRole="button">
-                <Text style={{ color: colors.danger, fontWeight: '700' }}>Delete comment</Text>
-              </Pressable>
+          {!awaitingConfirm ? (
+            <View style={{ marginTop: spacing.md, flexDirection: 'row', justifyContent: 'flex-end', gap: spacing.md }}>
+              {!isOwnComment ? (
+                <Pressable
+                  onPress={() => onReportRequest(comment.id)}
+                  accessibilityRole="button"
+                  accessibilityLabel={`Report comment by ${authorDisplayName}`}
+                  style={({ pressed }) => ({
+                    minHeight: 44,
+                    flexDirection: 'row',
+                    alignItems: 'center',
+                    gap: spacing.xs,
+                    opacity: pressed ? 0.7 : 1,
+                  })}
+                >
+                  <Flag size={16} color={colors.muted} strokeWidth={2.2} />
+                  <Text style={{ color: colors.muted, fontWeight: '700' }}>Report</Text>
+                </Pressable>
+              ) : null}
+              {isOwnComment ? (
+                <Pressable
+                  onPress={() => onDeleteRequest(comment.id)}
+                  accessibilityRole="button"
+                  style={({ pressed }) => ({
+                    minHeight: 44,
+                    justifyContent: 'center',
+                    opacity: pressed ? 0.7 : 1,
+                  })}
+                >
+                  <Text style={{ color: colors.danger, fontWeight: '700' }}>Delete comment</Text>
+                </Pressable>
+              ) : null}
             </View>
           ) : null}
           {awaitingConfirm ? (
@@ -780,6 +818,7 @@ export function StoryScreen({
   getPublicProfile = userService.getPublicProfile,
 }: StoryScreenProps) {
   const { colors, spacing, typography } = useAppTheme();
+  const { toast } = useToast();
   const [state, setState] = useState(() =>
     createInitialStoryDetailUiState(session?.role !== undefined && session.role !== roles.guest),
   );
@@ -791,6 +830,9 @@ export function StoryScreen({
   const [storyDeleteError, setStoryDeleteError] = useState<string>();
   const [isCommentSubmitting, setIsCommentSubmitting] = useState(false);
   const [isStoryDeleting, setIsStoryDeleting] = useState(false);
+  const [reportTarget, setReportTarget] = useState<ReportTarget | null>(null);
+  const [isReportSubmitting, setIsReportSubmitting] = useState(false);
+  const [reportError, setReportError] = useState<string>();
   const [confirmDeleteId, setConfirmDeleteId] = useState<string>();
   const [interactionError, setInteractionError] = useState<string>();
   const [contributorVisibilityOverride, setContributorVisibilityOverride] = useState<string | null>(null);
@@ -810,6 +852,9 @@ export function StoryScreen({
     setCommentError(undefined);
     setDeleteError(undefined);
     setStoryDeleteError(undefined);
+    setReportTarget(null);
+    setIsReportSubmitting(false);
+    setReportError(undefined);
     setConfirmDeleteId(undefined);
     setInteractionError(undefined);
     setContributorVisibilityOverride(null);
@@ -1070,6 +1115,52 @@ export function StoryScreen({
     onRequestLogin?.();
   };
 
+  const handleReportRequest = (targetType: ReportTargetType, targetId: string) => {
+    if (!state.isAuthenticated) {
+      setState((current) => ({
+        ...current,
+        loginPromptVisible: true,
+      }));
+      onRequestLogin?.();
+      return;
+    }
+
+    setReportError(undefined);
+    setReportTarget({ targetType, targetId });
+  };
+
+  const handleSubmitReport = async ({
+    reason,
+    description,
+  }: {
+    reason: ReportReason;
+    description?: string;
+  }) => {
+    if (!reportTarget || isReportSubmitting) {
+      return;
+    }
+
+    setIsReportSubmitting(true);
+    setReportError(undefined);
+
+    try {
+      await reportService.reportContent({
+        ...reportTarget,
+        reason,
+        description,
+      });
+      setReportTarget(null);
+      toast.success('Report submitted. Our team will review it.');
+    } catch (error) {
+      const message = extractInteractionError(error, 'Failed to submit report. Please try again.');
+      setReportError(message.toLowerCase().includes('already reported')
+        ? 'You have already reported this content.'
+        : message);
+    } finally {
+      setIsReportSubmitting(false);
+    }
+  };
+
   const handleSubmitComment = async () => {
     const trimmedText = commentText.trim();
 
@@ -1156,6 +1247,7 @@ export function StoryScreen({
   const story = state.story;
   const isStoryOwner = session?.user?.id !== undefined && String(session.user.id) === story.contributorUserId;
   const canDeleteStory = session?.role === roles.admin || isStoryOwner;
+  const canReportStory = !isStoryOwner;
   const contributorName = contributorVisibilityOverride ?? getResolvedContributorName(story);
   const shouldShowContributor = contributorName.trim().length > 0;
   const contributorDisplayName = shouldShowContributor ? getDisplayNameWithYouLabel(contributorName, isStoryOwner) : undefined;
@@ -1344,11 +1436,35 @@ export function StoryScreen({
             {story.savedByViewer ? 'Saved' : 'Save'}
           </Text>
         </Pressable>
+
+        {canReportStory ? (
+          <Pressable
+            onPress={() => handleReportRequest('story', story.id)}
+            style={({ pressed }) => ({
+              paddingVertical: spacing.md,
+              paddingHorizontal: spacing.lg,
+              borderRadius: 999,
+              alignSelf: 'flex-start',
+              backgroundColor: colors.surface,
+              borderWidth: 1,
+              borderColor: colors.border,
+              flexDirection: 'row',
+              alignItems: 'center',
+              gap: spacing.xs,
+              opacity: pressed ? 0.75 : 1,
+            })}
+            accessibilityRole="button"
+            accessibilityLabel="Report story"
+          >
+            <Flag size={18} color={colors.muted} strokeWidth={2.2} />
+            <Text style={{ color: colors.muted, fontWeight: '700' }}>Report</Text>
+          </Pressable>
+        ) : null}
       </View>
 
       {state.loginPromptVisible ? (
         <Text style={{ marginTop: spacing.sm, color: colors.muted }}>
-          Log in to like, bookmark, or comment on this story.
+          Log in to like, bookmark, comment, or report this story.
         </Text>
       ) : null}
       {interactionError ? (
@@ -1380,6 +1496,23 @@ export function StoryScreen({
         onDeleteCancel={() => setConfirmDeleteId(undefined)}
         onDeleteConfirm={(commentId) => {
           void handleDeleteComment(commentId);
+        }}
+        onReportRequest={(commentId) => handleReportRequest('comment', commentId)}
+      />
+      <ReportSheet
+        key={reportTarget ? `${reportTarget.targetType}-${reportTarget.targetId}` : 'hidden-report-sheet'}
+        visible={Boolean(reportTarget)}
+        targetType={reportTarget?.targetType}
+        isSubmitting={isReportSubmitting}
+        error={reportError}
+        onClose={() => {
+          if (!isReportSubmitting) {
+            setReportTarget(null);
+            setReportError(undefined);
+          }
+        }}
+        onSubmit={(input) => {
+          void handleSubmitReport(input);
         }}
       />
       <StoryMiniMap story={story} />

--- a/mobile/src/features/stories/presentation/screens/__tests__/StoryScreen.test.tsx
+++ b/mobile/src/features/stories/presentation/screens/__tests__/StoryScreen.test.tsx
@@ -5,6 +5,9 @@ import { StoryScreen } from '../StoryScreen';
 import { Session } from '../../../../../core/auth/session';
 import { StoryEntity } from '../../../domain/entities';
 import { interactionService } from '../../../../interactions/application/services';
+import { reportService } from '../../../../reports/application/services';
+
+const mockToastSuccess = jest.fn();
 
 jest.mock('../../../../../shared/components/WebMapView', () => {
   const React = require('react');
@@ -27,6 +30,23 @@ jest.mock('../../../../interactions/application/services', () => ({
     addComment: jest.fn(async () => undefined),
     deleteComment: jest.fn(async () => undefined),
   },
+}));
+
+jest.mock('../../../../reports/application/services', () => ({
+  reportService: {
+    reportContent: jest.fn(async () => undefined),
+  },
+}));
+
+jest.mock('../../../../../shared/hooks/useToast', () => ({
+  useToast: () => ({
+    toast: {
+      success: mockToastSuccess,
+      error: jest.fn(),
+      info: jest.fn(),
+      show: jest.fn(),
+    },
+  }),
 }));
 
 const baseStory: StoryEntity = {
@@ -452,7 +472,7 @@ describe('StoryScreen', () => {
     fireEvent.press(screen.getByText('♡ 27'));
 
     await waitFor(() => {
-      expect(screen.getByText('Log in to like, bookmark, or comment on this story.')).toBeTruthy();
+      expect(screen.getByText('Log in to like, bookmark, comment, or report this story.')).toBeTruthy();
     });
     expect(onRequestLogin).toHaveBeenCalledTimes(1);
   });
@@ -540,7 +560,7 @@ describe('StoryScreen', () => {
     fireEvent.press(screen.getByLabelText('Bookmark story'));
 
     await waitFor(() => {
-      expect(screen.getByText('Log in to like, bookmark, or comment on this story.')).toBeTruthy();
+      expect(screen.getByText('Log in to like, bookmark, comment, or report this story.')).toBeTruthy();
     });
     expect(onRequestLogin).toHaveBeenCalledTimes(1);
     expect(interactionService.bookmarkStory).not.toHaveBeenCalled();
@@ -642,6 +662,106 @@ describe('StoryScreen', () => {
     expect(comments[0]).toHaveTextContent('My new comment');
   });
 
+  it('opens the story report sheet, requires a reason, submits, and shows a success toast', async () => {
+    render(
+      <StoryScreen
+        storyId="story-001"
+        session={userSession}
+        getStory={async () => baseStory}
+      />,
+    );
+
+    fireEvent.press(await screen.findByLabelText('Report story'));
+    expect(screen.getByText('Report story')).toBeTruthy();
+
+    fireEvent.press(screen.getByText('Submit report'));
+    expect(reportService.reportContent).not.toHaveBeenCalled();
+
+    fireEvent.press(screen.getByLabelText('Report reason: Harassment'));
+    fireEvent.press(screen.getByText('Submit report'));
+
+    await waitFor(() => {
+      expect(reportService.reportContent).toHaveBeenCalledWith({
+        targetType: 'story',
+        targetId: 'story-001',
+        reason: 'harassment',
+        description: '',
+      });
+      expect(mockToastSuccess).toHaveBeenCalledWith('Report submitted. Our team will review it.');
+    });
+  });
+
+  it('closes the report sheet without submitting', async () => {
+    render(
+      <StoryScreen
+        storyId="story-001"
+        session={userSession}
+        getStory={async () => baseStory}
+      />,
+    );
+
+    fireEvent.press(await screen.findByLabelText('Report story'));
+    expect(screen.getByLabelText('Report reason: Spam')).toBeTruthy();
+
+    fireEvent.press(screen.getByLabelText('Close report modal'));
+
+    await waitFor(() => {
+      expect(screen.queryByLabelText('Report reason: Spam')).toBeNull();
+    });
+    expect(reportService.reportContent).not.toHaveBeenCalled();
+  });
+
+  it('submits comment reports with optional details for the other reason', async () => {
+    render(
+      <StoryScreen
+        storyId="story-001"
+        session={userSession}
+        getStory={async () => baseStory}
+      />,
+    );
+
+    await screen.findByText(baseStory.comments[0].body);
+    fireEvent.press(screen.getByLabelText('Report comment by Mert Kaya'));
+    expect(screen.getByText('Report comment')).toBeTruthy();
+
+    fireEvent.press(screen.getByLabelText('Report reason: Other'));
+    fireEvent.changeText(screen.getByLabelText('Report details'), 'This includes private information.');
+    fireEvent.press(screen.getByText('Submit report'));
+
+    await waitFor(() => {
+      expect(reportService.reportContent).toHaveBeenCalledWith({
+        targetType: 'comment',
+        targetId: 'comment-1',
+        reason: 'other',
+        description: 'This includes private information.',
+      });
+    });
+  });
+
+  it('shows duplicate report errors inside the report sheet', async () => {
+    (reportService.reportContent as jest.Mock).mockRejectedValueOnce({
+      response: {
+        data: {
+          non_field_errors: ['You have already reported this content.'],
+        },
+      },
+    });
+
+    render(
+      <StoryScreen
+        storyId="story-001"
+        session={userSession}
+        getStory={async () => baseStory}
+      />,
+    );
+
+    fireEvent.press(await screen.findByLabelText('Report story'));
+    fireEvent.press(screen.getByLabelText('Report reason: Spam'));
+    fireEvent.press(screen.getByText('Submit report'));
+
+    expect(await screen.findByText('You have already reported this content.')).toBeTruthy();
+  });
+
   it('shows delete controls only for the user’s own comments and deletes after confirmation', async () => {
     (interactionService.deleteComment as jest.Mock).mockResolvedValueOnce(undefined);
     (interactionService.getComments as jest.Mock).mockResolvedValueOnce([
@@ -686,6 +806,8 @@ describe('StoryScreen', () => {
     await screen.findByText('My own comment');
     expect(screen.getByText('Delete comment')).toBeTruthy();
     expect(screen.queryAllByText('Delete comment')).toHaveLength(1);
+    expect(screen.queryByLabelText('Report comment by Traveler (You)')).toBeNull();
+    expect(screen.getByLabelText('Report comment by Someone else')).toBeTruthy();
 
     fireEvent.press(screen.getByText('Delete comment'));
     expect(screen.getByText('Delete this comment?')).toBeTruthy();
@@ -739,6 +861,7 @@ describe('StoryScreen', () => {
     expect(screen.getByText('Traveler (You)')).toBeTruthy();
     expect(screen.queryByText('Anonymous')).toBeNull();
     expect(screen.getByText('Delete comment')).toBeTruthy();
+    expect(screen.queryByLabelText('Report comment by Traveler (You)')).toBeNull();
   });
 
   it('shows the delete story action only to the owner or an admin', async () => {
@@ -773,6 +896,19 @@ describe('StoryScreen', () => {
     );
 
     expect(await screen.findByLabelText('Delete story')).toBeTruthy();
+  });
+
+  it('does not show the report story action to the story owner', async () => {
+    render(
+      <StoryScreen
+        storyId="story-001"
+        session={ownerSession}
+        getStory={async () => baseStory}
+      />,
+    );
+
+    expect(await screen.findByLabelText('Delete story')).toBeTruthy();
+    expect(screen.queryByLabelText('Report story')).toBeNull();
   });
 
   it('confirms and deletes the story for authorized users', async () => {
@@ -891,6 +1027,25 @@ describe('StoryScreen', () => {
       expect(screen.getByText('Log in to comment on this story.')).toBeTruthy();
     });
     expect(onRequestLogin).toHaveBeenCalledTimes(1);
+  });
+
+  it('prompts unauthenticated users when they try to report', async () => {
+    const onRequestLogin = jest.fn();
+
+    render(
+      <StoryScreen
+        storyId="story-001"
+        session={guestSession}
+        onRequestLogin={onRequestLogin}
+        getStory={async () => baseStory}
+      />,
+    );
+
+    fireEvent.press(await screen.findByLabelText('Report story'));
+
+    expect(await screen.findByText('Log in to like, bookmark, comment, or report this story.')).toBeTruthy();
+    expect(onRequestLogin).toHaveBeenCalledTimes(1);
+    expect(reportService.reportContent).not.toHaveBeenCalled();
   });
 
   it('renders the 404 state when the story does not exist', async () => {


### PR DESCRIPTION
# 📝 Description
Fixes #214

Adds the mobile reporting flow for story detail and comments. Authenticated users can report other users' stories and comments from the story screen, choose a moderation reason, optionally add details for "Other", and submit through the reports API. The UI hides report actions for the signed-in user's own stories/comments and shows a login prompt for guests.

# 📊 Type of Change
- [ ]  Bug fix
- [x]  New feature
- [ ]  Refactoring
- [ ]  Documentation
 
# ✅ Acceptance Criteria / Checklist
- [x] Project builds successfully
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, especially in hard-to-understand parts
- [x] I have performed a self-review of my code
- [x] I have added/updated tests
- [x] New and existing unit tests pass locally with my changes

# 📸 Screenshots / Recordings
N/A

# ⏱️ Estimated Review Time
- [ ] < 5 min
- [x] 5-15 min
- [ ] > 15 min
