### PR TITLE
Feat/story pins by zoom level mobile

### DIFF
--- a/mobile/src/app/navigation/AdminNavigator.tsx
+++ b/mobile/src/app/navigation/AdminNavigator.tsx
@@ -1,10 +1,12 @@
 import React from 'react';
-import { View, Text } from 'react-native';
+import { ModerationScreen } from '../../features/moderation';
 
-export function AdminNavigator() {
-  return (
-    <View style={{ padding: 16 }}>
-      <Text>Admin Navigator Placeholder</Text>
-    </View>
-  );
+export function AdminNavigator({
+  onOpenStory,
+  onOpenComment,
+}: {
+  onOpenStory?: (storyId: string) => void;
+  onOpenComment?: (storyId: string, commentId: string) => void;
+}) {
+  return <ModerationScreen onOpenStory={onOpenStory} onOpenComment={onOpenComment} />;
 }

--- a/mobile/src/app/navigation/RootNavigator.tsx
+++ b/mobile/src/app/navigation/RootNavigator.tsx
@@ -731,15 +731,19 @@ export function RootNavigator() {
   };
 
   const handleViewTimelineNearPin = useCallback(
-    (coordinates: { latitude: number; longitude: number }) => {
+    (target: { latitude: number; longitude: number; label?: string }) => {
       updateFilters(
         {
           query: '',
           location: '',
           locationBounds: undefined,
           proximityRadiusKm: 0.5,
-          proximityCoordinates: coordinates,
+          proximityCoordinates: {
+            latitude: target.latitude,
+            longitude: target.longitude,
+          },
           proximitySource: 'map_pin',
+          proximityLabel: target.label,
           timeFrom: '',
           timeTo: '',
           tags: [],

--- a/mobile/src/app/navigation/RootNavigator.tsx
+++ b/mobile/src/app/navigation/RootNavigator.tsx
@@ -20,15 +20,17 @@ import { useToast } from '../../shared/hooks/useToast';
 import { APP_NAME } from '../../core/constants/app';
 import { NotificationScreen, notificationService } from '../../features/notifications';
 import { NotificationEntity } from '../../features/notifications/domain/entities';
+import { ModerationScreen } from '../../features/moderation';
 
 type AppRoute = (typeof ROUTES)[keyof typeof ROUTES];
 interface RouteSnapshot {
   route: AppRoute;
   storyId?: string | null;
+  commentId?: string | null;
   userId?: string | null;
 }
 
-const protectedRoutes: AppRoute[] = [ROUTES.PROFILE, ROUTES.SUBMISSION, ROUTES.NOTIFICATIONS];
+const protectedRoutes: AppRoute[] = [ROUTES.PROFILE, ROUTES.SUBMISSION, ROUTES.NOTIFICATIONS, ROUTES.ADMIN_HOME];
 const NOTIFICATION_REFRESH_INTERVAL_MS = 45000;
 const MAIN_PAGER_ROUTES: AppRoute[] = [ROUTES.MAP, ROUTES.TIMELINE, ROUTES.FEED];
 
@@ -360,6 +362,7 @@ export function RootNavigator() {
   const { width } = useWindowDimensions();
   const [currentRoute, setCurrentRoute] = useState<AppRoute>(ROUTES.FEED);
   const [activeStoryId, setActiveStoryId] = useState<string | null>(null);
+  const [focusedCommentId, setFocusedCommentId] = useState<string | null>(null);
   const [activeUserId, setActiveUserId] = useState<string | null>(null);
   const [pendingVerification, setPendingVerification] = useState<{ email: string; password: string } | null>(null);
   const [shouldCompleteProfileAfterLogin, setShouldCompleteProfileAfterLogin] = useState(false);
@@ -379,9 +382,10 @@ export function RootNavigator() {
     () => ({
       route: currentRoute,
       storyId: currentRoute === ROUTES.STORY_DETAIL ? activeStoryId : null,
+      commentId: currentRoute === ROUTES.STORY_DETAIL ? focusedCommentId : null,
       userId: currentRoute === ROUTES.USER_PROFILE ? activeUserId : null,
     }),
-    [activeStoryId, activeUserId, currentRoute],
+    [activeStoryId, activeUserId, currentRoute, focusedCommentId],
   );
   const [redirectTarget, setRedirectTarget] = useState<RouteSnapshot>({ route: ROUTES.PROFILE });
   const canGoBack = backStack.length > 0;
@@ -419,6 +423,7 @@ export function RootNavigator() {
   const restoreSnapshot = useCallback((snapshot: RouteSnapshot) => {
     setCurrentRoute(snapshot.route);
     setActiveStoryId(snapshot.route === ROUTES.STORY_DETAIL ? snapshot.storyId ?? null : null);
+    setFocusedCommentId(snapshot.route === ROUTES.STORY_DETAIL ? snapshot.commentId ?? null : null);
     setActiveUserId(snapshot.route === ROUTES.USER_PROFILE ? snapshot.userId ?? null : null);
   }, []);
 
@@ -455,6 +460,7 @@ export function RootNavigator() {
         !options?.resetStack &&
         snapshot.route === currentSnapshot.route &&
         snapshot.storyId === currentSnapshot.storyId &&
+        snapshot.commentId === currentSnapshot.commentId &&
         snapshot.userId === currentSnapshot.userId
       ) {
         return;
@@ -469,6 +475,7 @@ export function RootNavigator() {
           if (
             previous?.route === currentSnapshot.route &&
             previous?.storyId === currentSnapshot.storyId &&
+            previous?.commentId === currentSnapshot.commentId &&
             previous?.userId === currentSnapshot.userId
           ) {
             return current;
@@ -561,7 +568,9 @@ export function RootNavigator() {
       showAuthRequiredMessage(
         route === ROUTES.PROFILE
           ? 'Please sign in to view your profile.'
-          : 'Please sign in to submit a story.',
+          : route === ROUTES.ADMIN_HOME
+            ? 'Please sign in with an admin account to continue.'
+            : 'Please sign in to submit a story.',
       );
       return;
     }
@@ -627,6 +636,7 @@ export function RootNavigator() {
       if (
         previousSnapshot?.route === resolvedRedirectTarget.route &&
         previousSnapshot?.storyId === resolvedRedirectTarget.storyId &&
+        previousSnapshot?.commentId === resolvedRedirectTarget.commentId &&
         previousSnapshot?.userId === resolvedRedirectTarget.userId
       ) {
         nextStack.pop();
@@ -714,6 +724,10 @@ export function RootNavigator() {
 
   const handleOpenStoryDetail = (storyId: string) => {
     navigateToSnapshot({ route: ROUTES.STORY_DETAIL, storyId });
+  };
+
+  const handleOpenStoryComment = (storyId: string, commentId: string) => {
+    navigateToSnapshot({ route: ROUTES.STORY_DETAIL, storyId, commentId });
   };
 
   const handleViewTimelineNearPin = useCallback(
@@ -895,10 +909,31 @@ export function RootNavigator() {
         </ScreenShell>
       </ProtectedScreen>
     );
+  } else if (currentRoute === ROUTES.ADMIN_HOME) {
+    content = (
+      <ProtectedScreen
+        title="Admin tools require sign-in"
+        description="Sign in with an admin account to continue."
+        onAuthenticated={handleLoginComplete}
+        onRegistrationPending={handleRegistrationPending}
+      >
+        <ScreenShell
+          title="Admin moderation"
+          description="Review reports, stories, and tags."
+          framed={false}
+          fillContent
+          hideHeader
+          flushBottom
+        >
+          <ModerationScreen onOpenStory={handleOpenStoryDetail} onOpenComment={handleOpenStoryComment} />
+        </ScreenShell>
+      </ProtectedScreen>
+    );
   } else if (currentRoute === ROUTES.STORY_DETAIL && activeStoryId) {
     content = (
       <StoryScreen
         storyId={activeStoryId}
+        focusedCommentId={focusedCommentId ?? undefined}
         session={user ? { role: user.role, user } : undefined}
         onRequestLogin={() => showAuthRequiredMessage('Please sign in to like stories and join the discussion.')}
         onGoBack={handleBack}
@@ -1070,6 +1105,13 @@ export function RootNavigator() {
           )}
           {isAuthenticated ? (
             <View style={{ flexDirection: 'row', alignItems: 'center', gap: spacing.sm }}>
+              {user?.role === 'admin' ? (
+                <TopIconButton
+                  label="Admin"
+                  filled={currentRoute === ROUTES.ADMIN_HOME}
+                  onPress={() => handleNavigate(ROUTES.ADMIN_HOME)}
+                />
+              ) : null}
               <NotificationBellButton
                 unreadCount={unreadNotificationCount}
                 onPress={() => handleNavigate(ROUTES.NOTIFICATIONS)}

--- a/mobile/src/app/navigation/__tests__/RootNavigator.test.tsx
+++ b/mobile/src/app/navigation/__tests__/RootNavigator.test.tsx
@@ -1079,7 +1079,7 @@ describe('RootNavigator auth flow', () => {
         'GET /stories/feed/?page_size=100&sort_by=recent&latitude=41.02&longitude=28.96&radius_km=0.5&page=1',
       );
     });
-    expect(screen.getByLabelText('Remove Distance: 500 m from red location pin')).toBeTruthy();
+    expect(screen.getByLabelText('Remove Distance: 500 m from Harbor Memory red location pin')).toBeTruthy();
 
     fireEvent.press(await screen.findByLabelText('Open timeline story: Harbor Memory'));
 

--- a/mobile/src/features/map/presentation/components/MapCard.tsx
+++ b/mobile/src/features/map/presentation/components/MapCard.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useRef } from 'react';
-import { ActivityIndicator, LayoutChangeEvent, Pressable, ScrollView, Text, View } from 'react-native';
+import { ActivityIndicator, LayoutChangeEvent, ScrollView, Text, View } from 'react-native';
 import { Region } from 'react-native-maps';
 import { useAppTheme } from '../../../../core/hooks/useAppTheme';
 import { Button } from '../../../../shared/ui/Button';
@@ -17,7 +17,7 @@ interface MapCardProps {
   userLocation?: { latitude: number; longitude: number };
   onSelectMarker: (markerId: string) => void;
   onOpenStory: (storyId: string) => void;
-  onViewTimeline?: (coordinates: { latitude: number; longitude: number }) => void;
+  onViewTimeline?: (target: { latitude: number; longitude: number; label?: string }) => void;
   onRegionChangeComplete?: (region: Region) => void;
   onPreviewLayout?: (event: LayoutChangeEvent) => void;
   onMapTouchChange?: (isTouchingMap: boolean) => void;
@@ -52,7 +52,9 @@ export function MapCard({
         latitude: marker.latitude,
         longitude: marker.longitude,
         selected: marker.id === (highlightedMarkerId ?? selectedMarkerId),
-        label: marker.isCluster ? String(marker.count) : undefined,
+        label: marker.isCluster && marker.id !== highlightedMarkerId && marker.id !== selectedMarkerId
+          ? String(marker.count)
+          : undefined,
       })),
     [highlightedMarkerId, markers, selectedMarkerId],
   );
@@ -211,9 +213,15 @@ export function MapCard({
             <Button
               variant="outline"
               accessibilityLabel={`View timeline near ${selectedMarker.count} nearby stories`}
-              onPress={() => onViewTimeline?.({ latitude: selectedMarker.latitude, longitude: selectedMarker.longitude })}
+              onPress={() =>
+                onViewTimeline?.({
+                  latitude: selectedMarker.latitude,
+                  longitude: selectedMarker.longitude,
+                  label: `${selectedMarker.count} nearby stories`,
+                })
+              }
             >
-              View Timeline
+              View Group Timeline
             </Button>
             <ScrollView
               style={{ maxHeight: 240 }}
@@ -223,9 +231,8 @@ export function MapCard({
               testID="cluster-preview-list"
             >
               {selectedMarker.stories.map((story) => (
-                <Pressable
+                <View
                   key={story.id}
-                  onPress={() => onOpenStory(story.id)}
                   style={{
                     padding: spacing.md,
                     borderRadius: 16,
@@ -238,7 +245,29 @@ export function MapCard({
                   <Text {...passivePreviewTextProps} style={{ marginTop: spacing.xs, color: colors.muted }}>{story.placeName}</Text>
                   <Text {...passivePreviewTextProps} style={{ marginTop: spacing.xs, color: colors.muted }}>{story.timePeriod}</Text>
                   <Text {...passivePreviewTextProps} style={{ marginTop: spacing.sm, color: colors.text }}>{truncatePreview(story.previewText)}</Text>
-                </Pressable>
+                  <View style={{ flexDirection: 'row', flexWrap: 'wrap', gap: spacing.sm, marginTop: spacing.sm }}>
+                    <Button
+                      style={{ flexGrow: 1, flexBasis: 120 }}
+                      onPress={() => onOpenStory(story.id)}
+                    >
+                      Read full story
+                    </Button>
+                    <Button
+                      variant="outline"
+                      style={{ flexGrow: 1, flexBasis: 120 }}
+                      accessibilityLabel={`View timeline near ${story.title}`}
+                      onPress={() =>
+                        onViewTimeline?.({
+                          latitude: story.latitude,
+                          longitude: story.longitude,
+                          label: story.title,
+                        })
+                      }
+                    >
+                      View Timeline
+                    </Button>
+                  </View>
+                </View>
               ))}
             </ScrollView>
           </>
@@ -261,7 +290,13 @@ export function MapCard({
                 variant="outline"
                 style={{ flexGrow: 1, flexBasis: 140 }}
                 accessibilityLabel={`View timeline near ${selectedMarker.stories[0].title}`}
-                onPress={() => onViewTimeline?.({ latitude: selectedMarker.latitude, longitude: selectedMarker.longitude })}
+                onPress={() =>
+                  onViewTimeline?.({
+                    latitude: selectedMarker.stories[0].latitude,
+                    longitude: selectedMarker.stories[0].longitude,
+                    label: selectedMarker.stories[0].title,
+                  })
+                }
               >
                 View Timeline
               </Button>

--- a/mobile/src/features/map/presentation/screens/MapScreen.tsx
+++ b/mobile/src/features/map/presentation/screens/MapScreen.tsx
@@ -44,6 +44,8 @@ const LOCATION_BOUNDS_PADDING_FACTOR = 1.15;
 const PROXIMITY_PADDING_FACTOR = 2.4;
 const KILOMETERS_PER_LATITUDE_DEGREE = 111;
 const MAX_AUTO_REGION_DELTA = 20;
+const CLUSTER_RADIUS_REGION_FRACTION = 0.1;
+const MIN_CLUSTER_RADIUS_DEGREES = 0.0008;
 type StatusIndicatorMode = 'hidden' | 'filters' | 'area';
 
 export function MapScreen({
@@ -236,6 +238,18 @@ export function MapScreen({
     () => getMapPinFilterMarkerId(state.markers, filters),
     [filters, state.markers],
   );
+  const displayMarkers = useMemo(
+    () => clusterMarkersForRegion(state.markers, mapRegion),
+    [mapRegion, state.markers],
+  );
+  const displayedSelectedMarkerId = useMemo(
+    () => getDisplayedMarkerId(state.selectedMarkerId, displayMarkers, state.markers),
+    [displayMarkers, state.markers, state.selectedMarkerId],
+  );
+  const displayedHighlightedMarkerId = useMemo(
+    () => getDisplayedMarkerId(mapPinFilterMarkerId, displayMarkers, state.markers),
+    [displayMarkers, mapPinFilterMarkerId, state.markers],
+  );
   const statusStoryCount = useMemo(() => {
     if (statusIndicatorMode !== 'area' || !hasInteractedWithArea || !visibleRegion) {
       return totalStoryCount;
@@ -301,20 +315,29 @@ export function MapScreen({
       >
         <MapCard
           region={mapRegion}
-          markers={state.markers}
-          selectedMarkerId={state.selectedMarkerId}
-          highlightedMarkerId={mapPinFilterMarkerId}
+          markers={displayMarkers}
+          selectedMarkerId={displayedSelectedMarkerId}
+          highlightedMarkerId={displayedHighlightedMarkerId}
           isLoading={state.isLoading}
           error={state.error}
           statusBadgeText={statusBadgeText}
           userLocation={userLocation}
           onSelectMarker={(markerId) => {
-            const shouldOpenPreview = state.selectedMarkerId !== markerId;
+            const selectedMarker = displayMarkers.find((marker) => marker.id === markerId);
+            const shouldOpenPreview = displayedSelectedMarkerId !== markerId;
 
             setState((current) => ({
               ...current,
-              selectedMarkerId: current.selectedMarkerId === markerId ? undefined : markerId,
+              selectedMarkerId: displayedSelectedMarkerId === markerId ? undefined : markerId,
             }));
+
+            if (selectedMarker?.isCluster && shouldOpenPreview) {
+              const nextRegion = getRegionForCluster(selectedMarker, mapRegion);
+              setMapRegion(nextRegion);
+              setVisibleRegion(nextRegion);
+              setHasInteractedWithArea(true);
+              setStatusIndicatorMode('area');
+            }
 
             if (shouldOpenPreview) {
               handleMarkerPreviewRequest();
@@ -405,6 +428,122 @@ function countStoriesInRegion(markers: MapMarkerGroup[], region: Region) {
 
     return sum + (isMarkerVisible ? marker.count : 0);
   }, 0);
+}
+
+function clusterMarkersForRegion(markers: MapMarkerGroup[], region: Region): MapMarkerGroup[] {
+  if (markers.length < 2) {
+    return markers;
+  }
+
+  const clusterRadius = Math.max(
+    Math.max(Math.abs(region.latitudeDelta), Math.abs(region.longitudeDelta)) * CLUSTER_RADIUS_REGION_FRACTION,
+    MIN_CLUSTER_RADIUS_DEGREES,
+  );
+  const clusters: MapMarkerGroup[][] = [];
+
+  markers.forEach((marker) => {
+    const matchingCluster = clusters.find((cluster) => {
+      const center = getWeightedClusterCenter(cluster);
+
+      return getProjectedDistance(marker, center) <= clusterRadius;
+    });
+
+    if (matchingCluster) {
+      matchingCluster.push(marker);
+      return;
+    }
+
+    clusters.push([marker]);
+  });
+
+  return clusters.map((cluster) => {
+    if (cluster.length === 1) {
+      return cluster[0];
+    }
+
+    const center = getWeightedClusterCenter(cluster);
+    const stories = cluster.flatMap((marker) => marker.stories);
+    const count = cluster.reduce((sum, marker) => sum + marker.count, 0);
+    const clusterId = cluster
+      .map((marker) => marker.id)
+      .sort()
+      .join('|');
+
+    return {
+      id: `zoom-cluster:${clusterId}`,
+      latitude: center.latitude,
+      longitude: center.longitude,
+      stories,
+      count,
+      isCluster: true,
+    };
+  });
+}
+
+function getWeightedClusterCenter(markers: MapMarkerGroup[]) {
+  const totalCount = markers.reduce((sum, marker) => sum + marker.count, 0);
+  const latitude = markers.reduce((sum, marker) => sum + marker.latitude * marker.count, 0) / totalCount;
+  const longitude = markers.reduce((sum, marker) => sum + marker.longitude * marker.count, 0) / totalCount;
+
+  return { latitude, longitude };
+}
+
+function getProjectedDistance(
+  marker: Pick<MapMarkerGroup, 'latitude' | 'longitude'>,
+  center: { latitude: number; longitude: number },
+) {
+  const latitudeDistance = marker.latitude - center.latitude;
+  const longitudeScale = Math.max(Math.cos((center.latitude * Math.PI) / 180), 0.2);
+  const longitudeDistance = (marker.longitude - center.longitude) * longitudeScale;
+
+  return Math.sqrt(latitudeDistance ** 2 + longitudeDistance ** 2);
+}
+
+function getRegionForCluster(marker: MapMarkerGroup, currentRegion: Region): Region {
+  const latitudes = marker.stories.map((story) => story.latitude);
+  const longitudes = marker.stories.map((story) => story.longitude);
+  const minLatitude = Math.min(...latitudes, marker.latitude);
+  const maxLatitude = Math.max(...latitudes, marker.latitude);
+  const minLongitude = Math.min(...longitudes, marker.longitude);
+  const maxLongitude = Math.max(...longitudes, marker.longitude);
+  const latitudeDelta = Math.max((maxLatitude - minLatitude) * FIT_PADDING_FACTOR, MIN_LOCATION_DELTA);
+  const longitudeDelta = Math.max((maxLongitude - minLongitude) * FIT_PADDING_FACTOR, MIN_LOCATION_DELTA);
+  const nextLatitudeDelta = Math.min(latitudeDelta, Math.max(currentRegion.latitudeDelta * 0.45, MIN_LOCATION_DELTA));
+  const nextLongitudeDelta = Math.min(longitudeDelta, Math.max(currentRegion.longitudeDelta * 0.45, MIN_LOCATION_DELTA));
+
+  return {
+    latitude: (minLatitude + maxLatitude) / 2,
+    longitude: (minLongitude + maxLongitude) / 2,
+    latitudeDelta: clampRegionDelta(nextLatitudeDelta, MIN_LOCATION_DELTA),
+    longitudeDelta: clampRegionDelta(nextLongitudeDelta, MIN_LOCATION_DELTA),
+  };
+}
+
+function getDisplayedMarkerId(
+  markerId: string | undefined,
+  displayMarkers: MapMarkerGroup[],
+  sourceMarkers: MapMarkerGroup[],
+) {
+  if (!markerId) {
+    return undefined;
+  }
+
+  if (displayMarkers.some((marker) => marker.id === markerId)) {
+    return markerId;
+  }
+
+  const sourceMarker = sourceMarkers.find((marker) => marker.id === markerId);
+
+  if (!sourceMarker) {
+    return undefined;
+  }
+
+  const sourceStoryIds = new Set(sourceMarker.stories.map((story) => story.id));
+  const containingMarker = displayMarkers.find((marker) =>
+    marker.stories.some((story) => sourceStoryIds.has(story.id)),
+  );
+
+  return containingMarker?.id;
 }
 
 function formatStoryCount(count: number) {

--- a/mobile/src/features/map/presentation/screens/MapScreen.tsx
+++ b/mobile/src/features/map/presentation/screens/MapScreen.tsx
@@ -21,7 +21,7 @@ interface MapScreenProps {
   onOpenStory?: (storyId: string) => void;
   getMarkerGroups?: (filters?: StoryFilters) => Promise<MapMarkerGroup[]>;
   onMarkerPreviewRequested?: (targetY: number) => void;
-  onViewTimeline?: (coordinates: { latitude: number; longitude: number }) => void;
+  onViewTimeline?: (target: { latitude: number; longitude: number; label?: string }) => void;
   showSearchControls?: boolean;
   onRegisterRefresh?: (handler: (() => Promise<void>) | null) => void;
   onMapTouchChange?: (isTouchingMap: boolean) => void;
@@ -46,6 +46,7 @@ const KILOMETERS_PER_LATITUDE_DEGREE = 111;
 const MAX_AUTO_REGION_DELTA = 20;
 const CLUSTER_RADIUS_REGION_FRACTION = 0.1;
 const MIN_CLUSTER_RADIUS_DEGREES = 0.0008;
+const MIN_CLUSTER_ZOOM_DELTA = 0.00001;
 type StatusIndicatorMode = 'hidden' | 'filters' | 'area';
 
 export function MapScreen({
@@ -69,6 +70,8 @@ export function MapScreen({
   const [visibleRegion, setVisibleRegion] = useState<Region | undefined>();
   const [hasInteractedWithArea, setHasInteractedWithArea] = useState(false);
   const [statusIndicatorMode, setStatusIndicatorMode] = useState<StatusIndicatorMode>('hidden');
+  const [zoomedMarkerIds, setZoomedMarkerIds] = useState<Set<string>>(() => new Set());
+  const [expandedMarkerIds, setExpandedMarkerIds] = useState<Set<string>>(() => new Set());
   const lastAutoZoomContextKeyRef = useRef<string | null>(null);
   const previousMapPinFilterKeyRef = useRef<string | null>(null);
   const loadRequestIdRef = useRef(0);
@@ -136,7 +139,7 @@ export function MapScreen({
     try {
       const markers = await getMarkerGroups(activeFilters);
       const selectedMarkerId = getPreferredMarkerId(markers, activeFilters);
-      const nextAutoRegion = getAutoZoomRegion(markers, activeFilters);
+      const nextAutoRegion = getAutoZoomRegion(markers, activeFilters, filters.proximitySource);
 
       if (requestId !== loadRequestIdRef.current) {
         return;
@@ -149,6 +152,8 @@ export function MapScreen({
         markers,
         selectedMarkerId,
       });
+      setZoomedMarkerIds(new Set());
+      setExpandedMarkerIds(new Set());
 
       if (nextAutoRegion && lastAutoZoomContextKeyRef.current !== autoZoomContextKey) {
         lastAutoZoomContextKeyRef.current = autoZoomContextKey;
@@ -167,7 +172,7 @@ export function MapScreen({
         selectedMarkerId: undefined,
       });
     }
-  }, [activeFilters, autoZoomContextKey, getMarkerGroups]);
+  }, [activeFilters, autoZoomContextKey, filters.proximitySource, getMarkerGroups]);
 
   useEffect(() => {
     if (!isHydrated) {
@@ -239,16 +244,18 @@ export function MapScreen({
     [filters, state.markers],
   );
   const displayMarkers = useMemo(
-    () => clusterMarkersForRegion(state.markers, mapRegion),
-    [mapRegion, state.markers],
+    () => clusterMarkersForRegion(state.markers, mapRegion, expandedMarkerIds),
+    [expandedMarkerIds, mapRegion, state.markers],
   );
   const displayedSelectedMarkerId = useMemo(
     () => getDisplayedMarkerId(state.selectedMarkerId, displayMarkers, state.markers),
     [displayMarkers, state.markers, state.selectedMarkerId],
   );
   const displayedHighlightedMarkerId = useMemo(
-    () => getDisplayedMarkerId(mapPinFilterMarkerId, displayMarkers, state.markers),
-    [displayMarkers, mapPinFilterMarkerId, state.markers],
+    () =>
+      getDisplayedMarkerId(mapPinFilterMarkerId, displayMarkers, state.markers) ??
+      getDisplayedMapPinCoordinateMarkerId(displayMarkers, filters),
+    [displayMarkers, filters, mapPinFilterMarkerId, state.markers],
   );
   const statusStoryCount = useMemo(() => {
     if (statusIndicatorMode !== 'area' || !hasInteractedWithArea || !visibleRegion) {
@@ -324,14 +331,29 @@ export function MapScreen({
           userLocation={userLocation}
           onSelectMarker={(markerId) => {
             const selectedMarker = displayMarkers.find((marker) => marker.id === markerId);
-            const shouldOpenPreview = displayedSelectedMarkerId !== markerId;
+            const shouldZoomCluster = Boolean(
+              selectedMarker?.isCluster && hasDistinctStoryCoordinates(selectedMarker),
+            );
+            const shouldOpenPreview = displayedSelectedMarkerId !== markerId || shouldZoomCluster;
 
             setState((current) => ({
               ...current,
-              selectedMarkerId: displayedSelectedMarkerId === markerId ? undefined : markerId,
+              selectedMarkerId: displayedSelectedMarkerId === markerId && !shouldZoomCluster ? undefined : markerId,
             }));
 
-            if (selectedMarker?.isCluster && shouldOpenPreview) {
+            if (selectedMarker?.isCluster && shouldZoomCluster) {
+              const isSourceMarker = state.markers.some((marker) => marker.id === selectedMarker.id);
+
+              if (isSourceMarker) {
+                const hasZoomedMarkerBefore = zoomedMarkerIds.has(selectedMarker.id);
+
+                setZoomedMarkerIds((current) => new Set(current).add(selectedMarker.id));
+
+                if (hasZoomedMarkerBefore) {
+                  setExpandedMarkerIds((current) => new Set(current).add(selectedMarker.id));
+                }
+              }
+
               const nextRegion = getRegionForCluster(selectedMarker, mapRegion);
               setMapRegion(nextRegion);
               setVisibleRegion(nextRegion);
@@ -430,9 +452,15 @@ function countStoriesInRegion(markers: MapMarkerGroup[], region: Region) {
   }, 0);
 }
 
-function clusterMarkersForRegion(markers: MapMarkerGroup[], region: Region): MapMarkerGroup[] {
-  if (markers.length < 2) {
-    return markers;
+function clusterMarkersForRegion(
+  markers: MapMarkerGroup[],
+  region: Region,
+  expandedMarkerIds: Set<string>,
+): MapMarkerGroup[] {
+  const clusterableMarkers = expandDistinctStoryMarkers(markers, expandedMarkerIds);
+
+  if (clusterableMarkers.length < 2) {
+    return clusterableMarkers;
   }
 
   const clusterRadius = Math.max(
@@ -441,7 +469,7 @@ function clusterMarkersForRegion(markers: MapMarkerGroup[], region: Region): Map
   );
   const clusters: MapMarkerGroup[][] = [];
 
-  markers.forEach((marker) => {
+  clusterableMarkers.forEach((marker) => {
     const matchingCluster = clusters.find((cluster) => {
       const center = getWeightedClusterCenter(cluster);
 
@@ -480,6 +508,23 @@ function clusterMarkersForRegion(markers: MapMarkerGroup[], region: Region): Map
   });
 }
 
+function expandDistinctStoryMarkers(markers: MapMarkerGroup[], expandedMarkerIds: Set<string>) {
+  return markers.flatMap((marker) => {
+    if (!expandedMarkerIds.has(marker.id) || !marker.isCluster || !hasDistinctStoryCoordinates(marker)) {
+      return [marker];
+    }
+
+    return marker.stories.map((story) => ({
+      id: `${marker.id}:story:${story.id}`,
+      latitude: story.latitude,
+      longitude: story.longitude,
+      stories: [story],
+      count: 1,
+      isCluster: false,
+    }));
+  });
+}
+
 function getWeightedClusterCenter(markers: MapMarkerGroup[]) {
   const totalCount = markers.reduce((sum, marker) => sum + marker.count, 0);
   const latitude = markers.reduce((sum, marker) => sum + marker.latitude * marker.count, 0) / totalCount;
@@ -506,17 +551,29 @@ function getRegionForCluster(marker: MapMarkerGroup, currentRegion: Region): Reg
   const maxLatitude = Math.max(...latitudes, marker.latitude);
   const minLongitude = Math.min(...longitudes, marker.longitude);
   const maxLongitude = Math.max(...longitudes, marker.longitude);
-  const latitudeDelta = Math.max((maxLatitude - minLatitude) * FIT_PADDING_FACTOR, MIN_LOCATION_DELTA);
-  const longitudeDelta = Math.max((maxLongitude - minLongitude) * FIT_PADDING_FACTOR, MIN_LOCATION_DELTA);
-  const nextLatitudeDelta = Math.min(latitudeDelta, Math.max(currentRegion.latitudeDelta * 0.45, MIN_LOCATION_DELTA));
-  const nextLongitudeDelta = Math.min(longitudeDelta, Math.max(currentRegion.longitudeDelta * 0.45, MIN_LOCATION_DELTA));
+  const latitudeDelta = Math.max((maxLatitude - minLatitude) * FIT_PADDING_FACTOR, MIN_CLUSTER_ZOOM_DELTA);
+  const longitudeDelta = Math.max((maxLongitude - minLongitude) * FIT_PADDING_FACTOR, MIN_CLUSTER_ZOOM_DELTA);
+  const nextLatitudeDelta = Math.min(latitudeDelta, Math.max(currentRegion.latitudeDelta * 0.45, MIN_CLUSTER_ZOOM_DELTA));
+  const nextLongitudeDelta = Math.min(longitudeDelta, Math.max(currentRegion.longitudeDelta * 0.45, MIN_CLUSTER_ZOOM_DELTA));
 
   return {
     latitude: (minLatitude + maxLatitude) / 2,
     longitude: (minLongitude + maxLongitude) / 2,
-    latitudeDelta: clampRegionDelta(nextLatitudeDelta, MIN_LOCATION_DELTA),
-    longitudeDelta: clampRegionDelta(nextLongitudeDelta, MIN_LOCATION_DELTA),
+    latitudeDelta: clampRegionDelta(nextLatitudeDelta, MIN_CLUSTER_ZOOM_DELTA),
+    longitudeDelta: clampRegionDelta(nextLongitudeDelta, MIN_CLUSTER_ZOOM_DELTA),
   };
+}
+
+function hasDistinctStoryCoordinates(marker: MapMarkerGroup) {
+  const [firstStory] = marker.stories;
+
+  if (!firstStory) {
+    return false;
+  }
+
+  return marker.stories.some(
+    (story) => story.latitude !== firstStory.latitude || story.longitude !== firstStory.longitude,
+  );
 }
 
 function getDisplayedMarkerId(
@@ -565,7 +622,24 @@ function getMapPinFilterMarkerId(markers: MapMarkerGroup[], filters: SearchFilte
 
   const { latitude, longitude } = filters.proximityCoordinates;
   const matchingMarker = markers.find(
-    (marker) => coordinatesEqual(marker.latitude, latitude) && coordinatesEqual(marker.longitude, longitude),
+    (marker) =>
+      (coordinatesEqual(marker.latitude, latitude) && coordinatesEqual(marker.longitude, longitude)) ||
+      marker.stories.some((story) => coordinatesEqual(story.latitude, latitude) && coordinatesEqual(story.longitude, longitude)),
+  );
+
+  return matchingMarker?.id;
+}
+
+function getDisplayedMapPinCoordinateMarkerId(markers: MapMarkerGroup[], filters: SearchFiltersState) {
+  if (filters.proximitySource !== 'map_pin' || !filters.proximityCoordinates) {
+    return undefined;
+  }
+
+  const { latitude, longitude } = filters.proximityCoordinates;
+  const matchingMarker = markers.find(
+    (marker) =>
+      (coordinatesEqual(marker.latitude, latitude) && coordinatesEqual(marker.longitude, longitude)) ||
+      marker.stories.some((story) => coordinatesEqual(story.latitude, latitude) && coordinatesEqual(story.longitude, longitude)),
   );
 
   return matchingMarker?.id;
@@ -595,7 +669,11 @@ function buildAutoZoomContextKey(filters: StoryFilters) {
   });
 }
 
-function getAutoZoomRegion(markers: MapMarkerGroup[], filters: StoryFilters): Region | undefined {
+function getAutoZoomRegion(markers: MapMarkerGroup[], filters: StoryFilters, proximitySource?: SearchFiltersState['proximitySource']): Region | undefined {
+  if (proximitySource === 'map_pin') {
+    return undefined;
+  }
+
   if (filters.locationBounds) {
     return getRegionForLocationBounds(filters.locationBounds);
   }

--- a/mobile/src/features/map/presentation/screens/__tests__/MapScreen.test.tsx
+++ b/mobile/src/features/map/presentation/screens/__tests__/MapScreen.test.tsx
@@ -33,7 +33,7 @@ jest.mock('../../../../../shared/components/WebMapView', () => {
         latitudeDelta: number;
         longitudeDelta: number;
       };
-      markers?: Array<{ id: string; selected?: boolean }>;
+      markers?: Array<{ id: string; selected?: boolean; label?: string }>;
       userLocation?: {
         latitude: number;
         longitude: number;
@@ -84,6 +84,7 @@ jest.mock('../../../../../shared/components/WebMapView', () => {
             key={marker.id}
             onPress={() => onMarkerPress?.(marker.id)}
             testID="story-marker"
+            accessibilityLabel={`marker:${marker.id}:${marker.label ?? ''}`}
             accessibilityState={{ selected: Boolean(marker.selected) }}
           />
         ))}
@@ -161,6 +162,63 @@ const refreshedMarkerGroups: MapMarkerGroup[] = [
   },
 ];
 
+const zoomClusterMarkerGroups: MapMarkerGroup[] = [
+  {
+    id: 'near-1',
+    latitude: 41,
+    longitude: 29,
+    count: 1,
+    isCluster: false,
+    stories: [
+      {
+        id: 'story-near-1',
+        title: 'First Nearby Memory',
+        placeName: 'Kadikoy',
+        timePeriod: '1970s',
+        previewText: 'A nearby story.',
+        latitude: 41,
+        longitude: 29,
+      },
+    ],
+  },
+  {
+    id: 'near-2',
+    latitude: 41.012,
+    longitude: 29.012,
+    count: 1,
+    isCluster: false,
+    stories: [
+      {
+        id: 'story-near-2',
+        title: 'Second Nearby Memory',
+        placeName: 'Moda',
+        timePeriod: '1980s',
+        previewText: 'Another nearby story.',
+        latitude: 41.012,
+        longitude: 29.012,
+      },
+    ],
+  },
+  {
+    id: 'far-1',
+    latitude: 41.7,
+    longitude: 29.7,
+    count: 1,
+    isCluster: false,
+    stories: [
+      {
+        id: 'story-far-1',
+        title: 'Far Away Memory',
+        placeName: 'Sile',
+        timePeriod: '1990s',
+        previewText: 'A distant story.',
+        latitude: 41.7,
+        longitude: 29.7,
+      },
+    ],
+  },
+];
+
 function getRenderedMapRegion() {
   const label = screen.getByTestId('map-region-props').props.accessibilityLabel as string;
   const [, latitude, longitude, latitudeDelta, longitudeDelta] = label.split(':');
@@ -207,6 +265,35 @@ describe('MapScreen', () => {
       expect(screen.getByTestId('map-region-props').props.accessibilityLabel).toContain('region:41.0192:28.96735:0.06:0.06');
     });
     expect(screen.getByText('Select a story marker to preview.')).toBeTruthy();
+  });
+
+  it('clusters nearby pins while zoomed out and separates them after zooming in', async () => {
+    renderScreen(<MapScreen getMarkerGroups={async () => zoomClusterMarkerGroups} />);
+
+    await screen.findByText('Select a story marker to preview.');
+
+    await waitFor(() => {
+      expect(screen.getAllByTestId('story-marker')).toHaveLength(2);
+    });
+    expect(screen.getByLabelText(/^marker:zoom-cluster:.*:2$/)).toBeTruthy();
+
+    fireEvent.press(screen.getByLabelText(/^marker:zoom-cluster:.*:2$/));
+
+    await waitFor(() => {
+      const region = getRenderedMapRegion();
+
+      expect(region.latitude).toBeCloseTo(41.006);
+      expect(region.longitude).toBeCloseTo(29.006);
+      expect(region.latitudeDelta).toBeLessThan(1);
+      expect(region.longitudeDelta).toBeLessThan(1);
+    });
+    expect(screen.getByText('2 stories found in this area')).toBeTruthy();
+
+    fireEvent.press(screen.getByTestId('map-region-change'));
+
+    await waitFor(() => {
+      expect(screen.getAllByTestId('story-marker')).toHaveLength(3);
+    });
   });
 
   it('shows the selected marker preview and navigates to story detail', async () => {

--- a/mobile/src/features/map/presentation/screens/__tests__/MapScreen.test.tsx
+++ b/mobile/src/features/map/presentation/screens/__tests__/MapScreen.test.tsx
@@ -219,6 +219,45 @@ const zoomClusterMarkerGroups: MapMarkerGroup[] = [
   },
 ];
 
+const backendGroupedDistinctMarkerGroups: MapMarkerGroup[] = [
+  {
+    id: 'backend-group',
+    latitude: 41.01,
+    longitude: 28.97,
+    count: 3,
+    isCluster: true,
+    stories: [
+      {
+        id: 'backend-story-1',
+        title: 'Backend Group One',
+        placeName: 'Beyazit',
+        timePeriod: '1900s',
+        previewText: 'First grouped story.',
+        latitude: 41.01,
+        longitude: 28.97,
+      },
+      {
+        id: 'backend-story-2',
+        title: 'Backend Group Two',
+        placeName: 'Laleli',
+        timePeriod: '1910s',
+        previewText: 'Second grouped story.',
+        latitude: 41.012,
+        longitude: 28.972,
+      },
+      {
+        id: 'backend-story-3',
+        title: 'Backend Group Three',
+        placeName: 'Vezneciler',
+        timePeriod: '1920s',
+        previewText: 'Third grouped story.',
+        latitude: 41.014,
+        longitude: 28.974,
+      },
+    ],
+  },
+];
+
 function getRenderedMapRegion() {
   const label = screen.getByTestId('map-region-props').props.accessibilityLabel as string;
   const [, latitude, longitude, latitudeDelta, longitudeDelta] = label.split(':');
@@ -296,6 +335,41 @@ describe('MapScreen', () => {
     });
   });
 
+  it('keeps zooming a selected cluster when stories have different coordinates', async () => {
+    renderScreen(<MapScreen getMarkerGroups={async () => markerGroups} />);
+
+    await screen.findByText('Select a story marker to preview.');
+
+    const clusterMarker = await screen.findByLabelText('marker:41.01:28.97:2');
+    fireEvent.press(clusterMarker);
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('marker:41.01:28.97:').props.accessibilityState.selected).toBe(true);
+    });
+    const firstZoomRegion = getRenderedMapRegion();
+
+    fireEvent.press(await screen.findByLabelText('marker:41.01:28.97:'));
+
+    await waitFor(() => {
+      expect(getRenderedMapRegion().longitudeDelta).toBeLessThan(firstZoomRegion.longitudeDelta);
+    });
+  });
+
+  it('splits a backend grouped marker into story pins as the user keeps zooming', async () => {
+    renderScreen(<MapScreen getMarkerGroups={async () => backendGroupedDistinctMarkerGroups} />);
+
+    await screen.findByText('Select a story marker to preview.');
+    expect(await screen.findByLabelText('marker:backend-group:3')).toBeTruthy();
+
+    fireEvent.press(await screen.findByLabelText('marker:backend-group:3'));
+    fireEvent.press(await screen.findByLabelText('marker:backend-group:'));
+
+    await waitFor(() => {
+      expect(screen.getAllByTestId('story-marker')).toHaveLength(3);
+    });
+    expect(screen.queryByLabelText('marker:backend-group:3')).toBeNull();
+  });
+
   it('shows the selected marker preview and navigates to story detail', async () => {
     const onOpenStory = jest.fn();
 
@@ -323,6 +397,7 @@ describe('MapScreen', () => {
     expect(onViewTimeline).toHaveBeenCalledWith({
       latitude: 41.0284,
       longitude: 28.9647,
+      label: 'The Day the Harbor Fell Silent',
     });
   });
 
@@ -396,6 +471,19 @@ describe('MapScreen', () => {
     expect(screen.getByText('Voices of the Ferry Pier')).toBeTruthy();
   });
 
+  it('shows a selected grouped marker as a red pin while the group timeline action is visible', async () => {
+    renderScreen(<MapScreen getMarkerGroups={async () => markerGroups} />);
+
+    await screen.findByText('Select a story marker to preview.');
+    fireEvent.press(screen.getByLabelText('marker:41.01:28.97:2'));
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('View timeline near 2 nearby stories')).toBeTruthy();
+    });
+    expect(screen.getByLabelText('marker:41.01:28.97:').props.accessibilityState.selected).toBe(true);
+    expect(screen.queryByLabelText('marker:41.01:28.97:2')).toBeNull();
+  });
+
   it('offers a timeline action for a clustered marker', async () => {
     const onViewTimeline = jest.fn();
 
@@ -408,7 +496,80 @@ describe('MapScreen', () => {
     expect(onViewTimeline).toHaveBeenCalledWith({
       latitude: 41.01,
       longitude: 28.97,
+      label: '2 nearby stories',
     });
+  });
+
+  it('offers story-specific timeline actions inside a clustered marker', async () => {
+    const onViewTimeline = jest.fn();
+
+    renderScreen(<MapScreen getMarkerGroups={async () => markerGroups} onViewTimeline={onViewTimeline} />);
+
+    await screen.findByText('Select a story marker to preview.');
+    fireEvent.press(screen.getAllByTestId('story-marker')[1]);
+    fireEvent.press(await screen.findByLabelText('View timeline near Lanterns Above the Hill Market'));
+
+    expect(onViewTimeline).toHaveBeenCalledWith({
+      latitude: 41.0249,
+      longitude: 28.9548,
+      label: 'Lanterns Above the Hill Market',
+    });
+  });
+
+  it('highlights the grouped marker when a map-pin timeline filter targets a story inside it', async () => {
+    await storage.set(storageKeys.mapSearchFilters, {
+      proximityRadiusKm: 0.5,
+      proximityCoordinates: {
+        latitude: 41.0249,
+        longitude: 28.9548,
+      },
+      proximitySource: 'map_pin',
+      proximityLabel: 'Lanterns Above the Hill Market',
+    });
+
+    renderScreen(<MapScreen getMarkerGroups={async () => markerGroups} />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('story-marker').props.accessibilityState.selected).toBe(true);
+    });
+  });
+
+  it('shows a red pin instead of a cluster bubble for an active group timeline filter', async () => {
+    await storage.set(storageKeys.mapSearchFilters, {
+      proximityRadiusKm: 0.5,
+      proximityCoordinates: {
+        latitude: 41.01,
+        longitude: 28.97,
+      },
+      proximitySource: 'map_pin',
+      proximityLabel: '2 nearby stories',
+    });
+
+    renderScreen(<MapScreen getMarkerGroups={async () => markerGroups} />);
+
+    await waitFor(() => {
+      expect(screen.getByLabelText(/^marker:zoom-cluster:.*:$/).props.accessibilityState.selected).toBe(true);
+    });
+    expect(screen.queryByLabelText(/^marker:.*:2$/)).toBeNull();
+  });
+
+  it('keeps a client-side group timeline target red when only the displayed cluster coordinate matches', async () => {
+    await storage.set(storageKeys.mapSearchFilters, {
+      proximityRadiusKm: 0.5,
+      proximityCoordinates: {
+        latitude: 41.01613333333333,
+        longitude: 28.968233333333335,
+      },
+      proximitySource: 'map_pin',
+      proximityLabel: '2 nearby stories',
+    });
+
+    renderScreen(<MapScreen getMarkerGroups={async () => markerGroups} />);
+
+    await waitFor(() => {
+      expect(screen.getByLabelText(/^marker:zoom-cluster:.*:$/).props.accessibilityState.selected).toBe(true);
+    });
+    expect(screen.queryByLabelText(/^marker:zoom-cluster:.*:2$/)).toBeNull();
   });
 
   it('requests scrolling to the preview when a marker is pressed', async () => {
@@ -794,6 +955,32 @@ describe('MapScreen', () => {
     await waitFor(() => {
       expect(screen.queryByTestId('user-location-marker')).toBeNull();
     });
+  });
+
+  it('does not auto-zoom the map when a map-pin timeline filter is active', async () => {
+    await storage.set(storageKeys.mapSearchFilters, {
+      query: '',
+      location: '',
+      proximityRadiusKm: 0.5,
+      proximityCoordinates: {
+        latitude: 41.0284,
+        longitude: 28.9647,
+      },
+      proximitySource: 'map_pin',
+      proximityLabel: 'The Day the Harbor Fell Silent',
+      timeFrom: '',
+      timeTo: '',
+    });
+
+    renderScreen(<MapScreen getMarkerGroups={async () => markerGroups} />);
+
+    await screen.findByText('Select a story marker to preview.');
+    const region = getRenderedMapRegion();
+
+    expect(region.latitude).toBeCloseTo(41.0082);
+    expect(region.longitude).toBeCloseTo(28.9784);
+    expect(region.latitudeDelta).toBeCloseTo(0.32);
+    expect(region.longitudeDelta).toBeCloseTo(0.48);
   });
 
 

--- a/mobile/src/features/moderation/application/services/__tests__/adminService.test.ts
+++ b/mobile/src/features/moderation/application/services/__tests__/adminService.test.ts
@@ -1,0 +1,110 @@
+import { resetApiTransport, setApiTransport } from '../../../../../core/api/client';
+import { adminService } from '../adminService';
+
+describe('adminService', () => {
+  afterEach(() => {
+    resetApiTransport();
+  });
+
+  it('hydrates comment reports with their parent story id when the report payload omits it', async () => {
+    const requests: string[] = [];
+
+    setApiTransport(async (method, config) => {
+      requests.push(`${method} ${config.url ?? ''}`);
+
+      if (method === 'GET' && config.url === '/moderation/reports/?page=1&page_size=10&status=pending') {
+        return {
+          status: 200,
+          data: {
+            count: 1,
+            next: null,
+            results: [
+              {
+                id: 11,
+                reporter: {
+                  id: 2,
+                  username: 'Reporter',
+                  email: 'reporter@example.com',
+                },
+                target_type: 'comment',
+                target_id: 99,
+                reason: 'spam',
+                status: 'pending',
+                created_at: '2026-05-01T12:00:00Z',
+              },
+            ],
+          } as never,
+          config,
+        };
+      }
+
+      if (method === 'GET' && config.url === '/stories/feed/?page=1&page_size=100&sort_by=recent') {
+        return {
+          status: 200,
+          data: {
+            count: 1,
+            next: null,
+            results: [
+              {
+                id: 7,
+                title: 'Reported story',
+              },
+            ],
+          } as never,
+          config,
+        };
+      }
+
+      if (method === 'GET' && config.url === '/stories/7/comments/?page=1&page_size=100') {
+        return {
+          status: 200,
+          data: {
+            count: 1,
+            next: null,
+            results: [
+              {
+                id: 99,
+                text: 'Reported comment',
+              },
+            ],
+          } as never,
+          config,
+        };
+      }
+
+      throw new Error(`Unexpected request: ${method} ${config.url}`);
+    });
+
+    const reports = await adminService.getReports({ status: 'pending' });
+
+    expect(reports.items[0]).toEqual(expect.objectContaining({
+      targetId: '99',
+      targetStoryId: '7',
+      targetType: 'comment',
+    }));
+    expect(requests).toContain('GET /stories/feed/?page=1&page_size=100&sort_by=recent');
+    expect(requests).toContain('GET /stories/7/comments/?page=1&page_size=100');
+  });
+
+  it('bans a user through the moderation endpoint', async () => {
+    const requests: string[] = [];
+
+    setApiTransport(async (method, config) => {
+      requests.push(`${method} ${config.url ?? ''}`);
+
+      if (method === 'PATCH' && config.url === '/moderation/users/12/ban/') {
+        return {
+          status: 204,
+          data: undefined as never,
+          config,
+        };
+      }
+
+      throw new Error(`Unexpected request: ${method} ${config.url}`);
+    });
+
+    await adminService.banUser('12');
+
+    expect(requests).toEqual(['PATCH /moderation/users/12/ban/']);
+  });
+});

--- a/mobile/src/features/moderation/application/services/adminService.ts
+++ b/mobile/src/features/moderation/application/services/adminService.ts
@@ -1,0 +1,373 @@
+import { apiClient } from '../../../../core/api/client';
+
+export type AdminReportStatus = 'pending' | 'resolved';
+export type AdminReportAction = 'no_action' | 'remove_content' | 'ban_user';
+
+export interface AdminPage<T> {
+  items: T[];
+  page: number;
+  totalCount: number;
+  hasNextPage: boolean;
+}
+
+export interface AdminUserSummary {
+  id: string;
+  username: string;
+  email?: string;
+}
+
+export interface AdminReport {
+  id: string;
+  reporter: AdminUserSummary;
+  targetType: string;
+  targetId: string;
+  targetStoryId?: string;
+  reason: string;
+  description?: string;
+  status: AdminReportStatus;
+  createdAt: string;
+  resolvedAt?: string | null;
+  resolutionOutcome?: string | null;
+}
+
+export interface AdminStory {
+  id: string;
+  title: string;
+  contributorName?: string | null;
+  locationName?: string | null;
+  status?: string;
+  submittedAt?: string | null;
+}
+
+export interface AdminTag {
+  id: string;
+  name: string;
+  storyCount: number;
+}
+
+type PaginatedResponse = {
+  count?: number;
+  next?: string | null;
+  results?: unknown[];
+};
+
+const PAGE_SIZE = 10;
+const COMMENT_STORY_LOOKUP_PAGE_SIZE = 100;
+const MAX_COMMENT_STORY_LOOKUP_PAGES = 20;
+const commentStoryIdCache = new Map<string, string>();
+
+export const adminService = {
+  async getReports({ page = 1, status }: { page?: number; status?: AdminReportStatus | 'all' } = {}): Promise<AdminPage<AdminReport>> {
+    const query = buildQuery({ page, page_size: PAGE_SIZE, status: status && status !== 'all' ? status : undefined });
+    const response = await getPage(`/moderation/reports/${query}`);
+
+    const reportsPage = mapPage(response, page, mapReport);
+
+    return {
+      ...reportsPage,
+      items: await hydrateCommentReportStoryIds(reportsPage.items),
+    };
+  },
+
+  async resolveReport(reportId: string, action: AdminReportAction, note = ''): Promise<AdminReport> {
+    const resolutionNote = [formatAction(action), note.trim()].filter(Boolean).join(' - ');
+    const response = await apiClient.patch<Record<string, unknown>>(
+      `/moderation/reports/${reportId}/resolve/`,
+      {
+        action,
+        resolution_note: resolutionNote,
+      },
+    );
+
+    if (!response) {
+      throw new Error('Report resolution did not return a report.');
+    }
+
+    return mapReport(response);
+  },
+
+  async getStories({ page = 1, query = '' }: { page?: number; query?: string } = {}): Promise<AdminPage<AdminStory>> {
+    const endpoint = query.trim() ? '/stories/search/' : '/stories/';
+    const response = await getPage(`${endpoint}${buildQuery({ page, page_size: PAGE_SIZE, q: query.trim() || undefined })}`);
+
+    return mapPage(response, page, mapStory);
+  },
+
+  async removeStory(storyId: string, reason: string): Promise<void> {
+    await apiClient.delete<void>(`/moderation/stories/${storyId}/`, {
+      data: {
+        moderation_reason: reason,
+      },
+    });
+  },
+
+  async banUser(userId: string): Promise<void> {
+    await apiClient.patch<void>(`/moderation/users/${userId}/ban/`);
+  },
+
+  async getTags({ page = 1, query = '' }: { page?: number; query?: string } = {}): Promise<AdminPage<AdminTag>> {
+    const response = await getPage(`/tags/${buildQuery({ page, page_size: PAGE_SIZE, q: query.trim() || undefined })}`);
+
+    return mapPage(response, page, mapTag);
+  },
+
+  async removeTag(tagId: string): Promise<void> {
+    await apiClient.delete<void>(`/moderation/tags/${tagId}/`);
+  },
+};
+
+export const moderationService = adminService;
+
+async function getPage(path: string): Promise<PaginatedResponse> {
+  const response = await apiClient.get<PaginatedResponse | unknown[]>(path);
+
+  if (Array.isArray(response)) {
+    return {
+      count: response.length,
+      next: null,
+      results: response,
+    };
+  }
+
+  return (response as PaginatedResponse | null) ?? {
+    count: 0,
+    next: null,
+    results: [],
+  };
+}
+
+function mapPage<T>(response: PaginatedResponse, page: number, mapper: (item: unknown) => T): AdminPage<T> {
+  const items = (response.results ?? []).map(mapper);
+
+  return {
+    items,
+    page,
+    totalCount: response.count ?? items.length,
+    hasNextPage: Boolean(response.next),
+  };
+}
+
+async function hydrateCommentReportStoryIds(reports: AdminReport[]) {
+  const missingCommentIds = Array.from(
+    new Set(
+      reports
+        .filter((report) => report.targetType === 'comment' && !report.targetStoryId)
+        .map((report) => report.targetId)
+        .filter(Boolean),
+    ),
+  );
+
+  const unresolvedCommentIds = missingCommentIds.filter((commentId) => !commentStoryIdCache.has(commentId));
+
+  if (unresolvedCommentIds.length) {
+    const resolved = await resolveStoryIdsForComments(unresolvedCommentIds);
+
+    resolved.forEach((storyId, commentId) => {
+      commentStoryIdCache.set(commentId, storyId);
+    });
+  }
+
+  return reports.map((report) => {
+    if (report.targetType !== 'comment' || report.targetStoryId) {
+      return report;
+    }
+
+    const targetStoryId = commentStoryIdCache.get(report.targetId);
+
+    return targetStoryId ? { ...report, targetStoryId } : report;
+  });
+}
+
+async function resolveStoryIdsForComments(commentIds: string[]) {
+  const unresolved = new Set(commentIds);
+  const resolved = new Map<string, string>();
+  let page = 1;
+  let hasNext = true;
+
+  while (hasNext && unresolved.size > 0 && page <= MAX_COMMENT_STORY_LOOKUP_PAGES) {
+    const storiesResponse = await getPage(
+      `/stories/feed/${buildQuery({
+        page,
+        page_size: COMMENT_STORY_LOOKUP_PAGE_SIZE,
+        sort_by: 'recent',
+      })}`,
+    );
+
+    const storyIds = (storiesResponse.results ?? [])
+      .map(getRecordId)
+      .filter((storyId): storyId is string => Boolean(storyId));
+
+    await Promise.all(
+      storyIds.map(async (storyId) => {
+        if (!unresolved.size) {
+          return;
+        }
+
+        const comments = await fetchStoryCommentsForLookup(storyId);
+
+        comments.forEach((comment) => {
+          const commentId = getRecordId(comment);
+
+          if (commentId && unresolved.has(commentId)) {
+            resolved.set(commentId, storyId);
+            unresolved.delete(commentId);
+          }
+        });
+      }),
+    );
+
+    hasNext = Boolean(storiesResponse.next);
+    page += 1;
+  }
+
+  return resolved;
+}
+
+async function fetchStoryCommentsForLookup(storyId: string) {
+  const comments: unknown[] = [];
+  let page = 1;
+  let hasNext = true;
+
+  while (hasNext) {
+    const response = await getPage(
+      `/stories/${storyId}/comments/${buildQuery({
+        page,
+        page_size: COMMENT_STORY_LOOKUP_PAGE_SIZE,
+      })}`,
+    );
+
+    comments.push(...(response.results ?? []));
+    hasNext = Boolean(response.next);
+    page += 1;
+  }
+
+  return comments;
+}
+
+function buildQuery(params: Record<string, string | number | undefined>) {
+  const searchParams = new URLSearchParams();
+
+  Object.entries(params).forEach(([key, value]) => {
+    if (value !== undefined && value !== '') {
+      searchParams.append(key, String(value));
+    }
+  });
+
+  const query = searchParams.toString();
+
+  return query ? `?${query}` : '';
+}
+
+function mapReport(item: unknown): AdminReport {
+  const record = asRecord(item);
+  const reporter = asRecord(record.reporter);
+
+  return {
+    id: asString(record.id),
+    reporter: {
+      id: asString(reporter.id),
+      username: asString(reporter.username, 'Unknown reporter'),
+      email: optionalString(reporter.email),
+    },
+    targetType: asString(record.target_type ?? record.targetType, 'content'),
+    targetId: asString(record.target_id ?? record.targetId),
+    targetStoryId: optionalString(
+      record.target_story_id ??
+        record.targetStoryId ??
+        record.story_id ??
+        record.storyId ??
+        asRecord(record.comment).story_id ??
+        asRecord(record.comment).storyId,
+    ),
+    reason: asString(record.reason, 'Unspecified'),
+    description: optionalString(record.description),
+    status: normalizeReportStatus(record.status),
+    createdAt: asString(record.created_at ?? record.createdAt),
+    resolvedAt: optionalString(record.resolved_at ?? record.resolvedAt),
+    resolutionOutcome: optionalString(record.resolution_outcome ?? record.resolutionOutcome),
+  };
+}
+
+function mapStory(item: unknown): AdminStory {
+  const record = asRecord(item);
+
+  return {
+    id: asString(record.id),
+    title: asString(record.title, 'Untitled story'),
+    contributorName: optionalString(record.contributor_name ?? record.contributorName),
+    locationName: optionalString(record.location_name ?? record.locationName),
+    status: optionalString(record.status),
+    submittedAt: optionalString(record.submitted_at ?? record.submittedAt),
+  };
+}
+
+function mapTag(item: unknown): AdminTag {
+  const record = asRecord(item);
+
+  return {
+    id: asString(record.id),
+    name: asString(record.name, 'untitled'),
+    storyCount: asNumber(record.story_count ?? record.storyCount),
+  };
+}
+
+function normalizeReportStatus(value: unknown): AdminReportStatus {
+  if (value === 'resolved') {
+    return value;
+  }
+
+  return 'pending';
+}
+
+function formatAction(action: AdminReportAction) {
+  if (action === 'remove_content') {
+    return 'Remove content';
+  }
+
+  if (action === 'ban_user') {
+    return 'Ban user';
+  }
+
+  return 'No action';
+}
+
+function asRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === 'object' ? (value as Record<string, unknown>) : {};
+}
+
+function getRecordId(value: unknown) {
+  const record = asRecord(value);
+
+  return asString(record.id);
+}
+
+function asString(value: unknown, fallback = '') {
+  if (typeof value === 'string') {
+    return value;
+  }
+
+  if (typeof value === 'number') {
+    return String(value);
+  }
+
+  return fallback;
+}
+
+function optionalString(value: unknown) {
+  const resolved = asString(value);
+
+  return resolved || undefined;
+}
+
+function asNumber(value: unknown) {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return value;
+  }
+
+  if (typeof value === 'string' && value.trim()) {
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : 0;
+  }
+
+  return 0;
+}

--- a/mobile/src/features/moderation/application/services/index.ts
+++ b/mobile/src/features/moderation/application/services/index.ts
@@ -1,1 +1,1 @@
-export const moderationService = {};
+export * from './adminService';

--- a/mobile/src/features/moderation/domain/entities/index.ts
+++ b/mobile/src/features/moderation/domain/entities/index.ts
@@ -1,3 +1,9 @@
-export interface ModerationEntity {
-  id: string;
-}
+export type {
+  AdminPage,
+  AdminReport,
+  AdminReportAction,
+  AdminReportStatus,
+  AdminStory,
+  AdminTag,
+  AdminUserSummary,
+} from '../../application/services';

--- a/mobile/src/features/moderation/presentation/screens/ModerationScreen.tsx
+++ b/mobile/src/features/moderation/presentation/screens/ModerationScreen.tsx
@@ -1,10 +1,911 @@
-import React from 'react';
-import { View, Text } from 'react-native';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import { FlatList, Modal, Pressable, Text, View } from 'react-native';
+import { Input } from '../../../../shared/ui/Input';
+import { Button } from '../../../../shared/ui/Button';
+import { EmptyState, ErrorState, Loader, SkeletonCard } from '../../../../shared';
+import { useAppTheme } from '../../../../core/hooks/useAppTheme';
+import { useAuth } from '../../../auth';
+import { useToast } from '../../../../shared/hooks/useToast';
+import {
+  AdminPage,
+  AdminReport,
+  AdminReportAction,
+  AdminReportStatus,
+  AdminStory,
+  AdminTag,
+  adminService,
+} from '../../application/services';
 
-export function ModerationScreen() {
+type AdminTab = 'reports' | 'stories' | 'tags';
+type AdminService = typeof adminService;
+type AdminListItem = AdminReport | AdminStory | AdminTag;
+
+interface ListState<T> {
+  items: T[];
+  page: number;
+  totalCount: number;
+  hasNextPage: boolean;
+  isLoading: boolean;
+  isRefreshing: boolean;
+  isLoadingMore: boolean;
+  error?: string;
+}
+
+interface ConfirmState {
+  title: string;
+  message: string;
+  confirmLabel: string;
+  destructive?: boolean;
+  reasonLabel?: string;
+  reasonPlaceholder?: string;
+  onConfirm: (reason: string) => Promise<void>;
+}
+
+interface ModerationScreenProps {
+  service?: AdminService;
+  onOpenStory?: (storyId: string) => void;
+  onOpenComment?: (storyId: string, commentId: string) => void;
+}
+
+const tabs: Array<{ key: AdminTab; label: string }> = [
+  { key: 'reports', label: 'Reports' },
+  { key: 'stories', label: 'Stories' },
+  { key: 'tags', label: 'Tags' },
+];
+
+const reportStatuses: Array<AdminReportStatus | 'all'> = ['all', 'pending', 'resolved'];
+
+function createListState<T>(): ListState<T> {
+  return {
+    items: [],
+    page: 1,
+    totalCount: 0,
+    hasNextPage: false,
+    isLoading: true,
+    isRefreshing: false,
+    isLoadingMore: false,
+  };
+}
+
+export function ModerationScreen({ service = adminService, onOpenStory, onOpenComment }: ModerationScreenProps) {
+  const { colors, spacing, typography } = useAppTheme();
+  const { user } = useAuth();
+  const { toast } = useToast();
+  const [activeTab, setActiveTab] = useState<AdminTab>('reports');
+  const [reportStatus, setReportStatus] = useState<AdminReportStatus | 'all'>('pending');
+  const [storyQuery, setStoryQuery] = useState('');
+  const [tagQuery, setTagQuery] = useState('');
+  const [reports, setReports] = useState<ListState<AdminReport>>(() => createListState());
+  const [stories, setStories] = useState<ListState<AdminStory>>(() => createListState());
+  const [tags, setTags] = useState<ListState<AdminTag>>(() => createListState());
+  const [confirmState, setConfirmState] = useState<ConfirmState | null>(null);
+  const [pendingActionId, setPendingActionId] = useState<string | null>(null);
+
+  const isAdmin = user?.role === 'admin';
+
+  const loadReports = useCallback(
+    async (page = 1, mode: LoadMode = 'initial') => {
+      await loadList(setReports, () => service.getReports({ page, status: reportStatus }), page, mode);
+    },
+    [reportStatus, service],
+  );
+
+  const loadStories = useCallback(
+    async (page = 1, mode: LoadMode = 'initial') => {
+      await loadList(setStories, () => service.getStories({ page, query: storyQuery }), page, mode);
+    },
+    [service, storyQuery],
+  );
+
+  const loadTags = useCallback(
+    async (page = 1, mode: LoadMode = 'initial') => {
+      await loadList(setTags, () => service.getTags({ page, query: tagQuery }), page, mode);
+    },
+    [service, tagQuery],
+  );
+
+  useEffect(() => {
+    if (!isAdmin) {
+      return;
+    }
+
+    if (activeTab === 'reports') {
+      void loadReports();
+    } else if (activeTab === 'stories') {
+      void loadStories();
+    } else {
+      void loadTags();
+    }
+  }, [activeTab, isAdmin, loadReports, loadStories, loadTags]);
+
+  const reloadActiveTab = useCallback(async () => {
+    if (activeTab === 'reports') {
+      await loadReports(1, 'refresh');
+    } else if (activeTab === 'stories') {
+      await loadStories(1, 'refresh');
+    } else {
+      await loadTags(1, 'refresh');
+    }
+  }, [activeTab, loadReports, loadStories, loadTags]);
+
+  const runConfirmedAction = useCallback(
+    (state: ConfirmState) => {
+      setConfirmState(state);
+    },
+    [],
+  );
+
+  const resolveReport = useCallback(
+    async (report: AdminReport, action: AdminReportAction) => {
+      setPendingActionId(`${report.id}:${action}`);
+      try {
+        const updatedReport = await service.resolveReport(report.id, action);
+        setReports((current) => ({
+          ...current,
+          items: current.items.map((item) => (item.id === report.id ? updatedReport : item)),
+        }));
+        toast.success('Report resolved.');
+      } catch (error) {
+        toast.error(error instanceof Error ? error.message : 'Failed to resolve report.');
+      } finally {
+        setPendingActionId(null);
+      }
+    },
+    [service, toast],
+  );
+
+  const confirmStoryRemoval = useCallback(
+    (story: AdminStory) => {
+      runConfirmedAction({
+        title: 'Remove story?',
+        message: `"${story.title}" will be removed from public views.`,
+        confirmLabel: 'Remove story',
+        destructive: true,
+        reasonLabel: 'Removal reason',
+        reasonPlaceholder: 'Explain why this story is being removed',
+        onConfirm: async (reason) => {
+          if (!reason.trim()) {
+            throw new Error('A removal reason is required.');
+          }
+
+          setPendingActionId(story.id);
+          await service.removeStory(story.id, reason.trim());
+          setStories((current) => ({
+            ...current,
+            items: current.items.filter((item) => item.id !== story.id),
+            totalCount: Math.max(current.totalCount - 1, 0),
+          }));
+          toast.success('Story removed.');
+          setPendingActionId(null);
+        },
+      });
+    },
+    [runConfirmedAction, service, toast],
+  );
+
+  const confirmTagRemoval = useCallback(
+    (tag: AdminTag) => {
+      runConfirmedAction({
+        title: 'Remove tag?',
+        message: `${tag.name} will be removed from associated stories.`,
+        confirmLabel: 'Remove tag',
+        destructive: true,
+        onConfirm: async () => {
+          setPendingActionId(tag.id);
+          await service.removeTag(tag.id);
+          setTags((current) => ({
+            ...current,
+            items: current.items.filter((item) => item.id !== tag.id),
+            totalCount: Math.max(current.totalCount - 1, 0),
+          }));
+          toast.success('Tag removed.');
+          setPendingActionId(null);
+        },
+      });
+    },
+    [runConfirmedAction, service, toast],
+  );
+
+  const activeState = useMemo(() => {
+    if (activeTab === 'reports') {
+      return reports;
+    }
+
+    if (activeTab === 'stories') {
+      return stories;
+    }
+
+    return tags;
+  }, [activeTab, reports, stories, tags]);
+
+  if (!isAdmin) {
+    return (
+      <View style={{ flex: 1, padding: spacing.lg, backgroundColor: colors.background }}>
+        <ErrorState
+          title="Not authorized"
+          message="Only admins can access moderation tools."
+        />
+      </View>
+    );
+  }
+
   return (
-    <View style={{ padding: 16 }}>
-      <Text>Moderation Screen Placeholder</Text>
+    <View style={{ flex: 1, backgroundColor: colors.background }}>
+      <View style={{ paddingHorizontal: spacing.lg, paddingTop: spacing.lg, gap: spacing.md }}>
+        <Text style={{ color: colors.text, fontSize: typography.title, fontWeight: '800' }}>
+          Admin moderation
+        </Text>
+        <Text style={{ color: colors.muted }}>
+          Review reports, moderate stories, and clean up tags.
+        </Text>
+        <View
+          accessibilityRole="tablist"
+          style={{
+            flexDirection: 'row',
+            padding: 3,
+            borderRadius: 12,
+            borderWidth: 1,
+            borderColor: colors.border,
+            backgroundColor: colors.infoSurface,
+          }}
+        >
+          {tabs.map((tab) => {
+            const selected = activeTab === tab.key;
+
+            return (
+              <Pressable
+                key={tab.key}
+                accessibilityRole="tab"
+                accessibilityLabel={`${tab.label} tab`}
+                accessibilityState={{ selected }}
+                onPress={() => setActiveTab(tab.key)}
+                style={{
+                  flex: 1,
+                  alignItems: 'center',
+                  paddingVertical: spacing.sm,
+                  borderRadius: 9,
+                  backgroundColor: selected ? colors.primary : 'transparent',
+                }}
+              >
+                <Text
+                  numberOfLines={1}
+                  style={{
+                    color: selected ? colors.background : colors.text,
+                    fontSize: typography.caption,
+                    fontWeight: '800',
+                  }}
+                >
+                  {tab.label}
+                </Text>
+              </Pressable>
+            );
+          })}
+        </View>
+        {renderControls({
+          activeTab,
+          reportStatus,
+          setReportStatus,
+          storyQuery,
+          setStoryQuery,
+          tagQuery,
+          setTagQuery,
+          reloadActiveTab,
+        })}
+      </View>
+      <View style={{ flex: 1, paddingTop: spacing.md }}>
+        {renderContent({
+          activeTab,
+          activeState,
+          reports,
+          stories,
+          tags,
+          pendingActionId,
+          onRetry: reloadActiveTab,
+          onLoadMore: () => {
+            if (activeTab === 'reports') {
+              void loadReports(reports.page + 1, 'append');
+            } else if (activeTab === 'stories') {
+              void loadStories(stories.page + 1, 'append');
+            } else {
+              void loadTags(tags.page + 1, 'append');
+            }
+          },
+          onRefresh: reloadActiveTab,
+          onResolveReport: resolveReport,
+          onRemoveStory: confirmStoryRemoval,
+          onRemoveTag: confirmTagRemoval,
+          onOpenStory,
+          onOpenComment,
+        })}
+      </View>
+      <ConfirmActionDialog
+        state={confirmState}
+        onClose={() => {
+          setConfirmState(null);
+          setPendingActionId(null);
+        }}
+      />
     </View>
   );
+}
+
+type LoadMode = 'initial' | 'refresh' | 'append';
+
+async function loadList<T>(
+  setState: React.Dispatch<React.SetStateAction<ListState<T>>>,
+  fetchPage: () => Promise<AdminPage<T>>,
+  page: number,
+  mode: LoadMode,
+) {
+  setState((current) => ({
+    ...current,
+    isLoading: mode === 'initial',
+    isRefreshing: mode === 'refresh',
+    isLoadingMore: mode === 'append',
+    error: undefined,
+  }));
+
+  try {
+    const response = await fetchPage();
+
+    setState((current) => ({
+      items: mode === 'append' ? [...current.items, ...response.items] : response.items,
+      page: response.page,
+      totalCount: response.totalCount,
+      hasNextPage: response.hasNextPage,
+      isLoading: false,
+      isRefreshing: false,
+      isLoadingMore: false,
+      error: undefined,
+    }));
+  } catch (error) {
+    setState((current) => ({
+      ...current,
+      isLoading: false,
+      isRefreshing: false,
+      isLoadingMore: false,
+      error: error instanceof Error ? error.message : 'Unable to load moderation data.',
+    }));
+  }
+}
+
+function renderControls({
+  activeTab,
+  reportStatus,
+  setReportStatus,
+  storyQuery,
+  setStoryQuery,
+  tagQuery,
+  setTagQuery,
+  reloadActiveTab,
+}: {
+  activeTab: AdminTab;
+  reportStatus: AdminReportStatus | 'all';
+  setReportStatus: (value: AdminReportStatus | 'all') => void;
+  storyQuery: string;
+  setStoryQuery: (value: string) => void;
+  tagQuery: string;
+  setTagQuery: (value: string) => void;
+  reloadActiveTab: () => Promise<void>;
+}) {
+  if (activeTab === 'reports') {
+    return (
+      <FilterPills
+        label="Report status"
+        options={reportStatuses.map((status) => ({ value: status, label: titleCase(status) }))}
+        value={reportStatus}
+        onChange={setReportStatus}
+      />
+    );
+  }
+
+  const query = activeTab === 'stories' ? storyQuery : tagQuery;
+  const setQuery = activeTab === 'stories' ? setStoryQuery : setTagQuery;
+  const label = activeTab === 'stories' ? 'Search stories' : 'Search tags';
+
+  return (
+    <Input
+      value={query}
+      onChangeText={setQuery}
+      placeholder={label}
+      accessibilityLabel={label}
+      returnKeyType="search"
+      onSubmitEditing={() => {
+        void reloadActiveTab();
+      }}
+      trailingActionLabel="Search"
+      trailingActionAccessibilityLabel={`Apply ${label.toLowerCase()}`}
+      onTrailingActionPress={() => {
+        void reloadActiveTab();
+      }}
+    />
+  );
+}
+
+function renderContent({
+  activeTab,
+  activeState,
+  reports,
+  stories,
+  tags,
+  pendingActionId,
+  onRetry,
+  onLoadMore,
+  onRefresh,
+  onResolveReport,
+  onRemoveStory,
+  onRemoveTag,
+  onOpenStory,
+  onOpenComment,
+}: {
+  activeTab: AdminTab;
+  activeState: ListState<unknown>;
+  reports: ListState<AdminReport>;
+  stories: ListState<AdminStory>;
+  tags: ListState<AdminTag>;
+  pendingActionId: string | null;
+  onRetry: () => Promise<void>;
+  onLoadMore: () => void;
+  onRefresh: () => Promise<void>;
+  onResolveReport: (report: AdminReport, action: AdminReportAction) => Promise<void>;
+  onRemoveStory: (story: AdminStory) => void;
+  onRemoveTag: (tag: AdminTag) => void;
+  onOpenStory?: (storyId: string) => void;
+  onOpenComment?: (storyId: string, commentId: string) => void;
+}) {
+  if (activeState.isLoading && !activeState.items.length) {
+    return (
+      <View accessibilityLabel="Loading admin data" style={{ paddingHorizontal: 16, gap: 12 }}>
+        {Array.from({ length: 4 }).map((_, index) => (
+          <SkeletonCard key={index} showMedia={false} />
+        ))}
+      </View>
+    );
+  }
+
+  if (activeState.error && !activeState.items.length) {
+    return (
+      <ErrorState
+        title="Moderation unavailable"
+        message={activeState.error}
+        retryLabel="Try again"
+        onRetry={() => {
+          void onRetry();
+        }}
+      />
+    );
+  }
+
+  if (!activeState.items.length) {
+    return (
+      <EmptyState
+        title={`No ${activeTab} found`}
+        message="There is nothing to review here right now."
+        actionLabel="Refresh"
+        onAction={() => {
+          void onRefresh();
+        }}
+      />
+    );
+  }
+
+  const data: AdminListItem[] =
+    activeTab === 'reports'
+      ? reports.items
+      : activeTab === 'stories'
+        ? stories.items
+        : tags.items;
+
+  return (
+    <FlatList<AdminListItem>
+      testID={`admin-${activeTab}-list`}
+      data={data}
+      keyExtractor={(item) => item.id}
+      contentContainerStyle={{ paddingHorizontal: 16, paddingBottom: 24 }}
+      ItemSeparatorComponent={() => <View style={{ height: 12 }} />}
+      refreshing={activeState.isRefreshing}
+      onRefresh={() => {
+        void onRefresh();
+      }}
+      renderItem={({ item }) => {
+        if (activeTab === 'reports') {
+          return (
+            <ReportRow
+              report={item as AdminReport}
+              pendingActionId={pendingActionId}
+              onResolve={onResolveReport}
+              onOpenStory={onOpenStory}
+              onOpenComment={onOpenComment}
+            />
+          );
+        }
+
+        if (activeTab === 'stories') {
+          return (
+            <StoryRow
+              story={item as AdminStory}
+              isPending={pendingActionId === item.id}
+              onRemove={onRemoveStory}
+              onOpenStory={onOpenStory}
+            />
+          );
+        }
+
+        return (
+          <TagRow
+            tag={item as AdminTag}
+            isPending={pendingActionId === item.id}
+            onRemove={onRemoveTag}
+          />
+        );
+      }}
+      ListHeaderComponent={<ListSummary count={activeState.totalCount} label={activeTab} />}
+      ListFooterComponent={
+        activeState.isLoadingMore ? (
+          <Loader message="Loading more..." size="small" />
+        ) : activeState.hasNextPage ? (
+          <View style={{ paddingTop: 16 }}>
+            <Button variant="outline" onPress={onLoadMore} accessibilityLabel={`Load more ${activeTab}`}>
+              Load more
+            </Button>
+          </View>
+        ) : null
+      }
+    />
+  );
+}
+
+function FilterPills<T extends string>({
+  label,
+  options,
+  value,
+  onChange,
+}: {
+  label: string;
+  options: Array<{ value: T; label: string }>;
+  value: T;
+  onChange: (value: T) => void;
+}) {
+  const { colors, spacing, typography } = useAppTheme();
+
+  return (
+    <View accessibilityRole="radiogroup" accessibilityLabel={label} style={{ flexDirection: 'row', flexWrap: 'wrap', gap: spacing.sm }}>
+      {options.map((option) => {
+        const selected = value === option.value;
+
+        return (
+          <Pressable
+            key={option.value}
+            accessibilityRole="radio"
+            accessibilityLabel={`${label}: ${option.label}`}
+            accessibilityState={{ selected }}
+            onPress={() => onChange(option.value)}
+            style={{
+              paddingHorizontal: spacing.md,
+              paddingVertical: spacing.sm,
+              borderRadius: 999,
+              borderWidth: 1,
+              borderColor: selected ? colors.primary : colors.border,
+              backgroundColor: selected ? colors.primary : colors.background,
+            }}
+          >
+            <Text style={{ color: selected ? colors.background : colors.text, fontSize: typography.caption, fontWeight: '700' }}>
+              {option.label}
+            </Text>
+          </Pressable>
+        );
+      })}
+    </View>
+  );
+}
+
+function ListSummary({ count, label }: { count: number; label: string }) {
+  const { colors, spacing, typography } = useAppTheme();
+
+  return (
+    <Text style={{ color: colors.muted, fontSize: typography.caption, marginBottom: spacing.sm }}>
+      {count} {label}
+    </Text>
+  );
+}
+
+function RowFrame({
+  children,
+  onPress,
+  accessibilityLabel,
+}: {
+  children: React.ReactNode;
+  onPress?: () => void;
+  accessibilityLabel?: string;
+}) {
+  const { colors, spacing } = useAppTheme();
+  const content = (
+    <View
+      style={{
+        padding: spacing.md,
+        gap: spacing.sm,
+        borderWidth: 1,
+        borderColor: colors.border,
+        borderRadius: 8,
+        backgroundColor: colors.surface,
+      }}
+    >
+      {children}
+    </View>
+  );
+
+  if (!onPress) {
+    return content;
+  }
+
+  return (
+    <Pressable
+      accessibilityRole="button"
+      accessibilityLabel={accessibilityLabel}
+      onPress={onPress}
+      style={({ pressed }) => ({
+        opacity: pressed ? 0.82 : 1,
+      })}
+    >
+      {content}
+    </Pressable>
+  );
+}
+
+function ReportRow({
+  report,
+  pendingActionId,
+  onResolve,
+  onOpenStory,
+  onOpenComment,
+}: {
+  report: AdminReport;
+  pendingActionId: string | null;
+  onResolve: (report: AdminReport, action: AdminReportAction) => Promise<void>;
+  onOpenStory?: (storyId: string) => void;
+  onOpenComment?: (storyId: string, commentId: string) => void;
+}) {
+  const { colors, spacing, typography } = useAppTheme();
+  const isResolved = report.status !== 'pending';
+  const canOpenStory = report.targetType === 'story' && Boolean(onOpenStory);
+  const canOpenComment = report.targetType === 'comment' && Boolean(report.targetStoryId) && Boolean(onOpenComment);
+
+  return (
+    <RowFrame
+      onPress={
+        canOpenComment
+          ? () => onOpenComment?.(report.targetStoryId!, report.targetId)
+          : canOpenStory
+            ? () => onOpenStory?.(report.targetId)
+            : undefined
+      }
+      accessibilityLabel={
+        canOpenComment
+          ? `Open reported comment ${report.targetId}`
+          : canOpenStory
+            ? `Open reported story ${report.targetId}`
+            : undefined
+      }
+    >
+      <View style={{ flexDirection: 'row', justifyContent: 'space-between', gap: spacing.sm }}>
+        <Text style={{ flex: 1, color: colors.text, fontSize: typography.subtitle, fontWeight: '800' }}>
+          {report.targetType} #{report.targetId}
+        </Text>
+        <StatusBadge label={report.status} tone={isResolved ? 'success' : 'danger'} />
+      </View>
+      <Text style={{ color: colors.muted }}>Reporter: {report.reporter.username}</Text>
+      <Text style={{ color: colors.text }}>Reason: {titleCase(report.reason)}</Text>
+      <Text style={{ color: colors.muted }}>Date: {formatDate(report.createdAt)}</Text>
+      {report.description ? <Text style={{ color: colors.text }}>{report.description}</Text> : null}
+      {canOpenComment || canOpenStory ? (
+        <Text style={{ color: colors.primary, fontWeight: '700' }}>
+          {canOpenComment ? 'Tap to open comment' : 'Tap to open story'}
+        </Text>
+      ) : null}
+      {!isResolved ? (
+        <View style={{ flexDirection: 'row', flexWrap: 'wrap', gap: spacing.sm }}>
+          <Button
+            variant="outline"
+            disabled={Boolean(pendingActionId)}
+            onPress={() => void onResolve(report, 'no_action')}
+            accessibilityLabel={`Resolve report ${report.id} with no action`}
+          >
+            No action
+          </Button>
+          <Button
+            variant="outline"
+            disabled={Boolean(pendingActionId)}
+            onPress={() => void onResolve(report, 'remove_content')}
+            accessibilityLabel={`Resolve report ${report.id} and remove content`}
+          >
+            Remove
+          </Button>
+          <Button
+            disabled={Boolean(pendingActionId)}
+            onPress={() => void onResolve(report, 'ban_user')}
+            accessibilityLabel={`Resolve report ${report.id} and ban user`}
+          >
+            Ban user
+          </Button>
+        </View>
+      ) : null}
+    </RowFrame>
+  );
+}
+
+function StoryRow({
+  story,
+  isPending,
+  onRemove,
+  onOpenStory,
+}: {
+  story: AdminStory;
+  isPending: boolean;
+  onRemove: (story: AdminStory) => void;
+  onOpenStory?: (storyId: string) => void;
+}) {
+  const { colors, spacing, typography } = useAppTheme();
+
+  return (
+    <RowFrame
+      onPress={onOpenStory ? () => onOpenStory(story.id) : undefined}
+      accessibilityLabel={`Open story ${story.title}`}
+    >
+      <Text style={{ color: colors.text, fontSize: typography.subtitle, fontWeight: '800' }}>{story.title}</Text>
+      <Text style={{ color: colors.muted }}>{story.contributorName ?? 'Anonymous'} - {story.locationName ?? 'Unknown place'}</Text>
+      <Text style={{ color: colors.muted }}>Status: {story.status ?? 'unknown'} - {formatDate(story.submittedAt)}</Text>
+      {onOpenStory ? <Text style={{ color: colors.primary, fontWeight: '700' }}>Tap to open story</Text> : null}
+      <View style={{ alignSelf: 'flex-start', marginTop: spacing.xs }}>
+        <Button
+          variant="outline"
+          disabled={isPending}
+          onPress={() => onRemove(story)}
+          accessibilityLabel={`Remove story ${story.title}`}
+        >
+          Remove
+        </Button>
+      </View>
+    </RowFrame>
+  );
+}
+
+function TagRow({ tag, isPending, onRemove }: { tag: AdminTag; isPending: boolean; onRemove: (tag: AdminTag) => void }) {
+  const { colors, spacing, typography } = useAppTheme();
+
+  return (
+    <RowFrame>
+      <Text style={{ color: colors.text, fontSize: typography.subtitle, fontWeight: '800' }}>{tag.name}</Text>
+      <Text style={{ color: colors.muted }}>{tag.storyCount} stories</Text>
+      <View style={{ alignSelf: 'flex-start', marginTop: spacing.xs }}>
+        <Button
+          variant="outline"
+          disabled={isPending}
+          onPress={() => onRemove(tag)}
+          accessibilityLabel={`Remove tag ${tag.name}`}
+        >
+          Remove
+        </Button>
+      </View>
+    </RowFrame>
+  );
+}
+
+function StatusBadge({ label, tone }: { label: string; tone: 'success' | 'danger' }) {
+  const { colors, spacing, typography } = useAppTheme();
+
+  return (
+    <View
+      style={{
+        alignSelf: 'flex-start',
+        paddingHorizontal: spacing.sm,
+        paddingVertical: spacing.xs,
+        borderRadius: 999,
+        backgroundColor: tone === 'success' ? colors.successSurface : colors.dangerSurface,
+      }}
+    >
+      <Text style={{ color: tone === 'success' ? colors.success : colors.danger, fontSize: typography.caption, fontWeight: '800' }}>
+        {titleCase(label)}
+      </Text>
+    </View>
+  );
+}
+
+function ConfirmActionDialog({ state, onClose }: { state: ConfirmState | null; onClose: () => void }) {
+  const { colors, spacing, typography } = useAppTheme();
+  const { toast } = useToast();
+  const [reason, setReason] = useState('');
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  useEffect(() => {
+    if (state) {
+      setReason('');
+      setIsSubmitting(false);
+    }
+  }, [state]);
+
+  if (!state) {
+    return null;
+  }
+
+  const confirm = async () => {
+    setIsSubmitting(true);
+    try {
+      await state.onConfirm(reason);
+      onClose();
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : 'Action failed.');
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <Modal transparent animationType="fade" visible>
+      <View
+        style={{
+          flex: 1,
+          justifyContent: 'center',
+          padding: spacing.lg,
+          backgroundColor: 'rgba(0,0,0,0.28)',
+        }}
+      >
+        <View
+          accessibilityRole="alert"
+          style={{
+            gap: spacing.md,
+            padding: spacing.lg,
+            borderRadius: 8,
+            borderWidth: 1,
+            borderColor: colors.border,
+            backgroundColor: colors.background,
+          }}
+        >
+          <Text style={{ color: colors.text, fontSize: typography.subtitle, fontWeight: '800' }}>
+            {state.title}
+          </Text>
+          <Text style={{ color: colors.muted }}>{state.message}</Text>
+          {state.reasonLabel ? (
+            <View style={{ gap: spacing.xs }}>
+              <Text style={{ color: colors.text, fontWeight: '700' }}>{state.reasonLabel}</Text>
+              <Input
+                value={reason}
+                onChangeText={setReason}
+                placeholder={state.reasonPlaceholder}
+                accessibilityLabel={state.reasonLabel}
+                multiline
+                numberOfLines={3}
+              />
+            </View>
+          ) : null}
+          <View style={{ flexDirection: 'row', justifyContent: 'flex-end', gap: spacing.sm }}>
+            <Button variant="ghost" disabled={isSubmitting} onPress={onClose}>
+              Cancel
+            </Button>
+            <Button disabled={isSubmitting} onPress={() => void confirm()}>
+              {state.confirmLabel}
+            </Button>
+          </View>
+        </View>
+      </View>
+    </Modal>
+  );
+}
+
+function titleCase(value: string) {
+  return value
+    .replace(/_/g, ' ')
+    .replace(/\b\w/g, (match) => match.toUpperCase());
+}
+
+function formatDate(value?: string | null) {
+  if (!value) {
+    return 'Unknown date';
+  }
+
+  const date = new Date(value);
+
+  if (Number.isNaN(date.getTime())) {
+    return value;
+  }
+
+  return date.toLocaleDateString();
 }

--- a/mobile/src/features/moderation/presentation/screens/__tests__/ModerationScreen.test.tsx
+++ b/mobile/src/features/moderation/presentation/screens/__tests__/ModerationScreen.test.tsx
@@ -1,0 +1,195 @@
+import React from 'react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react-native';
+import { ModerationScreen } from '../ModerationScreen';
+import { AdminPage, AdminReport, AdminStory, AdminTag, adminService } from '../../../application/services';
+
+const mockToastSuccess = jest.fn();
+const mockToastError = jest.fn();
+let mockRole: 'user' | 'admin' = 'admin';
+
+jest.mock('../../../../auth', () => ({
+  useAuth: () => ({
+    user: {
+      id: 1,
+      email: 'admin@example.com',
+      username: 'Admin',
+      role: mockRole,
+    },
+  }),
+}));
+
+jest.mock('../../../../../shared/hooks/useToast', () => ({
+  useToast: () => ({
+    toast: {
+      success: mockToastSuccess,
+      error: mockToastError,
+      info: jest.fn(),
+      show: jest.fn(),
+    },
+  }),
+}));
+
+const report: AdminReport = {
+  id: '10',
+  reporter: {
+    id: '2',
+    username: 'Reporter',
+    email: 'reporter@example.com',
+  },
+  targetType: 'story',
+  targetId: '7',
+  reason: 'spam',
+  description: 'Promotional content',
+  status: 'pending',
+  createdAt: '2026-05-01T12:00:00Z',
+};
+
+const story: AdminStory = {
+  id: '7',
+  title: 'Unsafe Story',
+  contributorName: 'Writer',
+  locationName: 'Istanbul',
+  status: 'published',
+  submittedAt: '2026-05-01T12:00:00Z',
+};
+
+const tag: AdminTag = {
+  id: '5',
+  name: 'spam-tag',
+  storyCount: 3,
+};
+
+function page<T>(items: T[], overrides: Partial<AdminPage<T>> = {}): AdminPage<T> {
+  return {
+    items,
+    page: 1,
+    totalCount: items.length,
+    hasNextPage: false,
+    ...overrides,
+  };
+}
+
+function createService(overrides: Partial<typeof adminService> = {}): typeof adminService {
+  return {
+    getReports: jest.fn(async () => page([report])),
+    resolveReport: jest.fn(async () => ({
+      ...report,
+      status: 'resolved' as const,
+      resolutionOutcome: 'No action',
+    })),
+    getStories: jest.fn(async () => page([story])),
+    removeStory: jest.fn(async () => undefined),
+    banUser: jest.fn(async () => undefined),
+    getTags: jest.fn(async () => page([tag])),
+    removeTag: jest.fn(async () => undefined),
+    ...overrides,
+  };
+}
+
+describe('ModerationScreen', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockRole = 'admin';
+  });
+
+  it('blocks non-admin users', () => {
+    mockRole = 'user';
+
+    render(<ModerationScreen service={createService()} />);
+
+    expect(screen.getByText('Not authorized')).toBeTruthy();
+    expect(screen.getByText('Only admins can access moderation tools.')).toBeTruthy();
+  });
+
+  it('lists reports, filters by status, and resolves a report', async () => {
+    const service = createService();
+    const onOpenStory = jest.fn();
+
+    render(<ModerationScreen service={service} onOpenStory={onOpenStory} />);
+
+    expect(await screen.findByText('story #7')).toBeTruthy();
+    fireEvent.press(screen.getByLabelText('Open reported story 7'));
+    expect(onOpenStory).toHaveBeenCalledWith('7');
+
+    expect(service.getReports).toHaveBeenLastCalledWith({ page: 1, status: 'pending' });
+
+    fireEvent.press(screen.getByLabelText('Report status: All'));
+
+    await waitFor(() => {
+      expect(service.getReports).toHaveBeenLastCalledWith({ page: 1, status: 'all' });
+    });
+
+    fireEvent.press(screen.getByLabelText('Resolve report 10 with no action'));
+
+    await waitFor(() => {
+      expect(service.resolveReport).toHaveBeenCalledWith('10', 'no_action');
+      expect(mockToastSuccess).toHaveBeenCalledWith('Report resolved.');
+    });
+  });
+
+  it('opens reported comments on their parent story when story metadata is available', async () => {
+    const commentReport: AdminReport = {
+      ...report,
+      id: '11',
+      targetType: 'comment',
+      targetId: '99',
+      targetStoryId: '7',
+    };
+    const service = createService({
+      getReports: jest.fn(async () => page([commentReport])),
+    });
+    const onOpenComment = jest.fn();
+
+    render(<ModerationScreen service={service} onOpenComment={onOpenComment} />);
+
+    expect(await screen.findByText('comment #99')).toBeTruthy();
+    fireEvent.press(screen.getByLabelText('Open reported comment 99'));
+
+    expect(onOpenComment).toHaveBeenCalledWith('7', '99');
+  });
+
+  it('requires a reason before removing a story', async () => {
+    const service = createService();
+    const onOpenStory = jest.fn();
+
+    render(<ModerationScreen service={service} onOpenStory={onOpenStory} />);
+
+    fireEvent.press(await screen.findByLabelText('Stories tab'));
+    expect(await screen.findByText('Unsafe Story')).toBeTruthy();
+    fireEvent.press(screen.getByLabelText('Open story Unsafe Story'));
+    expect(onOpenStory).toHaveBeenCalledWith('7');
+
+    fireEvent.press(screen.getByLabelText('Remove story Unsafe Story'));
+    fireEvent.press(screen.getByText('Remove story'));
+
+    await waitFor(() => {
+      expect(mockToastError).toHaveBeenCalledWith('A removal reason is required.');
+    });
+    expect(service.removeStory).not.toHaveBeenCalled();
+
+    fireEvent.changeText(screen.getByLabelText('Removal reason'), 'Harassment');
+    fireEvent.press(screen.getByText('Remove story'));
+
+    await waitFor(() => {
+      expect(service.removeStory).toHaveBeenCalledWith('7', 'Harassment');
+      expect(mockToastSuccess).toHaveBeenCalledWith('Story removed.');
+    });
+  });
+
+  it('removes tags after confirmation', async () => {
+    const service = createService();
+
+    render(<ModerationScreen service={service} />);
+
+    fireEvent.press(await screen.findByLabelText('Tags tab'));
+    expect(await screen.findByText('spam-tag')).toBeTruthy();
+
+    fireEvent.press(screen.getByLabelText('Remove tag spam-tag'));
+    fireEvent.press(screen.getByText('Remove tag'));
+
+    await waitFor(() => {
+      expect(service.removeTag).toHaveBeenCalledWith('5');
+      expect(mockToastSuccess).toHaveBeenCalledWith('Tag removed.');
+    });
+  });
+});

--- a/mobile/src/features/profile/presentation/screens/ProfileScreen.tsx
+++ b/mobile/src/features/profile/presentation/screens/ProfileScreen.tsx
@@ -1,6 +1,6 @@
 import * as ImagePicker from 'expo-image-picker';
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { Image, Modal, Pressable, ScrollView, Text, View } from 'react-native';
+import { Alert, Image, Modal, Pressable, ScrollView, Text, View } from 'react-native';
 import { GestureResponderEvent } from 'react-native';
 import { navigationRef } from '../../../../app/navigation/navigationRef';
 import { ROUTES } from '../../../../app/navigation/routes';
@@ -12,6 +12,7 @@ import { authService } from '../../../auth/application/services';
 import { useAuth } from '../../../auth';
 import { NotificationPreferencesSection } from '../../../notifications';
 import { interactionService } from '../../../interactions/application/services';
+import { adminService } from '../../../moderation/application/services';
 import { FeedCard } from '../../../feed/presentation/components/FeedCard';
 import { FeedEntity, FeedPageEntity } from '../../../feed/domain/entities';
 import { userService } from '../../application/services';
@@ -59,6 +60,7 @@ interface ProfileScreenProps {
   deleteAccount?: typeof userService.deleteAccount;
   followUser?: typeof userService.followUser;
   unfollowUser?: typeof userService.unfollowUser;
+  banUser?: typeof adminService.banUser;
   getFollowers?: typeof userService.getFollowers;
   getFollowing?: typeof userService.getFollowing;
   getSavedStories?: typeof userService.getSavedStories;
@@ -1488,6 +1490,7 @@ export function ProfileScreen({
   deleteAccount = userService.deleteAccount,
   followUser = userService.followUser,
   unfollowUser = userService.unfollowUser,
+  banUser = adminService.banUser,
   getFollowers = userService.getFollowers,
   getFollowing = userService.getFollowing,
   getSavedStories = userService.getSavedStories,
@@ -1525,6 +1528,8 @@ export function ProfileScreen({
   const [followingCount, setFollowingCount] = useState(0);
   const [isFollowing, setIsFollowing] = useState(false);
   const [isFollowLoading, setIsFollowLoading] = useState(false);
+  const [isBanLoading, setIsBanLoading] = useState(false);
+  const [isBanned, setIsBanned] = useState(false);
   const [followListMode, setFollowListMode] = useState<'followers' | 'following'>('followers');
   const [isFollowListVisible, setIsFollowListVisible] = useState(false);
   const [activeSelfTab, setActiveSelfTab] = useState<SelfProfileTab>('profile');
@@ -1580,6 +1585,7 @@ export function ProfileScreen({
       setFollowersCount(nextProfile.followersCount ?? 0);
       setFollowingCount(nextProfile.followingCount ?? 0);
       setIsFollowing(Boolean(resolvedFollowState));
+      setIsBanned(false);
       setFormState(createFormState(nextProfile));
       resetPhotoDraft();
       setIsEditing(false);
@@ -1926,6 +1932,43 @@ export function ProfileScreen({
     .join(' ');
   const joinedDate = formatJoinedDate(profile?.dateJoined);
   const birthDateDisplay = isSelfMode ? formatProfileBirthDate(profile?.birthDate) : undefined;
+  const canBanProfileUser = !isSelfMode && user?.role === 'admin' && Boolean(profile) && String(user.id) !== profile?.id;
+
+  const handleBanUser = useCallback(async () => {
+    if (!profile || isBanLoading || isBanned) {
+      return;
+    }
+
+    setIsBanLoading(true);
+
+    try {
+      await banUser(profile.id);
+      setIsBanned(true);
+      toast.success('User banned.');
+    } catch (banError) {
+      toast.error(banError instanceof Error ? banError.message : 'Failed to ban user. Please try again.');
+    } finally {
+      setIsBanLoading(false);
+    }
+  }, [banUser, isBanLoading, isBanned, profile, toast]);
+
+  const promptBanUser = useCallback(() => {
+    if (!profile || isBanLoading || isBanned) {
+      return;
+    }
+
+    Alert.alert('Ban user?', `${resolvedName} will lose access to the app.`, [
+      { text: 'Cancel', style: 'cancel' },
+      {
+        text: 'Ban',
+        style: 'destructive',
+        onPress: () => {
+          void handleBanUser();
+        },
+      },
+    ]);
+  }, [handleBanUser, isBanLoading, isBanned, profile, resolvedName]);
+
   const isDirty = useMemo(() => {
     if (!profile) {
       return false;
@@ -2086,13 +2129,25 @@ export function ProfileScreen({
           </View>
 
           {!isSelfMode ? (
-            <FollowActionButton
-              isAuthenticated={Boolean(isAuthenticated)}
-              isFollowing={isFollowing}
-              isLoading={isFollowLoading}
-              onToggle={() => void handleToggleFollow()}
-              onRequestLogin={handleRequestLoginForFollow}
-            />
+            <View style={{ flexDirection: 'row', flexWrap: 'wrap', gap: spacing.sm, alignItems: 'center' }}>
+              <FollowActionButton
+                isAuthenticated={Boolean(isAuthenticated)}
+                isFollowing={isFollowing}
+                isLoading={isFollowLoading}
+                onToggle={() => void handleToggleFollow()}
+                onRequestLogin={handleRequestLoginForFollow}
+              />
+              {canBanProfileUser ? (
+                <Button
+                  variant="outline"
+                  disabled={isBanLoading || isBanned}
+                  onPress={promptBanUser}
+                  accessibilityLabel={isBanned ? 'User banned' : `Ban ${resolvedName}`}
+                >
+                  {isBanLoading ? 'Banning...' : isBanned ? 'Banned' : 'Ban user'}
+                </Button>
+              ) : null}
+            </View>
           ) : null}
 
           {profile.bio ? (

--- a/mobile/src/features/profile/presentation/screens/__tests__/ProfileScreen.test.tsx
+++ b/mobile/src/features/profile/presentation/screens/__tests__/ProfileScreen.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
-import { fireEvent, render, screen, waitFor } from '@testing-library/react-native';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react-native';
 import * as ImagePicker from 'expo-image-picker';
-import { ScrollView } from 'react-native';
+import { Alert, ScrollView } from 'react-native';
 import { ProfileScreen } from '../ProfileScreen';
 import { navigationRef } from '../../../../../app/navigation/navigationRef';
 import { userService } from '../../../application/services';
@@ -17,7 +17,7 @@ let mockAuthUser: {
   id: number;
   email: string;
   username: string;
-  role: 'user';
+  role: 'user' | 'admin';
   isUsernamePublic: boolean;
 } | null = {
   id: 7,
@@ -813,6 +813,55 @@ describe('ProfileScreen', () => {
     await waitFor(() => {
       expect(followUser).toHaveBeenCalledWith('13');
     });
+  });
+
+  it('shows a ban action to admins on public profiles and confirms before banning', async () => {
+    mockAuthUser = {
+      id: 7,
+      email: 'admin@example.com',
+      username: 'Admin',
+      role: 'admin',
+      isUsernamePublic: true,
+    };
+    const banUser = jest.fn(async () => undefined);
+    const alertSpy = jest.spyOn(Alert, 'alert').mockImplementation(() => undefined);
+
+    render(
+      <ProfileScreen
+        mode="public"
+        userId="12"
+        getPublicProfile={async () => publicProfile}
+        banUser={banUser}
+      />,
+    );
+
+    expect(await screen.findByText('Aylin')).toBeTruthy();
+
+    fireEvent.press(screen.getByLabelText('Ban Aylin'));
+
+    expect(alertSpy).toHaveBeenCalledWith(
+      'Ban user?',
+      'Aylin will lose access to the app.',
+      expect.arrayContaining([
+        expect.objectContaining({ text: 'Cancel' }),
+        expect.objectContaining({ text: 'Ban' }),
+      ]),
+    );
+
+    const buttons = alertSpy.mock.calls[0]?.[2] as Array<{ text: string; onPress?: () => void }>;
+    const banButton = buttons.find((button) => button.text === 'Ban');
+
+    await act(async () => {
+      banButton?.onPress?.();
+    });
+
+    await waitFor(() => {
+      expect(banUser).toHaveBeenCalledWith('12');
+      expect(mockToastSuccess).toHaveBeenCalledWith('User banned.');
+    });
+    expect(screen.getByLabelText('User banned')).toBeTruthy();
+
+    alertSpy.mockRestore();
   });
 
   it('keeps the following state after leaving and returning when the profile response omits it', async () => {

--- a/mobile/src/features/search/presentation/components/StorySearchControls.tsx
+++ b/mobile/src/features/search/presentation/components/StorySearchControls.tsx
@@ -25,7 +25,7 @@ function buildChips(filters: ReturnType<typeof useSearchFilters>['filters']): Fi
 
     chips.push({
       key: 'proximityRadiusKm',
-      label: `Distance: ${formatDistance(filters.proximityRadiusKm)} from`,
+      label: `Distance: ${formatDistance(filters.proximityRadiusKm)} from ${filters.proximityLabel ?? ''}`.trim(),
       visual: isMapPinFilter ? 'redPin' : 'bluePin',
       visualAccessibilityLabel: isMapPinFilter ? 'red location pin' : 'current location blue pin',
     });
@@ -393,6 +393,7 @@ export function StorySearchControls({ helperText, hideHeading = false, scope }: 
                     proximityRadiusKm: draftProximityRadiusKm,
                     proximityCoordinates: draftProximityRadiusKm ? draftProximityCoordinates : undefined,
                     proximitySource: draftProximityRadiusKm ? 'current_location' : undefined,
+                    proximityLabel: undefined,
                     timeFrom: draftTimeFrom,
                     timeTo: draftTimeTo,
                     tags: draftTags,

--- a/mobile/src/features/search/presentation/context/SearchFiltersContext.tsx
+++ b/mobile/src/features/search/presentation/context/SearchFiltersContext.tsx
@@ -20,6 +20,7 @@ export interface SearchFiltersState {
   proximityRadiusKm?: ProximityRadiusKm;
   proximityCoordinates?: ProximityCoordinates;
   proximitySource?: ProximitySource;
+  proximityLabel?: string;
   timeFrom: string;
   timeTo: string;
   tags: string[];
@@ -43,6 +44,7 @@ const initialFilters: SearchFiltersState = {
   proximityRadiusKm: undefined,
   proximityCoordinates: undefined,
   proximitySource: undefined,
+  proximityLabel: undefined,
   timeFrom: '',
   timeTo: '',
   tags: [],
@@ -154,9 +156,10 @@ export function SearchFiltersProvider({ children }: PropsWithChildren) {
             ...currentFilters,
             [key]: key === 'tags' ? [] : '',
             ...(key === 'location' ? { locationBounds: undefined } : {}),
-            ...(key === 'proximityRadiusKm' ? { proximityRadiusKm: undefined, proximityCoordinates: undefined, proximitySource: undefined } : {}),
-            ...(key === 'proximityCoordinates' ? { proximityRadiusKm: undefined, proximityCoordinates: undefined, proximitySource: undefined } : {}),
-            ...(key === 'proximitySource' ? { proximityRadiusKm: undefined, proximityCoordinates: undefined, proximitySource: undefined } : {}),
+            ...(key === 'proximityRadiusKm' ? { proximityRadiusKm: undefined, proximityCoordinates: undefined, proximitySource: undefined, proximityLabel: undefined } : {}),
+            ...(key === 'proximityCoordinates' ? { proximityRadiusKm: undefined, proximityCoordinates: undefined, proximitySource: undefined, proximityLabel: undefined } : {}),
+            ...(key === 'proximitySource' ? { proximityRadiusKm: undefined, proximityCoordinates: undefined, proximitySource: undefined, proximityLabel: undefined } : {}),
+            ...(key === 'proximityLabel' ? { proximityRadiusKm: undefined, proximityCoordinates: undefined, proximitySource: undefined, proximityLabel: undefined } : {}),
           }),
           { refresh: true },
         );
@@ -236,6 +239,7 @@ function normalizeStoredFilters(filters?: Partial<SearchFiltersState> | null): S
     proximityRadiusKm: normalizeProximityRadius(filters?.proximityRadiusKm),
     proximityCoordinates: normalizeProximityCoordinates(filters?.proximityCoordinates),
     proximitySource: normalizeProximitySource(filters?.proximitySource),
+    proximityLabel: normalizeOptionalString(filters?.proximityLabel),
     timeFrom: filters?.timeFrom ?? '',
     timeTo: filters?.timeTo ?? '',
     tags: normalizeTags(filters?.tags),
@@ -275,6 +279,12 @@ function normalizeProximityCoordinates(coordinates?: ProximityCoordinates | null
     latitude,
     longitude,
   };
+}
+
+function normalizeOptionalString(value?: string | null): string | undefined {
+  const normalized = value?.trim();
+
+  return normalized ? normalized : undefined;
 }
 
 function normalizeLocationBounds(bounds?: LocationBounds | null): LocationBounds | undefined {

--- a/mobile/src/features/stories/presentation/screens/StoryScreen.tsx
+++ b/mobile/src/features/stories/presentation/screens/StoryScreen.tsx
@@ -28,6 +28,7 @@ import { loadStoryDetail } from '../state/storyDetailController';
 
 interface StoryScreenProps {
   storyId: string;
+  focusedCommentId?: string;
   session?: Pick<Session, 'role' | 'user'>;
   onRequestLogin?: () => void;
   onGoBack?: () => void;
@@ -636,6 +637,8 @@ interface CommentsSectionProps {
   comments: StoryEntity['comments'];
   isAuthenticated: boolean;
   currentUsername?: string;
+  canModerateComments?: boolean;
+  focusedCommentId?: string;
   loginPromptVisible: boolean;
   commentText: string;
   commentError?: string;
@@ -655,6 +658,8 @@ function CommentsSection({
   comments,
   isAuthenticated,
   currentUsername,
+  canModerateComments = false,
+  focusedCommentId,
   loginPromptVisible,
   commentText,
   commentError,
@@ -719,6 +724,7 @@ function CommentsSection({
 
       {displayedComments.map((comment) => {
         const isOwnComment = isAuthenticated && currentUsername === comment.authorName;
+        const canDeleteComment = isOwnComment || canModerateComments;
         const awaitingConfirm = confirmDeleteId === comment.id;
         const authorDisplayName = getDisplayNameWithYouLabel(comment.authorName, isOwnComment);
 
@@ -730,8 +736,8 @@ function CommentsSection({
             padding: spacing.md,
             borderRadius: 16,
             borderWidth: 1,
-            borderColor: colors.border,
-            backgroundColor: colors.surface,
+            borderColor: focusedCommentId === comment.id ? colors.primary : colors.border,
+            backgroundColor: focusedCommentId === comment.id ? colors.infoSurface : colors.surface,
           }}
         >
           <Text style={{ color: colors.text, fontWeight: '700' }}>{authorDisplayName}</Text>
@@ -758,10 +764,11 @@ function CommentsSection({
                   <Text style={{ color: colors.muted, fontWeight: '700' }}>Report</Text>
                 </Pressable>
               ) : null}
-              {isOwnComment ? (
+              {canDeleteComment ? (
                 <Pressable
                   onPress={() => onDeleteRequest(comment.id)}
                   accessibilityRole="button"
+                  accessibilityLabel={`Delete comment by ${authorDisplayName}`}
                   style={({ pressed }) => ({
                     minHeight: 44,
                     justifyContent: 'center',
@@ -806,6 +813,7 @@ function CommentsSection({
 
 export function StoryScreen({
   storyId,
+  focusedCommentId,
   session,
   onRequestLogin,
   onGoBack,
@@ -839,7 +847,9 @@ export function StoryScreen({
   const [contributorPhotoUrl, setContributorPhotoUrl] = useState<string | null>(null);
   const [isNarrativeExpanded, setIsNarrativeExpanded] = useState(false);
   const [narrativeTop, setNarrativeTop] = useState(0);
+  const [commentsTop, setCommentsTop] = useState(0);
   const scrollViewRef = useRef<ScrollView>(null);
+  const hasScrolledToFocusedCommentRef = useRef(false);
   const deletedCommentIdsRef = useRef<Set<string>>(new Set());
 
   useEffect(() => {
@@ -861,6 +871,8 @@ export function StoryScreen({
     setContributorPhotoUrl(null);
     setIsNarrativeExpanded(false);
     setNarrativeTop(0);
+    setCommentsTop(0);
+    hasScrolledToFocusedCommentRef.current = false;
     deletedCommentIdsRef.current = new Set();
 
     loadStoryDetail(storyId, session?.role, getStory).then((nextState) => {
@@ -899,6 +911,21 @@ export function StoryScreen({
       isMounted = false;
     };
   }, [getStory, session?.role, storyId]);
+
+  useEffect(() => {
+    hasScrolledToFocusedCommentRef.current = false;
+  }, [focusedCommentId, storyId]);
+
+  useEffect(() => {
+    if (!focusedCommentId || !commentsTop || hasScrolledToFocusedCommentRef.current || !comments.length) {
+      return;
+    }
+
+    hasScrolledToFocusedCommentRef.current = true;
+    requestAnimationFrame(() => {
+      scrollViewRef.current?.scrollTo({ y: Math.max(0, commentsTop - spacing.md), animated: true });
+    });
+  }, [comments.length, commentsTop, focusedCommentId, spacing.md]);
 
   useEffect(() => {
     let isMounted = true;
@@ -1471,10 +1498,13 @@ export function StoryScreen({
         <Text style={{ marginTop: spacing.sm, color: colors.danger }}>{interactionError}</Text>
       ) : null}
 
+      <View testID="story-comments-section" onLayout={(event) => setCommentsTop(event.nativeEvent.layout.y)}>
       <CommentsSection
         comments={comments}
         isAuthenticated={state.isAuthenticated}
         currentUsername={session?.user.username}
+        canModerateComments={session?.role === roles.admin}
+        focusedCommentId={focusedCommentId}
         loginPromptVisible={state.loginPromptVisible}
         commentText={commentText}
         commentError={commentError}
@@ -1499,6 +1529,7 @@ export function StoryScreen({
         }}
         onReportRequest={(commentId) => handleReportRequest('comment', commentId)}
       />
+      </View>
       <ReportSheet
         key={reportTarget ? `${reportTarget.targetType}-${reportTarget.targetId}` : 'hidden-report-sheet'}
         visible={Boolean(reportTarget)}

--- a/mobile/src/features/stories/presentation/screens/__tests__/StoryScreen.test.tsx
+++ b/mobile/src/features/stories/presentation/screens/__tests__/StoryScreen.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Alert } from 'react-native';
+import { Alert, ScrollView } from 'react-native';
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react-native';
 import { StoryScreen } from '../StoryScreen';
 import { Session } from '../../../../../core/auth/session';
@@ -821,6 +821,91 @@ describe('StoryScreen', () => {
     await waitFor(() => {
       expect(screen.queryByText('Delete this comment?')).toBeNull();
     });
+  });
+
+  it('lets admins delete comments written by other users', async () => {
+    (interactionService.deleteComment as jest.Mock).mockResolvedValueOnce(undefined);
+    (interactionService.getComments as jest.Mock).mockResolvedValueOnce([
+      {
+        id: 'comment-other',
+        authorUsername: 'Someone else',
+        text: 'Moderate this comment',
+        createdAt: '2026-03-20T12:00:00Z',
+      },
+    ]);
+
+    render(
+      <StoryScreen
+        storyId="story-001"
+        session={adminSession}
+        getStory={async () => ({
+          ...baseStory,
+          comments: [
+            {
+              id: 'comment-other',
+              authorName: 'Someone else',
+              body: 'Moderate this comment',
+              createdAt: '2026-03-20T12:00:00Z',
+            },
+          ],
+        })}
+      />,
+    );
+
+    await screen.findByText('Moderate this comment');
+    expect(screen.getByLabelText('Delete comment by Someone else')).toBeTruthy();
+
+    fireEvent.press(screen.getByLabelText('Delete comment by Someone else'));
+    fireEvent.press(screen.getByText('Delete'));
+
+    await waitFor(() => {
+      expect(interactionService.deleteComment).toHaveBeenCalledWith('comment-other');
+    });
+  });
+
+  it('scrolls to the comments section when a focused comment is provided', async () => {
+    const scrollToSpy = jest.spyOn(ScrollView.prototype, 'scrollTo').mockImplementation(jest.fn());
+
+    try {
+      (interactionService.getComments as jest.Mock).mockResolvedValueOnce([
+        {
+          id: 'comment-focus',
+          authorUsername: 'Someone else',
+          text: 'Focus this comment',
+          createdAt: '2026-03-20T12:00:00Z',
+        },
+      ]);
+
+      render(
+        <StoryScreen
+          storyId="story-001"
+          focusedCommentId="comment-focus"
+          session={adminSession}
+          getStory={async () => ({
+            ...baseStory,
+            comments: [
+              {
+                id: 'comment-focus',
+                authorName: 'Someone else',
+                body: 'Focus this comment',
+                createdAt: '2026-03-20T12:00:00Z',
+              },
+            ],
+          })}
+        />,
+      );
+
+      await screen.findByText('Focus this comment');
+      fireEvent(screen.getByTestId('story-comments-section'), 'layout', {
+        nativeEvent: { layout: { y: 900 } },
+      });
+
+      await waitFor(() => {
+        expect(scrollToSpy).toHaveBeenCalledWith({ y: 884, animated: true });
+      });
+    } finally {
+      scrollToSpy.mockRestore();
+    }
   });
 
   it('marks the signed-in user on their own comments even when private', async () => {

--- a/mobile/src/shared/components/WebMapView.tsx
+++ b/mobile/src/shared/components/WebMapView.tsx
@@ -46,7 +46,7 @@ type MapUpdatePayload = {
   transitionDurationMs?: number;
 };
 
-const MAP_HTML_VERSION = 'current-location-pin-size-v2';
+const MAP_HTML_VERSION = 'colored-cluster-markers-v1';
 
 const mapHtml = ({
   region,
@@ -96,6 +96,16 @@ const mapHtml = ({
         height: 34px;
       }
 
+      .marker.cluster {
+        width: 42px;
+        height: 42px;
+      }
+
+      .marker.cluster.selected {
+        width: 48px;
+        height: 48px;
+      }
+
       .marker-dot {
         position: relative;
         width: 18px;
@@ -117,6 +127,39 @@ const mapHtml = ({
         box-shadow: 0 4px 12px rgba(220, 38, 38, 0.32);
       }
 
+      .marker-cluster {
+        position: relative;
+        width: 38px;
+        height: 38px;
+        border-radius: 9999px;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        border: 4px solid rgba(255, 255, 255, 0.82);
+        box-shadow: 0 4px 14px rgba(15, 23, 42, 0.24);
+      }
+
+      .marker.cluster.selected .marker-cluster {
+        width: 44px;
+        height: 44px;
+        border-color: #ffffff;
+        box-shadow:
+          0 0 0 4px rgba(220, 38, 38, 0.18),
+          0 5px 16px rgba(15, 23, 42, 0.3);
+      }
+
+      .marker-cluster-small {
+        background: rgba(181, 226, 140, 0.94);
+      }
+
+      .marker-cluster-medium {
+        background: rgba(241, 211, 87, 0.96);
+      }
+
+      .marker-cluster-large {
+        background: rgba(253, 156, 115, 0.97);
+      }
+
       .marker.selected .marker-pin {
         width: 18px;
         height: 18px;
@@ -130,8 +173,8 @@ const mapHtml = ({
         min-width: 14px;
         max-width: 18px;
         color: #ffffff;
-        font-size: 10px;
-        font-weight: 700;
+        font-size: 12px;
+        font-weight: 800;
         line-height: 1;
         text-align: center;
         text-shadow: 0 1px 2px rgba(0, 0, 0, 0.35);
@@ -268,11 +311,34 @@ const mapHtml = ({
         }, Math.max(duration, 0) + 120);
       };
 
+      const getClusterSizeClass = (label) => {
+        const count = Number.parseInt(label, 10);
+
+        if (Number.isFinite(count) && count >= 100) {
+          return 'marker-cluster-large';
+        }
+
+        if (Number.isFinite(count) && count >= 10) {
+          return 'marker-cluster-medium';
+        }
+
+        return 'marker-cluster-small';
+      };
+
       const createStoryMarker = (marker) => {
         const element = document.createElement('div');
-        element.className = marker.selected ? 'marker selected' : 'marker';
+        const isCluster = Boolean(marker.label);
+        element.className = [
+          'marker',
+          isCluster ? 'cluster' : '',
+          marker.selected ? 'selected' : '',
+        ].filter(Boolean).join(' ');
         const markerBody = document.createElement('div');
-        markerBody.className = marker.selected ? 'marker-pin' : 'marker-dot';
+        markerBody.className = isCluster
+          ? 'marker-cluster ' + getClusterSizeClass(marker.label)
+          : marker.selected
+            ? 'marker-pin'
+            : 'marker-dot';
         element.appendChild(markerBody);
 
         if (marker.label) {
@@ -289,7 +355,7 @@ const mapHtml = ({
           );
         });
 
-        return new maplibregl.Marker({ element, anchor: marker.selected ? 'bottom' : 'center' })
+        return new maplibregl.Marker({ element, anchor: marker.selected && !isCluster ? 'bottom' : 'center' })
           .setLngLat([marker.longitude, marker.latitude])
           .addTo(map);
       };


### PR DESCRIPTION
# 📝 Description
Fixes #585 

Implemented mobile map pin clustering similar to the web map:
- Nearby story pins are grouped into numbered clusters when zoomed out.
- Clusters split into smaller clusters or individual pins as the user zooms in.
- Cluster markers use web-like colored styling based on cluster size.
- Tapping a cluster zooms/focuses the map on that cluster area.
- The “stories found in this area” badge updates after cluster selection.

# 📊 Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Refactoring
- [ ] Documentation
 
# ✅ Acceptance Criteria / Checklist
- [x] Project builds successfully
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, especially in hard-to-understand parts
- [x] I have performed a self-review of my code
- [x] I have added/updated tests
- [x] New and existing unit tests pass locally with my changes



# ⏱️ Estimated Review Time
- [ ] < 5 min
- [x] 5-15 min
- [ ] > 15 min
