### PR TITLE
fix: mobile preserve own profile follow counts

### DIFF
--- a/mobile/src/features/profile/application/services/__tests__/userService.test.ts
+++ b/mobile/src/features/profile/application/services/__tests__/userService.test.ts
@@ -43,6 +43,8 @@ describe('userService', () => {
             username: 'Traveler',
             total_points: 5,
             published_story_count: 3,
+            followers_count: 14,
+            following_count: 6,
             birth_year: 1995,
             location: 'Istanbul',
             bio: 'Collecting neighborhood memories.',
@@ -60,6 +62,8 @@ describe('userService', () => {
       email: 'traveler@example.com',
       location: 'Istanbul',
       publishedStoryCount: 3,
+      followersCount: 14,
+      followingCount: 6,
       birthYear: 1995,
     });
   });

--- a/mobile/src/features/profile/data/mappers/__tests__/profileMappers.test.ts
+++ b/mobile/src/features/profile/data/mappers/__tests__/profileMappers.test.ts
@@ -56,6 +56,8 @@ describe('profile mappers', () => {
         username: 'Traveler',
         email: 'traveler@example.com',
         totalPoints: 5,
+        followers_count: 8,
+        following_count: '13',
         isUsernamePublic: true,
         profile: {
           firstName: 'Ada',
@@ -72,6 +74,8 @@ describe('profile mappers', () => {
       firstName: 'Ada',
       birthDate: '1994-01-01',
       profilePhoto: 'https://example.com/me.jpg',
+      followersCount: 8,
+      followingCount: 13,
       isUsernamePublic: true,
       isPhotoPublic: true,
     });
@@ -89,16 +93,20 @@ describe('profile mappers', () => {
           stats: {
             publishedStoryCount: 6,
           },
+          followers_count: 11,
+          following_count: 9,
           birthYear: 1994,
         },
       ),
     ).toMatchObject({
       publishedStoryCount: 6,
+      followersCount: 11,
+      followingCount: 9,
       birthYear: 1994,
     });
   });
 
-  it('keeps existing published story count when public summary omits it', () => {
+  it('keeps existing summary counts when public summary omits them', () => {
     expect(
       mergePublicProfileSummary(
         {
@@ -106,6 +114,8 @@ describe('profile mappers', () => {
           username: 'Traveler',
           totalPoints: 5,
           publishedStoryCount: 4,
+          followersCount: 8,
+          followingCount: 13,
         },
         {
           stats: {},
@@ -114,6 +124,8 @@ describe('profile mappers', () => {
       ),
     ).toMatchObject({
       publishedStoryCount: 4,
+      followersCount: 8,
+      followingCount: 13,
       birthYear: 1994,
     });
   });

--- a/mobile/src/features/profile/data/mappers/index.ts
+++ b/mobile/src/features/profile/data/mappers/index.ts
@@ -68,6 +68,14 @@ function hasPublishedStoryCount(profile: Record<string, unknown>) {
   );
 }
 
+function hasFollowersCount(profile: Record<string, unknown>) {
+  return profile.followers_count !== undefined || profile.followersCount !== undefined;
+}
+
+function hasFollowingCount(profile: Record<string, unknown>) {
+  return profile.following_count !== undefined || profile.followingCount !== undefined;
+}
+
 export function mapCurrentProfile(profile: Record<string, unknown>): ProfileEntity {
   const nestedProfile = getNestedProfile(profile);
 
@@ -112,6 +120,12 @@ export function mapCurrentProfile(profile: Record<string, unknown>): ProfileEnti
       nestedProfile.is_photo_public === undefined && nestedProfile.isPhotoPublic === undefined
         ? undefined
         : Boolean(nestedProfile.is_photo_public ?? nestedProfile.isPhotoPublic),
+    ...(hasFollowersCount(profile)
+      ? { followersCount: asNumber(profile.followers_count ?? profile.followersCount) }
+      : {}),
+    ...(hasFollowingCount(profile)
+      ? { followingCount: asNumber(profile.following_count ?? profile.followingCount) }
+      : {}),
   };
 }
 
@@ -172,6 +186,12 @@ export function mergePublicProfileSummary(
     publishedStoryCount: hasPublishedStoryCount(publicProfile)
       ? mappedPublicProfile.publishedStoryCount
       : profile.publishedStoryCount,
+    followersCount: hasFollowersCount(publicProfile)
+      ? mappedPublicProfile.followersCount
+      : profile.followersCount,
+    followingCount: hasFollowingCount(publicProfile)
+      ? mappedPublicProfile.followingCount
+      : profile.followingCount,
     birthYear: profile.birthDate ? profile.birthYear : mappedPublicProfile.birthYear ?? profile.birthYear,
   };
 }


### PR DESCRIPTION
# 📝 Description
Fixes #576

Preserves follower and following counts on the authenticated user's own profile.

The self-profile flow loads `/users/me/` first and then merges the public profile summary. The current-profile mapper did not accept follower/following counts, and the public summary merge only preserved story count and birth year. As a result, `ProfileScreen` received missing counts and displayed `0`.

This PR maps counts from `/users/me/` when available, merges counts from the public profile summary, and keeps existing counts when the summary omits them.

# 📊 Type of Change
- [x]  Bug fix
- [ ]  New feature
- [ ]  Refactoring
- [ ]  Documentation
 
# ✅ Acceptance Criteria / Checklist
- [x] Project builds successfully
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, especially in hard-to-understand parts
- [x] I have performed a self-review of my code
- [x] I have added/updated tests
- [x] New and existing unit tests pass locally with my changes

# 📸 Screenshots / Recordings
Not applicable; this is a data mapping fix covered by unit tests.

# ⏱️ Estimated Review Time
- [ ] < 5 min
- [x] 5-15 min
- [ ] > 15 min
