### PR TITLE
feat:admin-moderation-mobile

### DIFF
--- a/mobile/src/app/navigation/AdminNavigator.tsx
+++ b/mobile/src/app/navigation/AdminNavigator.tsx
@@ -1,10 +1,12 @@
 import React from 'react';
-import { View, Text } from 'react-native';
+import { ModerationScreen } from '../../features/moderation';
 
-export function AdminNavigator() {
-  return (
-    <View style={{ padding: 16 }}>
-      <Text>Admin Navigator Placeholder</Text>
-    </View>
-  );
+export function AdminNavigator({
+  onOpenStory,
+  onOpenComment,
+}: {
+  onOpenStory?: (storyId: string) => void;
+  onOpenComment?: (storyId: string, commentId: string) => void;
+}) {
+  return <ModerationScreen onOpenStory={onOpenStory} onOpenComment={onOpenComment} />;
 }

--- a/mobile/src/app/navigation/RootNavigator.tsx
+++ b/mobile/src/app/navigation/RootNavigator.tsx
@@ -474,7 +474,6 @@ export function RootNavigator() {
         snapshot.commentId === currentSnapshot.commentId &&
         snapshot.userId === currentSnapshot.userId &&
         snapshot.resetToken === currentSnapshot.resetToken
-        snapshot.commentId === currentSnapshot.commentId
       ) {
         return;
       }
@@ -491,7 +490,6 @@ export function RootNavigator() {
             previous?.commentId === currentSnapshot.commentId &&
             previous?.userId === currentSnapshot.userId &&
             previous?.resetToken === currentSnapshot.resetToken
-            previous?.commentId === currentSnapshot.commentId
           ) {
             return current;
           }
@@ -689,7 +687,6 @@ export function RootNavigator() {
         previousSnapshot?.commentId === resolvedRedirectTarget.commentId &&
         previousSnapshot?.userId === resolvedRedirectTarget.userId &&
         previousSnapshot?.resetToken === resolvedRedirectTarget.resetToken
-        previousSnapshot?.commentId === resolvedRedirectTarget.commentId
       ) {
         nextStack.pop();
       }

--- a/mobile/src/app/navigation/RootNavigator.tsx
+++ b/mobile/src/app/navigation/RootNavigator.tsx
@@ -20,15 +20,17 @@ import { useToast } from '../../shared/hooks/useToast';
 import { APP_NAME } from '../../core/constants/app';
 import { NotificationScreen, notificationService } from '../../features/notifications';
 import { NotificationEntity } from '../../features/notifications/domain/entities';
+import { ModerationScreen } from '../../features/moderation';
 
 type AppRoute = (typeof ROUTES)[keyof typeof ROUTES];
 interface RouteSnapshot {
   route: AppRoute;
   storyId?: string | null;
+  commentId?: string | null;
   userId?: string | null;
 }
 
-const protectedRoutes: AppRoute[] = [ROUTES.PROFILE, ROUTES.SUBMISSION, ROUTES.NOTIFICATIONS];
+const protectedRoutes: AppRoute[] = [ROUTES.PROFILE, ROUTES.SUBMISSION, ROUTES.NOTIFICATIONS, ROUTES.ADMIN_HOME];
 const NOTIFICATION_REFRESH_INTERVAL_MS = 45000;
 const MAIN_PAGER_ROUTES: AppRoute[] = [ROUTES.MAP, ROUTES.TIMELINE, ROUTES.FEED];
 
@@ -360,6 +362,7 @@ export function RootNavigator() {
   const { width } = useWindowDimensions();
   const [currentRoute, setCurrentRoute] = useState<AppRoute>(ROUTES.FEED);
   const [activeStoryId, setActiveStoryId] = useState<string | null>(null);
+  const [focusedCommentId, setFocusedCommentId] = useState<string | null>(null);
   const [activeUserId, setActiveUserId] = useState<string | null>(null);
   const [pendingVerification, setPendingVerification] = useState<{ email: string; password: string } | null>(null);
   const [shouldCompleteProfileAfterLogin, setShouldCompleteProfileAfterLogin] = useState(false);
@@ -379,9 +382,10 @@ export function RootNavigator() {
     () => ({
       route: currentRoute,
       storyId: currentRoute === ROUTES.STORY_DETAIL ? activeStoryId : null,
+      commentId: currentRoute === ROUTES.STORY_DETAIL ? focusedCommentId : null,
       userId: currentRoute === ROUTES.USER_PROFILE ? activeUserId : null,
     }),
-    [activeStoryId, activeUserId, currentRoute],
+    [activeStoryId, activeUserId, currentRoute, focusedCommentId],
   );
   const [redirectTarget, setRedirectTarget] = useState<RouteSnapshot>({ route: ROUTES.PROFILE });
   const canGoBack = backStack.length > 0;
@@ -419,6 +423,7 @@ export function RootNavigator() {
   const restoreSnapshot = useCallback((snapshot: RouteSnapshot) => {
     setCurrentRoute(snapshot.route);
     setActiveStoryId(snapshot.route === ROUTES.STORY_DETAIL ? snapshot.storyId ?? null : null);
+    setFocusedCommentId(snapshot.route === ROUTES.STORY_DETAIL ? snapshot.commentId ?? null : null);
     setActiveUserId(snapshot.route === ROUTES.USER_PROFILE ? snapshot.userId ?? null : null);
   }, []);
 
@@ -455,6 +460,7 @@ export function RootNavigator() {
         !options?.resetStack &&
         snapshot.route === currentSnapshot.route &&
         snapshot.storyId === currentSnapshot.storyId &&
+        snapshot.commentId === currentSnapshot.commentId &&
         snapshot.userId === currentSnapshot.userId
       ) {
         return;
@@ -469,6 +475,7 @@ export function RootNavigator() {
           if (
             previous?.route === currentSnapshot.route &&
             previous?.storyId === currentSnapshot.storyId &&
+            previous?.commentId === currentSnapshot.commentId &&
             previous?.userId === currentSnapshot.userId
           ) {
             return current;
@@ -561,7 +568,9 @@ export function RootNavigator() {
       showAuthRequiredMessage(
         route === ROUTES.PROFILE
           ? 'Please sign in to view your profile.'
-          : 'Please sign in to submit a story.',
+          : route === ROUTES.ADMIN_HOME
+            ? 'Please sign in with an admin account to continue.'
+            : 'Please sign in to submit a story.',
       );
       return;
     }
@@ -627,6 +636,7 @@ export function RootNavigator() {
       if (
         previousSnapshot?.route === resolvedRedirectTarget.route &&
         previousSnapshot?.storyId === resolvedRedirectTarget.storyId &&
+        previousSnapshot?.commentId === resolvedRedirectTarget.commentId &&
         previousSnapshot?.userId === resolvedRedirectTarget.userId
       ) {
         nextStack.pop();
@@ -714,6 +724,10 @@ export function RootNavigator() {
 
   const handleOpenStoryDetail = (storyId: string) => {
     navigateToSnapshot({ route: ROUTES.STORY_DETAIL, storyId });
+  };
+
+  const handleOpenStoryComment = (storyId: string, commentId: string) => {
+    navigateToSnapshot({ route: ROUTES.STORY_DETAIL, storyId, commentId });
   };
 
   const handleViewTimelineNearPin = useCallback(
@@ -895,10 +909,31 @@ export function RootNavigator() {
         </ScreenShell>
       </ProtectedScreen>
     );
+  } else if (currentRoute === ROUTES.ADMIN_HOME) {
+    content = (
+      <ProtectedScreen
+        title="Admin tools require sign-in"
+        description="Sign in with an admin account to continue."
+        onAuthenticated={handleLoginComplete}
+        onRegistrationPending={handleRegistrationPending}
+      >
+        <ScreenShell
+          title="Admin moderation"
+          description="Review reports, stories, and tags."
+          framed={false}
+          fillContent
+          hideHeader
+          flushBottom
+        >
+          <ModerationScreen onOpenStory={handleOpenStoryDetail} onOpenComment={handleOpenStoryComment} />
+        </ScreenShell>
+      </ProtectedScreen>
+    );
   } else if (currentRoute === ROUTES.STORY_DETAIL && activeStoryId) {
     content = (
       <StoryScreen
         storyId={activeStoryId}
+        focusedCommentId={focusedCommentId ?? undefined}
         session={user ? { role: user.role, user } : undefined}
         onRequestLogin={() => showAuthRequiredMessage('Please sign in to like stories and join the discussion.')}
         onGoBack={handleBack}
@@ -1070,6 +1105,13 @@ export function RootNavigator() {
           )}
           {isAuthenticated ? (
             <View style={{ flexDirection: 'row', alignItems: 'center', gap: spacing.sm }}>
+              {user?.role === 'admin' ? (
+                <TopIconButton
+                  label="Admin"
+                  filled={currentRoute === ROUTES.ADMIN_HOME}
+                  onPress={() => handleNavigate(ROUTES.ADMIN_HOME)}
+                />
+              ) : null}
               <NotificationBellButton
                 unreadCount={unreadNotificationCount}
                 onPress={() => handleNavigate(ROUTES.NOTIFICATIONS)}

--- a/mobile/src/features/moderation/application/services/__tests__/adminService.test.ts
+++ b/mobile/src/features/moderation/application/services/__tests__/adminService.test.ts
@@ -1,0 +1,110 @@
+import { resetApiTransport, setApiTransport } from '../../../../../core/api/client';
+import { adminService } from '../adminService';
+
+describe('adminService', () => {
+  afterEach(() => {
+    resetApiTransport();
+  });
+
+  it('hydrates comment reports with their parent story id when the report payload omits it', async () => {
+    const requests: string[] = [];
+
+    setApiTransport(async (method, config) => {
+      requests.push(`${method} ${config.url ?? ''}`);
+
+      if (method === 'GET' && config.url === '/moderation/reports/?page=1&page_size=10&status=pending') {
+        return {
+          status: 200,
+          data: {
+            count: 1,
+            next: null,
+            results: [
+              {
+                id: 11,
+                reporter: {
+                  id: 2,
+                  username: 'Reporter',
+                  email: 'reporter@example.com',
+                },
+                target_type: 'comment',
+                target_id: 99,
+                reason: 'spam',
+                status: 'pending',
+                created_at: '2026-05-01T12:00:00Z',
+              },
+            ],
+          } as never,
+          config,
+        };
+      }
+
+      if (method === 'GET' && config.url === '/stories/feed/?page=1&page_size=100&sort_by=recent') {
+        return {
+          status: 200,
+          data: {
+            count: 1,
+            next: null,
+            results: [
+              {
+                id: 7,
+                title: 'Reported story',
+              },
+            ],
+          } as never,
+          config,
+        };
+      }
+
+      if (method === 'GET' && config.url === '/stories/7/comments/?page=1&page_size=100') {
+        return {
+          status: 200,
+          data: {
+            count: 1,
+            next: null,
+            results: [
+              {
+                id: 99,
+                text: 'Reported comment',
+              },
+            ],
+          } as never,
+          config,
+        };
+      }
+
+      throw new Error(`Unexpected request: ${method} ${config.url}`);
+    });
+
+    const reports = await adminService.getReports({ status: 'pending' });
+
+    expect(reports.items[0]).toEqual(expect.objectContaining({
+      targetId: '99',
+      targetStoryId: '7',
+      targetType: 'comment',
+    }));
+    expect(requests).toContain('GET /stories/feed/?page=1&page_size=100&sort_by=recent');
+    expect(requests).toContain('GET /stories/7/comments/?page=1&page_size=100');
+  });
+
+  it('bans a user through the moderation endpoint', async () => {
+    const requests: string[] = [];
+
+    setApiTransport(async (method, config) => {
+      requests.push(`${method} ${config.url ?? ''}`);
+
+      if (method === 'PATCH' && config.url === '/moderation/users/12/ban/') {
+        return {
+          status: 204,
+          data: undefined as never,
+          config,
+        };
+      }
+
+      throw new Error(`Unexpected request: ${method} ${config.url}`);
+    });
+
+    await adminService.banUser('12');
+
+    expect(requests).toEqual(['PATCH /moderation/users/12/ban/']);
+  });
+});

--- a/mobile/src/features/moderation/application/services/adminService.ts
+++ b/mobile/src/features/moderation/application/services/adminService.ts
@@ -1,0 +1,373 @@
+import { apiClient } from '../../../../core/api/client';
+
+export type AdminReportStatus = 'pending' | 'resolved';
+export type AdminReportAction = 'no_action' | 'remove_content' | 'ban_user';
+
+export interface AdminPage<T> {
+  items: T[];
+  page: number;
+  totalCount: number;
+  hasNextPage: boolean;
+}
+
+export interface AdminUserSummary {
+  id: string;
+  username: string;
+  email?: string;
+}
+
+export interface AdminReport {
+  id: string;
+  reporter: AdminUserSummary;
+  targetType: string;
+  targetId: string;
+  targetStoryId?: string;
+  reason: string;
+  description?: string;
+  status: AdminReportStatus;
+  createdAt: string;
+  resolvedAt?: string | null;
+  resolutionOutcome?: string | null;
+}
+
+export interface AdminStory {
+  id: string;
+  title: string;
+  contributorName?: string | null;
+  locationName?: string | null;
+  status?: string;
+  submittedAt?: string | null;
+}
+
+export interface AdminTag {
+  id: string;
+  name: string;
+  storyCount: number;
+}
+
+type PaginatedResponse = {
+  count?: number;
+  next?: string | null;
+  results?: unknown[];
+};
+
+const PAGE_SIZE = 10;
+const COMMENT_STORY_LOOKUP_PAGE_SIZE = 100;
+const MAX_COMMENT_STORY_LOOKUP_PAGES = 20;
+const commentStoryIdCache = new Map<string, string>();
+
+export const adminService = {
+  async getReports({ page = 1, status }: { page?: number; status?: AdminReportStatus | 'all' } = {}): Promise<AdminPage<AdminReport>> {
+    const query = buildQuery({ page, page_size: PAGE_SIZE, status: status && status !== 'all' ? status : undefined });
+    const response = await getPage(`/moderation/reports/${query}`);
+
+    const reportsPage = mapPage(response, page, mapReport);
+
+    return {
+      ...reportsPage,
+      items: await hydrateCommentReportStoryIds(reportsPage.items),
+    };
+  },
+
+  async resolveReport(reportId: string, action: AdminReportAction, note = ''): Promise<AdminReport> {
+    const resolutionNote = [formatAction(action), note.trim()].filter(Boolean).join(' - ');
+    const response = await apiClient.patch<Record<string, unknown>>(
+      `/moderation/reports/${reportId}/resolve/`,
+      {
+        action,
+        resolution_note: resolutionNote,
+      },
+    );
+
+    if (!response) {
+      throw new Error('Report resolution did not return a report.');
+    }
+
+    return mapReport(response);
+  },
+
+  async getStories({ page = 1, query = '' }: { page?: number; query?: string } = {}): Promise<AdminPage<AdminStory>> {
+    const endpoint = query.trim() ? '/stories/search/' : '/stories/';
+    const response = await getPage(`${endpoint}${buildQuery({ page, page_size: PAGE_SIZE, q: query.trim() || undefined })}`);
+
+    return mapPage(response, page, mapStory);
+  },
+
+  async removeStory(storyId: string, reason: string): Promise<void> {
+    await apiClient.delete<void>(`/moderation/stories/${storyId}/`, {
+      data: {
+        moderation_reason: reason,
+      },
+    });
+  },
+
+  async banUser(userId: string): Promise<void> {
+    await apiClient.patch<void>(`/moderation/users/${userId}/ban/`);
+  },
+
+  async getTags({ page = 1, query = '' }: { page?: number; query?: string } = {}): Promise<AdminPage<AdminTag>> {
+    const response = await getPage(`/tags/${buildQuery({ page, page_size: PAGE_SIZE, q: query.trim() || undefined })}`);
+
+    return mapPage(response, page, mapTag);
+  },
+
+  async removeTag(tagId: string): Promise<void> {
+    await apiClient.delete<void>(`/moderation/tags/${tagId}/`);
+  },
+};
+
+export const moderationService = adminService;
+
+async function getPage(path: string): Promise<PaginatedResponse> {
+  const response = await apiClient.get<PaginatedResponse | unknown[]>(path);
+
+  if (Array.isArray(response)) {
+    return {
+      count: response.length,
+      next: null,
+      results: response,
+    };
+  }
+
+  return (response as PaginatedResponse | null) ?? {
+    count: 0,
+    next: null,
+    results: [],
+  };
+}
+
+function mapPage<T>(response: PaginatedResponse, page: number, mapper: (item: unknown) => T): AdminPage<T> {
+  const items = (response.results ?? []).map(mapper);
+
+  return {
+    items,
+    page,
+    totalCount: response.count ?? items.length,
+    hasNextPage: Boolean(response.next),
+  };
+}
+
+async function hydrateCommentReportStoryIds(reports: AdminReport[]) {
+  const missingCommentIds = Array.from(
+    new Set(
+      reports
+        .filter((report) => report.targetType === 'comment' && !report.targetStoryId)
+        .map((report) => report.targetId)
+        .filter(Boolean),
+    ),
+  );
+
+  const unresolvedCommentIds = missingCommentIds.filter((commentId) => !commentStoryIdCache.has(commentId));
+
+  if (unresolvedCommentIds.length) {
+    const resolved = await resolveStoryIdsForComments(unresolvedCommentIds);
+
+    resolved.forEach((storyId, commentId) => {
+      commentStoryIdCache.set(commentId, storyId);
+    });
+  }
+
+  return reports.map((report) => {
+    if (report.targetType !== 'comment' || report.targetStoryId) {
+      return report;
+    }
+
+    const targetStoryId = commentStoryIdCache.get(report.targetId);
+
+    return targetStoryId ? { ...report, targetStoryId } : report;
+  });
+}
+
+async function resolveStoryIdsForComments(commentIds: string[]) {
+  const unresolved = new Set(commentIds);
+  const resolved = new Map<string, string>();
+  let page = 1;
+  let hasNext = true;
+
+  while (hasNext && unresolved.size > 0 && page <= MAX_COMMENT_STORY_LOOKUP_PAGES) {
+    const storiesResponse = await getPage(
+      `/stories/feed/${buildQuery({
+        page,
+        page_size: COMMENT_STORY_LOOKUP_PAGE_SIZE,
+        sort_by: 'recent',
+      })}`,
+    );
+
+    const storyIds = (storiesResponse.results ?? [])
+      .map(getRecordId)
+      .filter((storyId): storyId is string => Boolean(storyId));
+
+    await Promise.all(
+      storyIds.map(async (storyId) => {
+        if (!unresolved.size) {
+          return;
+        }
+
+        const comments = await fetchStoryCommentsForLookup(storyId);
+
+        comments.forEach((comment) => {
+          const commentId = getRecordId(comment);
+
+          if (commentId && unresolved.has(commentId)) {
+            resolved.set(commentId, storyId);
+            unresolved.delete(commentId);
+          }
+        });
+      }),
+    );
+
+    hasNext = Boolean(storiesResponse.next);
+    page += 1;
+  }
+
+  return resolved;
+}
+
+async function fetchStoryCommentsForLookup(storyId: string) {
+  const comments: unknown[] = [];
+  let page = 1;
+  let hasNext = true;
+
+  while (hasNext) {
+    const response = await getPage(
+      `/stories/${storyId}/comments/${buildQuery({
+        page,
+        page_size: COMMENT_STORY_LOOKUP_PAGE_SIZE,
+      })}`,
+    );
+
+    comments.push(...(response.results ?? []));
+    hasNext = Boolean(response.next);
+    page += 1;
+  }
+
+  return comments;
+}
+
+function buildQuery(params: Record<string, string | number | undefined>) {
+  const searchParams = new URLSearchParams();
+
+  Object.entries(params).forEach(([key, value]) => {
+    if (value !== undefined && value !== '') {
+      searchParams.append(key, String(value));
+    }
+  });
+
+  const query = searchParams.toString();
+
+  return query ? `?${query}` : '';
+}
+
+function mapReport(item: unknown): AdminReport {
+  const record = asRecord(item);
+  const reporter = asRecord(record.reporter);
+
+  return {
+    id: asString(record.id),
+    reporter: {
+      id: asString(reporter.id),
+      username: asString(reporter.username, 'Unknown reporter'),
+      email: optionalString(reporter.email),
+    },
+    targetType: asString(record.target_type ?? record.targetType, 'content'),
+    targetId: asString(record.target_id ?? record.targetId),
+    targetStoryId: optionalString(
+      record.target_story_id ??
+        record.targetStoryId ??
+        record.story_id ??
+        record.storyId ??
+        asRecord(record.comment).story_id ??
+        asRecord(record.comment).storyId,
+    ),
+    reason: asString(record.reason, 'Unspecified'),
+    description: optionalString(record.description),
+    status: normalizeReportStatus(record.status),
+    createdAt: asString(record.created_at ?? record.createdAt),
+    resolvedAt: optionalString(record.resolved_at ?? record.resolvedAt),
+    resolutionOutcome: optionalString(record.resolution_outcome ?? record.resolutionOutcome),
+  };
+}
+
+function mapStory(item: unknown): AdminStory {
+  const record = asRecord(item);
+
+  return {
+    id: asString(record.id),
+    title: asString(record.title, 'Untitled story'),
+    contributorName: optionalString(record.contributor_name ?? record.contributorName),
+    locationName: optionalString(record.location_name ?? record.locationName),
+    status: optionalString(record.status),
+    submittedAt: optionalString(record.submitted_at ?? record.submittedAt),
+  };
+}
+
+function mapTag(item: unknown): AdminTag {
+  const record = asRecord(item);
+
+  return {
+    id: asString(record.id),
+    name: asString(record.name, 'untitled'),
+    storyCount: asNumber(record.story_count ?? record.storyCount),
+  };
+}
+
+function normalizeReportStatus(value: unknown): AdminReportStatus {
+  if (value === 'resolved') {
+    return value;
+  }
+
+  return 'pending';
+}
+
+function formatAction(action: AdminReportAction) {
+  if (action === 'remove_content') {
+    return 'Remove content';
+  }
+
+  if (action === 'ban_user') {
+    return 'Ban user';
+  }
+
+  return 'No action';
+}
+
+function asRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === 'object' ? (value as Record<string, unknown>) : {};
+}
+
+function getRecordId(value: unknown) {
+  const record = asRecord(value);
+
+  return asString(record.id);
+}
+
+function asString(value: unknown, fallback = '') {
+  if (typeof value === 'string') {
+    return value;
+  }
+
+  if (typeof value === 'number') {
+    return String(value);
+  }
+
+  return fallback;
+}
+
+function optionalString(value: unknown) {
+  const resolved = asString(value);
+
+  return resolved || undefined;
+}
+
+function asNumber(value: unknown) {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return value;
+  }
+
+  if (typeof value === 'string' && value.trim()) {
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : 0;
+  }
+
+  return 0;
+}

--- a/mobile/src/features/moderation/application/services/index.ts
+++ b/mobile/src/features/moderation/application/services/index.ts
@@ -1,1 +1,1 @@
-export const moderationService = {};
+export * from './adminService';

--- a/mobile/src/features/moderation/domain/entities/index.ts
+++ b/mobile/src/features/moderation/domain/entities/index.ts
@@ -1,3 +1,9 @@
-export interface ModerationEntity {
-  id: string;
-}
+export type {
+  AdminPage,
+  AdminReport,
+  AdminReportAction,
+  AdminReportStatus,
+  AdminStory,
+  AdminTag,
+  AdminUserSummary,
+} from '../../application/services';

--- a/mobile/src/features/moderation/presentation/screens/ModerationScreen.tsx
+++ b/mobile/src/features/moderation/presentation/screens/ModerationScreen.tsx
@@ -1,10 +1,911 @@
-import React from 'react';
-import { View, Text } from 'react-native';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import { FlatList, Modal, Pressable, Text, View } from 'react-native';
+import { Input } from '../../../../shared/ui/Input';
+import { Button } from '../../../../shared/ui/Button';
+import { EmptyState, ErrorState, Loader, SkeletonCard } from '../../../../shared';
+import { useAppTheme } from '../../../../core/hooks/useAppTheme';
+import { useAuth } from '../../../auth';
+import { useToast } from '../../../../shared/hooks/useToast';
+import {
+  AdminPage,
+  AdminReport,
+  AdminReportAction,
+  AdminReportStatus,
+  AdminStory,
+  AdminTag,
+  adminService,
+} from '../../application/services';
 
-export function ModerationScreen() {
+type AdminTab = 'reports' | 'stories' | 'tags';
+type AdminService = typeof adminService;
+type AdminListItem = AdminReport | AdminStory | AdminTag;
+
+interface ListState<T> {
+  items: T[];
+  page: number;
+  totalCount: number;
+  hasNextPage: boolean;
+  isLoading: boolean;
+  isRefreshing: boolean;
+  isLoadingMore: boolean;
+  error?: string;
+}
+
+interface ConfirmState {
+  title: string;
+  message: string;
+  confirmLabel: string;
+  destructive?: boolean;
+  reasonLabel?: string;
+  reasonPlaceholder?: string;
+  onConfirm: (reason: string) => Promise<void>;
+}
+
+interface ModerationScreenProps {
+  service?: AdminService;
+  onOpenStory?: (storyId: string) => void;
+  onOpenComment?: (storyId: string, commentId: string) => void;
+}
+
+const tabs: Array<{ key: AdminTab; label: string }> = [
+  { key: 'reports', label: 'Reports' },
+  { key: 'stories', label: 'Stories' },
+  { key: 'tags', label: 'Tags' },
+];
+
+const reportStatuses: Array<AdminReportStatus | 'all'> = ['all', 'pending', 'resolved'];
+
+function createListState<T>(): ListState<T> {
+  return {
+    items: [],
+    page: 1,
+    totalCount: 0,
+    hasNextPage: false,
+    isLoading: true,
+    isRefreshing: false,
+    isLoadingMore: false,
+  };
+}
+
+export function ModerationScreen({ service = adminService, onOpenStory, onOpenComment }: ModerationScreenProps) {
+  const { colors, spacing, typography } = useAppTheme();
+  const { user } = useAuth();
+  const { toast } = useToast();
+  const [activeTab, setActiveTab] = useState<AdminTab>('reports');
+  const [reportStatus, setReportStatus] = useState<AdminReportStatus | 'all'>('pending');
+  const [storyQuery, setStoryQuery] = useState('');
+  const [tagQuery, setTagQuery] = useState('');
+  const [reports, setReports] = useState<ListState<AdminReport>>(() => createListState());
+  const [stories, setStories] = useState<ListState<AdminStory>>(() => createListState());
+  const [tags, setTags] = useState<ListState<AdminTag>>(() => createListState());
+  const [confirmState, setConfirmState] = useState<ConfirmState | null>(null);
+  const [pendingActionId, setPendingActionId] = useState<string | null>(null);
+
+  const isAdmin = user?.role === 'admin';
+
+  const loadReports = useCallback(
+    async (page = 1, mode: LoadMode = 'initial') => {
+      await loadList(setReports, () => service.getReports({ page, status: reportStatus }), page, mode);
+    },
+    [reportStatus, service],
+  );
+
+  const loadStories = useCallback(
+    async (page = 1, mode: LoadMode = 'initial') => {
+      await loadList(setStories, () => service.getStories({ page, query: storyQuery }), page, mode);
+    },
+    [service, storyQuery],
+  );
+
+  const loadTags = useCallback(
+    async (page = 1, mode: LoadMode = 'initial') => {
+      await loadList(setTags, () => service.getTags({ page, query: tagQuery }), page, mode);
+    },
+    [service, tagQuery],
+  );
+
+  useEffect(() => {
+    if (!isAdmin) {
+      return;
+    }
+
+    if (activeTab === 'reports') {
+      void loadReports();
+    } else if (activeTab === 'stories') {
+      void loadStories();
+    } else {
+      void loadTags();
+    }
+  }, [activeTab, isAdmin, loadReports, loadStories, loadTags]);
+
+  const reloadActiveTab = useCallback(async () => {
+    if (activeTab === 'reports') {
+      await loadReports(1, 'refresh');
+    } else if (activeTab === 'stories') {
+      await loadStories(1, 'refresh');
+    } else {
+      await loadTags(1, 'refresh');
+    }
+  }, [activeTab, loadReports, loadStories, loadTags]);
+
+  const runConfirmedAction = useCallback(
+    (state: ConfirmState) => {
+      setConfirmState(state);
+    },
+    [],
+  );
+
+  const resolveReport = useCallback(
+    async (report: AdminReport, action: AdminReportAction) => {
+      setPendingActionId(`${report.id}:${action}`);
+      try {
+        const updatedReport = await service.resolveReport(report.id, action);
+        setReports((current) => ({
+          ...current,
+          items: current.items.map((item) => (item.id === report.id ? updatedReport : item)),
+        }));
+        toast.success('Report resolved.');
+      } catch (error) {
+        toast.error(error instanceof Error ? error.message : 'Failed to resolve report.');
+      } finally {
+        setPendingActionId(null);
+      }
+    },
+    [service, toast],
+  );
+
+  const confirmStoryRemoval = useCallback(
+    (story: AdminStory) => {
+      runConfirmedAction({
+        title: 'Remove story?',
+        message: `"${story.title}" will be removed from public views.`,
+        confirmLabel: 'Remove story',
+        destructive: true,
+        reasonLabel: 'Removal reason',
+        reasonPlaceholder: 'Explain why this story is being removed',
+        onConfirm: async (reason) => {
+          if (!reason.trim()) {
+            throw new Error('A removal reason is required.');
+          }
+
+          setPendingActionId(story.id);
+          await service.removeStory(story.id, reason.trim());
+          setStories((current) => ({
+            ...current,
+            items: current.items.filter((item) => item.id !== story.id),
+            totalCount: Math.max(current.totalCount - 1, 0),
+          }));
+          toast.success('Story removed.');
+          setPendingActionId(null);
+        },
+      });
+    },
+    [runConfirmedAction, service, toast],
+  );
+
+  const confirmTagRemoval = useCallback(
+    (tag: AdminTag) => {
+      runConfirmedAction({
+        title: 'Remove tag?',
+        message: `${tag.name} will be removed from associated stories.`,
+        confirmLabel: 'Remove tag',
+        destructive: true,
+        onConfirm: async () => {
+          setPendingActionId(tag.id);
+          await service.removeTag(tag.id);
+          setTags((current) => ({
+            ...current,
+            items: current.items.filter((item) => item.id !== tag.id),
+            totalCount: Math.max(current.totalCount - 1, 0),
+          }));
+          toast.success('Tag removed.');
+          setPendingActionId(null);
+        },
+      });
+    },
+    [runConfirmedAction, service, toast],
+  );
+
+  const activeState = useMemo(() => {
+    if (activeTab === 'reports') {
+      return reports;
+    }
+
+    if (activeTab === 'stories') {
+      return stories;
+    }
+
+    return tags;
+  }, [activeTab, reports, stories, tags]);
+
+  if (!isAdmin) {
+    return (
+      <View style={{ flex: 1, padding: spacing.lg, backgroundColor: colors.background }}>
+        <ErrorState
+          title="Not authorized"
+          message="Only admins can access moderation tools."
+        />
+      </View>
+    );
+  }
+
   return (
-    <View style={{ padding: 16 }}>
-      <Text>Moderation Screen Placeholder</Text>
+    <View style={{ flex: 1, backgroundColor: colors.background }}>
+      <View style={{ paddingHorizontal: spacing.lg, paddingTop: spacing.lg, gap: spacing.md }}>
+        <Text style={{ color: colors.text, fontSize: typography.title, fontWeight: '800' }}>
+          Admin moderation
+        </Text>
+        <Text style={{ color: colors.muted }}>
+          Review reports, moderate stories, and clean up tags.
+        </Text>
+        <View
+          accessibilityRole="tablist"
+          style={{
+            flexDirection: 'row',
+            padding: 3,
+            borderRadius: 12,
+            borderWidth: 1,
+            borderColor: colors.border,
+            backgroundColor: colors.infoSurface,
+          }}
+        >
+          {tabs.map((tab) => {
+            const selected = activeTab === tab.key;
+
+            return (
+              <Pressable
+                key={tab.key}
+                accessibilityRole="tab"
+                accessibilityLabel={`${tab.label} tab`}
+                accessibilityState={{ selected }}
+                onPress={() => setActiveTab(tab.key)}
+                style={{
+                  flex: 1,
+                  alignItems: 'center',
+                  paddingVertical: spacing.sm,
+                  borderRadius: 9,
+                  backgroundColor: selected ? colors.primary : 'transparent',
+                }}
+              >
+                <Text
+                  numberOfLines={1}
+                  style={{
+                    color: selected ? colors.background : colors.text,
+                    fontSize: typography.caption,
+                    fontWeight: '800',
+                  }}
+                >
+                  {tab.label}
+                </Text>
+              </Pressable>
+            );
+          })}
+        </View>
+        {renderControls({
+          activeTab,
+          reportStatus,
+          setReportStatus,
+          storyQuery,
+          setStoryQuery,
+          tagQuery,
+          setTagQuery,
+          reloadActiveTab,
+        })}
+      </View>
+      <View style={{ flex: 1, paddingTop: spacing.md }}>
+        {renderContent({
+          activeTab,
+          activeState,
+          reports,
+          stories,
+          tags,
+          pendingActionId,
+          onRetry: reloadActiveTab,
+          onLoadMore: () => {
+            if (activeTab === 'reports') {
+              void loadReports(reports.page + 1, 'append');
+            } else if (activeTab === 'stories') {
+              void loadStories(stories.page + 1, 'append');
+            } else {
+              void loadTags(tags.page + 1, 'append');
+            }
+          },
+          onRefresh: reloadActiveTab,
+          onResolveReport: resolveReport,
+          onRemoveStory: confirmStoryRemoval,
+          onRemoveTag: confirmTagRemoval,
+          onOpenStory,
+          onOpenComment,
+        })}
+      </View>
+      <ConfirmActionDialog
+        state={confirmState}
+        onClose={() => {
+          setConfirmState(null);
+          setPendingActionId(null);
+        }}
+      />
     </View>
   );
+}
+
+type LoadMode = 'initial' | 'refresh' | 'append';
+
+async function loadList<T>(
+  setState: React.Dispatch<React.SetStateAction<ListState<T>>>,
+  fetchPage: () => Promise<AdminPage<T>>,
+  page: number,
+  mode: LoadMode,
+) {
+  setState((current) => ({
+    ...current,
+    isLoading: mode === 'initial',
+    isRefreshing: mode === 'refresh',
+    isLoadingMore: mode === 'append',
+    error: undefined,
+  }));
+
+  try {
+    const response = await fetchPage();
+
+    setState((current) => ({
+      items: mode === 'append' ? [...current.items, ...response.items] : response.items,
+      page: response.page,
+      totalCount: response.totalCount,
+      hasNextPage: response.hasNextPage,
+      isLoading: false,
+      isRefreshing: false,
+      isLoadingMore: false,
+      error: undefined,
+    }));
+  } catch (error) {
+    setState((current) => ({
+      ...current,
+      isLoading: false,
+      isRefreshing: false,
+      isLoadingMore: false,
+      error: error instanceof Error ? error.message : 'Unable to load moderation data.',
+    }));
+  }
+}
+
+function renderControls({
+  activeTab,
+  reportStatus,
+  setReportStatus,
+  storyQuery,
+  setStoryQuery,
+  tagQuery,
+  setTagQuery,
+  reloadActiveTab,
+}: {
+  activeTab: AdminTab;
+  reportStatus: AdminReportStatus | 'all';
+  setReportStatus: (value: AdminReportStatus | 'all') => void;
+  storyQuery: string;
+  setStoryQuery: (value: string) => void;
+  tagQuery: string;
+  setTagQuery: (value: string) => void;
+  reloadActiveTab: () => Promise<void>;
+}) {
+  if (activeTab === 'reports') {
+    return (
+      <FilterPills
+        label="Report status"
+        options={reportStatuses.map((status) => ({ value: status, label: titleCase(status) }))}
+        value={reportStatus}
+        onChange={setReportStatus}
+      />
+    );
+  }
+
+  const query = activeTab === 'stories' ? storyQuery : tagQuery;
+  const setQuery = activeTab === 'stories' ? setStoryQuery : setTagQuery;
+  const label = activeTab === 'stories' ? 'Search stories' : 'Search tags';
+
+  return (
+    <Input
+      value={query}
+      onChangeText={setQuery}
+      placeholder={label}
+      accessibilityLabel={label}
+      returnKeyType="search"
+      onSubmitEditing={() => {
+        void reloadActiveTab();
+      }}
+      trailingActionLabel="Search"
+      trailingActionAccessibilityLabel={`Apply ${label.toLowerCase()}`}
+      onTrailingActionPress={() => {
+        void reloadActiveTab();
+      }}
+    />
+  );
+}
+
+function renderContent({
+  activeTab,
+  activeState,
+  reports,
+  stories,
+  tags,
+  pendingActionId,
+  onRetry,
+  onLoadMore,
+  onRefresh,
+  onResolveReport,
+  onRemoveStory,
+  onRemoveTag,
+  onOpenStory,
+  onOpenComment,
+}: {
+  activeTab: AdminTab;
+  activeState: ListState<unknown>;
+  reports: ListState<AdminReport>;
+  stories: ListState<AdminStory>;
+  tags: ListState<AdminTag>;
+  pendingActionId: string | null;
+  onRetry: () => Promise<void>;
+  onLoadMore: () => void;
+  onRefresh: () => Promise<void>;
+  onResolveReport: (report: AdminReport, action: AdminReportAction) => Promise<void>;
+  onRemoveStory: (story: AdminStory) => void;
+  onRemoveTag: (tag: AdminTag) => void;
+  onOpenStory?: (storyId: string) => void;
+  onOpenComment?: (storyId: string, commentId: string) => void;
+}) {
+  if (activeState.isLoading && !activeState.items.length) {
+    return (
+      <View accessibilityLabel="Loading admin data" style={{ paddingHorizontal: 16, gap: 12 }}>
+        {Array.from({ length: 4 }).map((_, index) => (
+          <SkeletonCard key={index} showMedia={false} />
+        ))}
+      </View>
+    );
+  }
+
+  if (activeState.error && !activeState.items.length) {
+    return (
+      <ErrorState
+        title="Moderation unavailable"
+        message={activeState.error}
+        retryLabel="Try again"
+        onRetry={() => {
+          void onRetry();
+        }}
+      />
+    );
+  }
+
+  if (!activeState.items.length) {
+    return (
+      <EmptyState
+        title={`No ${activeTab} found`}
+        message="There is nothing to review here right now."
+        actionLabel="Refresh"
+        onAction={() => {
+          void onRefresh();
+        }}
+      />
+    );
+  }
+
+  const data: AdminListItem[] =
+    activeTab === 'reports'
+      ? reports.items
+      : activeTab === 'stories'
+        ? stories.items
+        : tags.items;
+
+  return (
+    <FlatList<AdminListItem>
+      testID={`admin-${activeTab}-list`}
+      data={data}
+      keyExtractor={(item) => item.id}
+      contentContainerStyle={{ paddingHorizontal: 16, paddingBottom: 24 }}
+      ItemSeparatorComponent={() => <View style={{ height: 12 }} />}
+      refreshing={activeState.isRefreshing}
+      onRefresh={() => {
+        void onRefresh();
+      }}
+      renderItem={({ item }) => {
+        if (activeTab === 'reports') {
+          return (
+            <ReportRow
+              report={item as AdminReport}
+              pendingActionId={pendingActionId}
+              onResolve={onResolveReport}
+              onOpenStory={onOpenStory}
+              onOpenComment={onOpenComment}
+            />
+          );
+        }
+
+        if (activeTab === 'stories') {
+          return (
+            <StoryRow
+              story={item as AdminStory}
+              isPending={pendingActionId === item.id}
+              onRemove={onRemoveStory}
+              onOpenStory={onOpenStory}
+            />
+          );
+        }
+
+        return (
+          <TagRow
+            tag={item as AdminTag}
+            isPending={pendingActionId === item.id}
+            onRemove={onRemoveTag}
+          />
+        );
+      }}
+      ListHeaderComponent={<ListSummary count={activeState.totalCount} label={activeTab} />}
+      ListFooterComponent={
+        activeState.isLoadingMore ? (
+          <Loader message="Loading more..." size="small" />
+        ) : activeState.hasNextPage ? (
+          <View style={{ paddingTop: 16 }}>
+            <Button variant="outline" onPress={onLoadMore} accessibilityLabel={`Load more ${activeTab}`}>
+              Load more
+            </Button>
+          </View>
+        ) : null
+      }
+    />
+  );
+}
+
+function FilterPills<T extends string>({
+  label,
+  options,
+  value,
+  onChange,
+}: {
+  label: string;
+  options: Array<{ value: T; label: string }>;
+  value: T;
+  onChange: (value: T) => void;
+}) {
+  const { colors, spacing, typography } = useAppTheme();
+
+  return (
+    <View accessibilityRole="radiogroup" accessibilityLabel={label} style={{ flexDirection: 'row', flexWrap: 'wrap', gap: spacing.sm }}>
+      {options.map((option) => {
+        const selected = value === option.value;
+
+        return (
+          <Pressable
+            key={option.value}
+            accessibilityRole="radio"
+            accessibilityLabel={`${label}: ${option.label}`}
+            accessibilityState={{ selected }}
+            onPress={() => onChange(option.value)}
+            style={{
+              paddingHorizontal: spacing.md,
+              paddingVertical: spacing.sm,
+              borderRadius: 999,
+              borderWidth: 1,
+              borderColor: selected ? colors.primary : colors.border,
+              backgroundColor: selected ? colors.primary : colors.background,
+            }}
+          >
+            <Text style={{ color: selected ? colors.background : colors.text, fontSize: typography.caption, fontWeight: '700' }}>
+              {option.label}
+            </Text>
+          </Pressable>
+        );
+      })}
+    </View>
+  );
+}
+
+function ListSummary({ count, label }: { count: number; label: string }) {
+  const { colors, spacing, typography } = useAppTheme();
+
+  return (
+    <Text style={{ color: colors.muted, fontSize: typography.caption, marginBottom: spacing.sm }}>
+      {count} {label}
+    </Text>
+  );
+}
+
+function RowFrame({
+  children,
+  onPress,
+  accessibilityLabel,
+}: {
+  children: React.ReactNode;
+  onPress?: () => void;
+  accessibilityLabel?: string;
+}) {
+  const { colors, spacing } = useAppTheme();
+  const content = (
+    <View
+      style={{
+        padding: spacing.md,
+        gap: spacing.sm,
+        borderWidth: 1,
+        borderColor: colors.border,
+        borderRadius: 8,
+        backgroundColor: colors.surface,
+      }}
+    >
+      {children}
+    </View>
+  );
+
+  if (!onPress) {
+    return content;
+  }
+
+  return (
+    <Pressable
+      accessibilityRole="button"
+      accessibilityLabel={accessibilityLabel}
+      onPress={onPress}
+      style={({ pressed }) => ({
+        opacity: pressed ? 0.82 : 1,
+      })}
+    >
+      {content}
+    </Pressable>
+  );
+}
+
+function ReportRow({
+  report,
+  pendingActionId,
+  onResolve,
+  onOpenStory,
+  onOpenComment,
+}: {
+  report: AdminReport;
+  pendingActionId: string | null;
+  onResolve: (report: AdminReport, action: AdminReportAction) => Promise<void>;
+  onOpenStory?: (storyId: string) => void;
+  onOpenComment?: (storyId: string, commentId: string) => void;
+}) {
+  const { colors, spacing, typography } = useAppTheme();
+  const isResolved = report.status !== 'pending';
+  const canOpenStory = report.targetType === 'story' && Boolean(onOpenStory);
+  const canOpenComment = report.targetType === 'comment' && Boolean(report.targetStoryId) && Boolean(onOpenComment);
+
+  return (
+    <RowFrame
+      onPress={
+        canOpenComment
+          ? () => onOpenComment?.(report.targetStoryId!, report.targetId)
+          : canOpenStory
+            ? () => onOpenStory?.(report.targetId)
+            : undefined
+      }
+      accessibilityLabel={
+        canOpenComment
+          ? `Open reported comment ${report.targetId}`
+          : canOpenStory
+            ? `Open reported story ${report.targetId}`
+            : undefined
+      }
+    >
+      <View style={{ flexDirection: 'row', justifyContent: 'space-between', gap: spacing.sm }}>
+        <Text style={{ flex: 1, color: colors.text, fontSize: typography.subtitle, fontWeight: '800' }}>
+          {report.targetType} #{report.targetId}
+        </Text>
+        <StatusBadge label={report.status} tone={isResolved ? 'success' : 'danger'} />
+      </View>
+      <Text style={{ color: colors.muted }}>Reporter: {report.reporter.username}</Text>
+      <Text style={{ color: colors.text }}>Reason: {titleCase(report.reason)}</Text>
+      <Text style={{ color: colors.muted }}>Date: {formatDate(report.createdAt)}</Text>
+      {report.description ? <Text style={{ color: colors.text }}>{report.description}</Text> : null}
+      {canOpenComment || canOpenStory ? (
+        <Text style={{ color: colors.primary, fontWeight: '700' }}>
+          {canOpenComment ? 'Tap to open comment' : 'Tap to open story'}
+        </Text>
+      ) : null}
+      {!isResolved ? (
+        <View style={{ flexDirection: 'row', flexWrap: 'wrap', gap: spacing.sm }}>
+          <Button
+            variant="outline"
+            disabled={Boolean(pendingActionId)}
+            onPress={() => void onResolve(report, 'no_action')}
+            accessibilityLabel={`Resolve report ${report.id} with no action`}
+          >
+            No action
+          </Button>
+          <Button
+            variant="outline"
+            disabled={Boolean(pendingActionId)}
+            onPress={() => void onResolve(report, 'remove_content')}
+            accessibilityLabel={`Resolve report ${report.id} and remove content`}
+          >
+            Remove
+          </Button>
+          <Button
+            disabled={Boolean(pendingActionId)}
+            onPress={() => void onResolve(report, 'ban_user')}
+            accessibilityLabel={`Resolve report ${report.id} and ban user`}
+          >
+            Ban user
+          </Button>
+        </View>
+      ) : null}
+    </RowFrame>
+  );
+}
+
+function StoryRow({
+  story,
+  isPending,
+  onRemove,
+  onOpenStory,
+}: {
+  story: AdminStory;
+  isPending: boolean;
+  onRemove: (story: AdminStory) => void;
+  onOpenStory?: (storyId: string) => void;
+}) {
+  const { colors, spacing, typography } = useAppTheme();
+
+  return (
+    <RowFrame
+      onPress={onOpenStory ? () => onOpenStory(story.id) : undefined}
+      accessibilityLabel={`Open story ${story.title}`}
+    >
+      <Text style={{ color: colors.text, fontSize: typography.subtitle, fontWeight: '800' }}>{story.title}</Text>
+      <Text style={{ color: colors.muted }}>{story.contributorName ?? 'Anonymous'} - {story.locationName ?? 'Unknown place'}</Text>
+      <Text style={{ color: colors.muted }}>Status: {story.status ?? 'unknown'} - {formatDate(story.submittedAt)}</Text>
+      {onOpenStory ? <Text style={{ color: colors.primary, fontWeight: '700' }}>Tap to open story</Text> : null}
+      <View style={{ alignSelf: 'flex-start', marginTop: spacing.xs }}>
+        <Button
+          variant="outline"
+          disabled={isPending}
+          onPress={() => onRemove(story)}
+          accessibilityLabel={`Remove story ${story.title}`}
+        >
+          Remove
+        </Button>
+      </View>
+    </RowFrame>
+  );
+}
+
+function TagRow({ tag, isPending, onRemove }: { tag: AdminTag; isPending: boolean; onRemove: (tag: AdminTag) => void }) {
+  const { colors, spacing, typography } = useAppTheme();
+
+  return (
+    <RowFrame>
+      <Text style={{ color: colors.text, fontSize: typography.subtitle, fontWeight: '800' }}>{tag.name}</Text>
+      <Text style={{ color: colors.muted }}>{tag.storyCount} stories</Text>
+      <View style={{ alignSelf: 'flex-start', marginTop: spacing.xs }}>
+        <Button
+          variant="outline"
+          disabled={isPending}
+          onPress={() => onRemove(tag)}
+          accessibilityLabel={`Remove tag ${tag.name}`}
+        >
+          Remove
+        </Button>
+      </View>
+    </RowFrame>
+  );
+}
+
+function StatusBadge({ label, tone }: { label: string; tone: 'success' | 'danger' }) {
+  const { colors, spacing, typography } = useAppTheme();
+
+  return (
+    <View
+      style={{
+        alignSelf: 'flex-start',
+        paddingHorizontal: spacing.sm,
+        paddingVertical: spacing.xs,
+        borderRadius: 999,
+        backgroundColor: tone === 'success' ? colors.successSurface : colors.dangerSurface,
+      }}
+    >
+      <Text style={{ color: tone === 'success' ? colors.success : colors.danger, fontSize: typography.caption, fontWeight: '800' }}>
+        {titleCase(label)}
+      </Text>
+    </View>
+  );
+}
+
+function ConfirmActionDialog({ state, onClose }: { state: ConfirmState | null; onClose: () => void }) {
+  const { colors, spacing, typography } = useAppTheme();
+  const { toast } = useToast();
+  const [reason, setReason] = useState('');
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  useEffect(() => {
+    if (state) {
+      setReason('');
+      setIsSubmitting(false);
+    }
+  }, [state]);
+
+  if (!state) {
+    return null;
+  }
+
+  const confirm = async () => {
+    setIsSubmitting(true);
+    try {
+      await state.onConfirm(reason);
+      onClose();
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : 'Action failed.');
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <Modal transparent animationType="fade" visible>
+      <View
+        style={{
+          flex: 1,
+          justifyContent: 'center',
+          padding: spacing.lg,
+          backgroundColor: 'rgba(0,0,0,0.28)',
+        }}
+      >
+        <View
+          accessibilityRole="alert"
+          style={{
+            gap: spacing.md,
+            padding: spacing.lg,
+            borderRadius: 8,
+            borderWidth: 1,
+            borderColor: colors.border,
+            backgroundColor: colors.background,
+          }}
+        >
+          <Text style={{ color: colors.text, fontSize: typography.subtitle, fontWeight: '800' }}>
+            {state.title}
+          </Text>
+          <Text style={{ color: colors.muted }}>{state.message}</Text>
+          {state.reasonLabel ? (
+            <View style={{ gap: spacing.xs }}>
+              <Text style={{ color: colors.text, fontWeight: '700' }}>{state.reasonLabel}</Text>
+              <Input
+                value={reason}
+                onChangeText={setReason}
+                placeholder={state.reasonPlaceholder}
+                accessibilityLabel={state.reasonLabel}
+                multiline
+                numberOfLines={3}
+              />
+            </View>
+          ) : null}
+          <View style={{ flexDirection: 'row', justifyContent: 'flex-end', gap: spacing.sm }}>
+            <Button variant="ghost" disabled={isSubmitting} onPress={onClose}>
+              Cancel
+            </Button>
+            <Button disabled={isSubmitting} onPress={() => void confirm()}>
+              {state.confirmLabel}
+            </Button>
+          </View>
+        </View>
+      </View>
+    </Modal>
+  );
+}
+
+function titleCase(value: string) {
+  return value
+    .replace(/_/g, ' ')
+    .replace(/\b\w/g, (match) => match.toUpperCase());
+}
+
+function formatDate(value?: string | null) {
+  if (!value) {
+    return 'Unknown date';
+  }
+
+  const date = new Date(value);
+
+  if (Number.isNaN(date.getTime())) {
+    return value;
+  }
+
+  return date.toLocaleDateString();
 }

--- a/mobile/src/features/moderation/presentation/screens/__tests__/ModerationScreen.test.tsx
+++ b/mobile/src/features/moderation/presentation/screens/__tests__/ModerationScreen.test.tsx
@@ -1,0 +1,195 @@
+import React from 'react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react-native';
+import { ModerationScreen } from '../ModerationScreen';
+import { AdminPage, AdminReport, AdminStory, AdminTag, adminService } from '../../../application/services';
+
+const mockToastSuccess = jest.fn();
+const mockToastError = jest.fn();
+let mockRole: 'user' | 'admin' = 'admin';
+
+jest.mock('../../../../auth', () => ({
+  useAuth: () => ({
+    user: {
+      id: 1,
+      email: 'admin@example.com',
+      username: 'Admin',
+      role: mockRole,
+    },
+  }),
+}));
+
+jest.mock('../../../../../shared/hooks/useToast', () => ({
+  useToast: () => ({
+    toast: {
+      success: mockToastSuccess,
+      error: mockToastError,
+      info: jest.fn(),
+      show: jest.fn(),
+    },
+  }),
+}));
+
+const report: AdminReport = {
+  id: '10',
+  reporter: {
+    id: '2',
+    username: 'Reporter',
+    email: 'reporter@example.com',
+  },
+  targetType: 'story',
+  targetId: '7',
+  reason: 'spam',
+  description: 'Promotional content',
+  status: 'pending',
+  createdAt: '2026-05-01T12:00:00Z',
+};
+
+const story: AdminStory = {
+  id: '7',
+  title: 'Unsafe Story',
+  contributorName: 'Writer',
+  locationName: 'Istanbul',
+  status: 'published',
+  submittedAt: '2026-05-01T12:00:00Z',
+};
+
+const tag: AdminTag = {
+  id: '5',
+  name: 'spam-tag',
+  storyCount: 3,
+};
+
+function page<T>(items: T[], overrides: Partial<AdminPage<T>> = {}): AdminPage<T> {
+  return {
+    items,
+    page: 1,
+    totalCount: items.length,
+    hasNextPage: false,
+    ...overrides,
+  };
+}
+
+function createService(overrides: Partial<typeof adminService> = {}): typeof adminService {
+  return {
+    getReports: jest.fn(async () => page([report])),
+    resolveReport: jest.fn(async () => ({
+      ...report,
+      status: 'resolved' as const,
+      resolutionOutcome: 'No action',
+    })),
+    getStories: jest.fn(async () => page([story])),
+    removeStory: jest.fn(async () => undefined),
+    banUser: jest.fn(async () => undefined),
+    getTags: jest.fn(async () => page([tag])),
+    removeTag: jest.fn(async () => undefined),
+    ...overrides,
+  };
+}
+
+describe('ModerationScreen', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockRole = 'admin';
+  });
+
+  it('blocks non-admin users', () => {
+    mockRole = 'user';
+
+    render(<ModerationScreen service={createService()} />);
+
+    expect(screen.getByText('Not authorized')).toBeTruthy();
+    expect(screen.getByText('Only admins can access moderation tools.')).toBeTruthy();
+  });
+
+  it('lists reports, filters by status, and resolves a report', async () => {
+    const service = createService();
+    const onOpenStory = jest.fn();
+
+    render(<ModerationScreen service={service} onOpenStory={onOpenStory} />);
+
+    expect(await screen.findByText('story #7')).toBeTruthy();
+    fireEvent.press(screen.getByLabelText('Open reported story 7'));
+    expect(onOpenStory).toHaveBeenCalledWith('7');
+
+    expect(service.getReports).toHaveBeenLastCalledWith({ page: 1, status: 'pending' });
+
+    fireEvent.press(screen.getByLabelText('Report status: All'));
+
+    await waitFor(() => {
+      expect(service.getReports).toHaveBeenLastCalledWith({ page: 1, status: 'all' });
+    });
+
+    fireEvent.press(screen.getByLabelText('Resolve report 10 with no action'));
+
+    await waitFor(() => {
+      expect(service.resolveReport).toHaveBeenCalledWith('10', 'no_action');
+      expect(mockToastSuccess).toHaveBeenCalledWith('Report resolved.');
+    });
+  });
+
+  it('opens reported comments on their parent story when story metadata is available', async () => {
+    const commentReport: AdminReport = {
+      ...report,
+      id: '11',
+      targetType: 'comment',
+      targetId: '99',
+      targetStoryId: '7',
+    };
+    const service = createService({
+      getReports: jest.fn(async () => page([commentReport])),
+    });
+    const onOpenComment = jest.fn();
+
+    render(<ModerationScreen service={service} onOpenComment={onOpenComment} />);
+
+    expect(await screen.findByText('comment #99')).toBeTruthy();
+    fireEvent.press(screen.getByLabelText('Open reported comment 99'));
+
+    expect(onOpenComment).toHaveBeenCalledWith('7', '99');
+  });
+
+  it('requires a reason before removing a story', async () => {
+    const service = createService();
+    const onOpenStory = jest.fn();
+
+    render(<ModerationScreen service={service} onOpenStory={onOpenStory} />);
+
+    fireEvent.press(await screen.findByLabelText('Stories tab'));
+    expect(await screen.findByText('Unsafe Story')).toBeTruthy();
+    fireEvent.press(screen.getByLabelText('Open story Unsafe Story'));
+    expect(onOpenStory).toHaveBeenCalledWith('7');
+
+    fireEvent.press(screen.getByLabelText('Remove story Unsafe Story'));
+    fireEvent.press(screen.getByText('Remove story'));
+
+    await waitFor(() => {
+      expect(mockToastError).toHaveBeenCalledWith('A removal reason is required.');
+    });
+    expect(service.removeStory).not.toHaveBeenCalled();
+
+    fireEvent.changeText(screen.getByLabelText('Removal reason'), 'Harassment');
+    fireEvent.press(screen.getByText('Remove story'));
+
+    await waitFor(() => {
+      expect(service.removeStory).toHaveBeenCalledWith('7', 'Harassment');
+      expect(mockToastSuccess).toHaveBeenCalledWith('Story removed.');
+    });
+  });
+
+  it('removes tags after confirmation', async () => {
+    const service = createService();
+
+    render(<ModerationScreen service={service} />);
+
+    fireEvent.press(await screen.findByLabelText('Tags tab'));
+    expect(await screen.findByText('spam-tag')).toBeTruthy();
+
+    fireEvent.press(screen.getByLabelText('Remove tag spam-tag'));
+    fireEvent.press(screen.getByText('Remove tag'));
+
+    await waitFor(() => {
+      expect(service.removeTag).toHaveBeenCalledWith('5');
+      expect(mockToastSuccess).toHaveBeenCalledWith('Tag removed.');
+    });
+  });
+});

--- a/mobile/src/features/profile/presentation/screens/ProfileScreen.tsx
+++ b/mobile/src/features/profile/presentation/screens/ProfileScreen.tsx
@@ -1,6 +1,6 @@
 import * as ImagePicker from 'expo-image-picker';
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { Image, Modal, Pressable, ScrollView, Text, View } from 'react-native';
+import { Alert, Image, Modal, Pressable, ScrollView, Text, View } from 'react-native';
 import { GestureResponderEvent } from 'react-native';
 import { navigationRef } from '../../../../app/navigation/navigationRef';
 import { ROUTES } from '../../../../app/navigation/routes';
@@ -12,6 +12,7 @@ import { authService } from '../../../auth/application/services';
 import { useAuth } from '../../../auth';
 import { NotificationPreferencesSection } from '../../../notifications';
 import { interactionService } from '../../../interactions/application/services';
+import { adminService } from '../../../moderation/application/services';
 import { FeedCard } from '../../../feed/presentation/components/FeedCard';
 import { FeedEntity, FeedPageEntity } from '../../../feed/domain/entities';
 import { userService } from '../../application/services';
@@ -59,6 +60,7 @@ interface ProfileScreenProps {
   deleteAccount?: typeof userService.deleteAccount;
   followUser?: typeof userService.followUser;
   unfollowUser?: typeof userService.unfollowUser;
+  banUser?: typeof adminService.banUser;
   getFollowers?: typeof userService.getFollowers;
   getFollowing?: typeof userService.getFollowing;
   getSavedStories?: typeof userService.getSavedStories;
@@ -1488,6 +1490,7 @@ export function ProfileScreen({
   deleteAccount = userService.deleteAccount,
   followUser = userService.followUser,
   unfollowUser = userService.unfollowUser,
+  banUser = adminService.banUser,
   getFollowers = userService.getFollowers,
   getFollowing = userService.getFollowing,
   getSavedStories = userService.getSavedStories,
@@ -1525,6 +1528,8 @@ export function ProfileScreen({
   const [followingCount, setFollowingCount] = useState(0);
   const [isFollowing, setIsFollowing] = useState(false);
   const [isFollowLoading, setIsFollowLoading] = useState(false);
+  const [isBanLoading, setIsBanLoading] = useState(false);
+  const [isBanned, setIsBanned] = useState(false);
   const [followListMode, setFollowListMode] = useState<'followers' | 'following'>('followers');
   const [isFollowListVisible, setIsFollowListVisible] = useState(false);
   const [activeSelfTab, setActiveSelfTab] = useState<SelfProfileTab>('profile');
@@ -1580,6 +1585,7 @@ export function ProfileScreen({
       setFollowersCount(nextProfile.followersCount ?? 0);
       setFollowingCount(nextProfile.followingCount ?? 0);
       setIsFollowing(Boolean(resolvedFollowState));
+      setIsBanned(false);
       setFormState(createFormState(nextProfile));
       resetPhotoDraft();
       setIsEditing(false);
@@ -1926,6 +1932,43 @@ export function ProfileScreen({
     .join(' ');
   const joinedDate = formatJoinedDate(profile?.dateJoined);
   const birthDateDisplay = isSelfMode ? formatProfileBirthDate(profile?.birthDate) : undefined;
+  const canBanProfileUser = !isSelfMode && user?.role === 'admin' && Boolean(profile) && String(user.id) !== profile?.id;
+
+  const handleBanUser = useCallback(async () => {
+    if (!profile || isBanLoading || isBanned) {
+      return;
+    }
+
+    setIsBanLoading(true);
+
+    try {
+      await banUser(profile.id);
+      setIsBanned(true);
+      toast.success('User banned.');
+    } catch (banError) {
+      toast.error(banError instanceof Error ? banError.message : 'Failed to ban user. Please try again.');
+    } finally {
+      setIsBanLoading(false);
+    }
+  }, [banUser, isBanLoading, isBanned, profile, toast]);
+
+  const promptBanUser = useCallback(() => {
+    if (!profile || isBanLoading || isBanned) {
+      return;
+    }
+
+    Alert.alert('Ban user?', `${resolvedName} will lose access to the app.`, [
+      { text: 'Cancel', style: 'cancel' },
+      {
+        text: 'Ban',
+        style: 'destructive',
+        onPress: () => {
+          void handleBanUser();
+        },
+      },
+    ]);
+  }, [handleBanUser, isBanLoading, isBanned, profile, resolvedName]);
+
   const isDirty = useMemo(() => {
     if (!profile) {
       return false;
@@ -2086,13 +2129,25 @@ export function ProfileScreen({
           </View>
 
           {!isSelfMode ? (
-            <FollowActionButton
-              isAuthenticated={Boolean(isAuthenticated)}
-              isFollowing={isFollowing}
-              isLoading={isFollowLoading}
-              onToggle={() => void handleToggleFollow()}
-              onRequestLogin={handleRequestLoginForFollow}
-            />
+            <View style={{ flexDirection: 'row', flexWrap: 'wrap', gap: spacing.sm, alignItems: 'center' }}>
+              <FollowActionButton
+                isAuthenticated={Boolean(isAuthenticated)}
+                isFollowing={isFollowing}
+                isLoading={isFollowLoading}
+                onToggle={() => void handleToggleFollow()}
+                onRequestLogin={handleRequestLoginForFollow}
+              />
+              {canBanProfileUser ? (
+                <Button
+                  variant="outline"
+                  disabled={isBanLoading || isBanned}
+                  onPress={promptBanUser}
+                  accessibilityLabel={isBanned ? 'User banned' : `Ban ${resolvedName}`}
+                >
+                  {isBanLoading ? 'Banning...' : isBanned ? 'Banned' : 'Ban user'}
+                </Button>
+              ) : null}
+            </View>
           ) : null}
 
           {profile.bio ? (

--- a/mobile/src/features/profile/presentation/screens/__tests__/ProfileScreen.test.tsx
+++ b/mobile/src/features/profile/presentation/screens/__tests__/ProfileScreen.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
-import { fireEvent, render, screen, waitFor } from '@testing-library/react-native';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react-native';
 import * as ImagePicker from 'expo-image-picker';
-import { ScrollView } from 'react-native';
+import { Alert, ScrollView } from 'react-native';
 import { ProfileScreen } from '../ProfileScreen';
 import { navigationRef } from '../../../../../app/navigation/navigationRef';
 import { userService } from '../../../application/services';
@@ -17,7 +17,7 @@ let mockAuthUser: {
   id: number;
   email: string;
   username: string;
-  role: 'user';
+  role: 'user' | 'admin';
   isUsernamePublic: boolean;
 } | null = {
   id: 7,
@@ -813,6 +813,55 @@ describe('ProfileScreen', () => {
     await waitFor(() => {
       expect(followUser).toHaveBeenCalledWith('13');
     });
+  });
+
+  it('shows a ban action to admins on public profiles and confirms before banning', async () => {
+    mockAuthUser = {
+      id: 7,
+      email: 'admin@example.com',
+      username: 'Admin',
+      role: 'admin',
+      isUsernamePublic: true,
+    };
+    const banUser = jest.fn(async () => undefined);
+    const alertSpy = jest.spyOn(Alert, 'alert').mockImplementation(() => undefined);
+
+    render(
+      <ProfileScreen
+        mode="public"
+        userId="12"
+        getPublicProfile={async () => publicProfile}
+        banUser={banUser}
+      />,
+    );
+
+    expect(await screen.findByText('Aylin')).toBeTruthy();
+
+    fireEvent.press(screen.getByLabelText('Ban Aylin'));
+
+    expect(alertSpy).toHaveBeenCalledWith(
+      'Ban user?',
+      'Aylin will lose access to the app.',
+      expect.arrayContaining([
+        expect.objectContaining({ text: 'Cancel' }),
+        expect.objectContaining({ text: 'Ban' }),
+      ]),
+    );
+
+    const buttons = alertSpy.mock.calls[0]?.[2] as Array<{ text: string; onPress?: () => void }>;
+    const banButton = buttons.find((button) => button.text === 'Ban');
+
+    await act(async () => {
+      banButton?.onPress?.();
+    });
+
+    await waitFor(() => {
+      expect(banUser).toHaveBeenCalledWith('12');
+      expect(mockToastSuccess).toHaveBeenCalledWith('User banned.');
+    });
+    expect(screen.getByLabelText('User banned')).toBeTruthy();
+
+    alertSpy.mockRestore();
   });
 
   it('keeps the following state after leaving and returning when the profile response omits it', async () => {

--- a/mobile/src/features/stories/presentation/screens/StoryScreen.tsx
+++ b/mobile/src/features/stories/presentation/screens/StoryScreen.tsx
@@ -28,6 +28,7 @@ import { loadStoryDetail } from '../state/storyDetailController';
 
 interface StoryScreenProps {
   storyId: string;
+  focusedCommentId?: string;
   session?: Pick<Session, 'role' | 'user'>;
   onRequestLogin?: () => void;
   onGoBack?: () => void;
@@ -636,6 +637,8 @@ interface CommentsSectionProps {
   comments: StoryEntity['comments'];
   isAuthenticated: boolean;
   currentUsername?: string;
+  canModerateComments?: boolean;
+  focusedCommentId?: string;
   loginPromptVisible: boolean;
   commentText: string;
   commentError?: string;
@@ -655,6 +658,8 @@ function CommentsSection({
   comments,
   isAuthenticated,
   currentUsername,
+  canModerateComments = false,
+  focusedCommentId,
   loginPromptVisible,
   commentText,
   commentError,
@@ -719,6 +724,7 @@ function CommentsSection({
 
       {displayedComments.map((comment) => {
         const isOwnComment = isAuthenticated && currentUsername === comment.authorName;
+        const canDeleteComment = isOwnComment || canModerateComments;
         const awaitingConfirm = confirmDeleteId === comment.id;
         const authorDisplayName = getDisplayNameWithYouLabel(comment.authorName, isOwnComment);
 
@@ -730,8 +736,8 @@ function CommentsSection({
             padding: spacing.md,
             borderRadius: 16,
             borderWidth: 1,
-            borderColor: colors.border,
-            backgroundColor: colors.surface,
+            borderColor: focusedCommentId === comment.id ? colors.primary : colors.border,
+            backgroundColor: focusedCommentId === comment.id ? colors.infoSurface : colors.surface,
           }}
         >
           <Text style={{ color: colors.text, fontWeight: '700' }}>{authorDisplayName}</Text>
@@ -758,10 +764,11 @@ function CommentsSection({
                   <Text style={{ color: colors.muted, fontWeight: '700' }}>Report</Text>
                 </Pressable>
               ) : null}
-              {isOwnComment ? (
+              {canDeleteComment ? (
                 <Pressable
                   onPress={() => onDeleteRequest(comment.id)}
                   accessibilityRole="button"
+                  accessibilityLabel={`Delete comment by ${authorDisplayName}`}
                   style={({ pressed }) => ({
                     minHeight: 44,
                     justifyContent: 'center',
@@ -806,6 +813,7 @@ function CommentsSection({
 
 export function StoryScreen({
   storyId,
+  focusedCommentId,
   session,
   onRequestLogin,
   onGoBack,
@@ -839,7 +847,9 @@ export function StoryScreen({
   const [contributorPhotoUrl, setContributorPhotoUrl] = useState<string | null>(null);
   const [isNarrativeExpanded, setIsNarrativeExpanded] = useState(false);
   const [narrativeTop, setNarrativeTop] = useState(0);
+  const [commentsTop, setCommentsTop] = useState(0);
   const scrollViewRef = useRef<ScrollView>(null);
+  const hasScrolledToFocusedCommentRef = useRef(false);
   const deletedCommentIdsRef = useRef<Set<string>>(new Set());
 
   useEffect(() => {
@@ -861,6 +871,8 @@ export function StoryScreen({
     setContributorPhotoUrl(null);
     setIsNarrativeExpanded(false);
     setNarrativeTop(0);
+    setCommentsTop(0);
+    hasScrolledToFocusedCommentRef.current = false;
     deletedCommentIdsRef.current = new Set();
 
     loadStoryDetail(storyId, session?.role, getStory).then((nextState) => {
@@ -899,6 +911,21 @@ export function StoryScreen({
       isMounted = false;
     };
   }, [getStory, session?.role, storyId]);
+
+  useEffect(() => {
+    hasScrolledToFocusedCommentRef.current = false;
+  }, [focusedCommentId, storyId]);
+
+  useEffect(() => {
+    if (!focusedCommentId || !commentsTop || hasScrolledToFocusedCommentRef.current || !comments.length) {
+      return;
+    }
+
+    hasScrolledToFocusedCommentRef.current = true;
+    requestAnimationFrame(() => {
+      scrollViewRef.current?.scrollTo({ y: Math.max(0, commentsTop - spacing.md), animated: true });
+    });
+  }, [comments.length, commentsTop, focusedCommentId, spacing.md]);
 
   useEffect(() => {
     let isMounted = true;
@@ -1471,10 +1498,13 @@ export function StoryScreen({
         <Text style={{ marginTop: spacing.sm, color: colors.danger }}>{interactionError}</Text>
       ) : null}
 
+      <View testID="story-comments-section" onLayout={(event) => setCommentsTop(event.nativeEvent.layout.y)}>
       <CommentsSection
         comments={comments}
         isAuthenticated={state.isAuthenticated}
         currentUsername={session?.user.username}
+        canModerateComments={session?.role === roles.admin}
+        focusedCommentId={focusedCommentId}
         loginPromptVisible={state.loginPromptVisible}
         commentText={commentText}
         commentError={commentError}
@@ -1499,6 +1529,7 @@ export function StoryScreen({
         }}
         onReportRequest={(commentId) => handleReportRequest('comment', commentId)}
       />
+      </View>
       <ReportSheet
         key={reportTarget ? `${reportTarget.targetType}-${reportTarget.targetId}` : 'hidden-report-sheet'}
         visible={Boolean(reportTarget)}

--- a/mobile/src/features/stories/presentation/screens/__tests__/StoryScreen.test.tsx
+++ b/mobile/src/features/stories/presentation/screens/__tests__/StoryScreen.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Alert } from 'react-native';
+import { Alert, ScrollView } from 'react-native';
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react-native';
 import { StoryScreen } from '../StoryScreen';
 import { Session } from '../../../../../core/auth/session';
@@ -821,6 +821,91 @@ describe('StoryScreen', () => {
     await waitFor(() => {
       expect(screen.queryByText('Delete this comment?')).toBeNull();
     });
+  });
+
+  it('lets admins delete comments written by other users', async () => {
+    (interactionService.deleteComment as jest.Mock).mockResolvedValueOnce(undefined);
+    (interactionService.getComments as jest.Mock).mockResolvedValueOnce([
+      {
+        id: 'comment-other',
+        authorUsername: 'Someone else',
+        text: 'Moderate this comment',
+        createdAt: '2026-03-20T12:00:00Z',
+      },
+    ]);
+
+    render(
+      <StoryScreen
+        storyId="story-001"
+        session={adminSession}
+        getStory={async () => ({
+          ...baseStory,
+          comments: [
+            {
+              id: 'comment-other',
+              authorName: 'Someone else',
+              body: 'Moderate this comment',
+              createdAt: '2026-03-20T12:00:00Z',
+            },
+          ],
+        })}
+      />,
+    );
+
+    await screen.findByText('Moderate this comment');
+    expect(screen.getByLabelText('Delete comment by Someone else')).toBeTruthy();
+
+    fireEvent.press(screen.getByLabelText('Delete comment by Someone else'));
+    fireEvent.press(screen.getByText('Delete'));
+
+    await waitFor(() => {
+      expect(interactionService.deleteComment).toHaveBeenCalledWith('comment-other');
+    });
+  });
+
+  it('scrolls to the comments section when a focused comment is provided', async () => {
+    const scrollToSpy = jest.spyOn(ScrollView.prototype, 'scrollTo').mockImplementation(jest.fn());
+
+    try {
+      (interactionService.getComments as jest.Mock).mockResolvedValueOnce([
+        {
+          id: 'comment-focus',
+          authorUsername: 'Someone else',
+          text: 'Focus this comment',
+          createdAt: '2026-03-20T12:00:00Z',
+        },
+      ]);
+
+      render(
+        <StoryScreen
+          storyId="story-001"
+          focusedCommentId="comment-focus"
+          session={adminSession}
+          getStory={async () => ({
+            ...baseStory,
+            comments: [
+              {
+                id: 'comment-focus',
+                authorName: 'Someone else',
+                body: 'Focus this comment',
+                createdAt: '2026-03-20T12:00:00Z',
+              },
+            ],
+          })}
+        />,
+      );
+
+      await screen.findByText('Focus this comment');
+      fireEvent(screen.getByTestId('story-comments-section'), 'layout', {
+        nativeEvent: { layout: { y: 900 } },
+      });
+
+      await waitFor(() => {
+        expect(scrollToSpy).toHaveBeenCalledWith({ y: 884, animated: true });
+      });
+    } finally {
+      scrollToSpy.mockRestore();
+    }
   });
 
   it('marks the signed-in user on their own comments even when private', async () => {


### PR DESCRIPTION
# 📝 Description
Fixes #215

Implemented mobile admin moderation improvements:
- Added admin moderation panel for reports, stories, and tags.
- Removed the separate admin users tab and dismissed report filter.
- Added navigation from admin reports/stories/comments to the related story/comment area.
- Enabled admins to delete comments inside stories.
- Added “Ban user” action on other users’ public profiles for admins.

# 📊 Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Refactoring
- [ ] Documentation
 
# ✅ Acceptance Criteria / Checklist
- [x] Project builds successfully
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, especially in hard-to-understand parts
- [x] I have performed a self-review of my code
- [x] I have added/updated tests
- [x] New and existing unit tests pass locally with my changes

# 📸 Screenshots / Recordings
<!-- If applicable !-->

# ⏱️ Estimated Review Time
- [ ] < 5 min
- [x] 5-15 min
- [ ] > 15 min
