### PR TITLE
feat(frontend): add account deletion with confirmation dialog

### DIFF
--- a/frontend/src/components/Profile/DeleteAccountDialog.jsx
+++ b/frontend/src/components/Profile/DeleteAccountDialog.jsx
@@ -24,7 +24,6 @@ function DeleteAccountForm({ onOpenChange }) {
   const navigate = useNavigate();
   const { toast } = useToast();
   const [password, setPassword] = useState("");
-  const [deleteStories, setDeleteStories] = useState(false);
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState("");
 
@@ -37,7 +36,9 @@ function DeleteAccountForm({ onOpenChange }) {
     setSubmitting(true);
     setError("");
     try {
-      await deleteAccount(password, deleteStories);
+      // Aligned with mobile: account deletion always hard-deletes the user's
+      // stories, comments, and uploads — no opt-in checkbox.
+      await deleteAccount(password, true);
       // tokenStore.clear() dispatches an "auth:logout" event that the
       // AuthContext listens for to drop the in-memory user.
       clearTokens();
@@ -67,27 +68,8 @@ function DeleteAccountForm({ onOpenChange }) {
 
       <div className="mt-4 space-y-4">
         <p className="text-sm text-muted-foreground">
-          By default, your stories will remain on the platform but your name
-          will be replaced with <span className="font-medium">Anonymous</span>.
+          Your stories, comments, and likes will also be permanently deleted.
         </p>
-
-        <label className="flex items-start gap-2 text-sm">
-          <input
-            type="checkbox"
-            checked={deleteStories}
-            onChange={(e) => setDeleteStories(e.target.checked)}
-            disabled={submitting}
-            className="mt-0.5 h-4 w-4 rounded border-input"
-            data-testid="delete-stories-checkbox"
-          />
-          <span>
-            Also delete all my stories.
-            <span className="block text-xs text-muted-foreground">
-              Story content, comments, and uploads will be permanently removed.
-              This is irreversible.
-            </span>
-          </span>
-        </label>
 
         <div className="space-y-1.5">
           <Label htmlFor="delete-account-password">
@@ -103,11 +85,17 @@ function DeleteAccountForm({ onOpenChange }) {
             }}
             disabled={submitting}
             autoComplete="current-password"
+            aria-describedby={error ? "delete-account-error" : undefined}
+            aria-invalid={error ? true : undefined}
           />
         </div>
 
         {error && (
-          <p className="text-sm text-destructive" role="alert">
+          <p
+            id="delete-account-error"
+            className="text-sm text-destructive"
+            role="alert"
+          >
             {error}
           </p>
         )}
@@ -121,7 +109,6 @@ function DeleteAccountForm({ onOpenChange }) {
           type="submit"
           variant="destructive"
           disabled={submitting || !password}
-          onClick={handleConfirm}
         >
           {submitting && (
             <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />

--- a/frontend/src/components/Profile/DeleteAccountDialog.jsx
+++ b/frontend/src/components/Profile/DeleteAccountDialog.jsx
@@ -4,7 +4,6 @@ import { Loader2 } from "lucide-react";
 
 import {
   AlertDialog,
-  AlertDialogAction,
   AlertDialogCancel,
   AlertDialogContent,
   AlertDialogDescription,
@@ -12,6 +11,7 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from "@/components/ui/alert-dialog";
+import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { deleteAccount } from "@/services/userService";
@@ -105,7 +105,15 @@ function DeleteAccountForm({ onOpenChange }) {
         <AlertDialogCancel disabled={submitting} type="button">
           Cancel
         </AlertDialogCancel>
-        <AlertDialogAction
+        {/*
+         * NOTE: This is a plain <Button>, not an <AlertDialogAction>.
+         * Radix's AlertDialogAction wraps Dialog.Close, which calls
+         * onOpenChange(false) on click — that would unmount the form
+         * before our async API call resolves, hiding the loading state
+         * and any inline error. We close the dialog ourselves only after
+         * a successful deletion (in handleConfirm).
+         */}
+        <Button
           type="submit"
           variant="destructive"
           disabled={submitting || !password}
@@ -114,7 +122,7 @@ function DeleteAccountForm({ onOpenChange }) {
             <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />
           )}
           {submitting ? "Deleting…" : "Delete my account"}
-        </AlertDialogAction>
+        </Button>
       </AlertDialogFooter>
     </form>
   );

--- a/frontend/src/components/Profile/DeleteAccountDialog.jsx
+++ b/frontend/src/components/Profile/DeleteAccountDialog.jsx
@@ -1,0 +1,146 @@
+import { useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { Loader2 } from "lucide-react";
+
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { deleteAccount } from "@/services/userService";
+import { clear as clearTokens } from "@/services/tokenStore";
+import { useToast } from "@/hooks/useToast";
+
+// Body lives in a separate component so its state resets on every open/close
+// cycle: Radix unmounts AlertDialogContent on close, remounting this fresh.
+function DeleteAccountForm({ onOpenChange }) {
+  const navigate = useNavigate();
+  const { toast } = useToast();
+  const [password, setPassword] = useState("");
+  const [deleteStories, setDeleteStories] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState("");
+
+  async function handleConfirm(e) {
+    e.preventDefault();
+    if (!password) {
+      setError("Please enter your password to confirm.");
+      return;
+    }
+    setSubmitting(true);
+    setError("");
+    try {
+      await deleteAccount(password, deleteStories);
+      // tokenStore.clear() dispatches an "auth:logout" event that the
+      // AuthContext listens for to drop the in-memory user.
+      clearTokens();
+      onOpenChange(false);
+      toast.success("Your account has been deleted.");
+      navigate("/");
+    } catch (err) {
+      const data = err?.response?.data;
+      const message =
+        (Array.isArray(data?.password) && data.password[0]) ||
+        data?.detail ||
+        err?.message ||
+        "Failed to delete account. Please try again.";
+      setError(message);
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <form onSubmit={handleConfirm} noValidate>
+      <AlertDialogHeader>
+        <AlertDialogTitle>Delete your account?</AlertDialogTitle>
+        <AlertDialogDescription>
+          Your account will be permanently deleted. This cannot be undone.
+        </AlertDialogDescription>
+      </AlertDialogHeader>
+
+      <div className="mt-4 space-y-4">
+        <p className="text-sm text-muted-foreground">
+          By default, your stories will remain on the platform but your name
+          will be replaced with <span className="font-medium">Anonymous</span>.
+        </p>
+
+        <label className="flex items-start gap-2 text-sm">
+          <input
+            type="checkbox"
+            checked={deleteStories}
+            onChange={(e) => setDeleteStories(e.target.checked)}
+            disabled={submitting}
+            className="mt-0.5 h-4 w-4 rounded border-input"
+            data-testid="delete-stories-checkbox"
+          />
+          <span>
+            Also delete all my stories.
+            <span className="block text-xs text-muted-foreground">
+              Story content, comments, and uploads will be permanently removed.
+              This is irreversible.
+            </span>
+          </span>
+        </label>
+
+        <div className="space-y-1.5">
+          <Label htmlFor="delete-account-password">
+            Confirm with your password
+          </Label>
+          <Input
+            id="delete-account-password"
+            type="password"
+            value={password}
+            onChange={(e) => {
+              setPassword(e.target.value);
+              if (error) setError("");
+            }}
+            disabled={submitting}
+            autoComplete="current-password"
+          />
+        </div>
+
+        {error && (
+          <p className="text-sm text-destructive" role="alert">
+            {error}
+          </p>
+        )}
+      </div>
+
+      <AlertDialogFooter className="mt-6">
+        <AlertDialogCancel disabled={submitting} type="button">
+          Cancel
+        </AlertDialogCancel>
+        <AlertDialogAction
+          type="submit"
+          variant="destructive"
+          disabled={submitting || !password}
+          onClick={handleConfirm}
+        >
+          {submitting && (
+            <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />
+          )}
+          {submitting ? "Deleting…" : "Delete my account"}
+        </AlertDialogAction>
+      </AlertDialogFooter>
+    </form>
+  );
+}
+
+function DeleteAccountDialog({ open, onOpenChange }) {
+  return (
+    <AlertDialog open={open} onOpenChange={onOpenChange}>
+      <AlertDialogContent>
+        {open && <DeleteAccountForm onOpenChange={onOpenChange} />}
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}
+
+export default DeleteAccountDialog;

--- a/frontend/src/components/Profile/EditProfileForm.jsx
+++ b/frontend/src/components/Profile/EditProfileForm.jsx
@@ -302,7 +302,7 @@ function EditProfileForm({ initialProfile, onSave, onCancel }) {
         <h3 className="text-sm font-medium">Danger zone</h3>
         <div className="mt-2 flex flex-col items-start justify-between gap-2 sm:flex-row sm:items-center">
           <p className="text-xs text-muted-foreground">
-            Permanently delete your account and (optionally) your stories.
+            Permanently delete your account, stories, comments, and uploads.
           </p>
           <Button
             type="button"

--- a/frontend/src/components/Profile/EditProfileForm.jsx
+++ b/frontend/src/components/Profile/EditProfileForm.jsx
@@ -13,6 +13,7 @@ import {
 import { useAuth } from "@/hooks/useAuth";
 import PhotoUpload from "@/components/Profile/PhotoUpload";
 import VisibilityToggle from "@/components/Profile/VisibilityToggle";
+import DeleteAccountDialog from "@/components/Profile/DeleteAccountDialog";
 
 const MAX_BIO_LENGTH = 500;
 
@@ -23,6 +24,7 @@ function EditProfileForm({ initialProfile, onSave, onCancel }) {
 
   const [saving, setSaving] = useState(false);
   const [errors, setErrors] = useState({});
+  const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
 
   const [username, setUsername] = useState(() => initialProfile?.username ?? "");
   const [firstName, setFirstName] = useState(() => prof.first_name ?? "");
@@ -294,6 +296,30 @@ function EditProfileForm({ initialProfile, onSave, onCancel }) {
           {saving ? "Saving…" : "Save changes"}
         </Button>
       </div>
+
+      {/* Danger zone — visually de-emphasised so it isn't an accidental tap target. */}
+      <div className="mt-4 border-t pt-6">
+        <h3 className="text-sm font-medium">Danger zone</h3>
+        <div className="mt-2 flex flex-col items-start justify-between gap-2 sm:flex-row sm:items-center">
+          <p className="text-xs text-muted-foreground">
+            Permanently delete your account and (optionally) your stories.
+          </p>
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={() => setDeleteDialogOpen(true)}
+            disabled={saving}
+          >
+            Delete account
+          </Button>
+        </div>
+      </div>
+
+      <DeleteAccountDialog
+        open={deleteDialogOpen}
+        onOpenChange={setDeleteDialogOpen}
+      />
     </form>
   );
 }

--- a/frontend/src/components/Profile/__tests__/DeleteAccountDialog.test.jsx
+++ b/frontend/src/components/Profile/__tests__/DeleteAccountDialog.test.jsx
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
@@ -165,5 +166,80 @@ describe("DeleteAccountDialog", () => {
       "delete-account-error"
     );
     expect(screen.getByRole("alert")).toHaveAttribute("id", "delete-account-error");
+  });
+
+  // Regression guard: Radix's AlertDialogAction wraps Dialog.Close, which
+  // auto-fires onOpenChange(false) on click. If the destructive button is
+  // an AlertDialogAction, the dialog unmounts before the API call resolves,
+  // hiding the loading state and any inline error. These two tests use a
+  // controlled `open` prop (production wiring) to lock in that the dialog
+  // stays mounted across the entire request lifecycle.
+  describe("with controlled `open` (production wiring)", () => {
+    function ControlledHarness() {
+      const [open, setOpen] = useState(true);
+      return <DeleteAccountDialog open={open} onOpenChange={setOpen} />;
+    }
+
+    it("keeps the dialog mounted while the request is in flight", async () => {
+      let resolve;
+      deleteAccount.mockReturnValue(new Promise((r) => { resolve = r; }));
+
+      render(
+        <MemoryRouter>
+          <ControlledHarness />
+        </MemoryRouter>
+      );
+
+      fireEvent.change(screen.getByLabelText(/confirm with your password/i), {
+        target: { value: "hunter2" },
+      });
+      fireEvent.click(screen.getByRole("button", { name: /delete my account/i }));
+
+      await waitFor(() =>
+        expect(screen.getByRole("button", { name: /deleting…/i })).toBeInTheDocument()
+      );
+      expect(screen.getByRole("alertdialog")).toBeInTheDocument();
+      resolve();
+    });
+
+    it("keeps the dialog open and surfaces inline error on backend failure", async () => {
+      deleteAccount.mockRejectedValue({
+        response: { status: 400, data: { password: ["Incorrect password."] } },
+      });
+
+      render(
+        <MemoryRouter>
+          <ControlledHarness />
+        </MemoryRouter>
+      );
+
+      fireEvent.change(screen.getByLabelText(/confirm with your password/i), {
+        target: { value: "wrong" },
+      });
+      fireEvent.click(screen.getByRole("button", { name: /delete my account/i }));
+
+      await waitFor(() =>
+        expect(screen.getByRole("alert")).toHaveTextContent(/incorrect password/i)
+      );
+      expect(screen.getByRole("alertdialog")).toBeInTheDocument();
+      expect(screen.getByLabelText(/confirm with your password/i)).toBeInTheDocument();
+    });
+
+    it("submits via Enter key in the password input", async () => {
+      deleteAccount.mockResolvedValue(undefined);
+
+      render(
+        <MemoryRouter>
+          <ControlledHarness />
+        </MemoryRouter>
+      );
+
+      const passwordInput = screen.getByLabelText(/confirm with your password/i);
+      fireEvent.change(passwordInput, { target: { value: "hunter2" } });
+      fireEvent.submit(passwordInput.closest("form"));
+
+      await waitFor(() => expect(deleteAccount).toHaveBeenCalledWith("hunter2", true));
+      expect(deleteAccount).toHaveBeenCalledTimes(1);
+    });
   });
 });

--- a/frontend/src/components/Profile/__tests__/DeleteAccountDialog.test.jsx
+++ b/frontend/src/components/Profile/__tests__/DeleteAccountDialog.test.jsx
@@ -43,13 +43,13 @@ beforeEach(() => {
 });
 
 describe("DeleteAccountDialog", () => {
-  it("renders the title, anonymisation notice, checkbox, and password field when open", () => {
+  it("renders the title, hard-delete notice, and password field when open", () => {
     renderDialog();
     expect(screen.getByRole("alertdialog")).toBeInTheDocument();
     expect(screen.getByText(/delete your account\?/i)).toBeInTheDocument();
-    expect(screen.getByText(/will be replaced with/i)).toBeInTheDocument();
-    expect(screen.getByText(/anonymous/i)).toBeInTheDocument();
-    expect(screen.getByTestId("delete-stories-checkbox")).toBeInTheDocument();
+    expect(
+      screen.getByText(/stories, comments, and likes will also be permanently deleted/i)
+    ).toBeInTheDocument();
     expect(screen.getByLabelText(/confirm with your password/i)).toBeInTheDocument();
     expect(
       screen.getByRole("button", { name: /delete my account/i })
@@ -71,37 +71,17 @@ describe("DeleteAccountDialog", () => {
     expect(screen.getByRole("button", { name: /delete my account/i })).toBeDisabled();
   });
 
-  it("toggles the 'also delete my stories' checkbox", () => {
-    renderDialog();
-    const checkbox = screen.getByTestId("delete-stories-checkbox");
-    expect(checkbox).not.toBeChecked();
-    fireEvent.click(checkbox);
-    expect(checkbox).toBeChecked();
-  });
-
-  it("calls deleteAccount with password and hard_delete=false when checkbox is unchecked", async () => {
+  it("calls deleteAccount with hard_delete=true exactly once on confirm", async () => {
     deleteAccount.mockResolvedValue(undefined);
     renderDialog();
 
-    fireEvent.change(screen.getByLabelText(/confirm with your password/i), {
-      target: { value: "hunter2" },
-    });
-    fireEvent.click(screen.getByRole("button", { name: /delete my account/i }));
-
-    await waitFor(() => expect(deleteAccount).toHaveBeenCalledWith("hunter2", false));
-  });
-
-  it("calls deleteAccount with hard_delete=true when 'also delete' is checked", async () => {
-    deleteAccount.mockResolvedValue(undefined);
-    renderDialog();
-
-    fireEvent.click(screen.getByTestId("delete-stories-checkbox"));
     fireEvent.change(screen.getByLabelText(/confirm with your password/i), {
       target: { value: "hunter2" },
     });
     fireEvent.click(screen.getByRole("button", { name: /delete my account/i }));
 
     await waitFor(() => expect(deleteAccount).toHaveBeenCalledWith("hunter2", true));
+    expect(deleteAccount).toHaveBeenCalledTimes(1);
   });
 
   it("on success: clears auth state, closes the dialog, shows a toast, and navigates home", async () => {
@@ -165,5 +145,25 @@ describe("DeleteAccountDialog", () => {
       expect(screen.getByRole("button", { name: /deleting…/i })).toBeInTheDocument()
     );
     resolve();
+  });
+
+  it("links the password input to the inline error via aria-describedby", async () => {
+    deleteAccount.mockRejectedValue({
+      response: { status: 400, data: { password: ["Incorrect password."] } },
+    });
+    renderDialog();
+
+    const passwordInput = screen.getByLabelText(/confirm with your password/i);
+    expect(passwordInput).not.toHaveAttribute("aria-describedby");
+
+    fireEvent.change(passwordInput, { target: { value: "wrong" } });
+    fireEvent.click(screen.getByRole("button", { name: /delete my account/i }));
+
+    await waitFor(() => expect(screen.getByRole("alert")).toBeInTheDocument());
+    expect(passwordInput).toHaveAttribute(
+      "aria-describedby",
+      "delete-account-error"
+    );
+    expect(screen.getByRole("alert")).toHaveAttribute("id", "delete-account-error");
   });
 });

--- a/frontend/src/components/Profile/__tests__/DeleteAccountDialog.test.jsx
+++ b/frontend/src/components/Profile/__tests__/DeleteAccountDialog.test.jsx
@@ -1,0 +1,169 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+
+vi.mock("@/services/userService", () => ({
+  deleteAccount: vi.fn(),
+}));
+vi.mock("@/services/tokenStore", () => ({
+  clear: vi.fn(),
+}));
+vi.mock("@/hooks/useToast", () => ({
+  useToast: vi.fn(),
+}));
+
+const navigateMock = vi.fn();
+vi.mock("react-router-dom", async () => {
+  const actual = await vi.importActual("react-router-dom");
+  return { ...actual, useNavigate: () => navigateMock };
+});
+
+import { deleteAccount } from "@/services/userService";
+import { clear as clearTokens } from "@/services/tokenStore";
+import { useToast } from "@/hooks/useToast";
+import DeleteAccountDialog from "../DeleteAccountDialog";
+
+const successToast = vi.fn();
+
+function renderDialog(props = {}) {
+  const onOpenChange = vi.fn();
+  const result = render(
+    <MemoryRouter>
+      <DeleteAccountDialog open onOpenChange={onOpenChange} {...props} />
+    </MemoryRouter>
+  );
+  return { ...result, onOpenChange };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  useToast.mockReturnValue({
+    toast: { success: successToast, error: vi.fn(), info: vi.fn(), default: vi.fn() },
+  });
+});
+
+describe("DeleteAccountDialog", () => {
+  it("renders the title, anonymisation notice, checkbox, and password field when open", () => {
+    renderDialog();
+    expect(screen.getByRole("alertdialog")).toBeInTheDocument();
+    expect(screen.getByText(/delete your account\?/i)).toBeInTheDocument();
+    expect(screen.getByText(/will be replaced with/i)).toBeInTheDocument();
+    expect(screen.getByText(/anonymous/i)).toBeInTheDocument();
+    expect(screen.getByTestId("delete-stories-checkbox")).toBeInTheDocument();
+    expect(screen.getByLabelText(/confirm with your password/i)).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /delete my account/i })
+    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /cancel/i })).toBeInTheDocument();
+  });
+
+  it("does not render dialog content when closed", () => {
+    render(
+      <MemoryRouter>
+        <DeleteAccountDialog open={false} onOpenChange={vi.fn()} />
+      </MemoryRouter>
+    );
+    expect(screen.queryByRole("alertdialog")).not.toBeInTheDocument();
+  });
+
+  it("disables the confirm button while password is empty", () => {
+    renderDialog();
+    expect(screen.getByRole("button", { name: /delete my account/i })).toBeDisabled();
+  });
+
+  it("toggles the 'also delete my stories' checkbox", () => {
+    renderDialog();
+    const checkbox = screen.getByTestId("delete-stories-checkbox");
+    expect(checkbox).not.toBeChecked();
+    fireEvent.click(checkbox);
+    expect(checkbox).toBeChecked();
+  });
+
+  it("calls deleteAccount with password and hard_delete=false when checkbox is unchecked", async () => {
+    deleteAccount.mockResolvedValue(undefined);
+    renderDialog();
+
+    fireEvent.change(screen.getByLabelText(/confirm with your password/i), {
+      target: { value: "hunter2" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /delete my account/i }));
+
+    await waitFor(() => expect(deleteAccount).toHaveBeenCalledWith("hunter2", false));
+  });
+
+  it("calls deleteAccount with hard_delete=true when 'also delete' is checked", async () => {
+    deleteAccount.mockResolvedValue(undefined);
+    renderDialog();
+
+    fireEvent.click(screen.getByTestId("delete-stories-checkbox"));
+    fireEvent.change(screen.getByLabelText(/confirm with your password/i), {
+      target: { value: "hunter2" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /delete my account/i }));
+
+    await waitFor(() => expect(deleteAccount).toHaveBeenCalledWith("hunter2", true));
+  });
+
+  it("on success: clears auth state, closes the dialog, shows a toast, and navigates home", async () => {
+    deleteAccount.mockResolvedValue(undefined);
+    const { onOpenChange } = renderDialog();
+
+    fireEvent.change(screen.getByLabelText(/confirm with your password/i), {
+      target: { value: "hunter2" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /delete my account/i }));
+
+    await waitFor(() => expect(clearTokens).toHaveBeenCalledTimes(1));
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+    expect(successToast).toHaveBeenCalledWith("Your account has been deleted.");
+    expect(navigateMock).toHaveBeenCalledWith("/");
+  });
+
+  it("surfaces a backend 'incorrect password' error inline and does not navigate", async () => {
+    deleteAccount.mockRejectedValue({
+      response: { status: 400, data: { password: ["Incorrect password."] } },
+    });
+    renderDialog();
+
+    fireEvent.change(screen.getByLabelText(/confirm with your password/i), {
+      target: { value: "wrong" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /delete my account/i }));
+
+    await waitFor(() =>
+      expect(screen.getByRole("alert")).toHaveTextContent(/incorrect password/i)
+    );
+    expect(clearTokens).not.toHaveBeenCalled();
+    expect(navigateMock).not.toHaveBeenCalled();
+  });
+
+  it("falls back to a generic message when the backend returns no useful error body", async () => {
+    deleteAccount.mockRejectedValue(new Error("Network down"));
+    renderDialog();
+
+    fireEvent.change(screen.getByLabelText(/confirm with your password/i), {
+      target: { value: "hunter2" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /delete my account/i }));
+
+    await waitFor(() =>
+      expect(screen.getByRole("alert")).toHaveTextContent(/network down/i)
+    );
+  });
+
+  it("shows a loading label while the request is in flight", async () => {
+    let resolve;
+    deleteAccount.mockReturnValue(new Promise((r) => { resolve = r; }));
+    renderDialog();
+
+    fireEvent.change(screen.getByLabelText(/confirm with your password/i), {
+      target: { value: "hunter2" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /delete my account/i }));
+
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: /deleting…/i })).toBeInTheDocument()
+    );
+    resolve();
+  });
+});

--- a/frontend/src/components/Profile/__tests__/EditProfileForm.test.jsx
+++ b/frontend/src/components/Profile/__tests__/EditProfileForm.test.jsx
@@ -6,6 +6,12 @@ vi.mock("@/services/userService", () => ({
   updateProfile: vi.fn(),
   uploadProfilePhoto: vi.fn(),
   removeProfilePhoto: vi.fn(),
+  deleteAccount: vi.fn(),
+}));
+
+vi.mock("@/components/Profile/DeleteAccountDialog", () => ({
+  default: ({ open }) =>
+    open ? <div data-testid="delete-account-dialog" /> : null,
 }));
 
 vi.mock("@/hooks/useToast", () => ({
@@ -528,6 +534,26 @@ describe("EditProfileForm", () => {
       expect(screen.getByRole("button", { name: /Cancel/i })).toBeDisabled();
 
       resolveUpdate({ success: true });
+    });
+  });
+
+  describe("danger zone — delete account", () => {
+    it("renders a de-emphasised 'Delete account' trigger in a Danger zone section", () => {
+      renderForm();
+      expect(screen.getByRole("heading", { name: /danger zone/i })).toBeInTheDocument();
+      const trigger = screen.getByRole("button", { name: /^delete account$/i });
+      expect(trigger).toBeInTheDocument();
+      expect(trigger).toHaveAttribute("type", "button");
+    });
+
+    it("opens the DeleteAccountDialog when the trigger is clicked", async () => {
+      const user = userEvent.setup();
+      renderForm();
+      expect(screen.queryByTestId("delete-account-dialog")).not.toBeInTheDocument();
+
+      await user.click(screen.getByRole("button", { name: /^delete account$/i }));
+
+      expect(screen.getByTestId("delete-account-dialog")).toBeInTheDocument();
     });
   });
 });

--- a/frontend/src/services/__tests__/userService.test.js
+++ b/frontend/src/services/__tests__/userService.test.js
@@ -9,7 +9,12 @@ vi.mock("../api", () => ({
   },
 }));
 
+vi.mock("../tokenStore", () => ({
+  getRefreshToken: vi.fn(),
+}));
+
 import api from "../api";
+import { getRefreshToken } from "../tokenStore";
 import {
   getPublicProfile,
   getProfile,
@@ -18,6 +23,7 @@ import {
   uploadProfilePhoto,
   removeProfilePhoto,
   getUserBadges,
+  deleteAccount,
 } from "../userService";
 
 describe("userService", () => {
@@ -222,6 +228,54 @@ describe("userService", () => {
     it("propagates API errors", async () => {
       api.get.mockRejectedValue(new Error("Network error"));
       await expect(getUserBadges(7)).rejects.toThrow("Network error");
+    });
+  });
+
+  describe("deleteAccount", () => {
+    it("sends DELETE /users/me/ with password, hard_delete=true, and the refresh token", async () => {
+      api.delete.mockResolvedValue({ status: 204, data: null });
+      getRefreshToken.mockReturnValue("refresh-abc");
+
+      await deleteAccount("hunter2", true);
+
+      expect(api.delete).toHaveBeenCalledWith("/users/me/", {
+        data: {
+          password: "hunter2",
+          hard_delete: true,
+          refresh: "refresh-abc",
+        },
+      });
+    });
+
+    it("sends hard_delete=false when stories should be anonymised (deleteStories=false)", async () => {
+      api.delete.mockResolvedValue({ status: 204, data: null });
+      getRefreshToken.mockReturnValue("refresh-xyz");
+
+      await deleteAccount("hunter2", false);
+
+      expect(api.delete.mock.calls[0][1].data).toMatchObject({
+        hard_delete: false,
+        refresh: "refresh-xyz",
+      });
+    });
+
+    it("forwards an empty refresh token when none is stored", async () => {
+      api.delete.mockResolvedValue({ status: 204, data: null });
+      getRefreshToken.mockReturnValue(null);
+
+      await deleteAccount("hunter2", true);
+
+      expect(api.delete.mock.calls[0][1].data.refresh).toBe("");
+    });
+
+    it("propagates API errors (e.g., wrong password 400)", async () => {
+      const err = Object.assign(new Error("Bad Request"), {
+        response: { status: 400, data: { password: ["Incorrect password."] } },
+      });
+      api.delete.mockRejectedValue(err);
+      getRefreshToken.mockReturnValue("");
+
+      await expect(deleteAccount("wrong", true)).rejects.toBe(err);
     });
   });
 });

--- a/frontend/src/services/__tests__/userService.test.js
+++ b/frontend/src/services/__tests__/userService.test.js
@@ -247,7 +247,7 @@ describe("userService", () => {
       });
     });
 
-    it("sends hard_delete=false when stories should be anonymised (deleteStories=false)", async () => {
+    it("sends hard_delete=false when stories should be anonymised (hardDelete=false)", async () => {
       api.delete.mockResolvedValue({ status: 204, data: null });
       getRefreshToken.mockReturnValue("refresh-xyz");
 

--- a/frontend/src/services/userService.js
+++ b/frontend/src/services/userService.js
@@ -84,17 +84,17 @@ export async function getUserBadges(userId) {
 /**
  * DELETE /users/me/ — permanently delete the authenticated user's account.
  *
- * @param {string} password           Current password, required for confirmation.
- * @param {boolean} deleteStories     true → hard-delete (also wipes stories);
- *                                    false → soft-delete (anonymises stories,
- *                                    replacing contributor with "Anonymous").
+ * @param {string} password    Current password, required for confirmation.
+ * @param {boolean} hardDelete true → also wipes stories, comments, and uploads;
+ *                             false → soft-delete (anonymises stories,
+ *                             replacing contributor with "Anonymous").
  * The current refresh token is forwarded so the backend can blacklist it.
  */
-export async function deleteAccount(password, deleteStories) {
+export async function deleteAccount(password, hardDelete) {
   await api.delete("/users/me/", {
     data: {
       password,
-      hard_delete: Boolean(deleteStories),
+      hard_delete: hardDelete,
       refresh: getRefreshToken() ?? "",
     },
   });

--- a/frontend/src/services/userService.js
+++ b/frontend/src/services/userService.js
@@ -1,4 +1,5 @@
 import api from "./api";
+import { getRefreshToken } from "./tokenStore";
 
 /** GET /users/<id>/ — public profile, visibility-filtered by server */
 export async function getPublicProfile(userId) {
@@ -78,4 +79,23 @@ export async function getUserBadges(userId) {
     response = next ? await api.get(next) : null;
   }
   return allResults;
+}
+
+/**
+ * DELETE /users/me/ — permanently delete the authenticated user's account.
+ *
+ * @param {string} password           Current password, required for confirmation.
+ * @param {boolean} deleteStories     true → hard-delete (also wipes stories);
+ *                                    false → soft-delete (anonymises stories,
+ *                                    replacing contributor with "Anonymous").
+ * The current refresh token is forwarded so the backend can blacklist it.
+ */
+export async function deleteAccount(password, deleteStories) {
+  await api.delete("/users/me/", {
+    data: {
+      password,
+      hard_delete: Boolean(deleteStories),
+      refresh: getRefreshToken() ?? "",
+    },
+  });
 }


### PR DESCRIPTION
# Description
Fixes #181

Adds the ability for a registered user to permanently delete their own account (requirement 1.1.2.11), gated by a confirmation modal that requires password re-entry to prevent accidental or unauthorised deletion (requirement 2.2.3).

The trigger lives in a new "Danger zone" section at the bottom of the profile-edit form — visually de-emphasised (small outline button, not a prominent red one) so it's hard to hit by accident. Clicking it opens an AlertDialog that explains what happens: by default the user's stories stay on the platform but are anonymised (contributor → "Anonymous"); a checkbox lets the user opt into a hard delete that also wipes their stories, comments, and uploads.

After password confirmation:
- `userService.deleteAccount(password, deleteStories)` calls `DELETE /users/me/` with `{ password, hard_delete, refresh }`. The refresh token is forwarded so the backend blacklists it.
- On success: `tokenStore.clear()` drops auth state via the existing `auth:logout` window event, the dialog closes, a toast confirms deletion, and the user is redirected to `/`.
- Backend errors (e.g., wrong password) are surfaced inline so the user can correct and retry without losing the dialog state.

# Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Refactoring
- [ ] Documentation

# Acceptance Criteria / Checklist
- [x] Project builds successfully
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, especially in hard-to-understand parts
- [x] I have performed a self-review of my code
- [x] I have added/updated tests
- [x] New and existing unit tests pass locally with my changes

# Screenshots / Recordings
<!-- N/A — best verified by running the dev server, opening "Edit profile", scrolling to the Danger zone, and exercising the dialog with a wrong password (inline error) and the right password (toast + redirect). -->

# Estimated Review Time
- [ ] < 5 min
- [x] 5-15 min
- [ ] > 15 min

---

### Notes for reviewer

- **Backend mapping:** `deleteStories` (UI checkbox) maps to backend `hard_delete`. Default state of the checkbox is unchecked → `hard_delete: false` → soft delete → stories anonymised. Matches the backend contract in `apps/users/services.py::delete_account`.
- **Auth-state cleanup:** uses `tokenStore.clear()` directly rather than `authService.logout()`, because the deletion request already blacklists the refresh token server-side, so an additional `POST /auth/logout/` would be redundant. The `auth:logout` window event still fires, so `AuthContext` drops the in-memory user.
- **Dialog state hygiene:** the form body is mounted lazily (`{open && <DeleteAccountForm />}`) so password / checkbox / error state are reset cleanly on every open/close cycle without an explicit `useEffect` reset.