### PR TITLE
Feat/filter stories by image timeline

### DIFF
--- a/mobile/src/app/navigation/RootNavigator.tsx
+++ b/mobile/src/app/navigation/RootNavigator.tsx
@@ -731,15 +731,19 @@ export function RootNavigator() {
   };
 
   const handleViewTimelineNearPin = useCallback(
-    (coordinates: { latitude: number; longitude: number }) => {
+    (target: { latitude: number; longitude: number; label?: string }) => {
       updateFilters(
         {
           query: '',
           location: '',
           locationBounds: undefined,
           proximityRadiusKm: 0.5,
-          proximityCoordinates: coordinates,
+          proximityCoordinates: {
+            latitude: target.latitude,
+            longitude: target.longitude,
+          },
           proximitySource: 'map_pin',
+          proximityLabel: target.label,
           timeFrom: '',
           timeTo: '',
           tags: [],

--- a/mobile/src/app/navigation/__tests__/RootNavigator.test.tsx
+++ b/mobile/src/app/navigation/__tests__/RootNavigator.test.tsx
@@ -1079,7 +1079,7 @@ describe('RootNavigator auth flow', () => {
         'GET /stories/feed/?page_size=100&sort_by=recent&latitude=41.02&longitude=28.96&radius_km=0.5&page=1',
       );
     });
-    expect(screen.getByLabelText('Remove Distance: 500 m from red location pin')).toBeTruthy();
+    expect(screen.getByLabelText('Remove Distance: 500 m from Harbor Memory red location pin')).toBeTruthy();
 
     fireEvent.press(await screen.findByLabelText('Open timeline story: Harbor Memory'));
 

--- a/mobile/src/features/map/presentation/components/MapCard.tsx
+++ b/mobile/src/features/map/presentation/components/MapCard.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useRef } from 'react';
-import { ActivityIndicator, LayoutChangeEvent, Pressable, ScrollView, Text, View } from 'react-native';
+import { ActivityIndicator, LayoutChangeEvent, ScrollView, Text, View } from 'react-native';
 import { Region } from 'react-native-maps';
 import { useAppTheme } from '../../../../core/hooks/useAppTheme';
 import { Button } from '../../../../shared/ui/Button';
@@ -17,7 +17,7 @@ interface MapCardProps {
   userLocation?: { latitude: number; longitude: number };
   onSelectMarker: (markerId: string) => void;
   onOpenStory: (storyId: string) => void;
-  onViewTimeline?: (coordinates: { latitude: number; longitude: number }) => void;
+  onViewTimeline?: (target: { latitude: number; longitude: number; label?: string }) => void;
   onRegionChangeComplete?: (region: Region) => void;
   onPreviewLayout?: (event: LayoutChangeEvent) => void;
   onMapTouchChange?: (isTouchingMap: boolean) => void;
@@ -52,7 +52,9 @@ export function MapCard({
         latitude: marker.latitude,
         longitude: marker.longitude,
         selected: marker.id === (highlightedMarkerId ?? selectedMarkerId),
-        label: marker.isCluster ? String(marker.count) : undefined,
+        label: marker.isCluster && marker.id !== highlightedMarkerId && marker.id !== selectedMarkerId
+          ? String(marker.count)
+          : undefined,
       })),
     [highlightedMarkerId, markers, selectedMarkerId],
   );
@@ -211,9 +213,15 @@ export function MapCard({
             <Button
               variant="outline"
               accessibilityLabel={`View timeline near ${selectedMarker.count} nearby stories`}
-              onPress={() => onViewTimeline?.({ latitude: selectedMarker.latitude, longitude: selectedMarker.longitude })}
+              onPress={() =>
+                onViewTimeline?.({
+                  latitude: selectedMarker.latitude,
+                  longitude: selectedMarker.longitude,
+                  label: `${selectedMarker.count} nearby stories`,
+                })
+              }
             >
-              View Timeline
+              View Group Timeline
             </Button>
             <ScrollView
               style={{ maxHeight: 240 }}
@@ -223,9 +231,8 @@ export function MapCard({
               testID="cluster-preview-list"
             >
               {selectedMarker.stories.map((story) => (
-                <Pressable
+                <View
                   key={story.id}
-                  onPress={() => onOpenStory(story.id)}
                   style={{
                     padding: spacing.md,
                     borderRadius: 16,
@@ -238,7 +245,29 @@ export function MapCard({
                   <Text {...passivePreviewTextProps} style={{ marginTop: spacing.xs, color: colors.muted }}>{story.placeName}</Text>
                   <Text {...passivePreviewTextProps} style={{ marginTop: spacing.xs, color: colors.muted }}>{story.timePeriod}</Text>
                   <Text {...passivePreviewTextProps} style={{ marginTop: spacing.sm, color: colors.text }}>{truncatePreview(story.previewText)}</Text>
-                </Pressable>
+                  <View style={{ flexDirection: 'row', flexWrap: 'wrap', gap: spacing.sm, marginTop: spacing.sm }}>
+                    <Button
+                      style={{ flexGrow: 1, flexBasis: 120 }}
+                      onPress={() => onOpenStory(story.id)}
+                    >
+                      Read full story
+                    </Button>
+                    <Button
+                      variant="outline"
+                      style={{ flexGrow: 1, flexBasis: 120 }}
+                      accessibilityLabel={`View timeline near ${story.title}`}
+                      onPress={() =>
+                        onViewTimeline?.({
+                          latitude: story.latitude,
+                          longitude: story.longitude,
+                          label: story.title,
+                        })
+                      }
+                    >
+                      View Timeline
+                    </Button>
+                  </View>
+                </View>
               ))}
             </ScrollView>
           </>
@@ -261,7 +290,13 @@ export function MapCard({
                 variant="outline"
                 style={{ flexGrow: 1, flexBasis: 140 }}
                 accessibilityLabel={`View timeline near ${selectedMarker.stories[0].title}`}
-                onPress={() => onViewTimeline?.({ latitude: selectedMarker.latitude, longitude: selectedMarker.longitude })}
+                onPress={() =>
+                  onViewTimeline?.({
+                    latitude: selectedMarker.stories[0].latitude,
+                    longitude: selectedMarker.stories[0].longitude,
+                    label: selectedMarker.stories[0].title,
+                  })
+                }
               >
                 View Timeline
               </Button>

--- a/mobile/src/features/map/presentation/screens/MapScreen.tsx
+++ b/mobile/src/features/map/presentation/screens/MapScreen.tsx
@@ -44,6 +44,8 @@ const LOCATION_BOUNDS_PADDING_FACTOR = 1.15;
 const PROXIMITY_PADDING_FACTOR = 2.4;
 const KILOMETERS_PER_LATITUDE_DEGREE = 111;
 const MAX_AUTO_REGION_DELTA = 20;
+const CLUSTER_RADIUS_REGION_FRACTION = 0.1;
+const MIN_CLUSTER_RADIUS_DEGREES = 0.0008;
 type StatusIndicatorMode = 'hidden' | 'filters' | 'area';
 
 export function MapScreen({
@@ -236,6 +238,18 @@ export function MapScreen({
     () => getMapPinFilterMarkerId(state.markers, filters),
     [filters, state.markers],
   );
+  const displayMarkers = useMemo(
+    () => clusterMarkersForRegion(state.markers, mapRegion),
+    [mapRegion, state.markers],
+  );
+  const displayedSelectedMarkerId = useMemo(
+    () => getDisplayedMarkerId(state.selectedMarkerId, displayMarkers, state.markers),
+    [displayMarkers, state.markers, state.selectedMarkerId],
+  );
+  const displayedHighlightedMarkerId = useMemo(
+    () => getDisplayedMarkerId(mapPinFilterMarkerId, displayMarkers, state.markers),
+    [displayMarkers, mapPinFilterMarkerId, state.markers],
+  );
   const statusStoryCount = useMemo(() => {
     if (statusIndicatorMode !== 'area' || !hasInteractedWithArea || !visibleRegion) {
       return totalStoryCount;
@@ -301,20 +315,29 @@ export function MapScreen({
       >
         <MapCard
           region={mapRegion}
-          markers={state.markers}
-          selectedMarkerId={state.selectedMarkerId}
-          highlightedMarkerId={mapPinFilterMarkerId}
+          markers={displayMarkers}
+          selectedMarkerId={displayedSelectedMarkerId}
+          highlightedMarkerId={displayedHighlightedMarkerId}
           isLoading={state.isLoading}
           error={state.error}
           statusBadgeText={statusBadgeText}
           userLocation={userLocation}
           onSelectMarker={(markerId) => {
-            const shouldOpenPreview = state.selectedMarkerId !== markerId;
+            const selectedMarker = displayMarkers.find((marker) => marker.id === markerId);
+            const shouldOpenPreview = displayedSelectedMarkerId !== markerId;
 
             setState((current) => ({
               ...current,
-              selectedMarkerId: current.selectedMarkerId === markerId ? undefined : markerId,
+              selectedMarkerId: displayedSelectedMarkerId === markerId ? undefined : markerId,
             }));
+
+            if (selectedMarker?.isCluster && shouldOpenPreview) {
+              const nextRegion = getRegionForCluster(selectedMarker, mapRegion);
+              setMapRegion(nextRegion);
+              setVisibleRegion(nextRegion);
+              setHasInteractedWithArea(true);
+              setStatusIndicatorMode('area');
+            }
 
             if (shouldOpenPreview) {
               handleMarkerPreviewRequest();
@@ -405,6 +428,122 @@ function countStoriesInRegion(markers: MapMarkerGroup[], region: Region) {
 
     return sum + (isMarkerVisible ? marker.count : 0);
   }, 0);
+}
+
+function clusterMarkersForRegion(markers: MapMarkerGroup[], region: Region): MapMarkerGroup[] {
+  if (markers.length < 2) {
+    return markers;
+  }
+
+  const clusterRadius = Math.max(
+    Math.max(Math.abs(region.latitudeDelta), Math.abs(region.longitudeDelta)) * CLUSTER_RADIUS_REGION_FRACTION,
+    MIN_CLUSTER_RADIUS_DEGREES,
+  );
+  const clusters: MapMarkerGroup[][] = [];
+
+  markers.forEach((marker) => {
+    const matchingCluster = clusters.find((cluster) => {
+      const center = getWeightedClusterCenter(cluster);
+
+      return getProjectedDistance(marker, center) <= clusterRadius;
+    });
+
+    if (matchingCluster) {
+      matchingCluster.push(marker);
+      return;
+    }
+
+    clusters.push([marker]);
+  });
+
+  return clusters.map((cluster) => {
+    if (cluster.length === 1) {
+      return cluster[0];
+    }
+
+    const center = getWeightedClusterCenter(cluster);
+    const stories = cluster.flatMap((marker) => marker.stories);
+    const count = cluster.reduce((sum, marker) => sum + marker.count, 0);
+    const clusterId = cluster
+      .map((marker) => marker.id)
+      .sort()
+      .join('|');
+
+    return {
+      id: `zoom-cluster:${clusterId}`,
+      latitude: center.latitude,
+      longitude: center.longitude,
+      stories,
+      count,
+      isCluster: true,
+    };
+  });
+}
+
+function getWeightedClusterCenter(markers: MapMarkerGroup[]) {
+  const totalCount = markers.reduce((sum, marker) => sum + marker.count, 0);
+  const latitude = markers.reduce((sum, marker) => sum + marker.latitude * marker.count, 0) / totalCount;
+  const longitude = markers.reduce((sum, marker) => sum + marker.longitude * marker.count, 0) / totalCount;
+
+  return { latitude, longitude };
+}
+
+function getProjectedDistance(
+  marker: Pick<MapMarkerGroup, 'latitude' | 'longitude'>,
+  center: { latitude: number; longitude: number },
+) {
+  const latitudeDistance = marker.latitude - center.latitude;
+  const longitudeScale = Math.max(Math.cos((center.latitude * Math.PI) / 180), 0.2);
+  const longitudeDistance = (marker.longitude - center.longitude) * longitudeScale;
+
+  return Math.sqrt(latitudeDistance ** 2 + longitudeDistance ** 2);
+}
+
+function getRegionForCluster(marker: MapMarkerGroup, currentRegion: Region): Region {
+  const latitudes = marker.stories.map((story) => story.latitude);
+  const longitudes = marker.stories.map((story) => story.longitude);
+  const minLatitude = Math.min(...latitudes, marker.latitude);
+  const maxLatitude = Math.max(...latitudes, marker.latitude);
+  const minLongitude = Math.min(...longitudes, marker.longitude);
+  const maxLongitude = Math.max(...longitudes, marker.longitude);
+  const latitudeDelta = Math.max((maxLatitude - minLatitude) * FIT_PADDING_FACTOR, MIN_LOCATION_DELTA);
+  const longitudeDelta = Math.max((maxLongitude - minLongitude) * FIT_PADDING_FACTOR, MIN_LOCATION_DELTA);
+  const nextLatitudeDelta = Math.min(latitudeDelta, Math.max(currentRegion.latitudeDelta * 0.45, MIN_LOCATION_DELTA));
+  const nextLongitudeDelta = Math.min(longitudeDelta, Math.max(currentRegion.longitudeDelta * 0.45, MIN_LOCATION_DELTA));
+
+  return {
+    latitude: (minLatitude + maxLatitude) / 2,
+    longitude: (minLongitude + maxLongitude) / 2,
+    latitudeDelta: clampRegionDelta(nextLatitudeDelta, MIN_LOCATION_DELTA),
+    longitudeDelta: clampRegionDelta(nextLongitudeDelta, MIN_LOCATION_DELTA),
+  };
+}
+
+function getDisplayedMarkerId(
+  markerId: string | undefined,
+  displayMarkers: MapMarkerGroup[],
+  sourceMarkers: MapMarkerGroup[],
+) {
+  if (!markerId) {
+    return undefined;
+  }
+
+  if (displayMarkers.some((marker) => marker.id === markerId)) {
+    return markerId;
+  }
+
+  const sourceMarker = sourceMarkers.find((marker) => marker.id === markerId);
+
+  if (!sourceMarker) {
+    return undefined;
+  }
+
+  const sourceStoryIds = new Set(sourceMarker.stories.map((story) => story.id));
+  const containingMarker = displayMarkers.find((marker) =>
+    marker.stories.some((story) => sourceStoryIds.has(story.id)),
+  );
+
+  return containingMarker?.id;
 }
 
 function formatStoryCount(count: number) {

--- a/mobile/src/features/map/presentation/screens/MapScreen.tsx
+++ b/mobile/src/features/map/presentation/screens/MapScreen.tsx
@@ -21,7 +21,7 @@ interface MapScreenProps {
   onOpenStory?: (storyId: string) => void;
   getMarkerGroups?: (filters?: StoryFilters) => Promise<MapMarkerGroup[]>;
   onMarkerPreviewRequested?: (targetY: number) => void;
-  onViewTimeline?: (coordinates: { latitude: number; longitude: number }) => void;
+  onViewTimeline?: (target: { latitude: number; longitude: number; label?: string }) => void;
   showSearchControls?: boolean;
   onRegisterRefresh?: (handler: (() => Promise<void>) | null) => void;
   onMapTouchChange?: (isTouchingMap: boolean) => void;
@@ -46,6 +46,7 @@ const KILOMETERS_PER_LATITUDE_DEGREE = 111;
 const MAX_AUTO_REGION_DELTA = 20;
 const CLUSTER_RADIUS_REGION_FRACTION = 0.1;
 const MIN_CLUSTER_RADIUS_DEGREES = 0.0008;
+const MIN_CLUSTER_ZOOM_DELTA = 0.00001;
 type StatusIndicatorMode = 'hidden' | 'filters' | 'area';
 
 export function MapScreen({
@@ -69,6 +70,8 @@ export function MapScreen({
   const [visibleRegion, setVisibleRegion] = useState<Region | undefined>();
   const [hasInteractedWithArea, setHasInteractedWithArea] = useState(false);
   const [statusIndicatorMode, setStatusIndicatorMode] = useState<StatusIndicatorMode>('hidden');
+  const [zoomedMarkerIds, setZoomedMarkerIds] = useState<Set<string>>(() => new Set());
+  const [expandedMarkerIds, setExpandedMarkerIds] = useState<Set<string>>(() => new Set());
   const lastAutoZoomContextKeyRef = useRef<string | null>(null);
   const previousMapPinFilterKeyRef = useRef<string | null>(null);
   const loadRequestIdRef = useRef(0);
@@ -136,7 +139,7 @@ export function MapScreen({
     try {
       const markers = await getMarkerGroups(activeFilters);
       const selectedMarkerId = getPreferredMarkerId(markers, activeFilters);
-      const nextAutoRegion = getAutoZoomRegion(markers, activeFilters);
+      const nextAutoRegion = getAutoZoomRegion(markers, activeFilters, filters.proximitySource);
 
       if (requestId !== loadRequestIdRef.current) {
         return;
@@ -149,6 +152,8 @@ export function MapScreen({
         markers,
         selectedMarkerId,
       });
+      setZoomedMarkerIds(new Set());
+      setExpandedMarkerIds(new Set());
 
       if (nextAutoRegion && lastAutoZoomContextKeyRef.current !== autoZoomContextKey) {
         lastAutoZoomContextKeyRef.current = autoZoomContextKey;
@@ -167,7 +172,7 @@ export function MapScreen({
         selectedMarkerId: undefined,
       });
     }
-  }, [activeFilters, autoZoomContextKey, getMarkerGroups]);
+  }, [activeFilters, autoZoomContextKey, filters.proximitySource, getMarkerGroups]);
 
   useEffect(() => {
     if (!isHydrated) {
@@ -239,16 +244,18 @@ export function MapScreen({
     [filters, state.markers],
   );
   const displayMarkers = useMemo(
-    () => clusterMarkersForRegion(state.markers, mapRegion),
-    [mapRegion, state.markers],
+    () => clusterMarkersForRegion(state.markers, mapRegion, expandedMarkerIds),
+    [expandedMarkerIds, mapRegion, state.markers],
   );
   const displayedSelectedMarkerId = useMemo(
     () => getDisplayedMarkerId(state.selectedMarkerId, displayMarkers, state.markers),
     [displayMarkers, state.markers, state.selectedMarkerId],
   );
   const displayedHighlightedMarkerId = useMemo(
-    () => getDisplayedMarkerId(mapPinFilterMarkerId, displayMarkers, state.markers),
-    [displayMarkers, mapPinFilterMarkerId, state.markers],
+    () =>
+      getDisplayedMarkerId(mapPinFilterMarkerId, displayMarkers, state.markers) ??
+      getDisplayedMapPinCoordinateMarkerId(displayMarkers, filters),
+    [displayMarkers, filters, mapPinFilterMarkerId, state.markers],
   );
   const statusStoryCount = useMemo(() => {
     if (statusIndicatorMode !== 'area' || !hasInteractedWithArea || !visibleRegion) {
@@ -324,14 +331,29 @@ export function MapScreen({
           userLocation={userLocation}
           onSelectMarker={(markerId) => {
             const selectedMarker = displayMarkers.find((marker) => marker.id === markerId);
-            const shouldOpenPreview = displayedSelectedMarkerId !== markerId;
+            const shouldZoomCluster = Boolean(
+              selectedMarker?.isCluster && hasDistinctStoryCoordinates(selectedMarker),
+            );
+            const shouldOpenPreview = displayedSelectedMarkerId !== markerId || shouldZoomCluster;
 
             setState((current) => ({
               ...current,
-              selectedMarkerId: displayedSelectedMarkerId === markerId ? undefined : markerId,
+              selectedMarkerId: displayedSelectedMarkerId === markerId && !shouldZoomCluster ? undefined : markerId,
             }));
 
-            if (selectedMarker?.isCluster && shouldOpenPreview) {
+            if (selectedMarker?.isCluster && shouldZoomCluster) {
+              const isSourceMarker = state.markers.some((marker) => marker.id === selectedMarker.id);
+
+              if (isSourceMarker) {
+                const hasZoomedMarkerBefore = zoomedMarkerIds.has(selectedMarker.id);
+
+                setZoomedMarkerIds((current) => new Set(current).add(selectedMarker.id));
+
+                if (hasZoomedMarkerBefore) {
+                  setExpandedMarkerIds((current) => new Set(current).add(selectedMarker.id));
+                }
+              }
+
               const nextRegion = getRegionForCluster(selectedMarker, mapRegion);
               setMapRegion(nextRegion);
               setVisibleRegion(nextRegion);
@@ -430,9 +452,15 @@ function countStoriesInRegion(markers: MapMarkerGroup[], region: Region) {
   }, 0);
 }
 
-function clusterMarkersForRegion(markers: MapMarkerGroup[], region: Region): MapMarkerGroup[] {
-  if (markers.length < 2) {
-    return markers;
+function clusterMarkersForRegion(
+  markers: MapMarkerGroup[],
+  region: Region,
+  expandedMarkerIds: Set<string>,
+): MapMarkerGroup[] {
+  const clusterableMarkers = expandDistinctStoryMarkers(markers, expandedMarkerIds);
+
+  if (clusterableMarkers.length < 2) {
+    return clusterableMarkers;
   }
 
   const clusterRadius = Math.max(
@@ -441,7 +469,7 @@ function clusterMarkersForRegion(markers: MapMarkerGroup[], region: Region): Map
   );
   const clusters: MapMarkerGroup[][] = [];
 
-  markers.forEach((marker) => {
+  clusterableMarkers.forEach((marker) => {
     const matchingCluster = clusters.find((cluster) => {
       const center = getWeightedClusterCenter(cluster);
 
@@ -480,6 +508,23 @@ function clusterMarkersForRegion(markers: MapMarkerGroup[], region: Region): Map
   });
 }
 
+function expandDistinctStoryMarkers(markers: MapMarkerGroup[], expandedMarkerIds: Set<string>) {
+  return markers.flatMap((marker) => {
+    if (!expandedMarkerIds.has(marker.id) || !marker.isCluster || !hasDistinctStoryCoordinates(marker)) {
+      return [marker];
+    }
+
+    return marker.stories.map((story) => ({
+      id: `${marker.id}:story:${story.id}`,
+      latitude: story.latitude,
+      longitude: story.longitude,
+      stories: [story],
+      count: 1,
+      isCluster: false,
+    }));
+  });
+}
+
 function getWeightedClusterCenter(markers: MapMarkerGroup[]) {
   const totalCount = markers.reduce((sum, marker) => sum + marker.count, 0);
   const latitude = markers.reduce((sum, marker) => sum + marker.latitude * marker.count, 0) / totalCount;
@@ -506,17 +551,29 @@ function getRegionForCluster(marker: MapMarkerGroup, currentRegion: Region): Reg
   const maxLatitude = Math.max(...latitudes, marker.latitude);
   const minLongitude = Math.min(...longitudes, marker.longitude);
   const maxLongitude = Math.max(...longitudes, marker.longitude);
-  const latitudeDelta = Math.max((maxLatitude - minLatitude) * FIT_PADDING_FACTOR, MIN_LOCATION_DELTA);
-  const longitudeDelta = Math.max((maxLongitude - minLongitude) * FIT_PADDING_FACTOR, MIN_LOCATION_DELTA);
-  const nextLatitudeDelta = Math.min(latitudeDelta, Math.max(currentRegion.latitudeDelta * 0.45, MIN_LOCATION_DELTA));
-  const nextLongitudeDelta = Math.min(longitudeDelta, Math.max(currentRegion.longitudeDelta * 0.45, MIN_LOCATION_DELTA));
+  const latitudeDelta = Math.max((maxLatitude - minLatitude) * FIT_PADDING_FACTOR, MIN_CLUSTER_ZOOM_DELTA);
+  const longitudeDelta = Math.max((maxLongitude - minLongitude) * FIT_PADDING_FACTOR, MIN_CLUSTER_ZOOM_DELTA);
+  const nextLatitudeDelta = Math.min(latitudeDelta, Math.max(currentRegion.latitudeDelta * 0.45, MIN_CLUSTER_ZOOM_DELTA));
+  const nextLongitudeDelta = Math.min(longitudeDelta, Math.max(currentRegion.longitudeDelta * 0.45, MIN_CLUSTER_ZOOM_DELTA));
 
   return {
     latitude: (minLatitude + maxLatitude) / 2,
     longitude: (minLongitude + maxLongitude) / 2,
-    latitudeDelta: clampRegionDelta(nextLatitudeDelta, MIN_LOCATION_DELTA),
-    longitudeDelta: clampRegionDelta(nextLongitudeDelta, MIN_LOCATION_DELTA),
+    latitudeDelta: clampRegionDelta(nextLatitudeDelta, MIN_CLUSTER_ZOOM_DELTA),
+    longitudeDelta: clampRegionDelta(nextLongitudeDelta, MIN_CLUSTER_ZOOM_DELTA),
   };
+}
+
+function hasDistinctStoryCoordinates(marker: MapMarkerGroup) {
+  const [firstStory] = marker.stories;
+
+  if (!firstStory) {
+    return false;
+  }
+
+  return marker.stories.some(
+    (story) => story.latitude !== firstStory.latitude || story.longitude !== firstStory.longitude,
+  );
 }
 
 function getDisplayedMarkerId(
@@ -565,7 +622,24 @@ function getMapPinFilterMarkerId(markers: MapMarkerGroup[], filters: SearchFilte
 
   const { latitude, longitude } = filters.proximityCoordinates;
   const matchingMarker = markers.find(
-    (marker) => coordinatesEqual(marker.latitude, latitude) && coordinatesEqual(marker.longitude, longitude),
+    (marker) =>
+      (coordinatesEqual(marker.latitude, latitude) && coordinatesEqual(marker.longitude, longitude)) ||
+      marker.stories.some((story) => coordinatesEqual(story.latitude, latitude) && coordinatesEqual(story.longitude, longitude)),
+  );
+
+  return matchingMarker?.id;
+}
+
+function getDisplayedMapPinCoordinateMarkerId(markers: MapMarkerGroup[], filters: SearchFiltersState) {
+  if (filters.proximitySource !== 'map_pin' || !filters.proximityCoordinates) {
+    return undefined;
+  }
+
+  const { latitude, longitude } = filters.proximityCoordinates;
+  const matchingMarker = markers.find(
+    (marker) =>
+      (coordinatesEqual(marker.latitude, latitude) && coordinatesEqual(marker.longitude, longitude)) ||
+      marker.stories.some((story) => coordinatesEqual(story.latitude, latitude) && coordinatesEqual(story.longitude, longitude)),
   );
 
   return matchingMarker?.id;
@@ -595,7 +669,11 @@ function buildAutoZoomContextKey(filters: StoryFilters) {
   });
 }
 
-function getAutoZoomRegion(markers: MapMarkerGroup[], filters: StoryFilters): Region | undefined {
+function getAutoZoomRegion(markers: MapMarkerGroup[], filters: StoryFilters, proximitySource?: SearchFiltersState['proximitySource']): Region | undefined {
+  if (proximitySource === 'map_pin') {
+    return undefined;
+  }
+
   if (filters.locationBounds) {
     return getRegionForLocationBounds(filters.locationBounds);
   }

--- a/mobile/src/features/map/presentation/screens/__tests__/MapScreen.test.tsx
+++ b/mobile/src/features/map/presentation/screens/__tests__/MapScreen.test.tsx
@@ -33,7 +33,7 @@ jest.mock('../../../../../shared/components/WebMapView', () => {
         latitudeDelta: number;
         longitudeDelta: number;
       };
-      markers?: Array<{ id: string; selected?: boolean }>;
+      markers?: Array<{ id: string; selected?: boolean; label?: string }>;
       userLocation?: {
         latitude: number;
         longitude: number;
@@ -84,6 +84,7 @@ jest.mock('../../../../../shared/components/WebMapView', () => {
             key={marker.id}
             onPress={() => onMarkerPress?.(marker.id)}
             testID="story-marker"
+            accessibilityLabel={`marker:${marker.id}:${marker.label ?? ''}`}
             accessibilityState={{ selected: Boolean(marker.selected) }}
           />
         ))}
@@ -161,6 +162,63 @@ const refreshedMarkerGroups: MapMarkerGroup[] = [
   },
 ];
 
+const zoomClusterMarkerGroups: MapMarkerGroup[] = [
+  {
+    id: 'near-1',
+    latitude: 41,
+    longitude: 29,
+    count: 1,
+    isCluster: false,
+    stories: [
+      {
+        id: 'story-near-1',
+        title: 'First Nearby Memory',
+        placeName: 'Kadikoy',
+        timePeriod: '1970s',
+        previewText: 'A nearby story.',
+        latitude: 41,
+        longitude: 29,
+      },
+    ],
+  },
+  {
+    id: 'near-2',
+    latitude: 41.012,
+    longitude: 29.012,
+    count: 1,
+    isCluster: false,
+    stories: [
+      {
+        id: 'story-near-2',
+        title: 'Second Nearby Memory',
+        placeName: 'Moda',
+        timePeriod: '1980s',
+        previewText: 'Another nearby story.',
+        latitude: 41.012,
+        longitude: 29.012,
+      },
+    ],
+  },
+  {
+    id: 'far-1',
+    latitude: 41.7,
+    longitude: 29.7,
+    count: 1,
+    isCluster: false,
+    stories: [
+      {
+        id: 'story-far-1',
+        title: 'Far Away Memory',
+        placeName: 'Sile',
+        timePeriod: '1990s',
+        previewText: 'A distant story.',
+        latitude: 41.7,
+        longitude: 29.7,
+      },
+    ],
+  },
+];
+
 function getRenderedMapRegion() {
   const label = screen.getByTestId('map-region-props').props.accessibilityLabel as string;
   const [, latitude, longitude, latitudeDelta, longitudeDelta] = label.split(':');
@@ -207,6 +265,35 @@ describe('MapScreen', () => {
       expect(screen.getByTestId('map-region-props').props.accessibilityLabel).toContain('region:41.0192:28.96735:0.06:0.06');
     });
     expect(screen.getByText('Select a story marker to preview.')).toBeTruthy();
+  });
+
+  it('clusters nearby pins while zoomed out and separates them after zooming in', async () => {
+    renderScreen(<MapScreen getMarkerGroups={async () => zoomClusterMarkerGroups} />);
+
+    await screen.findByText('Select a story marker to preview.');
+
+    await waitFor(() => {
+      expect(screen.getAllByTestId('story-marker')).toHaveLength(2);
+    });
+    expect(screen.getByLabelText(/^marker:zoom-cluster:.*:2$/)).toBeTruthy();
+
+    fireEvent.press(screen.getByLabelText(/^marker:zoom-cluster:.*:2$/));
+
+    await waitFor(() => {
+      const region = getRenderedMapRegion();
+
+      expect(region.latitude).toBeCloseTo(41.006);
+      expect(region.longitude).toBeCloseTo(29.006);
+      expect(region.latitudeDelta).toBeLessThan(1);
+      expect(region.longitudeDelta).toBeLessThan(1);
+    });
+    expect(screen.getByText('2 stories found in this area')).toBeTruthy();
+
+    fireEvent.press(screen.getByTestId('map-region-change'));
+
+    await waitFor(() => {
+      expect(screen.getAllByTestId('story-marker')).toHaveLength(3);
+    });
   });
 
   it('shows the selected marker preview and navigates to story detail', async () => {

--- a/mobile/src/features/map/presentation/screens/__tests__/MapScreen.test.tsx
+++ b/mobile/src/features/map/presentation/screens/__tests__/MapScreen.test.tsx
@@ -219,6 +219,45 @@ const zoomClusterMarkerGroups: MapMarkerGroup[] = [
   },
 ];
 
+const backendGroupedDistinctMarkerGroups: MapMarkerGroup[] = [
+  {
+    id: 'backend-group',
+    latitude: 41.01,
+    longitude: 28.97,
+    count: 3,
+    isCluster: true,
+    stories: [
+      {
+        id: 'backend-story-1',
+        title: 'Backend Group One',
+        placeName: 'Beyazit',
+        timePeriod: '1900s',
+        previewText: 'First grouped story.',
+        latitude: 41.01,
+        longitude: 28.97,
+      },
+      {
+        id: 'backend-story-2',
+        title: 'Backend Group Two',
+        placeName: 'Laleli',
+        timePeriod: '1910s',
+        previewText: 'Second grouped story.',
+        latitude: 41.012,
+        longitude: 28.972,
+      },
+      {
+        id: 'backend-story-3',
+        title: 'Backend Group Three',
+        placeName: 'Vezneciler',
+        timePeriod: '1920s',
+        previewText: 'Third grouped story.',
+        latitude: 41.014,
+        longitude: 28.974,
+      },
+    ],
+  },
+];
+
 function getRenderedMapRegion() {
   const label = screen.getByTestId('map-region-props').props.accessibilityLabel as string;
   const [, latitude, longitude, latitudeDelta, longitudeDelta] = label.split(':');
@@ -296,6 +335,41 @@ describe('MapScreen', () => {
     });
   });
 
+  it('keeps zooming a selected cluster when stories have different coordinates', async () => {
+    renderScreen(<MapScreen getMarkerGroups={async () => markerGroups} />);
+
+    await screen.findByText('Select a story marker to preview.');
+
+    const clusterMarker = await screen.findByLabelText('marker:41.01:28.97:2');
+    fireEvent.press(clusterMarker);
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('marker:41.01:28.97:').props.accessibilityState.selected).toBe(true);
+    });
+    const firstZoomRegion = getRenderedMapRegion();
+
+    fireEvent.press(await screen.findByLabelText('marker:41.01:28.97:'));
+
+    await waitFor(() => {
+      expect(getRenderedMapRegion().longitudeDelta).toBeLessThan(firstZoomRegion.longitudeDelta);
+    });
+  });
+
+  it('splits a backend grouped marker into story pins as the user keeps zooming', async () => {
+    renderScreen(<MapScreen getMarkerGroups={async () => backendGroupedDistinctMarkerGroups} />);
+
+    await screen.findByText('Select a story marker to preview.');
+    expect(await screen.findByLabelText('marker:backend-group:3')).toBeTruthy();
+
+    fireEvent.press(await screen.findByLabelText('marker:backend-group:3'));
+    fireEvent.press(await screen.findByLabelText('marker:backend-group:'));
+
+    await waitFor(() => {
+      expect(screen.getAllByTestId('story-marker')).toHaveLength(3);
+    });
+    expect(screen.queryByLabelText('marker:backend-group:3')).toBeNull();
+  });
+
   it('shows the selected marker preview and navigates to story detail', async () => {
     const onOpenStory = jest.fn();
 
@@ -323,6 +397,7 @@ describe('MapScreen', () => {
     expect(onViewTimeline).toHaveBeenCalledWith({
       latitude: 41.0284,
       longitude: 28.9647,
+      label: 'The Day the Harbor Fell Silent',
     });
   });
 
@@ -396,6 +471,19 @@ describe('MapScreen', () => {
     expect(screen.getByText('Voices of the Ferry Pier')).toBeTruthy();
   });
 
+  it('shows a selected grouped marker as a red pin while the group timeline action is visible', async () => {
+    renderScreen(<MapScreen getMarkerGroups={async () => markerGroups} />);
+
+    await screen.findByText('Select a story marker to preview.');
+    fireEvent.press(screen.getByLabelText('marker:41.01:28.97:2'));
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('View timeline near 2 nearby stories')).toBeTruthy();
+    });
+    expect(screen.getByLabelText('marker:41.01:28.97:').props.accessibilityState.selected).toBe(true);
+    expect(screen.queryByLabelText('marker:41.01:28.97:2')).toBeNull();
+  });
+
   it('offers a timeline action for a clustered marker', async () => {
     const onViewTimeline = jest.fn();
 
@@ -408,7 +496,80 @@ describe('MapScreen', () => {
     expect(onViewTimeline).toHaveBeenCalledWith({
       latitude: 41.01,
       longitude: 28.97,
+      label: '2 nearby stories',
     });
+  });
+
+  it('offers story-specific timeline actions inside a clustered marker', async () => {
+    const onViewTimeline = jest.fn();
+
+    renderScreen(<MapScreen getMarkerGroups={async () => markerGroups} onViewTimeline={onViewTimeline} />);
+
+    await screen.findByText('Select a story marker to preview.');
+    fireEvent.press(screen.getAllByTestId('story-marker')[1]);
+    fireEvent.press(await screen.findByLabelText('View timeline near Lanterns Above the Hill Market'));
+
+    expect(onViewTimeline).toHaveBeenCalledWith({
+      latitude: 41.0249,
+      longitude: 28.9548,
+      label: 'Lanterns Above the Hill Market',
+    });
+  });
+
+  it('highlights the grouped marker when a map-pin timeline filter targets a story inside it', async () => {
+    await storage.set(storageKeys.mapSearchFilters, {
+      proximityRadiusKm: 0.5,
+      proximityCoordinates: {
+        latitude: 41.0249,
+        longitude: 28.9548,
+      },
+      proximitySource: 'map_pin',
+      proximityLabel: 'Lanterns Above the Hill Market',
+    });
+
+    renderScreen(<MapScreen getMarkerGroups={async () => markerGroups} />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('story-marker').props.accessibilityState.selected).toBe(true);
+    });
+  });
+
+  it('shows a red pin instead of a cluster bubble for an active group timeline filter', async () => {
+    await storage.set(storageKeys.mapSearchFilters, {
+      proximityRadiusKm: 0.5,
+      proximityCoordinates: {
+        latitude: 41.01,
+        longitude: 28.97,
+      },
+      proximitySource: 'map_pin',
+      proximityLabel: '2 nearby stories',
+    });
+
+    renderScreen(<MapScreen getMarkerGroups={async () => markerGroups} />);
+
+    await waitFor(() => {
+      expect(screen.getByLabelText(/^marker:zoom-cluster:.*:$/).props.accessibilityState.selected).toBe(true);
+    });
+    expect(screen.queryByLabelText(/^marker:.*:2$/)).toBeNull();
+  });
+
+  it('keeps a client-side group timeline target red when only the displayed cluster coordinate matches', async () => {
+    await storage.set(storageKeys.mapSearchFilters, {
+      proximityRadiusKm: 0.5,
+      proximityCoordinates: {
+        latitude: 41.01613333333333,
+        longitude: 28.968233333333335,
+      },
+      proximitySource: 'map_pin',
+      proximityLabel: '2 nearby stories',
+    });
+
+    renderScreen(<MapScreen getMarkerGroups={async () => markerGroups} />);
+
+    await waitFor(() => {
+      expect(screen.getByLabelText(/^marker:zoom-cluster:.*:$/).props.accessibilityState.selected).toBe(true);
+    });
+    expect(screen.queryByLabelText(/^marker:zoom-cluster:.*:2$/)).toBeNull();
   });
 
   it('requests scrolling to the preview when a marker is pressed', async () => {
@@ -794,6 +955,32 @@ describe('MapScreen', () => {
     await waitFor(() => {
       expect(screen.queryByTestId('user-location-marker')).toBeNull();
     });
+  });
+
+  it('does not auto-zoom the map when a map-pin timeline filter is active', async () => {
+    await storage.set(storageKeys.mapSearchFilters, {
+      query: '',
+      location: '',
+      proximityRadiusKm: 0.5,
+      proximityCoordinates: {
+        latitude: 41.0284,
+        longitude: 28.9647,
+      },
+      proximitySource: 'map_pin',
+      proximityLabel: 'The Day the Harbor Fell Silent',
+      timeFrom: '',
+      timeTo: '',
+    });
+
+    renderScreen(<MapScreen getMarkerGroups={async () => markerGroups} />);
+
+    await screen.findByText('Select a story marker to preview.');
+    const region = getRenderedMapRegion();
+
+    expect(region.latitude).toBeCloseTo(41.0082);
+    expect(region.longitude).toBeCloseTo(28.9784);
+    expect(region.latitudeDelta).toBeCloseTo(0.32);
+    expect(region.longitudeDelta).toBeCloseTo(0.48);
   });
 
 

--- a/mobile/src/features/search/presentation/components/StorySearchControls.tsx
+++ b/mobile/src/features/search/presentation/components/StorySearchControls.tsx
@@ -25,7 +25,7 @@ function buildChips(filters: ReturnType<typeof useSearchFilters>['filters']): Fi
 
     chips.push({
       key: 'proximityRadiusKm',
-      label: `Distance: ${formatDistance(filters.proximityRadiusKm)} from`,
+      label: `Distance: ${formatDistance(filters.proximityRadiusKm)} from ${filters.proximityLabel ?? ''}`.trim(),
       visual: isMapPinFilter ? 'redPin' : 'bluePin',
       visualAccessibilityLabel: isMapPinFilter ? 'red location pin' : 'current location blue pin',
     });
@@ -393,6 +393,7 @@ export function StorySearchControls({ helperText, hideHeading = false, scope }: 
                     proximityRadiusKm: draftProximityRadiusKm,
                     proximityCoordinates: draftProximityRadiusKm ? draftProximityCoordinates : undefined,
                     proximitySource: draftProximityRadiusKm ? 'current_location' : undefined,
+                    proximityLabel: undefined,
                     timeFrom: draftTimeFrom,
                     timeTo: draftTimeTo,
                     tags: draftTags,

--- a/mobile/src/features/search/presentation/context/SearchFiltersContext.tsx
+++ b/mobile/src/features/search/presentation/context/SearchFiltersContext.tsx
@@ -20,6 +20,7 @@ export interface SearchFiltersState {
   proximityRadiusKm?: ProximityRadiusKm;
   proximityCoordinates?: ProximityCoordinates;
   proximitySource?: ProximitySource;
+  proximityLabel?: string;
   timeFrom: string;
   timeTo: string;
   tags: string[];
@@ -43,6 +44,7 @@ const initialFilters: SearchFiltersState = {
   proximityRadiusKm: undefined,
   proximityCoordinates: undefined,
   proximitySource: undefined,
+  proximityLabel: undefined,
   timeFrom: '',
   timeTo: '',
   tags: [],
@@ -154,9 +156,10 @@ export function SearchFiltersProvider({ children }: PropsWithChildren) {
             ...currentFilters,
             [key]: key === 'tags' ? [] : '',
             ...(key === 'location' ? { locationBounds: undefined } : {}),
-            ...(key === 'proximityRadiusKm' ? { proximityRadiusKm: undefined, proximityCoordinates: undefined, proximitySource: undefined } : {}),
-            ...(key === 'proximityCoordinates' ? { proximityRadiusKm: undefined, proximityCoordinates: undefined, proximitySource: undefined } : {}),
-            ...(key === 'proximitySource' ? { proximityRadiusKm: undefined, proximityCoordinates: undefined, proximitySource: undefined } : {}),
+            ...(key === 'proximityRadiusKm' ? { proximityRadiusKm: undefined, proximityCoordinates: undefined, proximitySource: undefined, proximityLabel: undefined } : {}),
+            ...(key === 'proximityCoordinates' ? { proximityRadiusKm: undefined, proximityCoordinates: undefined, proximitySource: undefined, proximityLabel: undefined } : {}),
+            ...(key === 'proximitySource' ? { proximityRadiusKm: undefined, proximityCoordinates: undefined, proximitySource: undefined, proximityLabel: undefined } : {}),
+            ...(key === 'proximityLabel' ? { proximityRadiusKm: undefined, proximityCoordinates: undefined, proximitySource: undefined, proximityLabel: undefined } : {}),
           }),
           { refresh: true },
         );
@@ -236,6 +239,7 @@ function normalizeStoredFilters(filters?: Partial<SearchFiltersState> | null): S
     proximityRadiusKm: normalizeProximityRadius(filters?.proximityRadiusKm),
     proximityCoordinates: normalizeProximityCoordinates(filters?.proximityCoordinates),
     proximitySource: normalizeProximitySource(filters?.proximitySource),
+    proximityLabel: normalizeOptionalString(filters?.proximityLabel),
     timeFrom: filters?.timeFrom ?? '',
     timeTo: filters?.timeTo ?? '',
     tags: normalizeTags(filters?.tags),
@@ -275,6 +279,12 @@ function normalizeProximityCoordinates(coordinates?: ProximityCoordinates | null
     latitude,
     longitude,
   };
+}
+
+function normalizeOptionalString(value?: string | null): string | undefined {
+  const normalized = value?.trim();
+
+  return normalized ? normalized : undefined;
 }
 
 function normalizeLocationBounds(bounds?: LocationBounds | null): LocationBounds | undefined {

--- a/mobile/src/features/stories/domain/repositories/index.ts
+++ b/mobile/src/features/stories/domain/repositories/index.ts
@@ -15,6 +15,7 @@ export interface StoryFilters {
   latitude?: number;
   longitude?: number;
   radiusKm?: number;
+  hasMedia?: boolean;
 }
 
 export interface StoryRepository {

--- a/mobile/src/features/timeline/data/mappers/index.ts
+++ b/mobile/src/features/timeline/data/mappers/index.ts
@@ -121,6 +121,15 @@ function getDateYear(value?: string) {
   return Number.isFinite(parsed) ? parsed : undefined;
 }
 
+function formatHistoricalYear(year: number) {
+  return year < 0 ? `${Math.abs(year)} BC` : String(year);
+}
+
+function formatDecade(year: number) {
+  const decade = Math.floor(Math.abs(year) / 10) * 10;
+  return year < 0 ? `${decade}s BC` : `${decade}s`;
+}
+
 function formatTimePeriod(record: TimelineApiRecord) {
   const timeType = asString(record.time_type) || asString(record.timeType);
   const year = asNumber(record.year);
@@ -131,13 +140,15 @@ function formatTimePeriod(record: TimelineApiRecord) {
 
   switch (timeType) {
     case 'exact_year':
-      return year !== undefined ? String(year) : '';
+      return year !== undefined ? formatHistoricalYear(year) : '';
     case 'approximate_year':
-      return year !== undefined ? `c. ${year}` : '';
+      return year !== undefined ? `c. ${formatHistoricalYear(year)}` : '';
     case 'decade':
-      return year !== undefined ? `${Math.floor(year / 10) * 10}s` : '';
+      return year !== undefined ? formatDecade(year) : '';
     case 'year_range':
-      return yearStart !== undefined && yearEnd !== undefined ? `${yearStart}-${yearEnd}` : '';
+      return yearStart !== undefined && yearEnd !== undefined
+        ? `${formatHistoricalYear(yearStart)}-${formatHistoricalYear(yearEnd)}`
+        : '';
     case 'exact_date':
       return dateValue ? `${dateValue}${timeValue ? ` ${timeValue.slice(0, 5)}` : ''}` : '';
     default:

--- a/mobile/src/features/timeline/data/repositories/index.ts
+++ b/mobile/src/features/timeline/data/repositories/index.ts
@@ -1,7 +1,7 @@
 import { TimelinePageEntity } from '../../domain/entities';
 import { TimelineRepository, TimelineRequest } from '../../domain/repositories';
 import { mapTimelinePage } from '../mappers';
-import { timelineLocalSource, timelineRemoteSource } from '../sources';
+import { resolveTimelinePeriodYears, timelineLocalSource, timelineRemoteSource } from '../sources';
 
 export class TimelineRepositoryImpl implements TimelineRepository {
   async getTimeline(request: TimelineRequest = {}): Promise<TimelinePageEntity> {
@@ -13,6 +13,29 @@ export class TimelineRepositoryImpl implements TimelineRepository {
       pageSize,
     });
 
-    return mapTimelinePage(response, page, pageSize);
+    return filterTimelinePageByRequestedPeriod(mapTimelinePage(response, page, pageSize), request);
   }
+}
+
+function filterTimelinePageByRequestedPeriod(page: TimelinePageEntity, request: TimelineRequest): TimelinePageEntity {
+  const periodYears = resolveTimelinePeriodYears(request);
+
+  if (!periodYears) {
+    return page;
+  }
+
+  const items = page.items.filter((item) => {
+    if (item.historicalYear === undefined) {
+      return true;
+    }
+
+    return item.historicalYear >= periodYears.yearFrom && item.historicalYear <= periodYears.yearTo;
+  });
+
+  return {
+    ...page,
+    items,
+    totalCount: items.length,
+    hasNextPage: page.hasNextPage && items.length === page.items.length,
+  };
 }

--- a/mobile/src/features/timeline/data/sources/__tests__/timelineRemoteSource.test.ts
+++ b/mobile/src/features/timeline/data/sources/__tests__/timelineRemoteSource.test.ts
@@ -43,6 +43,31 @@ describe('timelineRemoteSource', () => {
     );
   });
 
+  it('uses the timeline endpoint with the image availability param', async () => {
+    const requests: string[] = [];
+
+    setApiTransport(async (_method, config) => {
+      requests.push(config.url ?? '');
+
+      return {
+        status: 200,
+        data: {
+          count: 0,
+          next: null,
+          previous: null,
+          results: [],
+        } as never,
+        config,
+      };
+    });
+
+    await timelineRemoteSource.getTimeline({
+      filters: { hasMedia: true },
+    });
+
+    expect(requests[0]).toBe('/stories/timeline/?page=1&page_size=10&has_image=true');
+  });
+
   it('resolves convenience period requests', () => {
     expect(resolveTimelinePeriodYears({ year: 1923 })).toEqual({ yearFrom: 1923, yearTo: 1923 });
     expect(resolveTimelinePeriodYears({ yearRange: { from: 1918, to: 1914 } })).toEqual({ yearFrom: 1914, yearTo: 1918 });
@@ -276,5 +301,119 @@ describe('timelineRemoteSource', () => {
       'Nearby Old',
       'Nearby New',
     ]);
+  });
+
+  it('refines fallback results by image URL availability', async () => {
+    const requests: string[] = [];
+
+    setApiTransport(async (_method, config) => {
+      requests.push(config.url ?? '');
+
+      return {
+        status: 200,
+        data: {
+          count: 3,
+          next: null,
+          previous: null,
+          results: [
+            {
+              id: 1,
+              title: 'Text only',
+              time_type: 'exact_year',
+              year: 1900,
+              photo_url: null,
+            },
+            {
+              id: 2,
+              title: 'With photo url harbor',
+              time_type: 'exact_year',
+              year: 1910,
+              photo_url: 'https://example.com/story.jpg',
+            },
+            {
+              id: 3,
+              title: 'With media item harbor',
+              time_type: 'exact_year',
+              year: 1920,
+              media_items: [{ media_type: 'image', url: 'https://example.com/media.jpg' }],
+            },
+          ],
+        } as never,
+        config,
+      };
+    });
+
+    const response = await timelineRemoteSource.getTimeline({
+      filters: { q: 'harbor', hasMedia: true },
+    });
+
+    expect(requests[0]).toBe('/stories/search/?page_size=100&q=harbor&page=1');
+    expect(response.count).toBe(2);
+    expect(response.results?.map((story) => (story as { title: string }).title)).toEqual([
+      'With photo url harbor',
+      'With media item harbor',
+    ]);
+  });
+
+  it('checks story details when fallback rows omit image URL metadata', async () => {
+    const requests: string[] = [];
+
+    setApiTransport(async (_method, config) => {
+      requests.push(config.url ?? '');
+
+      if (config.url === '/stories/search/?page_size=100&q=timeline&page=1') {
+        return {
+          status: 200,
+          data: {
+            count: 2,
+            next: null,
+            previous: null,
+            results: [
+              { id: 1, title: 'Timeline row with hidden image', time_type: 'exact_year', year: 1900 },
+              { id: 2, title: 'Timeline row without image', time_type: 'exact_year', year: 1910 },
+            ],
+          } as never,
+          config,
+        };
+      }
+
+      if (config.url === '/stories/1/') {
+        return {
+          status: 200,
+          data: {
+            id: 1,
+            title: 'Timeline row with hidden image',
+            media_items: [{ media_type: 'image', url: 'https://example.com/detail.jpg' }],
+          } as never,
+          config,
+        };
+      }
+
+      if (config.url === '/stories/2/') {
+        return {
+          status: 200,
+          data: {
+            id: 2,
+            title: 'Timeline row without image',
+            media_items: [],
+          } as never,
+          config,
+        };
+      }
+
+      throw new Error(`Unexpected request: ${config.url}`);
+    });
+
+    const response = await timelineRemoteSource.getTimeline({
+      filters: { q: 'timeline', hasMedia: true },
+    });
+
+    expect(requests).toEqual([
+      '/stories/search/?page_size=100&q=timeline&page=1',
+      '/stories/1/',
+      '/stories/2/',
+    ]);
+    expect(response.count).toBe(1);
+    expect(response.results?.[0]).toMatchObject({ id: 1 });
   });
 });

--- a/mobile/src/features/timeline/data/sources/__tests__/timelineRemoteSource.test.ts
+++ b/mobile/src/features/timeline/data/sources/__tests__/timelineRemoteSource.test.ts
@@ -72,6 +72,8 @@ describe('timelineRemoteSource', () => {
     expect(resolveTimelinePeriodYears({ year: 1923 })).toEqual({ yearFrom: 1923, yearTo: 1923 });
     expect(resolveTimelinePeriodYears({ yearRange: { from: 1918, to: 1914 } })).toEqual({ yearFrom: 1914, yearTo: 1918 });
     expect(resolveTimelinePeriodYears({ decade: 1928 })).toEqual({ yearFrom: 1920, yearTo: 1929 });
+    expect(resolveTimelinePeriodYears({ decade: -7495 })).toEqual({ yearFrom: -7499, yearTo: -7490 });
+    expect(resolveTimelinePeriodYears({ decade: -7500 })).toEqual({ yearFrom: -7509, yearTo: -7500 });
     expect(resolveTimelinePeriodYears({ approximatePeriod: { century: 1900, position: 'early' } })).toEqual({ yearFrom: 1900, yearTo: 1933 });
     expect(resolveTimelinePeriodYears({ approximatePeriod: { century: 1900, position: 'mid' } })).toEqual({ yearFrom: 1934, yearTo: 1966 });
     expect(resolveTimelinePeriodYears({ approximatePeriod: { century: 1900, position: 'late' } })).toEqual({ yearFrom: 1967, yearTo: 1999 });
@@ -109,6 +111,35 @@ describe('timelineRemoteSource', () => {
     expect(response.count).toBe(2);
     expect(response.next).toBe('client-next-page');
     expect(response.results?.[0]).toMatchObject({ title: 'Harbor Old' });
+  });
+
+  it('filters fallback results by the visible historical year badge', async () => {
+    setApiTransport(async (_method, config) => ({
+      status: 200,
+      data: {
+        count: 3,
+        next: null,
+        previous: null,
+        results: [
+          { id: 1, title: 'Visible midpoint', time_type: 'year_range', year_start: 1840, year_end: 1870 },
+          { id: 2, title: 'Exact same raw year', time_type: 'exact_year', year: 1840 },
+          { id: 3, title: 'Exact later year', time_type: 'exact_year', year: 1860 },
+        ],
+      } as never,
+      config,
+    }));
+
+    const response = await timelineRemoteSource.getTimeline({
+      page: 1,
+      pageSize: 10,
+      filters: { q: 'e' },
+      yearRange: { from: 1855, to: 1855 },
+    });
+
+    expect(response).toMatchObject({
+      count: 1,
+      results: [{ id: 1, title: 'Visible midpoint' }],
+    });
   });
 
   it('falls back to feed for tag filters and sends the first selected tag parameter', async () => {

--- a/mobile/src/features/timeline/data/sources/index.ts
+++ b/mobile/src/features/timeline/data/sources/index.ts
@@ -142,8 +142,9 @@ async function getTimelineViaFallback({
     ...normalizeFallbackFilters(filters, yearFrom, yearTo),
   };
   const results = await fetchAllPages(path, params);
-  const filteredResults = results
-    .filter((story) => storyMatchesFallbackFilters(story, filters, yearFrom, yearTo))
+  const matchingResults = results.filter((story) => storyMatchesFallbackFilters(story, filters, yearFrom, yearTo));
+  const mediaFilteredResults = await filterStoriesByMediaAvailability(matchingResults, filters.hasMedia);
+  const filteredResults = mediaFilteredResults
     .sort((left, right) => {
       const leftYear = getTimelineHistoricalYear(left) ?? Number.MAX_SAFE_INTEGER;
       const rightYear = getTimelineHistoricalYear(right) ?? Number.MAX_SAFE_INTEGER;
@@ -204,11 +205,17 @@ function normalizeTimelineFilters(filters: StoryFilters, yearFrom?: number, year
     params.tag = firstTag;
   }
 
+  if (filters.hasMedia !== undefined) {
+    params.has_image = filters.hasMedia ? 'true' : 'false';
+  }
+
   return params;
 }
 
 function normalizeFallbackFilters(filters: StoryFilters, yearFrom?: number, yearTo?: number) {
   const params = normalizeTimelineFilters(filters, yearFrom, yearTo);
+
+  delete params.has_image;
 
   if (filters.q?.trim()) {
     params.q = filters.q.trim();
@@ -300,6 +307,137 @@ function storyMatchesFallbackFilters(
   }
 
   return isRecordWithinYearWindow(record, yearFrom, yearTo);
+}
+
+async function filterStoriesByMediaAvailability(stories: unknown[], hasMedia?: boolean) {
+  if (hasMedia === undefined) {
+    return stories;
+  }
+
+  const mediaMatches = await Promise.all(
+    stories.map(async (story) => {
+      if (!story || typeof story !== 'object') {
+        return false;
+      }
+
+      const record = story as Record<string, unknown>;
+      const mediaAvailability = getRecordMediaAvailability(record);
+
+      if (mediaAvailability !== undefined) {
+        return mediaAvailability === hasMedia;
+      }
+
+      const detailedRecord = await fetchStoryDetailRecord(record);
+
+      return detailedRecord ? getRecordMediaAvailability(detailedRecord) === hasMedia : false;
+    }),
+  );
+
+  return stories.filter((_story, index) => mediaMatches[index]);
+}
+
+async function fetchStoryDetailRecord(record: Record<string, unknown>) {
+  const id = getRecordId(record);
+
+  if (!id) {
+    return undefined;
+  }
+
+  try {
+    const detail = await apiClient.get<unknown>(`${endpoints.stories}/${id}/`);
+
+    return detail && typeof detail === 'object' ? detail as Record<string, unknown> : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function getRecordId(record: Record<string, unknown>) {
+  const id = record.id;
+
+  return typeof id === 'string' || typeof id === 'number' ? String(id) : undefined;
+}
+
+function getRecordMediaAvailability(record: Record<string, unknown>): boolean | undefined {
+  if (typeof record.has_image === 'boolean') {
+    return record.has_image;
+  }
+
+  if (typeof record.hasImage === 'boolean') {
+    return record.hasImage;
+  }
+
+  const imageUrlKeys = [
+    'photo_url',
+    'photoUrl',
+    'image_url',
+    'imageUrl',
+    'thumbnail_url',
+    'thumbnailUrl',
+    'cover_image',
+    'coverImage',
+    'media_url',
+    'mediaUrl',
+  ];
+  const hasImageUrlField = imageUrlKeys.some((key) => Object.prototype.hasOwnProperty.call(record, key));
+  const imageUrl = imageUrlKeys.map((key) => asString(record[key])).find(Boolean);
+
+  if (imageUrl) {
+    return true;
+  }
+
+  if (hasImageUrlField) {
+    return false;
+  }
+
+  const mediaItems = getArrayField(record, 'media_items') ?? getArrayField(record, 'mediaItems') ?? getArrayField(record, 'media');
+
+  if (mediaItems) {
+    return mediaItems.some(itemLooksLikeImage);
+  }
+
+  const images = getArrayField(record, 'images') ?? getArrayField(record, 'image');
+
+  if (images) {
+    return images.some(itemLooksLikeImage);
+  }
+
+  if (record.image && typeof record.image === 'object') {
+    return itemLooksLikeImage(record.image);
+  }
+
+  return undefined;
+}
+
+function getArrayField(record: Record<string, unknown>, key: string) {
+  const value = record[key];
+
+  return Array.isArray(value) ? value : undefined;
+}
+
+function itemLooksLikeImage(item: unknown) {
+  if (typeof item === 'string') {
+    return Boolean(item.trim());
+  }
+
+  if (!item || typeof item !== 'object') {
+    return false;
+  }
+
+  const itemRecord = item as Record<string, unknown>;
+  const mediaType = asString(itemRecord.media_type) || asString(itemRecord.mediaType) || asString(itemRecord.type);
+  const url =
+    asString(itemRecord.url) ||
+    asString(itemRecord.file) ||
+    asString(itemRecord.image) ||
+    asString(itemRecord.media_url) ||
+    asString(itemRecord.mediaUrl);
+
+  if (!url) {
+    return false;
+  }
+
+  return !mediaType || mediaType === 'image' || mediaType.startsWith('image/');
 }
 
 function getSelectedTags(filters: StoryFilters) {

--- a/mobile/src/features/timeline/data/sources/index.ts
+++ b/mobile/src/features/timeline/data/sources/index.ts
@@ -70,12 +70,11 @@ export function resolveTimelinePeriodYears(request: TimelineRequest) {
   }
 
   if (request.decade !== undefined && Number.isFinite(request.decade)) {
-    const decade = Math.floor(request.decade / 10) * 10;
+    const decade = Math.floor(Math.abs(request.decade) / 10) * 10;
 
-    return {
-      yearFrom: decade,
-      yearTo: decade + 9,
-    };
+    return request.decade < 0
+      ? { yearFrom: -(decade + 9), yearTo: -decade }
+      : { yearFrom: decade, yearTo: decade + 9 };
   }
 
   if (request.approximatePeriod && Number.isFinite(request.approximatePeriod.century)) {
@@ -505,43 +504,21 @@ function isRecordWithinYearWindow(record: Record<string, unknown>, yearFrom?: nu
     return true;
   }
 
-  const interval = getRecordYearInterval(record);
+  const historicalYear = getTimelineHistoricalYear(record);
 
-  if (!interval) {
+  if (historicalYear === undefined) {
     return true;
   }
 
-  if (yearFrom !== undefined && interval.end < yearFrom) {
+  if (yearFrom !== undefined && historicalYear < yearFrom) {
     return false;
   }
 
-  if (yearTo !== undefined && interval.start > yearTo) {
+  if (yearTo !== undefined && historicalYear > yearTo) {
     return false;
   }
 
   return true;
-}
-
-function getRecordYearInterval(record: Record<string, unknown>) {
-  const timeType = asString(record.time_type) || asString(record.timeType);
-  const year = asNumber(record.year);
-  const yearStart = asNumber(record.year_start) ?? asNumber(record.yearStart);
-  const yearEnd = asNumber(record.year_end) ?? asNumber(record.yearEnd);
-  const dateValue = asString(record.date_value) || asString(record.dateValue);
-  const dateYear = dateValue ? asNumber(dateValue.slice(0, 4)) : undefined;
-
-  switch (timeType) {
-    case 'decade':
-      return year !== undefined ? { start: year, end: year + 9 } : undefined;
-    case 'year_range':
-      return yearStart !== undefined && yearEnd !== undefined
-        ? { start: Math.min(yearStart, yearEnd), end: Math.max(yearStart, yearEnd) }
-        : undefined;
-    case 'exact_date':
-      return dateYear !== undefined ? { start: dateYear, end: dateYear } : undefined;
-    default:
-      return year !== undefined ? { start: year, end: year } : undefined;
-  }
 }
 
 function isRecordWithinBounds(

--- a/mobile/src/features/timeline/presentation/components/TimelineCard.tsx
+++ b/mobile/src/features/timeline/presentation/components/TimelineCard.tsx
@@ -6,17 +6,22 @@ import { TimelineEntity } from '../../domain/entities';
 interface TimelineCardProps {
   story: TimelineEntity;
   onPress?: (storyId: string) => void;
+  isLast?: boolean;
 }
 
 function getBadgeLabel(story: TimelineEntity) {
   if (story.historicalYear !== undefined) {
-    return String(story.historicalYear);
+    return formatHistoricalYear(story.historicalYear);
   }
 
   return story.timePeriod || 'Time';
 }
 
-export function TimelineCard({ story, onPress }: TimelineCardProps) {
+function formatHistoricalYear(year: number) {
+  return year < 0 ? `${Math.abs(year)} BC` : String(year);
+}
+
+export function TimelineCard({ story, onPress, isLast = false }: TimelineCardProps) {
   const { colors, spacing, typography } = useAppTheme();
 
   return (
@@ -30,19 +35,19 @@ export function TimelineCard({ story, onPress }: TimelineCardProps) {
         opacity: pressed ? 0.86 : 1,
       })}
     >
-      <View style={{ width: 58, alignItems: 'center' }}>
+      <View style={{ width: 76, alignItems: 'center' }}>
         <View
           style={{
             position: 'absolute',
             top: 0,
-            bottom: -spacing.md,
+            ...(isLast ? { height: spacing.lg } : { bottom: -spacing.md }),
             width: 2,
             backgroundColor: colors.border,
           }}
         />
         <View
           style={{
-            minWidth: 54,
+            minWidth: 72,
             paddingHorizontal: spacing.sm,
             paddingVertical: spacing.xs + 2,
             borderRadius: 999,

--- a/mobile/src/features/timeline/presentation/components/TimelinePeriodSelector.tsx
+++ b/mobile/src/features/timeline/presentation/components/TimelinePeriodSelector.tsx
@@ -17,6 +17,7 @@ interface TimelinePeriodSelectorProps {
   value: TimelinePeriodSelection;
   onChange: (nextValue: TimelinePeriodSelection) => void;
   error?: string;
+  headerAccessory?: React.ReactNode;
 }
 
 const MODE_OPTIONS: Array<{ mode: TimelinePeriodMode; label: string }> = [
@@ -56,7 +57,7 @@ function mergeSelection(
   };
 }
 
-export function TimelinePeriodSelector({ value, onChange, error }: TimelinePeriodSelectorProps) {
+export function TimelinePeriodSelector({ value, onChange, error, headerAccessory }: TimelinePeriodSelectorProps) {
   const { colors, spacing, typography } = useAppTheme();
 
   const updateYearField = (field: 'year' | 'rangeFrom' | 'rangeTo' | 'decade') => (nextValue: string) => {
@@ -138,10 +139,11 @@ export function TimelinePeriodSelector({ value, onChange, error }: TimelinePerio
         gap: spacing.sm,
       }}
     >
-      <View>
+      <View style={{ flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between', gap: spacing.sm }}>
         <Text style={{ color: colors.text, fontSize: typography.body, fontWeight: '800' }}>
           Choose a time window
         </Text>
+        {headerAccessory}
       </View>
 
       <View accessibilityRole="radiogroup" accessibilityLabel="Timeline period mode" style={{ flexDirection: 'row', flexWrap: 'wrap', gap: spacing.xs }}>

--- a/mobile/src/features/timeline/presentation/components/TimelinePeriodSelector.tsx
+++ b/mobile/src/features/timeline/presentation/components/TimelinePeriodSelector.tsx
@@ -16,6 +16,7 @@ export interface TimelinePeriodSelection {
 interface TimelinePeriodSelectorProps {
   value: TimelinePeriodSelection;
   onChange: (nextValue: TimelinePeriodSelection) => void;
+  onSubmit: () => void;
   error?: string;
   headerAccessory?: React.ReactNode;
 }
@@ -40,7 +41,7 @@ function normalizeYearInput(value: string) {
     return value;
   }
 
-  if (!/^\d{0,4}$/.test(value)) {
+  if (!/^-?\d{0,5}$/.test(value)) {
     return null;
   }
 
@@ -57,7 +58,14 @@ function mergeSelection(
   };
 }
 
-export function TimelinePeriodSelector({ value, onChange, error, headerAccessory }: TimelinePeriodSelectorProps) {
+function selectionForMode(mode: TimelinePeriodMode): TimelinePeriodSelection {
+  return {
+    ...EMPTY_TIMELINE_PERIOD_SELECTION,
+    mode,
+  };
+}
+
+export function TimelinePeriodSelector({ value, onChange, onSubmit, error, headerAccessory }: TimelinePeriodSelectorProps) {
   const { colors, spacing, typography } = useAppTheme();
 
   const updateYearField = (field: 'year' | 'rangeFrom' | 'rangeTo' | 'decade') => (nextValue: string) => {
@@ -79,8 +87,9 @@ export function TimelinePeriodSelector({ value, onChange, error, headerAccessory
               value={value.year}
               onChangeText={updateYearField('year')}
               placeholder="Year, e.g. 1923"
-              keyboardType="number-pad"
+              keyboardType="numbers-and-punctuation"
               returnKeyType="done"
+              onSubmitEditing={onSubmit}
               accessibilityLabel="Timeline year"
             />
           </View>
@@ -93,8 +102,9 @@ export function TimelinePeriodSelector({ value, onChange, error, headerAccessory
                 value={value.rangeFrom}
                 onChangeText={updateYearField('rangeFrom')}
                 placeholder="Start"
-                keyboardType="number-pad"
+                keyboardType="numbers-and-punctuation"
                 returnKeyType="done"
+                onSubmitEditing={onSubmit}
                 accessibilityLabel="Timeline start year"
                 style={{ flex: 1 }}
               />
@@ -102,8 +112,9 @@ export function TimelinePeriodSelector({ value, onChange, error, headerAccessory
                 value={value.rangeTo}
                 onChangeText={updateYearField('rangeTo')}
                 placeholder="End"
-                keyboardType="number-pad"
+                keyboardType="numbers-and-punctuation"
                 returnKeyType="done"
+                onSubmitEditing={onSubmit}
                 accessibilityLabel="Timeline end year"
                 style={{ flex: 1 }}
               />
@@ -117,8 +128,9 @@ export function TimelinePeriodSelector({ value, onChange, error, headerAccessory
               value={value.decade}
               onChangeText={updateYearField('decade')}
               placeholder="Decade, e.g. 1980"
-              keyboardType="number-pad"
+              keyboardType="numbers-and-punctuation"
               returnKeyType="done"
+              onSubmitEditing={onSubmit}
               accessibilityLabel="Timeline decade"
             />
           </View>
@@ -156,7 +168,7 @@ export function TimelinePeriodSelector({ value, onChange, error, headerAccessory
               accessibilityRole="radio"
               accessibilityLabel={`Timeline mode ${option.label}`}
               accessibilityState={{ selected: isSelected }}
-              onPress={() => onChange(mergeSelection(value, { mode: option.mode }))}
+              onPress={() => onChange(selectionForMode(option.mode))}
               style={({ pressed }) => ({
                 paddingHorizontal: spacing.sm + 2,
                 paddingVertical: spacing.xs + 2,

--- a/mobile/src/features/timeline/presentation/screens/TimelineScreen.tsx
+++ b/mobile/src/features/timeline/presentation/screens/TimelineScreen.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { FlatList, Text, View } from 'react-native';
+import { FlatList, Pressable, Text, View } from 'react-native';
 import { useAppTheme } from '../../../../core/hooks/useAppTheme';
 import { EmptyState, ErrorState, Loader, SkeletonCard } from '../../../../shared';
 import { useDebounce } from '../../../../shared/hooks/useDebounce';
@@ -39,6 +39,7 @@ interface PeriodDescriptor {
 }
 
 const EMPTY_FILTERS: StoryFilters = {};
+type TimelineImageFilter = 'all' | 'with_image';
 
 export function TimelineScreen({
   initialFilters = EMPTY_FILTERS,
@@ -52,6 +53,7 @@ export function TimelineScreen({
   const debouncedQuery = useDebounce(filters.query, 350);
   const [useImmediateQuery, setUseImmediateQuery] = useState(false);
   const [periodSelection, setPeriodSelection] = useState<TimelinePeriodSelection>(EMPTY_TIMELINE_PERIOD_SELECTION);
+  const [imageFilter, setImageFilter] = useState<TimelineImageFilter>(() => getInitialImageFilter(initialFilters));
   const periodDescriptor = useMemo(() => describePeriodSelection(periodSelection), [periodSelection]);
   const [state, setState] = useState<TimelineUiState>(() => createInitialTimelineUiState(initialFilters));
   const stateRef = useRef(state);
@@ -87,8 +89,9 @@ export function TimelineScreen({
     () => ({
       ...initialFilters,
       ...toSearchParams({ ...filters, query: useImmediateQuery ? filters.query : debouncedQuery }),
+      hasMedia: getHasMediaFilter(imageFilter),
     }),
-    [debouncedQuery, filters, initialFilters, useImmediateQuery],
+    [debouncedQuery, filters, imageFilter, initialFilters, useImmediateQuery],
   );
 
   const hasActiveFilters = Boolean(
@@ -99,6 +102,7 @@ export function TimelineScreen({
       activeFilters.yearTo !== undefined ||
       activeFilters.radiusKm ||
       activeFilters.tags?.length ||
+      activeFilters.hasMedia !== undefined ||
       (periodSelection.mode !== 'all' && periodDescriptor.isReady),
   );
 
@@ -207,6 +211,12 @@ export function TimelineScreen({
         value={periodSelection}
         onChange={setPeriodSelection}
         error={periodDescriptor.error}
+        headerAccessory={
+          <TimelineImageFilterToggle
+            isActive={imageFilter === 'with_image'}
+            onPress={() => setImageFilter((current) => (current === 'with_image' ? 'all' : 'with_image'))}
+          />
+        }
       />
 
       <View
@@ -467,5 +477,47 @@ function areSearchStatesEqual(left: SearchFiltersState, right: SearchFiltersStat
     left.timeFrom === right.timeFrom &&
     left.timeTo === right.timeTo &&
     JSON.stringify(left.tags) === JSON.stringify(right.tags)
+  );
+}
+
+function getInitialImageFilter(filters: StoryFilters): TimelineImageFilter {
+  if (filters.hasMedia === true) {
+    return 'with_image';
+  }
+
+  return 'all';
+}
+
+function getHasMediaFilter(value: TimelineImageFilter) {
+  if (value === 'with_image') {
+    return true;
+  }
+
+  return undefined;
+}
+
+function TimelineImageFilterToggle({ isActive, onPress }: { isActive: boolean; onPress: () => void }) {
+  const { colors, spacing, typography } = useAppTheme();
+
+  return (
+    <Pressable
+      accessibilityRole="button"
+      accessibilityLabel="Timeline image filter With image"
+      accessibilityState={{ selected: isActive }}
+      onPress={onPress}
+      style={({ pressed }) => ({
+        paddingHorizontal: spacing.sm + 2,
+        paddingVertical: spacing.xs + 2,
+        borderRadius: 999,
+        borderWidth: 1,
+        borderColor: isActive ? colors.text : colors.border,
+        backgroundColor: isActive ? colors.text : colors.background,
+        opacity: pressed ? 0.8 : 1,
+      })}
+    >
+      <Text style={{ color: isActive ? colors.background : colors.text, fontSize: typography.caption + 1, fontWeight: '800' }}>
+        With image
+      </Text>
+    </Pressable>
   );
 }

--- a/mobile/src/features/timeline/presentation/screens/TimelineScreen.tsx
+++ b/mobile/src/features/timeline/presentation/screens/TimelineScreen.tsx
@@ -53,8 +53,9 @@ export function TimelineScreen({
   const debouncedQuery = useDebounce(filters.query, 350);
   const [useImmediateQuery, setUseImmediateQuery] = useState(false);
   const [periodSelection, setPeriodSelection] = useState<TimelinePeriodSelection>(EMPTY_TIMELINE_PERIOD_SELECTION);
+  const [appliedPeriodSelection, setAppliedPeriodSelection] = useState<TimelinePeriodSelection>(EMPTY_TIMELINE_PERIOD_SELECTION);
   const [imageFilter, setImageFilter] = useState<TimelineImageFilter>(() => getInitialImageFilter(initialFilters));
-  const periodDescriptor = useMemo(() => describePeriodSelection(periodSelection), [periodSelection]);
+  const periodDescriptor = useMemo(() => describePeriodSelection(appliedPeriodSelection), [appliedPeriodSelection]);
   const [state, setState] = useState<TimelineUiState>(() => createInitialTimelineUiState(initialFilters));
   const stateRef = useRef(state);
   const hasRequestedNextPage = useRef(false);
@@ -103,7 +104,7 @@ export function TimelineScreen({
       activeFilters.radiusKm ||
       activeFilters.tags?.length ||
       activeFilters.hasMedia !== undefined ||
-      (periodSelection.mode !== 'all' && periodDescriptor.isReady),
+      (periodDescriptor.isReady && Object.keys(periodDescriptor.request).length > 0),
   );
 
   const loadPage = useCallback(
@@ -186,6 +187,24 @@ export function TimelineScreen({
     });
   };
 
+  const handlePeriodSelectionChange = (nextSelection: TimelinePeriodSelection) => {
+    setPeriodSelection((currentSelection) => {
+      if (nextSelection.mode !== currentSelection.mode) {
+        if (nextSelection.mode === 'all') {
+          setAppliedPeriodSelection(nextSelection);
+        } else if (Object.keys(periodDescriptor.request).length > 0) {
+          setAppliedPeriodSelection(EMPTY_TIMELINE_PERIOD_SELECTION);
+        }
+      }
+
+      return nextSelection;
+    });
+  };
+
+  const handlePeriodSelectionSubmit = () => {
+    setAppliedPeriodSelection(periodSelection);
+  };
+
   const handleRetry = () => {
     if (periodDescriptor.error || !periodDescriptor.isReady) {
       return;
@@ -209,7 +228,8 @@ export function TimelineScreen({
 
       <TimelinePeriodSelector
         value={periodSelection}
-        onChange={setPeriodSelection}
+        onChange={handlePeriodSelectionChange}
+        onSubmit={handlePeriodSelectionSubmit}
         error={periodDescriptor.error}
         headerAccessory={
           <TimelineImageFilterToggle
@@ -241,7 +261,9 @@ export function TimelineScreen({
     return <Loader message="Restoring timeline filters..." />;
   }
 
-  if (state.isLoading && !state.items.length) {
+  const shouldShowInitialSkeleton = state.isLoading && !state.items.length && !hasActiveFilters;
+
+  if (shouldShowInitialSkeleton) {
     return (
       <View accessibilityLabel="Loading timeline stories" style={{ flex: 1, gap: spacing.md }}>
         {controls}
@@ -291,9 +313,9 @@ export function TimelineScreen({
       testID="timeline-list"
       data={state.items}
       keyExtractor={(item) => item.id}
-      renderItem={({ item }) => (
+      renderItem={({ item, index }) => (
         <View style={{ paddingHorizontal: spacing.lg }}>
-          <TimelineCard story={item} onPress={onOpenStory} />
+          <TimelineCard story={item} onPress={onOpenStory} isLast={index === state.items.length - 1} />
         </View>
       )}
       ListHeaderComponent={controls}
@@ -318,13 +340,21 @@ export function TimelineScreen({
 }
 
 function parseCompleteYear(value: string) {
-  if (!/^\d{4}$/.test(value.trim())) {
+  if (!/^-?\d{1,5}$/.test(value.trim())) {
     return undefined;
   }
 
   const parsed = Number(value);
 
-  return Number.isFinite(parsed) ? parsed : undefined;
+  if (!Number.isFinite(parsed)) {
+    return undefined;
+  }
+
+  return parsed;
+}
+
+function formatDescriptorYear(year: number) {
+  return year < 0 ? `${Math.abs(year)} BC` : String(year);
 }
 
 function describePeriodSelection(selection: TimelinePeriodSelection): PeriodDescriptor {
@@ -332,15 +362,23 @@ function describePeriodSelection(selection: TimelinePeriodSelection): PeriodDesc
     case 'all':
       return { request: {}, label: 'All time periods', key: 'all', isReady: true };
     case 'year': {
+      if (!selection.year) {
+        return { request: {}, label: 'All time periods', key: 'year-empty', isReady: true };
+      }
+
       const year = parseCompleteYear(selection.year);
 
       if (year === undefined) {
-        return { request: {}, label: 'Enter a 4-digit year', key: `year-draft-${selection.year}`, isReady: false };
+        return { request: {}, label: 'Enter a year', key: `year-draft-${selection.year}`, isReady: false };
       }
 
-      return { request: { year }, label: `Year ${year}`, key: `year-${year}`, isReady: true };
+      return { request: { year }, label: `Year ${formatDescriptorYear(year)}`, key: `year-${year}`, isReady: true };
     }
     case 'range': {
+      if (!selection.rangeFrom && !selection.rangeTo) {
+        return { request: {}, label: 'All time periods', key: 'range-empty', isReady: true };
+      }
+
       const from = parseCompleteYear(selection.rangeFrom);
       const to = parseCompleteYear(selection.rangeTo);
 
@@ -363,18 +401,23 @@ function describePeriodSelection(selection: TimelinePeriodSelection): PeriodDesc
         };
       }
 
-      return { request: { yearRange: { from, to } }, label: `${from}-${to}`, key: `range-${from}-${to}`, isReady: true };
+      return { request: { yearRange: { from, to } }, label: `${formatDescriptorYear(from)}-${formatDescriptorYear(to)}`, key: `range-${from}-${to}`, isReady: true };
     }
     case 'decade': {
+      if (!selection.decade) {
+        return { request: {}, label: 'All time periods', key: 'decade-empty', isReady: true };
+      }
+
       const decadeYear = parseCompleteYear(selection.decade);
 
       if (decadeYear === undefined) {
-        return { request: {}, label: 'Enter a 4-digit decade year', key: `decade-draft-${selection.decade}`, isReady: false };
+        return { request: {}, label: 'Enter a decade year', key: `decade-draft-${selection.decade}`, isReady: false };
       }
 
-      const decade = Math.floor(decadeYear / 10) * 10;
+      const decade = Math.floor(Math.abs(decadeYear) / 10) * 10;
+      const requestDecade = decadeYear < 0 ? -decade : decade;
 
-      return { request: { decade }, label: `${decade}s`, key: `decade-${decade}`, isReady: true };
+      return { request: { decade: requestDecade }, label: decadeYear < 0 ? `${decade}s BC` : `${decade}s`, key: `decade-${requestDecade}`, isReady: true };
     }
     default:
       return { request: {}, label: 'All time periods', key: 'all', isReady: true };

--- a/mobile/src/features/timeline/presentation/screens/__tests__/TimelineScreen.test.tsx
+++ b/mobile/src/features/timeline/presentation/screens/__tests__/TimelineScreen.test.tsx
@@ -246,6 +246,42 @@ describe('TimelineScreen', () => {
     });
   });
 
+  it('applies image availability filters from the timeline controls', async () => {
+    const getTimeline = jest.fn<Promise<TimelinePageEntity>, [any]>().mockResolvedValue(makeTimelinePage());
+
+    renderScreen(<TimelineScreen getTimeline={getTimeline} />);
+
+    await screen.findByText('Timeline Story 1');
+    fireEvent.press(screen.getByLabelText('Timeline image filter With image'));
+
+    await waitFor(() => {
+      expect(getTimeline).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          page: 1,
+          filters: expect.objectContaining({
+            hasMedia: true,
+          }),
+        }),
+      );
+    });
+
+    fireEvent.press(screen.getByLabelText('Timeline image filter With image'));
+
+    await waitFor(() => {
+      expect(getTimeline).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          page: 1,
+          filters: expect.objectContaining({
+            hasMedia: undefined,
+          }),
+        }),
+      );
+    });
+
+    expect(screen.queryByLabelText('Timeline image filter All')).toBeNull();
+    expect(screen.queryByLabelText('Timeline image filter Without image')).toBeNull();
+  });
+
   it('shows empty and error states', async () => {
     const { rerender } = render(
       <SearchFiltersProvider>

--- a/mobile/src/features/timeline/presentation/screens/__tests__/TimelineScreen.test.tsx
+++ b/mobile/src/features/timeline/presentation/screens/__tests__/TimelineScreen.test.tsx
@@ -103,7 +103,7 @@ describe('TimelineScreen', () => {
     expect(screen.queryByText('190X')).toBeNull();
   });
 
-  it('applies decade selection to timeline requests after a complete year is entered', async () => {
+  it('applies decade selection after Done is pressed', async () => {
     const getTimeline = jest.fn<Promise<TimelinePageEntity>, [any]>().mockResolvedValue(makeTimelinePage());
 
     renderScreen(<TimelineScreen getTimeline={getTimeline} showSearchControls={false} />);
@@ -112,12 +112,27 @@ describe('TimelineScreen', () => {
     const callCountAfterInitialLoad = getTimeline.mock.calls.length;
 
     fireEvent.press(screen.getByLabelText('Timeline mode Decade'));
+    const callCountAfterModeSwitch = getTimeline.mock.calls.length;
+    expect(callCountAfterModeSwitch).toBe(callCountAfterInitialLoad);
+
     fireEvent.changeText(screen.getByLabelText('Timeline decade'), '19');
 
-    expect(getTimeline).toHaveBeenCalledTimes(callCountAfterInitialLoad);
+    expect(getTimeline).toHaveBeenCalledTimes(callCountAfterModeSwitch);
+    fireEvent(screen.getByLabelText('Timeline decade'), 'submitEditing');
+
+    await waitFor(() => {
+      expect(getTimeline).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          page: 1,
+          decade: 10,
+        }),
+      );
+    });
     expect(screen.queryByText('Enter a valid decade base year.')).toBeNull();
 
     fireEvent.changeText(screen.getByLabelText('Timeline decade'), '1920');
+    expect(getTimeline).toHaveBeenCalledTimes(callCountAfterModeSwitch + 1);
+    fireEvent(screen.getByLabelText('Timeline decade'), 'submitEditing');
 
     await waitFor(() => {
       expect(getTimeline).toHaveBeenLastCalledWith(
@@ -130,7 +145,57 @@ describe('TimelineScreen', () => {
     expect(screen.getAllByText('1920s').length).toBeGreaterThan(0);
   });
 
-  it('keeps range typing local until both years are complete', async () => {
+  it('accepts short and negative historical decade years', async () => {
+    const getTimeline = jest.fn<Promise<TimelinePageEntity>, [any]>().mockResolvedValue(makeTimelinePage());
+
+    renderScreen(<TimelineScreen getTimeline={getTimeline} showSearchControls={false} />);
+
+    await screen.findByText('Timeline Story 1');
+
+    fireEvent.press(screen.getByLabelText('Timeline mode Decade'));
+    fireEvent.changeText(screen.getByLabelText('Timeline decade'), '445');
+    fireEvent(screen.getByLabelText('Timeline decade'), 'submitEditing');
+
+    await waitFor(() => {
+      expect(getTimeline).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          page: 1,
+          decade: 440,
+        }),
+      );
+    });
+
+    fireEvent.changeText(screen.getByLabelText('Timeline decade'), '-7500');
+    fireEvent(screen.getByLabelText('Timeline decade'), 'submitEditing');
+
+    await waitFor(() => {
+      expect(getTimeline).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          page: 1,
+          decade: -7500,
+        }),
+      );
+    });
+  });
+
+  it('keeps period inputs mounted while a typed filter is loading', async () => {
+    const getTimeline = jest
+      .fn<Promise<TimelinePageEntity>, [any]>()
+      .mockResolvedValueOnce(makeTimelinePage({ items: [], totalCount: 0 }))
+      .mockImplementation(() => new Promise<TimelinePageEntity>(() => undefined));
+
+    renderScreen(<TimelineScreen getTimeline={getTimeline} showSearchControls={false} />);
+
+    await screen.findByText('Timeline is empty');
+
+    fireEvent.press(screen.getByLabelText('Timeline mode Decade'));
+    fireEvent.changeText(screen.getByLabelText('Timeline decade'), '1');
+
+    expect(screen.queryByLabelText('Loading timeline stories')).toBeNull();
+    expect(screen.getByLabelText('Timeline decade')).toBeTruthy();
+  });
+
+  it('keeps range typing local until both years are provided', async () => {
     const getTimeline = jest.fn<Promise<TimelinePageEntity>, [any]>().mockResolvedValue(makeTimelinePage());
 
     renderScreen(<TimelineScreen getTimeline={getTimeline} showSearchControls={false} />);
@@ -139,21 +204,61 @@ describe('TimelineScreen', () => {
     const callCountAfterInitialLoad = getTimeline.mock.calls.length;
 
     fireEvent.press(screen.getByLabelText('Timeline mode Range'));
-    fireEvent.changeText(screen.getByLabelText('Timeline start year'), '191');
-    fireEvent.changeText(screen.getByLabelText('Timeline end year'), '1918');
+    const callCountAfterRangeMode = getTimeline.mock.calls.length;
+    expect(callCountAfterRangeMode).toBe(callCountAfterInitialLoad);
 
-    expect(getTimeline).toHaveBeenCalledTimes(callCountAfterInitialLoad);
+    fireEvent.changeText(screen.getByLabelText('Timeline start year'), '445');
 
-    fireEvent.changeText(screen.getByLabelText('Timeline start year'), '1914');
+    expect(getTimeline).toHaveBeenCalledTimes(callCountAfterRangeMode);
+
+    fireEvent.changeText(screen.getByLabelText('Timeline end year'), '1110');
+
+    expect(getTimeline).toHaveBeenCalledTimes(callCountAfterRangeMode);
+    fireEvent(screen.getByLabelText('Timeline end year'), 'submitEditing');
 
     await waitFor(() => {
       expect(getTimeline).toHaveBeenLastCalledWith(
         expect.objectContaining({
           page: 1,
-          yearRange: { from: 1914, to: 1918 },
+          yearRange: { from: 445, to: 1110 },
         }),
       );
     });
+  });
+
+  it('clears the previous period mode when switching between controls', async () => {
+    const getTimeline = jest.fn<Promise<TimelinePageEntity>, [any]>().mockResolvedValue(makeTimelinePage());
+
+    renderScreen(<TimelineScreen getTimeline={getTimeline} showSearchControls={false} />);
+
+    await screen.findByText('Timeline Story 1');
+
+    fireEvent.press(screen.getByLabelText('Timeline mode Year'));
+    fireEvent.changeText(screen.getByLabelText('Timeline year'), '100');
+    fireEvent(screen.getByLabelText('Timeline year'), 'submitEditing');
+
+    await waitFor(() => {
+      expect(getTimeline).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          page: 1,
+          year: 100,
+        }),
+      );
+    });
+
+    fireEvent.press(screen.getByLabelText('Timeline mode Range'));
+
+    await waitFor(() => {
+      const lastRequest = getTimeline.mock.calls[getTimeline.mock.calls.length - 1][0];
+
+      expect(lastRequest).toEqual(expect.objectContaining({ page: 1 }));
+      expect(lastRequest.year).toBeUndefined();
+      expect(lastRequest.yearRange).toBeUndefined();
+      expect(lastRequest.decade).toBeUndefined();
+    });
+    expect(screen.queryByLabelText('Timeline year')).toBeNull();
+    expect(screen.getByLabelText('Timeline start year').props.value).toBe('');
+    expect(screen.getByLabelText('Timeline end year').props.value).toBe('');
   });
 
   it('loads the next timeline page when the list reaches the end', async () => {

--- a/mobile/src/shared/components/WebMapView.tsx
+++ b/mobile/src/shared/components/WebMapView.tsx
@@ -46,7 +46,7 @@ type MapUpdatePayload = {
   transitionDurationMs?: number;
 };
 
-const MAP_HTML_VERSION = 'current-location-pin-size-v2';
+const MAP_HTML_VERSION = 'colored-cluster-markers-v1';
 
 const mapHtml = ({
   region,
@@ -96,6 +96,16 @@ const mapHtml = ({
         height: 34px;
       }
 
+      .marker.cluster {
+        width: 42px;
+        height: 42px;
+      }
+
+      .marker.cluster.selected {
+        width: 48px;
+        height: 48px;
+      }
+
       .marker-dot {
         position: relative;
         width: 18px;
@@ -117,6 +127,39 @@ const mapHtml = ({
         box-shadow: 0 4px 12px rgba(220, 38, 38, 0.32);
       }
 
+      .marker-cluster {
+        position: relative;
+        width: 38px;
+        height: 38px;
+        border-radius: 9999px;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        border: 4px solid rgba(255, 255, 255, 0.82);
+        box-shadow: 0 4px 14px rgba(15, 23, 42, 0.24);
+      }
+
+      .marker.cluster.selected .marker-cluster {
+        width: 44px;
+        height: 44px;
+        border-color: #ffffff;
+        box-shadow:
+          0 0 0 4px rgba(220, 38, 38, 0.18),
+          0 5px 16px rgba(15, 23, 42, 0.3);
+      }
+
+      .marker-cluster-small {
+        background: rgba(181, 226, 140, 0.94);
+      }
+
+      .marker-cluster-medium {
+        background: rgba(241, 211, 87, 0.96);
+      }
+
+      .marker-cluster-large {
+        background: rgba(253, 156, 115, 0.97);
+      }
+
       .marker.selected .marker-pin {
         width: 18px;
         height: 18px;
@@ -130,8 +173,8 @@ const mapHtml = ({
         min-width: 14px;
         max-width: 18px;
         color: #ffffff;
-        font-size: 10px;
-        font-weight: 700;
+        font-size: 12px;
+        font-weight: 800;
         line-height: 1;
         text-align: center;
         text-shadow: 0 1px 2px rgba(0, 0, 0, 0.35);
@@ -268,11 +311,34 @@ const mapHtml = ({
         }, Math.max(duration, 0) + 120);
       };
 
+      const getClusterSizeClass = (label) => {
+        const count = Number.parseInt(label, 10);
+
+        if (Number.isFinite(count) && count >= 100) {
+          return 'marker-cluster-large';
+        }
+
+        if (Number.isFinite(count) && count >= 10) {
+          return 'marker-cluster-medium';
+        }
+
+        return 'marker-cluster-small';
+      };
+
       const createStoryMarker = (marker) => {
         const element = document.createElement('div');
-        element.className = marker.selected ? 'marker selected' : 'marker';
+        const isCluster = Boolean(marker.label);
+        element.className = [
+          'marker',
+          isCluster ? 'cluster' : '',
+          marker.selected ? 'selected' : '',
+        ].filter(Boolean).join(' ');
         const markerBody = document.createElement('div');
-        markerBody.className = marker.selected ? 'marker-pin' : 'marker-dot';
+        markerBody.className = isCluster
+          ? 'marker-cluster ' + getClusterSizeClass(marker.label)
+          : marker.selected
+            ? 'marker-pin'
+            : 'marker-dot';
         element.appendChild(markerBody);
 
         if (marker.label) {
@@ -289,7 +355,7 @@ const mapHtml = ({
           );
         });
 
-        return new maplibregl.Marker({ element, anchor: marker.selected ? 'bottom' : 'center' })
+        return new maplibregl.Marker({ element, anchor: marker.selected && !isCluster ? 'bottom' : 'center' })
           .setLngLat([marker.longitude, marker.latitude])
           .addTo(map);
       };


### PR DESCRIPTION
# 📝 Description
Fixes #587

Adds an image-availability filter to the mobile timeline. Users can toggle `With image` near the timeline time-window controls; selecting it shows only stories with an image URL, and selecting it again clears the filter.

# 📊 Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Refactoring
- [ ] Documentation

# ✅ Acceptance Criteria / Checklist
- [x] Project builds successfully
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, especially in hard-to-understand parts
- [x] I have performed a self-review of my code
- [x] I have added/updated tests
- [x] New and existing unit tests pass locally with my changes

# 📸 Screenshots / Recordings
<!-- If applicable !-->

# ⏱️ Estimated Review Time
- [ ] < 5 min
- [x] 5-15 min
- [ ] > 15 min
