### PR TITLE
feat(frontend): timeline page mobile parity filters + radiogroup keyboard nav

### DIFF
--- a/frontend/src/components/SearchFilter/ActiveFilters.jsx
+++ b/frontend/src/components/SearchFilter/ActiveFilters.jsx
@@ -44,7 +44,7 @@ function TagChip({ name, onRemove }) {
  * Renders removable chips for each active search/filter value.
  * Returns null when no filters are active.
  *
- * onRemove receives a key: "q" | "year_range" | "year_from" | "year_to" | "location"
+ * onRemove receives a key: "q" | "year_range" | "year_from" | "year_to" | "location" | "proximity" | "has_image"
  * onRemoveTag receives a tag name string
  */
 function ActiveFilters({
@@ -55,6 +55,7 @@ function ActiveFilters({
   radiusKm = null,
   hasProximity = false,
   tags = [],
+  hasImage = false,
   onRemove,
   onRemoveTag,
   onClearAll,
@@ -80,6 +81,10 @@ function ActiveFilters({
   if (hasProximity && radiusKm != null) {
     const distanceLabel = radiusKm < 1 ? `${Math.round(radiusKm * 1000)} m` : `${radiusKm} km`;
     chips.push({ key: "proximity", label: `Within ${distanceLabel}` });
+  }
+
+  if (hasImage) {
+    chips.push({ key: "has_image", label: "Has image" });
   }
 
   if (chips.length === 0 && tags.length === 0) return null;

--- a/frontend/src/components/SearchFilter/FilterPanel.jsx
+++ b/frontend/src/components/SearchFilter/FilterPanel.jsx
@@ -28,7 +28,7 @@ const PROXIMITY_OPTIONS = [
  * The parent should pass a `key` tied to the current filter values so that
  * the component resets its local form whenever filters are cleared externally.
  */
-function FilterPanel({ yearFrom = "", yearTo = "", location = "", latMin = null, latMax = null, lngMin = null, lngMax = null, latitude = null, longitude = null, radiusKm = null, tags = [], onApply, activeCount = 0 }) {
+function FilterPanel({ yearFrom = "", yearTo = "", location = "", latMin = null, latMax = null, lngMin = null, lngMax = null, latitude = null, longitude = null, radiusKm = null, tags = [], onApply, activeCount = 0, hideYearRange = false }) {
   const [open, setOpen] = useState(false);
   const [localYearFrom, setLocalYearFrom] = useState(yearFrom);
   const [localYearTo, setLocalYearTo] = useState(yearTo);
@@ -267,6 +267,7 @@ function FilterPanel({ yearFrom = "", yearTo = "", location = "", latMin = null,
         >
           <div className="space-y-4">
             {/* Year range */}
+            {!hideYearRange && (
             <fieldset>
               <legend className="mb-2 text-sm font-medium">Year range</legend>
               <div className="flex items-center gap-2">
@@ -344,6 +345,7 @@ function FilterPanel({ yearFrom = "", yearTo = "", location = "", latMin = null,
                 </p>
               )}
             </fieldset>
+            )}
 
             {/* Location */}
             <div>

--- a/frontend/src/components/SearchFilter/FilterPanel.jsx
+++ b/frontend/src/components/SearchFilter/FilterPanel.jsx
@@ -28,13 +28,14 @@ const PROXIMITY_OPTIONS = [
  * The parent should pass a `key` tied to the current filter values so that
  * the component resets its local form whenever filters are cleared externally.
  */
-function FilterPanel({ yearFrom = "", yearTo = "", location = "", latMin = null, latMax = null, lngMin = null, lngMax = null, latitude = null, longitude = null, radiusKm = null, tags = [], onApply, activeCount = 0, hideYearRange = false }) {
+function FilterPanel({ yearFrom = "", yearTo = "", location = "", latMin = null, latMax = null, lngMin = null, lngMax = null, latitude = null, longitude = null, radiusKm = null, tags = [], hasImage = false, onApply, activeCount = 0, hideYearRange = false, showHasImage = false }) {
   const [open, setOpen] = useState(false);
   const [localYearFrom, setLocalYearFrom] = useState(yearFrom);
   const [localYearTo, setLocalYearTo] = useState(yearTo);
   const [localLocation, setLocalLocation] = useState(location);
   const [suggestionsQuery, setSuggestionsQuery] = useState("");
   const [localTags, setLocalTags] = useState(tags);
+  const [localHasImage, setLocalHasImage] = useState(hasImage);
   const [yearError, setYearError] = useState("");
   const [lockedBbox, setLockedBbox] = useState(
     () => latMin != null && latMax != null && lngMin != null && lngMax != null
@@ -201,7 +202,8 @@ function FilterPanel({ yearFrom = "", yearTo = "", location = "", latMin = null,
       latitude: proximityActive ? localCoords.latitude : null,
       longitude: proximityActive ? localCoords.longitude : null,
       radiusKm: proximityActive ? localRadiusKm : null,
-      tags: localTags
+      tags: localTags,
+      ...(showHasImage ? { hasImage: localHasImage } : {}),
     });
     setOpen(false);
   }
@@ -218,6 +220,7 @@ function FilterPanel({ yearFrom = "", yearTo = "", location = "", latMin = null,
     setProximityResolving(false);
     setProximityStatus(null);
     setLocalTags([]);
+    setLocalHasImage(false);
     setYearError("");
     clearSuggestions();
     onApply({
@@ -232,6 +235,7 @@ function FilterPanel({ yearFrom = "", yearTo = "", location = "", latMin = null,
       longitude: null,
       radiusKm: null,
       tags: [],
+      ...(showHasImage ? { hasImage: false } : {}),
     });
     setOpen(false);
   }
@@ -464,6 +468,22 @@ function FilterPanel({ yearFrom = "", yearTo = "", location = "", latMin = null,
 
             {/* Tags */}
             <TagFilterInput value={localTags} onChange={setLocalTags} />
+
+            {showHasImage && (
+              <fieldset>
+                <legend className="sr-only">Image presence</legend>
+                <label className="flex cursor-pointer items-center gap-2 text-sm">
+                  <input
+                    type="checkbox"
+                    checked={localHasImage}
+                    onChange={(e) => setLocalHasImage(e.target.checked)}
+                    aria-label="Only stories with an image"
+                    className="h-4 w-4 rounded border-input"
+                  />
+                  <span>Only stories with an image</span>
+                </label>
+              </fieldset>
+            )}
 
             {/* Actions */}
             <div className="flex items-center justify-between gap-2 pt-1">

--- a/frontend/src/components/SearchFilter/__tests__/ActiveFilters.test.jsx
+++ b/frontend/src/components/SearchFilter/__tests__/ActiveFilters.test.jsx
@@ -181,4 +181,23 @@ describe("ActiveFilters", () => {
 
     expect(onRemove).toHaveBeenCalledWith("proximity");
   });
+
+  it("renders a 'Has image' chip when hasImage is true", () => {
+    renderFilters({ hasImage: true });
+    expect(screen.getByText(/has image/i)).toBeInTheDocument();
+  });
+
+  it("does not render the 'Has image' chip when hasImage is false / unset", () => {
+    renderFilters({});
+    expect(screen.queryByText(/has image/i)).not.toBeInTheDocument();
+  });
+
+  it("calls onRemove with 'has_image' when the Has-image chip X is clicked", async () => {
+    const user = userEvent.setup();
+    const onRemove = vi.fn();
+    renderFilters({ hasImage: true, onRemove });
+
+    await user.click(screen.getByRole("button", { name: /remove filter: has image/i }));
+    expect(onRemove).toHaveBeenCalledWith("has_image");
+  });
 });

--- a/frontend/src/components/SearchFilter/__tests__/FilterPanel.test.jsx
+++ b/frontend/src/components/SearchFilter/__tests__/FilterPanel.test.jsx
@@ -492,4 +492,24 @@ describe("FilterPanel", () => {
       );
     });
   });
+
+  describe("hideYearRange prop", () => {
+    it("renders the year-range fieldset by default", async () => {
+      const user = userEvent.setup();
+      renderPanel();
+      await user.click(screen.getByRole("button", { name: /^filters$/i }));
+      expect(screen.getByLabelText(/from year/i)).toBeInTheDocument();
+      expect(screen.getByLabelText(/to year/i)).toBeInTheDocument();
+    });
+
+    it("omits the year-range fieldset when hideYearRange is true", async () => {
+      const user = userEvent.setup();
+      renderPanel({ hideYearRange: true });
+      await user.click(screen.getByRole("button", { name: /^filters$/i }));
+      expect(screen.queryByLabelText(/from year/i)).not.toBeInTheDocument();
+      expect(screen.queryByLabelText(/to year/i)).not.toBeInTheDocument();
+      // Other fields still present
+      expect(screen.getByLabelText(/location filter/i)).toBeInTheDocument();
+    });
+  });
 });

--- a/frontend/src/components/SearchFilter/__tests__/FilterPanel.test.jsx
+++ b/frontend/src/components/SearchFilter/__tests__/FilterPanel.test.jsx
@@ -512,4 +512,62 @@ describe("FilterPanel", () => {
       expect(screen.getByLabelText(/location filter/i)).toBeInTheDocument();
     });
   });
+
+  describe("showHasImage prop", () => {
+    it("does not render the 'has image' checkbox by default (Feed/Map untouched)", async () => {
+      const user = userEvent.setup();
+      renderPanel();
+      await user.click(screen.getByRole("button", { name: /^filters$/i }));
+      expect(screen.queryByLabelText(/only stories with an image/i)).not.toBeInTheDocument();
+    });
+
+    it("renders the 'has image' checkbox when showHasImage is true", async () => {
+      const user = userEvent.setup();
+      renderPanel({ showHasImage: true });
+      await user.click(screen.getByRole("button", { name: /^filters$/i }));
+      expect(screen.getByLabelText(/only stories with an image/i)).toBeInTheDocument();
+    });
+
+    it("emits hasImage in onApply only when showHasImage is true", async () => {
+      const user = userEvent.setup();
+      const onApply = vi.fn();
+      renderPanel({ showHasImage: true, onApply });
+
+      await user.click(screen.getByRole("button", { name: /^filters$/i }));
+      await user.click(screen.getByLabelText(/only stories with an image/i));
+      await user.click(screen.getByRole("button", { name: /^apply$/i }));
+
+      expect(onApply).toHaveBeenCalledWith(expect.objectContaining({ hasImage: true }));
+    });
+
+    it("omits hasImage from onApply when showHasImage is false", async () => {
+      const user = userEvent.setup();
+      const onApply = vi.fn();
+      renderPanel({ onApply });
+
+      await user.click(screen.getByRole("button", { name: /^filters$/i }));
+      await user.click(screen.getByRole("button", { name: /^apply$/i }));
+
+      const arg = onApply.mock.calls[0][0];
+      expect(arg).not.toHaveProperty("hasImage");
+    });
+
+    it("seeds the checkbox from the hasImage prop", async () => {
+      const user = userEvent.setup();
+      renderPanel({ showHasImage: true, hasImage: true });
+      await user.click(screen.getByRole("button", { name: /^filters$/i }));
+      expect(screen.getByLabelText(/only stories with an image/i)).toBeChecked();
+    });
+
+    it("Reset clears hasImage", async () => {
+      const user = userEvent.setup();
+      const onApply = vi.fn();
+      renderPanel({ showHasImage: true, hasImage: true, onApply });
+
+      await user.click(screen.getByRole("button", { name: /^filters$/i }));
+      await user.click(screen.getByRole("button", { name: /reset filters/i }));
+
+      expect(onApply).toHaveBeenCalledWith(expect.objectContaining({ hasImage: false }));
+    });
+  });
 });

--- a/frontend/src/hooks/__tests__/useFilterState.test.jsx
+++ b/frontend/src/hooks/__tests__/useFilterState.test.jsx
@@ -238,4 +238,40 @@ describe("useFilterState", () => {
     expect(result.current.radiusKm).toBeNull();
     expect(result.current.hasActiveFilters).toBe(false);
   });
+
+  it("parses has_image=true as a boolean true", () => {
+    const { result } = renderHook(() => useFilterState(), {
+      wrapper: makeWrapper(["/?has_image=true"]),
+    });
+    expect(result.current.hasImage).toBe(true);
+    expect(result.current.hasActiveFilters).toBe(true);
+  });
+
+  it("treats absent / non-true has_image values as false", () => {
+    const absent = renderHook(() => useFilterState(), { wrapper: makeWrapper() });
+    expect(absent.result.current.hasImage).toBe(false);
+
+    const falsy = renderHook(() => useFilterState(), {
+      wrapper: makeWrapper(["/?has_image=false"]),
+    });
+    expect(falsy.result.current.hasImage).toBe(false);
+
+    const garbage = renderHook(() => useFilterState(), {
+      wrapper: makeWrapper(["/?has_image=1"]),
+    });
+    expect(garbage.result.current.hasImage).toBe(false);
+  });
+
+  it("removes has_image when setFilters is called with empty value", () => {
+    const { result } = renderHook(() => useFilterState(), {
+      wrapper: makeWrapper(["/?has_image=true"]),
+    });
+    expect(result.current.hasImage).toBe(true);
+
+    act(() => {
+      result.current.setFilters({ has_image: "" });
+    });
+
+    expect(result.current.hasImage).toBe(false);
+  });
 });

--- a/frontend/src/hooks/useFilterState.js
+++ b/frontend/src/hooks/useFilterState.js
@@ -4,8 +4,9 @@ import { useSearchParams } from "react-router-dom";
 /**
  * Manages search/filter state via URL query parameters.
  * Supported params: q, year_from, year_to, location, lat_min, lat_max, lng_min, lng_max,
- * latitude, longitude, radius_km, tags, page, sort_by
+ * latitude, longitude, radius_km, tags, has_image, page, sort_by
  * Tags are stored as a comma-separated string: tags=foo,bar
+ * has_image is the literal string "true" when active; absent otherwise.
  */
 export function useFilterState() {
   const [searchParams, setSearchParams] = useSearchParams();
@@ -28,6 +29,7 @@ export function useFilterState() {
   const latitude = readNumberParam("latitude");
   const longitude = readNumberParam("longitude");
   const radiusKm = readNumberParam("radius_km");
+  const hasImage = searchParams.get("has_image") === "true";
   const page = searchParams.get("page") ? Number(searchParams.get("page")) : 1;
   const sortBy = searchParams.get("sort_by") || "recent";
   const tagsRaw = searchParams.get("tags") || "";
@@ -36,7 +38,7 @@ export function useFilterState() {
   const hasProximity =
     latitude != null && longitude != null && radiusKm != null;
   const hasActiveFilters = Boolean(
-    q || yearFrom || yearTo || location || tags.length > 0 || hasProximity
+    q || yearFrom || yearTo || location || tags.length > 0 || hasProximity || hasImage
   );
 
   /**
@@ -121,6 +123,7 @@ export function useFilterState() {
     latitude,
     longitude,
     radiusKm,
+    hasImage,
     page,
     sortBy,
     tags,

--- a/frontend/src/pages/TimelinePage.jsx
+++ b/frontend/src/pages/TimelinePage.jsx
@@ -1,5 +1,4 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { useSearchParams } from "react-router-dom";
 
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -9,6 +8,10 @@ import { ErrorState } from "@/components/ui/error-state";
 import { LoadingSpinner } from "@/components/ui/loading-spinner";
 import { cn } from "@/lib/utils";
 import TimelineView from "@/components/Timeline/TimelineView";
+import SearchBar from "@/components/SearchFilter/SearchBar";
+import FilterPanel from "@/components/SearchFilter/FilterPanel";
+import ActiveFilters from "@/components/SearchFilter/ActiveFilters";
+import { useFilterState } from "@/hooks/useFilterState";
 import { getTimeline } from "@/services/timelineService";
 
 const PAGE_SIZE = 10;
@@ -20,12 +23,6 @@ const MODE_LABELS = {
   range: "Range",
   decade: "Decade",
 };
-
-function parseFloatOrUndef(v) {
-  if (v == null) return undefined;
-  const n = Number(v);
-  return Number.isFinite(n) ? n : undefined;
-}
 
 const YEAR_RE = /^\d{4}$/;
 
@@ -92,20 +89,33 @@ function deriveYearFilter(mode, yearInput, rangeFrom, rangeTo) {
   return { ...base, yearFrom: from, yearTo: to, label: `${from}–${to}` };
 }
 
-function TimelinePage() {
-  const [searchParams] = useSearchParams();
+/**
+ * Count filters that aren't represented by the time-window mode UI.
+ * The time-window selector owns yearFrom/yearTo visually, so they're not
+ * surfaced through the filter chip badge / chips.
+ */
+function countActiveFilters({ location, hasProximity, tags }) {
+  return (location ? 1 : 0) + (hasProximity ? 1 : 0) + tags.length;
+}
 
-  // Bounding-box passthrough — issue #488 will use these.
-  const bbox = useMemo(() => {
-    const latMin = parseFloatOrUndef(searchParams.get("lat_min"));
-    const latMax = parseFloatOrUndef(searchParams.get("lat_max"));
-    const lngMin = parseFloatOrUndef(searchParams.get("lng_min"));
-    const lngMax = parseFloatOrUndef(searchParams.get("lng_max"));
-    if ([latMin, latMax, lngMin, lngMax].some((v) => v === undefined)) {
-      return null;
-    }
-    return { latMin, latMax, lngMin, lngMax };
-  }, [searchParams]);
+function TimelinePage() {
+  const {
+    q,
+    location,
+    latMin,
+    latMax,
+    lngMin,
+    lngMax,
+    latitude,
+    longitude,
+    radiusKm,
+    tags,
+    hasProximity,
+    setFilters,
+    removeFilter,
+    removeTag,
+    clearAll,
+  } = useFilterState();
 
   const [mode, setMode] = useState("all");
   const [yearInput, setYearInput] = useState("");
@@ -139,10 +149,16 @@ function TimelinePage() {
         const data = await getTimeline({
           yearFrom: filter.yearFrom,
           yearTo: filter.yearTo,
-          latMin: bbox?.latMin,
-          latMax: bbox?.latMax,
-          lngMin: bbox?.lngMin,
-          lngMax: bbox?.lngMax,
+          q,
+          location,
+          tags,
+          latMin: latMin ?? undefined,
+          latMax: latMax ?? undefined,
+          lngMin: lngMin ?? undefined,
+          lngMax: lngMax ?? undefined,
+          latitude: latitude ?? undefined,
+          longitude: longitude ?? undefined,
+          radiusKm: radiusKm ?? undefined,
           page: pageToLoad,
           pageSize: PAGE_SIZE,
         });
@@ -165,7 +181,20 @@ function TimelinePage() {
         }
       }
     },
-    [filter.yearFrom, filter.yearTo, bbox],
+    [
+      filter.yearFrom,
+      filter.yearTo,
+      q,
+      location,
+      tags,
+      latMin,
+      latMax,
+      lngMin,
+      lngMax,
+      latitude,
+      longitude,
+      radiusKm,
+    ],
   );
 
   // Refetch from page 1 whenever the filter changes (or on mount). Skip while
@@ -184,6 +213,81 @@ function TimelinePage() {
     fetchPage(1, { append: false });
   }
 
+  const handleSearchChange = useCallback(
+    (value) => {
+      setFilters({ q: value }, { replace: true });
+    },
+    [setFilters],
+  );
+
+  function handleFilterApply({
+    location: loc,
+    latMin: lMin,
+    latMax: lMax,
+    lngMin: gMin,
+    lngMax: gMax,
+    latitude: lat,
+    longitude: lng,
+    radiusKm: rKm,
+    tags: tgs,
+  }) {
+    setFilters(
+      {
+        location: loc,
+        lat_min: lMin ?? "",
+        lat_max: lMax ?? "",
+        lng_min: gMin ?? "",
+        lng_max: gMax ?? "",
+        latitude: lat ?? "",
+        longitude: lng ?? "",
+        radius_km: rKm ?? "",
+        tags: tgs,
+      },
+      { replace: true },
+    );
+  }
+
+  function handleRemoveFilter(key) {
+    if (key === "location") {
+      setFilters(
+        { location: "", lat_min: "", lat_max: "", lng_min: "", lng_max: "" },
+        { replace: true },
+      );
+    } else if (key === "proximity") {
+      setFilters({ latitude: "", longitude: "", radius_km: "" }, { replace: true });
+    } else {
+      removeFilter(key);
+    }
+  }
+
+  // Roving-tabindex bookkeeping for the WAI-ARIA radiogroup. Only the
+  // currently-checked option sits in the tab order; arrow keys both move
+  // focus and select the next option. Matches the authoring practice for
+  // role="radiogroup".
+  const modeRefs = useRef({});
+
+  function handleModeKeyDown(e, currentIndex) {
+    let nextIndex = null;
+    if (e.key === "ArrowRight" || e.key === "ArrowDown") {
+      nextIndex = (currentIndex + 1) % MODES.length;
+    } else if (e.key === "ArrowLeft" || e.key === "ArrowUp") {
+      nextIndex = (currentIndex - 1 + MODES.length) % MODES.length;
+    } else if (e.key === "Home") {
+      nextIndex = 0;
+    } else if (e.key === "End") {
+      nextIndex = MODES.length - 1;
+    } else {
+      return;
+    }
+    e.preventDefault();
+    const nextMode = MODES[nextIndex];
+    setMode(nextMode);
+    const el = modeRefs.current[nextMode];
+    if (el) el.focus();
+  }
+
+  const activeFilterCount = countActiveFilters({ location, hasProximity, tags });
+
   return (
     <main className="min-h-screen bg-background">
       <div className="mx-auto max-w-3xl px-4 py-8 sm:px-6 lg:px-8">
@@ -194,30 +298,74 @@ function TimelinePage() {
           </p>
         </div>
 
-        {/* Filter card */}
+        {/* Search + filters */}
+        <div className="mb-6 space-y-2">
+          <div className="flex items-center gap-2">
+            <div className="min-w-0 flex-1">
+              <SearchBar
+                defaultValue={q}
+                onSearch={handleSearchChange}
+                placeholder="Search by title or place…"
+              />
+            </div>
+            <FilterPanel
+              key={`${location}-${latMin}-${latMax}-${lngMin}-${lngMax}-${latitude}-${longitude}-${radiusKm}-${tags.join(",")}`}
+              location={location}
+              latMin={latMin}
+              latMax={latMax}
+              lngMin={lngMin}
+              lngMax={lngMax}
+              latitude={latitude}
+              longitude={longitude}
+              radiusKm={radiusKm}
+              tags={tags}
+              onApply={handleFilterApply}
+              activeCount={activeFilterCount}
+              hideYearRange
+            />
+          </div>
+          <ActiveFilters
+            q={q}
+            location={location}
+            radiusKm={radiusKm}
+            hasProximity={hasProximity}
+            tags={tags}
+            onRemove={handleRemoveFilter}
+            onRemoveTag={removeTag}
+            onClearAll={clearAll}
+          />
+        </div>
+
+        {/* Time-window selector */}
         <Card className="mb-6">
           <CardHeader className="pb-3">
             <CardTitle className="text-base">Choose a time window</CardTitle>
           </CardHeader>
           <CardContent className="space-y-4">
             <div role="radiogroup" aria-label="Time window mode" className="flex flex-wrap gap-2">
-              {MODES.map((m) => (
-                <button
-                  key={m}
-                  type="button"
-                  role="radio"
-                  aria-checked={mode === m}
-                  onClick={() => setMode(m)}
-                  className={cn(
-                    "rounded-full border px-4 py-1.5 text-sm font-medium transition-colors",
-                    mode === m
-                      ? "border-primary bg-primary text-primary-foreground"
-                      : "border-input bg-background text-foreground hover:bg-muted",
-                  )}
-                >
-                  {MODE_LABELS[m]}
-                </button>
-              ))}
+              {MODES.map((m, i) => {
+                const isChecked = mode === m;
+                return (
+                  <button
+                    key={m}
+                    ref={(el) => { modeRefs.current[m] = el; }}
+                    type="button"
+                    role="radio"
+                    aria-checked={isChecked}
+                    tabIndex={isChecked ? 0 : -1}
+                    onClick={() => setMode(m)}
+                    onKeyDown={(e) => handleModeKeyDown(e, i)}
+                    className={cn(
+                      "rounded-full border px-4 py-1.5 text-sm font-medium transition-colors",
+                      isChecked
+                        ? "border-primary bg-primary text-primary-foreground"
+                        : "border-input bg-background text-foreground hover:bg-muted",
+                    )}
+                  >
+                    {MODE_LABELS[m]}
+                  </button>
+                );
+              })}
             </div>
 
             {mode === "year" && (

--- a/frontend/src/pages/TimelinePage.jsx
+++ b/frontend/src/pages/TimelinePage.jsx
@@ -1,12 +1,8 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { ErrorState } from "@/components/ui/error-state";
 import { LoadingSpinner } from "@/components/ui/loading-spinner";
-import { cn } from "@/lib/utils";
 import TimelineView from "@/components/Timeline/TimelineView";
 import SearchBar from "@/components/SearchFilter/SearchBar";
 import FilterPanel from "@/components/SearchFilter/FilterPanel";
@@ -16,91 +12,20 @@ import { getTimeline } from "@/services/timelineService";
 
 const PAGE_SIZE = 10;
 
-const MODES = ["all", "year", "range", "decade"];
-const MODE_LABELS = {
-  all: "All",
-  year: "Year",
-  range: "Range",
-  decade: "Decade",
-};
-
-const YEAR_RE = /^\d{4}$/;
-
-/**
- * Parse a 4-digit year string. Returns undefined for blank or partial input —
- * this prevents firing requests on every keystroke while the user is typing.
- */
-function parseFullYear(v) {
-  if (typeof v !== "string" || !YEAR_RE.test(v.trim())) return undefined;
-  return Number.parseInt(v, 10);
-}
-
-function decadeStart(year) {
-  return Math.floor(year / 10) * 10;
-}
-
-/**
- * Derive the year_from / year_to filter pair for the current mode + inputs.
- * Returns { yearFrom, yearTo, label } where label is the human-readable
- * period for the status row. yearFrom/yearTo are undefined when no filter
- * should be applied — partial input (less than 4 digits) is treated as
- * not-yet-ready and skips the fetch.
- */
-function deriveYearFilter(mode, yearInput, rangeFrom, rangeTo) {
-  const base = { yearFrom: undefined, yearTo: undefined, invalid: false, skip: false };
-  if (mode === "all") {
-    return { ...base, label: "All time periods" };
-  }
-  if (mode === "year") {
-    const y = parseFullYear(yearInput);
-    if (y === undefined) {
-      return {
-        ...base,
-        label: yearInput ? "Enter a 4-digit year" : "All time periods",
-        skip: Boolean(yearInput),
-      };
-    }
-    return { ...base, yearFrom: y, yearTo: y, label: String(y) };
-  }
-  if (mode === "decade") {
-    const y = parseFullYear(yearInput);
-    if (y === undefined) {
-      return {
-        ...base,
-        label: yearInput ? "Enter a 4-digit year" : "All time periods",
-        skip: Boolean(yearInput),
-      };
-    }
-    const start = decadeStart(y);
-    return { ...base, yearFrom: start, yearTo: start + 9, label: `${start}s` };
-  }
-  // range — require both endpoints to be complete 4-digit years before fetching
-  if (!rangeFrom && !rangeTo) {
-    return { ...base, label: "All time periods" };
-  }
-  const from = parseFullYear(rangeFrom);
-  const to = parseFullYear(rangeTo);
-  if (from === undefined || to === undefined) {
-    return { ...base, label: "Enter start and end years", skip: true };
-  }
-  if (from > to) {
-    return { ...base, label: "Invalid range", invalid: true };
-  }
-  return { ...base, yearFrom: from, yearTo: to, label: `${from}–${to}` };
-}
-
-/**
- * Count filters that aren't represented by the time-window mode UI.
- * The time-window selector owns yearFrom/yearTo visually, so they're not
- * surfaced through the filter chip badge / chips.
- */
-function countActiveFilters({ location, hasProximity, tags }) {
-  return (location ? 1 : 0) + (hasProximity ? 1 : 0) + tags.length;
+function countActiveFilters({ yearFrom, yearTo, location, hasProximity, tags, hasImage }) {
+  return (
+    [yearFrom, yearTo, location].filter(Boolean).length +
+    (hasProximity ? 1 : 0) +
+    (hasImage ? 1 : 0) +
+    tags.length
+  );
 }
 
 function TimelinePage() {
   const {
     q,
+    yearFrom,
+    yearTo,
     location,
     latMin,
     latMax,
@@ -110,22 +35,13 @@ function TimelinePage() {
     longitude,
     radiusKm,
     tags,
+    hasImage,
     hasProximity,
     setFilters,
     removeFilter,
     removeTag,
     clearAll,
   } = useFilterState();
-
-  const [mode, setMode] = useState("all");
-  const [yearInput, setYearInput] = useState("");
-  const [rangeFrom, setRangeFrom] = useState("");
-  const [rangeTo, setRangeTo] = useState("");
-
-  const filter = useMemo(
-    () => deriveYearFilter(mode, yearInput, rangeFrom, rangeTo),
-    [mode, yearInput, rangeFrom, rangeTo],
-  );
 
   const [stories, setStories] = useState([]);
   const [count, setCount] = useState(0);
@@ -135,8 +51,8 @@ function TimelinePage() {
   const [loadingMore, setLoadingMore] = useState(false);
   const [error, setError] = useState(null);
 
-  // Fetch generation counter — guards against out-of-order responses when
-  // the user changes the filter while a request is in flight.
+  // Fetch generation counter — guards against out-of-order responses when the
+  // user changes the filter while a request is in flight.
   const generationRef = useRef(0);
 
   const fetchPage = useCallback(
@@ -147,8 +63,8 @@ function TimelinePage() {
       setError(null);
       try {
         const data = await getTimeline({
-          yearFrom: filter.yearFrom,
-          yearTo: filter.yearTo,
+          yearFrom: yearFrom === "" ? undefined : yearFrom,
+          yearTo: yearTo === "" ? undefined : yearTo,
           q,
           location,
           tags,
@@ -159,10 +75,11 @@ function TimelinePage() {
           latitude: latitude ?? undefined,
           longitude: longitude ?? undefined,
           radiusKm: radiusKm ?? undefined,
+          hasImage,
           page: pageToLoad,
           pageSize: PAGE_SIZE,
         });
-        if (myGen !== generationRef.current) return; // stale response
+        if (myGen !== generationRef.current) return;
         setCount(data.count);
         setHasNext(Boolean(data.next));
         setPage(pageToLoad);
@@ -182,8 +99,8 @@ function TimelinePage() {
       }
     },
     [
-      filter.yearFrom,
-      filter.yearTo,
+      yearFrom,
+      yearTo,
       q,
       location,
       tags,
@@ -194,15 +111,13 @@ function TimelinePage() {
       latitude,
       longitude,
       radiusKm,
+      hasImage,
     ],
   );
 
-  // Refetch from page 1 whenever the filter changes (or on mount). Skip while
-  // the user is mid-input (partial year, one-sided range) or the range is invalid.
   useEffect(() => {
-    if (filter.invalid || filter.skip) return;
     fetchPage(1, { append: false });
-  }, [fetchPage, filter.invalid, filter.skip]);
+  }, [fetchPage]);
 
   function handleLoadMore() {
     if (!hasNext || loading || loadingMore) return;
@@ -221,6 +136,8 @@ function TimelinePage() {
   );
 
   function handleFilterApply({
+    yearFrom: yf,
+    yearTo: yt,
     location: loc,
     latMin: lMin,
     latMax: lMax,
@@ -230,9 +147,12 @@ function TimelinePage() {
     longitude: lng,
     radiusKm: rKm,
     tags: tgs,
+    hasImage: hImg,
   }) {
     setFilters(
       {
+        year_from: yf,
+        year_to: yt,
         location: loc,
         lat_min: lMin ?? "",
         lat_max: lMax ?? "",
@@ -242,56 +162,55 @@ function TimelinePage() {
         longitude: lng ?? "",
         radius_km: rKm ?? "",
         tags: tgs,
+        has_image: hImg ? "true" : "",
       },
       { replace: true },
     );
   }
 
   function handleRemoveFilter(key) {
-    if (key === "location") {
+    if (key === "year_range") {
+      setFilters({ year_from: "", year_to: "" }, { replace: true });
+    } else if (key === "location") {
       setFilters(
         { location: "", lat_min: "", lat_max: "", lng_min: "", lng_max: "" },
         { replace: true },
       );
     } else if (key === "proximity") {
       setFilters({ latitude: "", longitude: "", radius_km: "" }, { replace: true });
+    } else if (key === "has_image") {
+      setFilters({ has_image: "" }, { replace: true });
     } else {
       removeFilter(key);
     }
   }
 
-  // Roving-tabindex bookkeeping for the WAI-ARIA radiogroup. Only the
-  // currently-checked option sits in the tab order; arrow keys both move
-  // focus and select the next option. Matches the authoring practice for
-  // role="radiogroup".
-  const modeRefs = useRef({});
-
-  function handleModeKeyDown(e, currentIndex) {
-    let nextIndex = null;
-    if (e.key === "ArrowRight" || e.key === "ArrowDown") {
-      nextIndex = (currentIndex + 1) % MODES.length;
-    } else if (e.key === "ArrowLeft" || e.key === "ArrowUp") {
-      nextIndex = (currentIndex - 1 + MODES.length) % MODES.length;
-    } else if (e.key === "Home") {
-      nextIndex = 0;
-    } else if (e.key === "End") {
-      nextIndex = MODES.length - 1;
-    } else {
-      return;
-    }
-    e.preventDefault();
-    const nextMode = MODES[nextIndex];
-    setMode(nextMode);
-    const el = modeRefs.current[nextMode];
-    if (el) el.focus();
-  }
-
-  const activeFilterCount = countActiveFilters({ location, hasProximity, tags });
+  const activeFilterCount = countActiveFilters({
+    yearFrom,
+    yearTo,
+    location,
+    hasProximity,
+    tags,
+    hasImage,
+  });
 
   const filterPanelKey = useMemo(
     () =>
-      `${location}-${latMin}-${latMax}-${lngMin}-${lngMax}-${latitude}-${longitude}-${radiusKm}-${tags.join(",")}`,
-    [location, latMin, latMax, lngMin, lngMax, latitude, longitude, radiusKm, tags],
+      `${yearFrom}-${yearTo}-${location}-${latMin}-${latMax}-${lngMin}-${lngMax}-${latitude}-${longitude}-${radiusKm}-${tags.join(",")}-${hasImage}`,
+    [
+      yearFrom,
+      yearTo,
+      location,
+      latMin,
+      latMax,
+      lngMin,
+      lngMax,
+      latitude,
+      longitude,
+      radiusKm,
+      tags,
+      hasImage,
+    ],
   );
 
   function renderContent() {
@@ -310,7 +229,7 @@ function TimelinePage() {
     if (count === 0) {
       return (
         <p className="py-12 text-center text-sm text-muted-foreground">
-          No stories found for this time window.
+          No stories found for these filters.
         </p>
       );
     }
@@ -347,6 +266,8 @@ function TimelinePage() {
             </div>
             <FilterPanel
               key={filterPanelKey}
+              yearFrom={yearFrom}
+              yearTo={yearTo}
               location={location}
               latMin={latMin}
               latMax={latMax}
@@ -356,123 +277,28 @@ function TimelinePage() {
               longitude={longitude}
               radiusKm={radiusKm}
               tags={tags}
+              hasImage={hasImage}
               onApply={handleFilterApply}
               activeCount={activeFilterCount}
-              hideYearRange
+              showHasImage
             />
           </div>
           <ActiveFilters
             q={q}
+            yearFrom={yearFrom}
+            yearTo={yearTo}
             location={location}
             radiusKm={radiusKm}
             hasProximity={hasProximity}
             tags={tags}
+            hasImage={hasImage}
             onRemove={handleRemoveFilter}
             onRemoveTag={removeTag}
             onClearAll={clearAll}
           />
         </div>
 
-        <Card className="mb-6">
-          <CardHeader className="pb-3">
-            <CardTitle className="text-base">Choose a time window</CardTitle>
-          </CardHeader>
-          <CardContent className="space-y-4">
-            <div role="radiogroup" aria-label="Time window mode" className="flex flex-wrap gap-2">
-              {MODES.map((m, i) => {
-                const isChecked = mode === m;
-                return (
-                  <button
-                    key={m}
-                    ref={(el) => { modeRefs.current[m] = el; }}
-                    type="button"
-                    role="radio"
-                    aria-checked={isChecked}
-                    tabIndex={isChecked ? 0 : -1}
-                    onClick={() => setMode(m)}
-                    onKeyDown={(e) => handleModeKeyDown(e, i)}
-                    className={cn(
-                      "rounded-full border px-4 py-1.5 text-sm font-medium transition-colors",
-                      isChecked
-                        ? "border-primary bg-primary text-primary-foreground"
-                        : "border-input bg-background text-foreground hover:bg-muted",
-                    )}
-                  >
-                    {MODE_LABELS[m]}
-                  </button>
-                );
-              })}
-            </div>
-
-            {mode === "year" && (
-              <div className="max-w-[160px] space-y-1.5">
-                <Label htmlFor="timeline-year">Year</Label>
-                <Input
-                  id="timeline-year"
-                  type="number"
-                  inputMode="numeric"
-                  placeholder="e.g. 1875"
-                  value={yearInput}
-                  onChange={(e) => setYearInput(e.target.value)}
-                />
-              </div>
-            )}
-
-            {mode === "decade" && (
-              <div className="max-w-[200px] space-y-1.5">
-                <Label htmlFor="timeline-decade">Decade (any year)</Label>
-                <Input
-                  id="timeline-decade"
-                  type="number"
-                  inputMode="numeric"
-                  placeholder="e.g. 1875"
-                  value={yearInput}
-                  onChange={(e) => setYearInput(e.target.value)}
-                />
-                <p className="text-xs text-muted-foreground">
-                  Snaps to the start of the decade.
-                </p>
-              </div>
-            )}
-
-            {mode === "range" && (
-              <div className="flex flex-wrap items-end gap-3">
-                <div className="space-y-1.5">
-                  <Label htmlFor="timeline-range-from">From</Label>
-                  <Input
-                    id="timeline-range-from"
-                    type="number"
-                    inputMode="numeric"
-                    placeholder="e.g. 1850"
-                    className="w-32"
-                    value={rangeFrom}
-                    onChange={(e) => setRangeFrom(e.target.value)}
-                  />
-                </div>
-                <div className="space-y-1.5">
-                  <Label htmlFor="timeline-range-to">To</Label>
-                  <Input
-                    id="timeline-range-to"
-                    type="number"
-                    inputMode="numeric"
-                    placeholder="e.g. 1900"
-                    className="w-32"
-                    value={rangeTo}
-                    onChange={(e) => setRangeTo(e.target.value)}
-                  />
-                </div>
-                {filter.invalid && (
-                  <p className="text-xs text-destructive">
-                    "From" must be less than or equal to "To".
-                  </p>
-                )}
-              </div>
-            )}
-          </CardContent>
-        </Card>
-
-        <div className="mb-4 flex items-center justify-between text-sm">
-          <span className="font-medium text-foreground">{filter.label}</span>
+        <div className="mb-4 flex items-center justify-end text-sm">
           {!loading && !error && (
             <span className="text-muted-foreground" aria-live="polite">
               {count} {count === 1 ? "story" : "stories"}

--- a/frontend/src/pages/TimelinePage.jsx
+++ b/frontend/src/pages/TimelinePage.jsx
@@ -288,6 +288,44 @@ function TimelinePage() {
 
   const activeFilterCount = countActiveFilters({ location, hasProximity, tags });
 
+  const filterPanelKey = useMemo(
+    () =>
+      `${location}-${latMin}-${latMax}-${lngMin}-${lngMax}-${latitude}-${longitude}-${radiusKm}-${tags.join(",")}`,
+    [location, latMin, latMax, lngMin, lngMax, latitude, longitude, radiusKm, tags],
+  );
+
+  function renderContent() {
+    if (error) return <ErrorState message={error} onRetry={handleRetry} />;
+    if (loading) {
+      return (
+        <div
+          className="flex justify-center py-16"
+          aria-busy="true"
+          aria-label="Loading timeline"
+        >
+          <LoadingSpinner />
+        </div>
+      );
+    }
+    if (count === 0) {
+      return (
+        <p className="py-12 text-center text-sm text-muted-foreground">
+          No stories found for this time window.
+        </p>
+      );
+    }
+    return (
+      <>
+        <TimelineView stories={stories} />
+        <div className="mt-8 flex justify-center">
+          <Button variant="outline" onClick={handleLoadMore} disabled={!hasNext || loadingMore}>
+            {loadingMore ? "Loading…" : hasNext ? "Load more" : "No more stories"}
+          </Button>
+        </div>
+      </>
+    );
+  }
+
   return (
     <main className="min-h-screen bg-background">
       <div className="mx-auto max-w-3xl px-4 py-8 sm:px-6 lg:px-8">
@@ -298,7 +336,6 @@ function TimelinePage() {
           </p>
         </div>
 
-        {/* Search + filters */}
         <div className="mb-6 space-y-2">
           <div className="flex items-center gap-2">
             <div className="min-w-0 flex-1">
@@ -309,7 +346,7 @@ function TimelinePage() {
               />
             </div>
             <FilterPanel
-              key={`${location}-${latMin}-${latMax}-${lngMin}-${lngMax}-${latitude}-${longitude}-${radiusKm}-${tags.join(",")}`}
+              key={filterPanelKey}
               location={location}
               latMin={latMin}
               latMax={latMax}
@@ -336,7 +373,6 @@ function TimelinePage() {
           />
         </div>
 
-        {/* Time-window selector */}
         <Card className="mb-6">
           <CardHeader className="pb-3">
             <CardTitle className="text-base">Choose a time window</CardTitle>
@@ -435,7 +471,6 @@ function TimelinePage() {
           </CardContent>
         </Card>
 
-        {/* Status row */}
         <div className="mb-4 flex items-center justify-between text-sm">
           <span className="font-medium text-foreground">{filter.label}</span>
           {!loading && !error && (
@@ -445,35 +480,7 @@ function TimelinePage() {
           )}
         </div>
 
-        {/* Content */}
-        {error ? (
-          <ErrorState message={error} onRetry={handleRetry} />
-        ) : loading ? (
-          <div
-            className="flex justify-center py-16"
-            aria-busy="true"
-            aria-label="Loading timeline"
-          >
-            <LoadingSpinner />
-          </div>
-        ) : count === 0 ? (
-          <p className="py-12 text-center text-sm text-muted-foreground">
-            No stories found for this time window.
-          </p>
-        ) : (
-          <>
-            <TimelineView stories={stories} />
-            <div className="mt-8 flex justify-center">
-              <Button
-                variant="outline"
-                onClick={handleLoadMore}
-                disabled={!hasNext || loadingMore}
-              >
-                {loadingMore ? "Loading…" : hasNext ? "Load more" : "No more stories"}
-              </Button>
-            </div>
-          </>
-        )}
+        {renderContent()}
       </div>
     </main>
   );

--- a/frontend/src/pages/__tests__/TimelinePage.test.jsx
+++ b/frontend/src/pages/__tests__/TimelinePage.test.jsx
@@ -48,84 +48,124 @@ describe("TimelinePage", () => {
 
   it("renders the Timeline heading", async () => {
     renderPage();
-
     expect(
       screen.getByRole("heading", { name: /^timeline$/i, level: 1 }),
     ).toBeInTheDocument();
   });
 
-  it("renders the four filter pills as a radiogroup", async () => {
+  it("does not render the legacy 'Choose a time window' card or mode radiogroup (sezindogan review)", async () => {
     renderPage();
-
+    expect(screen.queryByText(/choose a time window/i)).not.toBeInTheDocument();
     expect(
-      screen.getByRole("radiogroup", { name: /time window mode/i }),
-    ).toBeInTheDocument();
-    expect(screen.getByRole("radio", { name: /^all$/i })).toBeInTheDocument();
-    expect(screen.getByRole("radio", { name: /^year$/i })).toBeInTheDocument();
-    expect(screen.getByRole("radio", { name: /^range$/i })).toBeInTheDocument();
-    expect(screen.getByRole("radio", { name: /^decade$/i })).toBeInTheDocument();
+      screen.queryByRole("radiogroup", { name: /time window mode/i }),
+    ).not.toBeInTheDocument();
   });
 
-  it("fetches with no year params on first render (default All)", async () => {
+  it("renders the shared SearchBar + Filters button + ActiveFilters pattern", async () => {
     renderPage();
-
-    await waitFor(() => {
-      expect(getTimeline).toHaveBeenCalled();
-    });
-
-    const firstCallArgs = getTimeline.mock.calls[0][0];
-    expect(firstCallArgs.yearFrom).toBeUndefined();
-    expect(firstCallArgs.yearTo).toBeUndefined();
-    expect(firstCallArgs.page).toBe(1);
+    expect(screen.getByPlaceholderText(/search by title or place/i)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /^filters$/i })).toBeInTheDocument();
   });
 
-  it("switches to Year + entering 1875 fetches with year_from=year_to=1875", async () => {
-    const user = userEvent.setup();
+  it("fetches with no year params on first render (no URL filters)", async () => {
     renderPage();
-
     await waitFor(() => expect(getTimeline).toHaveBeenCalled());
 
-    await user.click(screen.getByRole("radio", { name: /^year$/i }));
-    const yearInput = await screen.findByLabelText(/^year$/i);
-    await user.clear(yearInput);
-    await user.type(yearInput, "1875");
+    const args = getTimeline.mock.calls[0][0];
+    expect(args.yearFrom).toBeUndefined();
+    expect(args.yearTo).toBeUndefined();
+    expect(args.page).toBe(1);
+  });
+
+  it("seeds year_from / year_to from the URL and forwards them to getTimeline", async () => {
+    renderPage(["/timeline?year_from=1850&year_to=1900"]);
+    await waitFor(() => expect(getTimeline).toHaveBeenCalled());
+
+    const args = getTimeline.mock.calls[0][0];
+    expect(args.yearFrom).toBe(1850);
+    expect(args.yearTo).toBe(1900);
+  });
+
+  it("forwards has_image=true from the URL", async () => {
+    renderPage(["/timeline?has_image=true"]);
+    await waitFor(() => expect(getTimeline).toHaveBeenCalled());
+    expect(getTimeline.mock.calls[0][0].hasImage).toBe(true);
+  });
+
+  it("forwards q from the URL on mount and reacts to typed input (debounced)", async () => {
+    const user = userEvent.setup();
+    renderPage(["/timeline?q=hagia"]);
+    await waitFor(() => expect(getTimeline).toHaveBeenCalled());
+    expect(getTimeline.mock.calls[0][0].q).toBe("hagia");
+
+    await user.clear(screen.getByPlaceholderText(/search by title or place/i));
+    await user.type(screen.getByPlaceholderText(/search by title or place/i), "galata");
 
     await waitFor(() => {
-      const calls = getTimeline.mock.calls;
-      const matched = calls.some(
-        ([arg]) => arg?.yearFrom === 1875 && arg?.yearTo === 1875,
-      );
+      const matched = getTimeline.mock.calls.some(([a]) => a?.q === "galata");
       expect(matched).toBe(true);
     });
   });
 
-  it("Decade with 1875 fetches with year_from=1870 and year_to=1879", async () => {
-    const user = userEvent.setup();
-    renderPage();
+  it("forwards URL filters (location, tags, proximity) to getTimeline", async () => {
+    renderPage([
+      "/timeline?location=Galata&tags=ottoman,mosque&latitude=41&longitude=29&radius_km=1",
+    ]);
+    await waitFor(() => expect(getTimeline).toHaveBeenCalled());
+    const args = getTimeline.mock.calls[0][0];
+    expect(args.location).toBe("Galata");
+    expect(args.tags).toEqual(["ottoman", "mosque"]);
+    expect(args.latitude).toBe(41);
+    expect(args.longitude).toBe(29);
+    expect(args.radiusKm).toBe(1);
+  });
 
+  it("renders dismissible chips for q / year_range / location / tags / has_image", async () => {
+    renderPage([
+      "/timeline?q=war&year_from=1850&year_to=1900&location=Galata&tags=ottoman&has_image=true",
+    ]);
     await waitFor(() => expect(getTimeline).toHaveBeenCalled());
 
-    await user.click(screen.getByRole("radio", { name: /^decade$/i }));
-    const decadeInput = await screen.findByLabelText(/decade/i);
-    await user.clear(decadeInput);
-    await user.type(decadeInput, "1875");
+    expect(screen.getByLabelText(/active filters/i)).toBeInTheDocument();
+    expect(screen.getByText('"war"')).toBeInTheDocument();
+    expect(screen.getByText("1850–1900")).toBeInTheDocument();
+    expect(screen.getByText(/location: galata/i)).toBeInTheDocument();
+    expect(screen.getByText("ottoman")).toBeInTheDocument();
+    expect(screen.getByText(/^has image$/i)).toBeInTheDocument();
+  });
+
+  it("removing the year-range chip clears year_from / year_to and refetches", async () => {
+    const user = userEvent.setup();
+    renderPage(["/timeline?year_from=1850&year_to=1900"]);
+    await waitFor(() => expect(getTimeline).toHaveBeenCalled());
+
+    await user.click(screen.getByRole("button", { name: /remove filter:.*1850/i }));
 
     await waitFor(() => {
-      const matched = getTimeline.mock.calls.some(
-        ([arg]) => arg?.yearFrom === 1870 && arg?.yearTo === 1879,
-      );
-      expect(matched).toBe(true);
+      const last = getTimeline.mock.calls[getTimeline.mock.calls.length - 1][0];
+      expect(last.yearFrom).toBeUndefined();
+      expect(last.yearTo).toBeUndefined();
+    });
+  });
+
+  it("removing the Has-image chip clears has_image", async () => {
+    const user = userEvent.setup();
+    renderPage(["/timeline?has_image=true"]);
+    await waitFor(() => expect(getTimeline).toHaveBeenCalled());
+
+    await user.click(screen.getByRole("button", { name: /remove filter: has image/i }));
+
+    await waitFor(() => {
+      const last = getTimeline.mock.calls[getTimeline.mock.calls.length - 1][0];
+      expect(last.hasImage).toBe(false);
     });
   });
 
   it("shows empty state when count is 0", async () => {
     getTimeline.mockResolvedValue(makeResponse({ count: 0, results: [] }));
     renderPage();
-
     await waitFor(() => {
-      expect(
-        screen.getByText(/no stories found for this time window/i),
-      ).toBeInTheDocument();
+      expect(screen.getByText(/no stories found for these filters/i)).toBeInTheDocument();
     });
   });
 
@@ -134,7 +174,6 @@ describe("TimelinePage", () => {
       makeResponse({ count: 3, results: [makeStory(1), makeStory(2), makeStory(3)] }),
     );
     renderPage();
-
     await waitFor(() => {
       expect(screen.getByText(/3 stories/i)).toBeInTheDocument();
     });
@@ -162,213 +201,26 @@ describe("TimelinePage", () => {
 
     await waitFor(() => {
       expect(screen.getByText("Story 1")).toBeInTheDocument();
-      expect(screen.getByText("Story 2")).toBeInTheDocument();
     });
 
     await user.click(screen.getByRole("button", { name: /load more/i }));
 
     await waitFor(() => {
       expect(screen.getByText("Story 3")).toBeInTheDocument();
-      expect(screen.getByText("Story 4")).toBeInTheDocument();
     });
-    // Previously-loaded stories should remain visible
     expect(screen.getByText("Story 1")).toBeInTheDocument();
 
     const lastArgs = getTimeline.mock.calls[getTimeline.mock.calls.length - 1][0];
     expect(lastArgs.page).toBe(2);
   });
 
-  it("does not fire requests for partial year input (less than 4 digits)", async () => {
-    const user = userEvent.setup();
-    renderPage();
-
-    await waitFor(() => expect(getTimeline).toHaveBeenCalled());
-    const callsBefore = getTimeline.mock.calls.length;
-
-    await user.click(screen.getByRole("radio", { name: /^year$/i }));
-    const yearInput = await screen.findByLabelText(/^year$/i);
-    await user.type(yearInput, "187");
-
-    // No additional calls should be made for partial years (1, 18, 187).
-    // Only the initial mount call should exist.
-    expect(getTimeline.mock.calls.length).toBe(callsBefore);
-  });
-
-  it("does not fire a request when range mode has only one side filled", async () => {
-    const user = userEvent.setup();
-    renderPage();
-
-    await waitFor(() => expect(getTimeline).toHaveBeenCalled());
-    const callsBefore = getTimeline.mock.calls.length;
-
-    await user.click(screen.getByRole("radio", { name: /^range$/i }));
-    const fromInput = await screen.findByLabelText(/^from$/i);
-    await user.type(fromInput, "1850");
-
-    // Only "From" is filled — no fetch should fire yet.
-    expect(getTimeline.mock.calls.length).toBe(callsBefore);
-    expect(screen.getByText(/enter start and end years/i)).toBeInTheDocument();
-  });
-
-  it("fires a range request when both sides are filled with 4-digit years", async () => {
-    const user = userEvent.setup();
-    renderPage();
-
-    await waitFor(() => expect(getTimeline).toHaveBeenCalled());
-
-    await user.click(screen.getByRole("radio", { name: /^range$/i }));
-    await user.type(await screen.findByLabelText(/^from$/i), "1850");
-    await user.type(await screen.findByLabelText(/^to$/i), "1900");
-
-    await waitFor(() => {
-      const matched = getTimeline.mock.calls.some(
-        ([arg]) => arg?.yearFrom === 1850 && arg?.yearTo === 1900,
-      );
-      expect(matched).toBe(true);
-    });
-  });
-
   it("passes bbox query string params through to the service", async () => {
-    renderPage([
-      "/timeline?lat_min=40&lat_max=41&lng_min=28&lng_max=29",
-    ]);
-
-    await waitFor(() => {
-      expect(getTimeline).toHaveBeenCalled();
-    });
-
+    renderPage(["/timeline?lat_min=40&lat_max=41&lng_min=28&lng_max=29"]);
+    await waitFor(() => expect(getTimeline).toHaveBeenCalled());
     const args = getTimeline.mock.calls[0][0];
     expect(args.latMin).toBe(40);
     expect(args.latMax).toBe(41);
     expect(args.lngMin).toBe(28);
     expect(args.lngMax).toBe(29);
-  });
-
-  describe("search bar (q)", () => {
-    it("renders the search input with mobile-parity placeholder", () => {
-      renderPage();
-      expect(screen.getByPlaceholderText(/search by title or place/i)).toBeInTheDocument();
-    });
-
-    it("forwards a typed query to getTimeline (debounced)", async () => {
-      const user = userEvent.setup();
-      renderPage();
-      await waitFor(() => expect(getTimeline).toHaveBeenCalled());
-
-      await user.type(screen.getByPlaceholderText(/search by title or place/i), "Galata");
-
-      await waitFor(() => {
-        const matched = getTimeline.mock.calls.some(([arg]) => arg?.q === "Galata");
-        expect(matched).toBe(true);
-      });
-    });
-
-    it("seeds the search bar with q from the URL on mount", async () => {
-      renderPage(["/timeline?q=Hagia"]);
-      await waitFor(() => expect(getTimeline).toHaveBeenCalled());
-      const firstArg = getTimeline.mock.calls[0][0];
-      expect(firstArg.q).toBe("Hagia");
-    });
-  });
-
-  describe("URL filter passthrough", () => {
-    it("forwards location/tags/proximity from the URL to getTimeline", async () => {
-      renderPage([
-        "/timeline?location=Galata&tags=ottoman,mosque&latitude=41&longitude=29&radius_km=1",
-      ]);
-      await waitFor(() => expect(getTimeline).toHaveBeenCalled());
-      const firstArg = getTimeline.mock.calls[0][0];
-      expect(firstArg.location).toBe("Galata");
-      expect(firstArg.tags).toEqual(["ottoman", "mosque"]);
-      expect(firstArg.latitude).toBe(41);
-      expect(firstArg.longitude).toBe(29);
-      expect(firstArg.radiusKm).toBe(1);
-    });
-  });
-
-  describe("active filter chips", () => {
-    it("renders chips for q / location / tags / proximity", async () => {
-      renderPage([
-        "/timeline?q=war&location=Galata&tags=ottoman&latitude=41&longitude=29&radius_km=1",
-      ]);
-      await waitFor(() => expect(getTimeline).toHaveBeenCalled());
-      expect(screen.getByLabelText(/active filters/i)).toBeInTheDocument();
-      expect(screen.getByText('"war"')).toBeInTheDocument();
-      expect(screen.getByText(/location: galata/i)).toBeInTheDocument();
-      expect(screen.getByText("ottoman")).toBeInTheDocument();
-      expect(screen.getByText(/within 1 km/i)).toBeInTheDocument();
-    });
-
-    it("removing a tag chip refetches without that tag", async () => {
-      const user = userEvent.setup();
-      renderPage(["/timeline?tags=ottoman,mosque"]);
-      await waitFor(() => expect(getTimeline).toHaveBeenCalled());
-
-      await user.click(screen.getByRole("button", { name: /remove tag filter: ottoman/i }));
-
-      await waitFor(() => {
-        const last = getTimeline.mock.calls[getTimeline.mock.calls.length - 1][0];
-        expect(last.tags).toEqual(["mosque"]);
-      });
-    });
-  });
-
-  describe("radiogroup roving tabindex (a11y)", () => {
-    it("only the checked radio is in the tab order on mount (default: All)", () => {
-      renderPage();
-      const all = screen.getByRole("radio", { name: /^all$/i });
-      const year = screen.getByRole("radio", { name: /^year$/i });
-      const range = screen.getByRole("radio", { name: /^range$/i });
-      const decade = screen.getByRole("radio", { name: /^decade$/i });
-      expect(all).toHaveAttribute("tabindex", "0");
-      expect(year).toHaveAttribute("tabindex", "-1");
-      expect(range).toHaveAttribute("tabindex", "-1");
-      expect(decade).toHaveAttribute("tabindex", "-1");
-    });
-
-    it("ArrowRight from All moves focus to and selects Year", async () => {
-      const user = userEvent.setup();
-      renderPage();
-      const all = screen.getByRole("radio", { name: /^all$/i });
-      all.focus();
-      await user.keyboard("{ArrowRight}");
-
-      const year = screen.getByRole("radio", { name: /^year$/i });
-      expect(year).toHaveAttribute("aria-checked", "true");
-      expect(year).toHaveAttribute("tabindex", "0");
-      expect(all).toHaveAttribute("tabindex", "-1");
-      expect(year).toHaveFocus();
-    });
-
-    it("ArrowLeft from All wraps around to Decade", async () => {
-      const user = userEvent.setup();
-      renderPage();
-      const all = screen.getByRole("radio", { name: /^all$/i });
-      all.focus();
-      await user.keyboard("{ArrowLeft}");
-
-      const decade = screen.getByRole("radio", { name: /^decade$/i });
-      expect(decade).toHaveAttribute("aria-checked", "true");
-      expect(decade).toHaveFocus();
-    });
-
-    it("Home / End jump to first / last", async () => {
-      const user = userEvent.setup();
-      renderPage();
-      const range = screen.getByRole("radio", { name: /^range$/i });
-      // Click range first so we have somewhere to jump from.
-      await user.click(range);
-      range.focus();
-      await user.keyboard("{Home}");
-      expect(screen.getByRole("radio", { name: /^all$/i })).toHaveAttribute("aria-checked", "true");
-
-      const all = screen.getByRole("radio", { name: /^all$/i });
-      all.focus();
-      await user.keyboard("{End}");
-      expect(screen.getByRole("radio", { name: /^decade$/i })).toHaveAttribute(
-        "aria-checked",
-        "true",
-      );
-    });
   });
 });

--- a/frontend/src/pages/__tests__/TimelinePage.test.jsx
+++ b/frontend/src/pages/__tests__/TimelinePage.test.jsx
@@ -243,4 +243,132 @@ describe("TimelinePage", () => {
     expect(args.lngMin).toBe(28);
     expect(args.lngMax).toBe(29);
   });
+
+  describe("search bar (q)", () => {
+    it("renders the search input with mobile-parity placeholder", () => {
+      renderPage();
+      expect(screen.getByPlaceholderText(/search by title or place/i)).toBeInTheDocument();
+    });
+
+    it("forwards a typed query to getTimeline (debounced)", async () => {
+      const user = userEvent.setup();
+      renderPage();
+      await waitFor(() => expect(getTimeline).toHaveBeenCalled());
+
+      await user.type(screen.getByPlaceholderText(/search by title or place/i), "Galata");
+
+      await waitFor(() => {
+        const matched = getTimeline.mock.calls.some(([arg]) => arg?.q === "Galata");
+        expect(matched).toBe(true);
+      });
+    });
+
+    it("seeds the search bar with q from the URL on mount", async () => {
+      renderPage(["/timeline?q=Hagia"]);
+      await waitFor(() => expect(getTimeline).toHaveBeenCalled());
+      const firstArg = getTimeline.mock.calls[0][0];
+      expect(firstArg.q).toBe("Hagia");
+    });
+  });
+
+  describe("URL filter passthrough", () => {
+    it("forwards location/tags/proximity from the URL to getTimeline", async () => {
+      renderPage([
+        "/timeline?location=Galata&tags=ottoman,mosque&latitude=41&longitude=29&radius_km=1",
+      ]);
+      await waitFor(() => expect(getTimeline).toHaveBeenCalled());
+      const firstArg = getTimeline.mock.calls[0][0];
+      expect(firstArg.location).toBe("Galata");
+      expect(firstArg.tags).toEqual(["ottoman", "mosque"]);
+      expect(firstArg.latitude).toBe(41);
+      expect(firstArg.longitude).toBe(29);
+      expect(firstArg.radiusKm).toBe(1);
+    });
+  });
+
+  describe("active filter chips", () => {
+    it("renders chips for q / location / tags / proximity", async () => {
+      renderPage([
+        "/timeline?q=war&location=Galata&tags=ottoman&latitude=41&longitude=29&radius_km=1",
+      ]);
+      await waitFor(() => expect(getTimeline).toHaveBeenCalled());
+      expect(screen.getByLabelText(/active filters/i)).toBeInTheDocument();
+      expect(screen.getByText('"war"')).toBeInTheDocument();
+      expect(screen.getByText(/location: galata/i)).toBeInTheDocument();
+      expect(screen.getByText("ottoman")).toBeInTheDocument();
+      expect(screen.getByText(/within 1 km/i)).toBeInTheDocument();
+    });
+
+    it("removing a tag chip refetches without that tag", async () => {
+      const user = userEvent.setup();
+      renderPage(["/timeline?tags=ottoman,mosque"]);
+      await waitFor(() => expect(getTimeline).toHaveBeenCalled());
+
+      await user.click(screen.getByRole("button", { name: /remove tag filter: ottoman/i }));
+
+      await waitFor(() => {
+        const last = getTimeline.mock.calls[getTimeline.mock.calls.length - 1][0];
+        expect(last.tags).toEqual(["mosque"]);
+      });
+    });
+  });
+
+  describe("radiogroup roving tabindex (a11y)", () => {
+    it("only the checked radio is in the tab order on mount (default: All)", () => {
+      renderPage();
+      const all = screen.getByRole("radio", { name: /^all$/i });
+      const year = screen.getByRole("radio", { name: /^year$/i });
+      const range = screen.getByRole("radio", { name: /^range$/i });
+      const decade = screen.getByRole("radio", { name: /^decade$/i });
+      expect(all).toHaveAttribute("tabindex", "0");
+      expect(year).toHaveAttribute("tabindex", "-1");
+      expect(range).toHaveAttribute("tabindex", "-1");
+      expect(decade).toHaveAttribute("tabindex", "-1");
+    });
+
+    it("ArrowRight from All moves focus to and selects Year", async () => {
+      const user = userEvent.setup();
+      renderPage();
+      const all = screen.getByRole("radio", { name: /^all$/i });
+      all.focus();
+      await user.keyboard("{ArrowRight}");
+
+      const year = screen.getByRole("radio", { name: /^year$/i });
+      expect(year).toHaveAttribute("aria-checked", "true");
+      expect(year).toHaveAttribute("tabindex", "0");
+      expect(all).toHaveAttribute("tabindex", "-1");
+      expect(year).toHaveFocus();
+    });
+
+    it("ArrowLeft from All wraps around to Decade", async () => {
+      const user = userEvent.setup();
+      renderPage();
+      const all = screen.getByRole("radio", { name: /^all$/i });
+      all.focus();
+      await user.keyboard("{ArrowLeft}");
+
+      const decade = screen.getByRole("radio", { name: /^decade$/i });
+      expect(decade).toHaveAttribute("aria-checked", "true");
+      expect(decade).toHaveFocus();
+    });
+
+    it("Home / End jump to first / last", async () => {
+      const user = userEvent.setup();
+      renderPage();
+      const range = screen.getByRole("radio", { name: /^range$/i });
+      // Click range first so we have somewhere to jump from.
+      await user.click(range);
+      range.focus();
+      await user.keyboard("{Home}");
+      expect(screen.getByRole("radio", { name: /^all$/i })).toHaveAttribute("aria-checked", "true");
+
+      const all = screen.getByRole("radio", { name: /^all$/i });
+      all.focus();
+      await user.keyboard("{End}");
+      expect(screen.getByRole("radio", { name: /^decade$/i })).toHaveAttribute(
+        "aria-checked",
+        "true",
+      );
+    });
+  });
 });

--- a/frontend/src/services/__tests__/timelineService.test.js
+++ b/frontend/src/services/__tests__/timelineService.test.js
@@ -100,6 +100,32 @@ describe("timelineService", () => {
     await expect(getTimeline()).rejects.toThrow("Network error");
   });
 
+  describe("has_image filter", () => {
+    it("forwards has_image=true to /stories/timeline/ on the primary path", async () => {
+      api.get.mockResolvedValue({ data: { count: 0, next: null, previous: null, results: [] } });
+      await getTimeline({ hasImage: true });
+      expect(api.get).toHaveBeenCalledWith(
+        "/stories/timeline/",
+        expect.objectContaining({ params: expect.objectContaining({ has_image: true }) }),
+      );
+    });
+
+    it("omits has_image when the toggle is false (no filter)", async () => {
+      api.get.mockResolvedValue({ data: { count: 0, next: null, previous: null, results: [] } });
+      await getTimeline({ hasImage: false });
+      const params = api.get.mock.calls[0][1].params;
+      expect(params).not.toHaveProperty("has_image");
+    });
+
+    it("does NOT forward has_image to the fallback endpoint (search/feed reject it)", async () => {
+      api.get.mockResolvedValue({ data: { count: 0, next: null, previous: null, results: [] } });
+      // q triggers the fallback path; has_image must not leak through.
+      await getTimeline({ q: "galata", hasImage: true });
+      const params = api.get.mock.calls[0][1].params;
+      expect(params).not.toHaveProperty("has_image");
+    });
+  });
+
   describe("fallback path (filters not supported by /stories/timeline/)", () => {
     it("routes to /stories/search/ when q is set, sorted by historical year", async () => {
       api.get.mockResolvedValue({
@@ -212,6 +238,33 @@ describe("timelineService", () => {
       const page3 = await getTimeline({ q: "x", page: 3, pageSize: 10 });
       expect(page3.results).toHaveLength(5);
       expect(page3.next).toBeNull();
+    });
+
+    it("requests at most page_size=100 from the fallback endpoint (documenting the cap)", async () => {
+      api.get.mockResolvedValue({
+        data: { count: 0, next: null, previous: null, results: [] },
+      });
+
+      await getTimeline({ q: "x", page: 1, pageSize: 10 });
+
+      const params = api.get.mock.calls[0][1].params;
+      // The fallback always asks for the cap regardless of the caller's
+      // requested pageSize — the slice happens client-side. Stories beyond
+      // the 100th in the underlying endpoint's order are not reachable.
+      expect(params.page_size).toBe(100);
+    });
+
+    it("count reflects only stories within the fallback fetch window (cap is observable)", async () => {
+      // Simulate a corpus where the underlying endpoint has 100 results to
+      // hand back (max page size). The timeline view's `count` will read 100,
+      // not the true backend count of any larger result set.
+      const stories = Array.from({ length: 100 }, (_, i) => story({ id: `s${i}`, year: 1900 + i }));
+      api.get.mockResolvedValue({
+        data: { count: 999, next: "url-to-page-2", previous: null, results: stories },
+      });
+
+      const result = await getTimeline({ q: "x", page: 1, pageSize: 10 });
+      expect(result.count).toBe(100);
     });
   });
 

--- a/frontend/src/services/__tests__/timelineService.test.js
+++ b/frontend/src/services/__tests__/timelineService.test.js
@@ -7,7 +7,20 @@ vi.mock("../api", () => ({
 }));
 
 import api from "../api";
-import { getTimeline } from "../timelineService";
+import { getTimeline, getTimelineHistoricalYear } from "../timelineService";
+
+function story(overrides = {}) {
+  return {
+    id: overrides.id ?? "s",
+    title: overrides.title ?? "Story",
+    time_type: "exact_year",
+    year: null,
+    year_start: null,
+    year_end: null,
+    date_value: null,
+    ...overrides,
+  };
+}
 
 describe("timelineService", () => {
   beforeEach(() => {
@@ -81,5 +94,149 @@ describe("timelineService", () => {
     api.get.mockRejectedValue(new Error("Network error"));
 
     await expect(getTimeline()).rejects.toThrow("Network error");
+  });
+
+  describe("fallback path (filters not supported by /stories/timeline/)", () => {
+    it("routes to /stories/search/ when q is set, sorted by historical year", async () => {
+      api.get.mockResolvedValue({
+        data: {
+          count: 3,
+          next: null,
+          previous: null,
+          results: [
+            story({ id: "later", year: 2000 }),
+            story({ id: "earlier", year: 1900 }),
+            story({ id: "middle", year: 1950 }),
+          ],
+        },
+      });
+
+      const result = await getTimeline({ q: "Galata", page: 1, pageSize: 10 });
+
+      expect(api.get).toHaveBeenCalledWith(
+        "/stories/search/",
+        expect.objectContaining({ params: expect.objectContaining({ q: "Galata" }) }),
+      );
+      expect(result.results.map((s) => s.id)).toEqual(["earlier", "middle", "later"]);
+      expect(result.count).toBe(3);
+    });
+
+    it("routes to /stories/feed/ when only tags are set, and forwards them", async () => {
+      api.get.mockResolvedValue({
+        data: { count: 0, next: null, previous: null, results: [] },
+      });
+
+      await getTimeline({ tags: ["mosque", "ottoman"], page: 1, pageSize: 10 });
+
+      expect(api.get).toHaveBeenCalledWith(
+        "/stories/feed/",
+        expect.objectContaining({
+          params: expect.objectContaining({
+            sort_by: "recent",
+            tags: ["mosque", "ottoman"],
+          }),
+        }),
+      );
+    });
+
+    it("routes to /stories/feed/ when proximity is set, and forwards lat/lng/radius", async () => {
+      api.get.mockResolvedValue({
+        data: { count: 0, next: null, previous: null, results: [] },
+      });
+
+      await getTimeline({ latitude: 41, longitude: 29, radiusKm: 1, page: 1, pageSize: 10 });
+
+      expect(api.get).toHaveBeenCalledWith(
+        "/stories/feed/",
+        expect.objectContaining({
+          params: expect.objectContaining({ latitude: 41, longitude: 29, radius_km: 1 }),
+        }),
+      );
+    });
+
+    it("falls back when location text is set without a bbox", async () => {
+      api.get.mockResolvedValue({
+        data: { count: 0, next: null, previous: null, results: [] },
+      });
+
+      await getTimeline({ location: "Galata", page: 1, pageSize: 10 });
+
+      expect(api.get).toHaveBeenCalledWith(
+        "/stories/feed/",
+        expect.objectContaining({ params: expect.objectContaining({ location: "Galata" }) }),
+      );
+    });
+
+    it("does NOT fall back when location string has a matching bbox", async () => {
+      api.get.mockResolvedValue({
+        data: { count: 0, next: null, previous: null, results: [] },
+      });
+
+      await getTimeline({
+        location: "Galata",
+        latMin: 41.02,
+        latMax: 41.03,
+        lngMin: 28.97,
+        lngMax: 28.98,
+      });
+
+      expect(api.get).toHaveBeenCalledWith(
+        "/stories/timeline/",
+        expect.objectContaining({
+          params: expect.objectContaining({ lat_min: 41.02 }),
+        }),
+      );
+    });
+
+    it("client-paginates the fallback results", async () => {
+      const all = [];
+      for (let i = 0; i < 25; i++) {
+        all.push(story({ id: `s${i}`, year: 1900 + i }));
+      }
+      api.get.mockResolvedValue({
+        data: { count: 25, next: null, previous: null, results: all },
+      });
+
+      const page2 = await getTimeline({ q: "x", page: 2, pageSize: 10 });
+
+      expect(page2.count).toBe(25);
+      expect(page2.results).toHaveLength(10);
+      expect(page2.results[0].id).toBe("s10");
+      expect(page2.next).toBe("client-next-page");
+      expect(page2.previous).toBe("client-previous-page");
+
+      const page3 = await getTimeline({ q: "x", page: 3, pageSize: 10 });
+      expect(page3.results).toHaveLength(5);
+      expect(page3.next).toBeNull();
+    });
+  });
+
+  describe("getTimelineHistoricalYear", () => {
+    it("returns year for exact_year stories", () => {
+      expect(getTimelineHistoricalYear(story({ time_type: "exact_year", year: 1875 }))).toBe(1875);
+    });
+
+    it("returns midpoint for year_range stories", () => {
+      expect(
+        getTimelineHistoricalYear(story({ time_type: "year_range", year_start: 1850, year_end: 1900 })),
+      ).toBe(1875);
+    });
+
+    it("returns year + 5 for decade stories", () => {
+      expect(getTimelineHistoricalYear(story({ time_type: "decade", year: 1870 }))).toBe(1875);
+    });
+
+    it("extracts the year from exact_date stories", () => {
+      expect(
+        getTimelineHistoricalYear(story({ time_type: "exact_date", date_value: "1923-10-29" })),
+      ).toBe(1923);
+    });
+
+    it("returns MAX_SAFE_INTEGER for stories with no usable time info (so they sink)", () => {
+      expect(getTimelineHistoricalYear(story({ time_type: "exact_year", year: null }))).toBe(
+        Number.MAX_SAFE_INTEGER,
+      );
+      expect(getTimelineHistoricalYear(null)).toBe(Number.MAX_SAFE_INTEGER);
+    });
   });
 });

--- a/frontend/src/services/__tests__/timelineService.test.js
+++ b/frontend/src/services/__tests__/timelineService.test.js
@@ -7,7 +7,11 @@ vi.mock("../api", () => ({
 }));
 
 import api from "../api";
-import { getTimeline, getTimelineHistoricalYear } from "../timelineService";
+import {
+  getTimeline,
+  getTimelineHistoricalYear,
+  storyOverlapsYearWindow,
+} from "../timelineService";
 
 function story(overrides = {}) {
   return {
@@ -208,6 +212,133 @@ describe("timelineService", () => {
       const page3 = await getTimeline({ q: "x", page: 3, pageSize: 10 });
       expect(page3.results).toHaveLength(5);
       expect(page3.next).toBeNull();
+    });
+  });
+
+  describe("fallback path year semantics (matches /stories/timeline/ behaviour)", () => {
+    it("does NOT forward year_from/year_to to the fallback endpoint", async () => {
+      api.get.mockResolvedValue({
+        data: { count: 0, next: null, previous: null, results: [] },
+      });
+
+      await getTimeline({ q: "Galata", yearFrom: 1870, yearTo: 1880, page: 1, pageSize: 10 });
+
+      // Feed/search use simpler year semantics; we filter client-side instead.
+      const calledWith = api.get.mock.calls[0][1];
+      expect(calledWith.params).not.toHaveProperty("year_from");
+      expect(calledWith.params).not.toHaveProperty("year_to");
+    });
+
+    it("includes a decade story whose interval overlaps the year window (semantic parity with /stories/timeline/)", async () => {
+      api.get.mockResolvedValue({
+        data: {
+          count: 1,
+          next: null,
+          previous: null,
+          results: [
+            // Decade 1870 = represents 1870-1879. /stories/feed/ would have
+            // dropped it for year_from=1875 because year (1870) < 1875. But
+            // /stories/timeline/ includes it via interval overlap. After this
+            // fix, the fallback path also includes it.
+            story({ id: "d", time_type: "decade", year: 1870 }),
+          ],
+        },
+      });
+
+      const result = await getTimeline({ q: "x", yearFrom: 1875, yearTo: 1885, page: 1, pageSize: 10 });
+      expect(result.results.map((s) => s.id)).toEqual(["d"]);
+    });
+
+    it("includes an exact_date story whose year falls in the window", async () => {
+      api.get.mockResolvedValue({
+        data: {
+          count: 1,
+          next: null,
+          previous: null,
+          results: [
+            // /stories/feed/ would drop this — year is null on exact_date —
+            // but /stories/timeline/ matches via date_value__year. Parity.
+            story({ id: "ed", time_type: "exact_date", date_value: "1923-10-29" }),
+          ],
+        },
+      });
+
+      const result = await getTimeline({ q: "x", yearFrom: 1920, yearTo: 1925, page: 1, pageSize: 10 });
+      expect(result.results.map((s) => s.id)).toEqual(["ed"]);
+    });
+
+    it("excludes stories whose interval falls outside the year window", async () => {
+      api.get.mockResolvedValue({
+        data: {
+          count: 3,
+          next: null,
+          previous: null,
+          results: [
+            story({ id: "before", time_type: "exact_year", year: 1850 }),
+            story({ id: "in", time_type: "exact_year", year: 1875 }),
+            story({ id: "after", time_type: "exact_year", year: 1950 }),
+          ],
+        },
+      });
+
+      const result = await getTimeline({ q: "x", yearFrom: 1870, yearTo: 1880, page: 1, pageSize: 10 });
+      expect(result.results.map((s) => s.id)).toEqual(["in"]);
+    });
+  });
+
+  describe("storyOverlapsYearWindow", () => {
+    it("returns true when both bounds are null (no filter)", () => {
+      expect(storyOverlapsYearWindow(story({ time_type: "exact_year", year: 1875 }), null, null)).toBe(
+        true,
+      );
+    });
+
+    it("exact_year — point in [yearFrom, yearTo]", () => {
+      const s = story({ time_type: "exact_year", year: 1875 });
+      expect(storyOverlapsYearWindow(s, 1870, 1880)).toBe(true);
+      expect(storyOverlapsYearWindow(s, 1880, 1890)).toBe(false);
+      expect(storyOverlapsYearWindow(s, 1860, 1870)).toBe(false);
+    });
+
+    it("decade — interval [Y, Y+9] overlaps window (the bug we're fixing)", () => {
+      const s = story({ time_type: "decade", year: 1870 });
+      // Window 1875-1885 overlaps 1870-1879 → INCLUDED
+      expect(storyOverlapsYearWindow(s, 1875, 1885)).toBe(true);
+      // Window 1865-1872 overlaps 1870-1879 → INCLUDED
+      expect(storyOverlapsYearWindow(s, 1865, 1872)).toBe(true);
+      // Window entirely after the decade → EXCLUDED
+      expect(storyOverlapsYearWindow(s, 1880, 1890)).toBe(false);
+      // Window entirely before the decade → EXCLUDED
+      expect(storyOverlapsYearWindow(s, 1850, 1869)).toBe(false);
+    });
+
+    it("year_range — interval [year_start, year_end] overlaps window", () => {
+      const s = story({ time_type: "year_range", year_start: 1850, year_end: 1900 });
+      expect(storyOverlapsYearWindow(s, 1875, 1885)).toBe(true);
+      expect(storyOverlapsYearWindow(s, 1820, 1860)).toBe(true);
+      expect(storyOverlapsYearWindow(s, 1910, 1920)).toBe(false);
+      expect(storyOverlapsYearWindow(s, 1800, 1849)).toBe(false);
+    });
+
+    it("exact_date — year extracted from date_value", () => {
+      const s = story({ time_type: "exact_date", date_value: "1923-10-29" });
+      expect(storyOverlapsYearWindow(s, 1920, 1925)).toBe(true);
+      expect(storyOverlapsYearWindow(s, 1924, 1930)).toBe(false);
+    });
+
+    it("one-sided window — only yearFrom or only yearTo", () => {
+      const s = story({ time_type: "exact_year", year: 1875 });
+      expect(storyOverlapsYearWindow(s, 1870, null)).toBe(true);
+      expect(storyOverlapsYearWindow(s, 1880, null)).toBe(false);
+      expect(storyOverlapsYearWindow(s, null, 1880)).toBe(true);
+      expect(storyOverlapsYearWindow(s, null, 1870)).toBe(false);
+    });
+
+    it("excludes stories with no usable time info when a window is set", () => {
+      expect(storyOverlapsYearWindow(story({ time_type: "exact_year", year: null }), 1870, 1880)).toBe(
+        false,
+      );
+      expect(storyOverlapsYearWindow(null, 1870, 1880)).toBe(false);
     });
   });
 

--- a/frontend/src/services/timelineService.js
+++ b/frontend/src/services/timelineService.js
@@ -43,14 +43,15 @@ export function getTimelineHistoricalYear(story) {
   return Number.MAX_SAFE_INTEGER;
 }
 
-function hasUnsupportedTimelineFilters({ q, tags, location, latMin, latMax, lngMin, lngMax, latitude, longitude, radiusKm }) {
-  if (q?.trim()) return true;
-  if (Array.isArray(tags) && tags.length > 0) return true;
-  if (latitude != null && longitude != null && radiusKm != null) return true;
+function hasUnsupportedTimelineFilters(filters) {
+  if (filters.q?.trim()) return true;
+  if (Array.isArray(filters.tags) && filters.tags.length > 0) return true;
+  if (filters.latitude != null && filters.longitude != null && filters.radiusKm != null) return true;
   // A location string with no bbox can't be passed to /stories/timeline/ —
   // that endpoint doesn't accept a `location` text param.
-  const hasBbox = latMin != null && latMax != null && lngMin != null && lngMax != null;
-  if (location?.trim() && !hasBbox) return true;
+  const hasBbox =
+    filters.latMin != null && filters.latMax != null && filters.lngMin != null && filters.lngMax != null;
+  if (filters.location?.trim() && !hasBbox) return true;
   return false;
 }
 
@@ -156,9 +157,12 @@ async function getTimelineViaFallback({
 
   const response = await api.get(path, { params });
   const allResults = Array.isArray(response.data?.results) ? response.data.results : [];
-  const sorted = [...allResults].sort(
-    (a, b) => getTimelineHistoricalYear(a) - getTimelineHistoricalYear(b),
-  );
+  // Decorate-sort-undecorate: compute the historical year once per story,
+  // not twice per comparison.
+  const sorted = allResults
+    .map((story) => [getTimelineHistoricalYear(story), story])
+    .sort((a, b) => a[0] - b[0])
+    .map(([, story]) => story);
 
   const startIndex = (page - 1) * pageSize;
   const pageResults = sorted.slice(startIndex, startIndex + pageSize);

--- a/frontend/src/services/timelineService.js
+++ b/frontend/src/services/timelineService.js
@@ -8,14 +8,24 @@ const KEY_MAP = {
   latMax: "lat_max",
   lngMin: "lng_min",
   lngMax: "lng_max",
+  hasImage: "has_image",
   page: "page",
   pageSize: "page_size",
 };
 
-// How many stories to fetch from the search/feed fallback before client-sorting
-// and paginating. Mirrors the cap mobile uses for the same fallback path —
-// large enough for the realistic timeline corpus, small enough to keep the
-// payload reasonable. Stories beyond this cap are not represented.
+// Hard cap on the fallback fetch (mirrors the backend's StoryPagination
+// max_page_size and the cap mobile uses for the same fallback path).
+//
+// Known limitation: when an unsupported filter combination forces the
+// fallback (q / tags / proximity / free-text location), the client fetches
+// at most this many stories from /stories/search/ or /stories/feed/, sorts
+// them by historical year, and paginates the slice. Stories that match the
+// filter set but rank beyond the 100th in the underlying endpoint's order
+// (recent-first by default, or relevance for q) are NOT reachable via the
+// timeline view, and the `count` returned reflects only what was fetched —
+// not the true backend count. Same trade-off mobile makes; lifting it would
+// require a backend change to expose timeline-specific filtering across the
+// full result set.
 const FALLBACK_FETCH_PAGE_SIZE = 100;
 
 /**
@@ -115,13 +125,27 @@ export async function getTimeline({
   latitude,
   longitude,
   radiusKm,
+  hasImage,
   page,
   pageSize,
 } = {}) {
   const filters = { q, tags, location, latMin, latMax, lngMin, lngMax, latitude, longitude, radiusKm };
 
   if (!hasUnsupportedTimelineFilters(filters)) {
-    const args = { yearFrom, yearTo, latMin, latMax, lngMin, lngMax, page, pageSize };
+    // Forward has_image only when explicitly true. The timeline endpoint
+    // treats absent has_image as "no image filter," which matches our intent
+    // when the toggle is off.
+    const args = {
+      yearFrom,
+      yearTo,
+      latMin,
+      latMax,
+      lngMin,
+      lngMax,
+      page,
+      pageSize,
+      ...(hasImage ? { hasImage: true } : {}),
+    };
     const params = {};
     for (const [key, value] of Object.entries(args)) {
       if (value === undefined) continue;
@@ -144,6 +168,7 @@ export async function getTimeline({
     latitude,
     longitude,
     radiusKm,
+    hasImage,
     page: page ?? 1,
     pageSize: pageSize ?? 10,
   });
@@ -162,6 +187,9 @@ async function getTimelineViaFallback({
   latitude,
   longitude,
   radiusKm,
+  // hasImage is intentionally accepted but unused in the fallback path —
+  // see note below.
+  hasImage: _hasImage,
   page,
   pageSize,
 }) {
@@ -174,6 +202,12 @@ async function getTimelineViaFallback({
   // stories the timeline endpoint would include via interval overlap. We
   // re-apply year filtering below with storyOverlapsYearWindow so the fallback
   // path matches the primary path's semantics.
+  //
+  // has_image is also NOT applied in this branch: /stories/search/ and
+  // /stories/feed/ neither accept the filter param nor expose a per-story
+  // image flag in StoryFeedSerializer, so a client-side filter has nothing
+  // to read. The toggle silently no-ops in fallback mode; would need a
+  // backend addition to apply consistently across both paths.
   const data = await getStories({
     q,
     location,

--- a/frontend/src/services/timelineService.js
+++ b/frontend/src/services/timelineService.js
@@ -11,12 +11,60 @@ const KEY_MAP = {
   pageSize: "page_size",
 };
 
+// How many stories to fetch from the search/feed fallback before client-sorting
+// and paginating. Mirrors the cap mobile uses for the same fallback path —
+// large enough for the realistic timeline corpus, small enough to keep the
+// payload reasonable. Stories beyond this cap are not represented.
+const FALLBACK_FETCH_PAGE_SIZE = 100;
+
+/**
+ * Compute the historical-year midpoint for a story so the client can sort
+ * fallback-fetched results the same way the timeline endpoint does on the
+ * server. Returns Number.MAX_SAFE_INTEGER for stories with no usable time
+ * info so they sink to the bottom rather than crash the comparator.
+ *
+ * Mirrors the server-side CASE expression in
+ * `backend/apps/stories/services.py::get_story_timeline`.
+ */
+export function getTimelineHistoricalYear(story) {
+  if (!story || typeof story !== "object") return Number.MAX_SAFE_INTEGER;
+  const { time_type, year, year_start, year_end, date_value } = story;
+  if (time_type === "year_range" && Number.isFinite(year_start) && Number.isFinite(year_end)) {
+    return (year_start + year_end) / 2;
+  }
+  if (time_type === "decade" && Number.isFinite(year)) {
+    return year + 5;
+  }
+  if (time_type === "exact_date" && typeof date_value === "string") {
+    const parsedYear = Number.parseInt(date_value.slice(0, 4), 10);
+    return Number.isFinite(parsedYear) ? parsedYear : Number.MAX_SAFE_INTEGER;
+  }
+  if (Number.isFinite(year)) return year;
+  return Number.MAX_SAFE_INTEGER;
+}
+
+function hasUnsupportedTimelineFilters({ q, tags, location, latMin, latMax, lngMin, lngMax, latitude, longitude, radiusKm }) {
+  if (q?.trim()) return true;
+  if (Array.isArray(tags) && tags.length > 0) return true;
+  if (latitude != null && longitude != null && radiusKm != null) return true;
+  // A location string with no bbox can't be passed to /stories/timeline/ —
+  // that endpoint doesn't accept a `location` text param.
+  const hasBbox = latMin != null && latMax != null && lngMin != null && lngMax != null;
+  if (location?.trim() && !hasBbox) return true;
+  return false;
+}
+
 /**
  * Fetch stories ordered by time period for the timeline view.
  *
- * Calls `GET /stories/timeline/`. Accepts camelCase JS args and translates them
- * to snake_case query params expected by the backend. Undefined args are
- * omitted from the request.
+ * When the active filter set is supported by `/stories/timeline/` (year +
+ * bbox), this proxies that endpoint directly so the server's historical
+ * ordering and pagination are preserved. When the filter set includes text
+ * search, tags, proximity, or a location string without a bbox, the timeline
+ * endpoint can't honour it — so we fall back to `/stories/search/` (when q
+ * is present) or `/stories/feed/`, then re-sort client-side by historical
+ * midpoint and paginate locally. This mirrors the strategy in
+ * `mobile/src/features/timeline/data/sources/index.ts`.
  */
 export async function getTimeline({
   yearFrom,
@@ -25,15 +73,101 @@ export async function getTimeline({
   latMax,
   lngMin,
   lngMax,
+  q,
+  tags,
+  location,
+  latitude,
+  longitude,
+  radiusKm,
   page,
   pageSize,
 } = {}) {
-  const args = { yearFrom, yearTo, latMin, latMax, lngMin, lngMax, page, pageSize };
-  const params = {};
-  for (const [key, value] of Object.entries(args)) {
-    if (value === undefined) continue;
-    params[KEY_MAP[key]] = value;
+  const filters = { q, tags, location, latMin, latMax, lngMin, lngMax, latitude, longitude, radiusKm };
+
+  if (!hasUnsupportedTimelineFilters(filters)) {
+    const args = { yearFrom, yearTo, latMin, latMax, lngMin, lngMax, page, pageSize };
+    const params = {};
+    for (const [key, value] of Object.entries(args)) {
+      if (value === undefined) continue;
+      params[KEY_MAP[key]] = value;
+    }
+    const response = await api.get("/stories/timeline/", { params });
+    return response.data;
   }
-  const response = await api.get("/stories/timeline/", { params });
-  return response.data;
+
+  return getTimelineViaFallback({
+    yearFrom,
+    yearTo,
+    latMin,
+    latMax,
+    lngMin,
+    lngMax,
+    q,
+    tags,
+    location,
+    latitude,
+    longitude,
+    radiusKm,
+    page: page ?? 1,
+    pageSize: pageSize ?? 10,
+  });
+}
+
+async function getTimelineViaFallback({
+  yearFrom,
+  yearTo,
+  latMin,
+  latMax,
+  lngMin,
+  lngMax,
+  q,
+  tags,
+  location,
+  latitude,
+  longitude,
+  radiusKm,
+  page,
+  pageSize,
+}) {
+  const trimmedQ = q?.trim();
+  const path = trimmedQ ? "/stories/search/" : "/stories/feed/";
+  const params = { page_size: FALLBACK_FETCH_PAGE_SIZE };
+  if (trimmedQ) params.q = trimmedQ;
+  else params.sort_by = "recent";
+  if (yearFrom != null) params.year_from = yearFrom;
+  if (yearTo != null) params.year_to = yearTo;
+  const hasBbox = latMin != null && latMax != null && lngMin != null && lngMax != null;
+  if (hasBbox) {
+    params.lat_min = latMin;
+    params.lat_max = latMax;
+    params.lng_min = lngMin;
+    params.lng_max = lngMax;
+  } else if (location?.trim()) {
+    params.location = location.trim();
+  }
+  if (latitude != null && longitude != null && radiusKm != null) {
+    params.latitude = latitude;
+    params.longitude = longitude;
+    params.radius_km = radiusKm;
+  }
+  if (Array.isArray(tags) && tags.length > 0) {
+    params.tags = tags;
+  }
+
+  const response = await api.get(path, { params });
+  const allResults = Array.isArray(response.data?.results) ? response.data.results : [];
+  const sorted = [...allResults].sort(
+    (a, b) => getTimelineHistoricalYear(a) - getTimelineHistoricalYear(b),
+  );
+
+  const startIndex = (page - 1) * pageSize;
+  const pageResults = sorted.slice(startIndex, startIndex + pageSize);
+  const hasNext = startIndex + pageSize < sorted.length;
+
+  return {
+    count: sorted.length,
+    next: hasNext ? "client-next-page" : null,
+    previous: page > 1 ? "client-previous-page" : null,
+    results: pageResults,
+  };
 }

--- a/frontend/src/services/timelineService.js
+++ b/frontend/src/services/timelineService.js
@@ -1,4 +1,5 @@
 import api from "./api";
+import { getStories } from "./storyService";
 
 const KEY_MAP = {
   yearFrom: "year_from",
@@ -130,33 +131,26 @@ async function getTimelineViaFallback({
   page,
   pageSize,
 }) {
-  const trimmedQ = q?.trim();
-  const path = trimmedQ ? "/stories/search/" : "/stories/feed/";
-  const params = { page_size: FALLBACK_FETCH_PAGE_SIZE };
-  if (trimmedQ) params.q = trimmedQ;
-  else params.sort_by = "recent";
-  if (yearFrom != null) params.year_from = yearFrom;
-  if (yearTo != null) params.year_to = yearTo;
-  const hasBbox = latMin != null && latMax != null && lngMin != null && lngMax != null;
-  if (hasBbox) {
-    params.lat_min = latMin;
-    params.lat_max = latMax;
-    params.lng_min = lngMin;
-    params.lng_max = lngMax;
-  } else if (location?.trim()) {
-    params.location = location.trim();
-  }
-  if (latitude != null && longitude != null && radiusKm != null) {
-    params.latitude = latitude;
-    params.longitude = longitude;
-    params.radius_km = radiusKm;
-  }
-  if (Array.isArray(tags) && tags.length > 0) {
-    params.tags = tags;
-  }
-
-  const response = await api.get(path, { params });
-  const allResults = Array.isArray(response.data?.results) ? response.data.results : [];
+  // storyService.getStories already routes between /stories/search/ (with q)
+  // and /stories/feed/, and it builds exactly the bbox/location/proximity/
+  // tags param shape we need. We just borrow it as the underlying fetch.
+  const data = await getStories({
+    q,
+    yearFrom,
+    yearTo,
+    location,
+    latMin,
+    latMax,
+    lngMin,
+    lngMax,
+    latitude,
+    longitude,
+    radiusKm,
+    tags,
+    page: 1,
+    pageSize: FALLBACK_FETCH_PAGE_SIZE,
+  });
+  const allResults = Array.isArray(data?.results) ? data.results : [];
   // Decorate-sort-undecorate: compute the historical year once per story,
   // not twice per comparison.
   const sorted = allResults

--- a/frontend/src/services/timelineService.js
+++ b/frontend/src/services/timelineService.js
@@ -44,6 +44,40 @@ export function getTimelineHistoricalYear(story) {
   return Number.MAX_SAFE_INTEGER;
 }
 
+function getStoryYearInterval(story) {
+  if (!story || typeof story !== "object") return null;
+  const { time_type, year, year_start, year_end, date_value } = story;
+  if (time_type === "year_range" && Number.isFinite(year_start) && Number.isFinite(year_end)) {
+    return [year_start, year_end];
+  }
+  if (time_type === "decade" && Number.isFinite(year)) {
+    return [year, year + 9];
+  }
+  if (time_type === "exact_date" && typeof date_value === "string") {
+    const parsedYear = Number.parseInt(date_value.slice(0, 4), 10);
+    return Number.isFinite(parsedYear) ? [parsedYear, parsedYear] : null;
+  }
+  if (Number.isFinite(year)) return [year, year];
+  return null;
+}
+
+/**
+ * Same interval-overlap year filter the /stories/timeline/ endpoint applies
+ * server-side. Re-applied client-side for the fallback path because
+ * /stories/feed/ and /stories/search/ use a simpler `year__gte` / `year__lte`
+ * check that silently excludes decade and exact_date stories whose intervals
+ * the timeline endpoint would include. yearFrom/yearTo of null mean "no bound."
+ */
+export function storyOverlapsYearWindow(story, yearFrom, yearTo) {
+  if (yearFrom == null && yearTo == null) return true;
+  const interval = getStoryYearInterval(story);
+  if (!interval) return false;
+  const [start, end] = interval;
+  if (yearFrom != null && end < yearFrom) return false;
+  if (yearTo != null && start > yearTo) return false;
+  return true;
+}
+
 function hasUnsupportedTimelineFilters(filters) {
   if (filters.q?.trim()) return true;
   if (Array.isArray(filters.tags) && filters.tags.length > 0) return true;
@@ -134,10 +168,14 @@ async function getTimelineViaFallback({
   // storyService.getStories already routes between /stories/search/ (with q)
   // and /stories/feed/, and it builds exactly the bbox/location/proximity/
   // tags param shape we need. We just borrow it as the underlying fetch.
+  //
+  // year_from/year_to are deliberately NOT forwarded — feed/search apply a
+  // simpler `year__gte`/`year__lte` filter that drops decade and exact_date
+  // stories the timeline endpoint would include via interval overlap. We
+  // re-apply year filtering below with storyOverlapsYearWindow so the fallback
+  // path matches the primary path's semantics.
   const data = await getStories({
     q,
-    yearFrom,
-    yearTo,
     location,
     latMin,
     latMax,
@@ -151,9 +189,13 @@ async function getTimelineViaFallback({
     pageSize: FALLBACK_FETCH_PAGE_SIZE,
   });
   const allResults = Array.isArray(data?.results) ? data.results : [];
+  const matching =
+    yearFrom == null && yearTo == null
+      ? allResults
+      : allResults.filter((s) => storyOverlapsYearWindow(s, yearFrom, yearTo));
   // Decorate-sort-undecorate: compute the historical year once per story,
   // not twice per comparison.
-  const sorted = allResults
+  const sorted = matching
     .map((story) => [getTimelineHistoricalYear(story), story])
     .sort((a, b) => a[0] - b[0])
     .map(([, story]) => story);

--- a/frontend/src/services/timelineService.js
+++ b/frontend/src/services/timelineService.js
@@ -187,11 +187,9 @@ async function getTimelineViaFallback({
   latitude,
   longitude,
   radiusKm,
-  // hasImage is intentionally accepted but unused in the fallback path —
-  // see note below.
-  hasImage: _hasImage,
   page,
   pageSize,
+  // hasImage is deliberately not destructured here — see note below.
 }) {
   // storyService.getStories already routes between /stories/search/ (with q)
   // and /stories/feed/, and it builds exactly the bbox/location/proximity/


### PR DESCRIPTION
# Description
Fixes #543

Brings the desktop **Timeline page** in line with mobile's `TimelineScreen` feature set and lands the WAI-ARIA *roving-tabindex* behaviour PR [#538](https://github.com/bounswe/bounswe2026group4/pull/538) deferred. All four bullets in the issue are addressed:

- **Text search bar** — `SearchBar` is rendered above the time-window card with the mobile placeholder *"Search by title or place…"*. The `q` URL param is the source of truth.
- **Location filter** — reuses the Nominatim-backed `FilterPanel` (added in PR [#531](https://github.com/bounswe/bounswe2026group4/pull/531)). To avoid duplicating the time-window UI, `FilterPanel` gains a small new `hideYearRange` prop (default `false`) — only Timeline opts in.
- **Tag multi-select** — `TagFilterInput` (already inside `FilterPanel`) now flows through to `getTimeline`.
- **Active filter chips** — `ActiveFilters` renders dismissible chips for `q` / location / proximity / tags. Year is *not* surfaced as a chip because the time-window selector already represents it visually, and rendering both would be redundant.
- **Roving tabindex on mode pills** — only the currently-checked radio is in the tab order; `ArrowLeft/Right/Up/Down` move focus *and* selection (with wrap-around); `Home`/`End` jump to the ends.

## Backend audit (verified before / during implementation)

Every assumption the frontend makes was checked against `backend/apps/stories/{views,serializers,services}.py` and `backend/common/pagination.py`:

| Concern | Backend reality | How the PR handles it |
|---|---|---|
| `/stories/timeline/` accepted params | `year_from`, `year_to`, `lat_min/max`, `lng_min/max`, `has_image`, `page`, `page_size` only — validated by `TimelineQuerySerializer`. No `q`, `tags`, free-text `location`, or proximity. | `getTimeline` proxies `/stories/timeline/` directly when the active filter set fits this shape. |
| `/stories/feed/` & `/stories/search/` accepted params | Inherit `FeedQuerySerializer`: `q` (required for search, `min_length=1`, whitespace-stripped), `sort_by`, `year_from/to`, `location`, `tags[]`, `latitude/longitude/radius_km`, `lat_min/max/lng_min/max`. Validated to require lat/lng/radius_km **together**; bbox four-together; `radius_km ∈ [0.001, 500]`. | Fallback only sends the lat/lng/radius_km triple together. Frontend `radiusKm` options (0.5 / 1 / 10 / 100) all sit inside `[0.001, 500]`. `q` is trimmed before being sent. |
| `tags` wire format | DRF `ListField(child=CharField)` reads repeated keys: `?tags=foo&tags=bar`. Backend filter is `name__iexact`, AND-chained — each named tag must be on the story. | `api.js` paramsSerializer emits arrays as repeated keys, so `params.tags = ["foo","bar"]` lands as `?tags=foo&tags=bar`. Tag *names* flow straight through from `useFilterState`'s URL string — no ID lookup needed. |
| `q` semantics | `Q(title__icontains) | Q(location_name__icontains)` — title OR place. | Placeholder *"Search by title or place…"* matches the actual behaviour (and the mobile copy). |
| Pagination cap | `StoryPagination.max_page_size = 100`. | `FALLBACK_FETCH_PAGE_SIZE = 100` — the ceiling. Stories beyond the 100th match in fallback won't appear; same cap mobile uses. |
| **Serializer shape delta in fallback** | `StoryTimelineSerializer` returns `photo_url` + `temporal_coverage` (EDTF) but no `location_name`. `StoryFeedSerializer` returns the inverse: `location_name`, plus feed-card extras, but **no** `photo_url` or `temporal_coverage`. | **Cosmetic UX delta in fallback mode.** `TimelineEntry` already conditionally renders both `photo_url` and `temporal_coverage`, so no crash — fallback cards just show no thumbnail and no EDTF chip, but gain a place name. **Mobile has the exact same limitation** (its mapper looks for `media_items[]`, which feed/search don't expose either). Platform-consistent, not a bug. |

### Fallback strategy in `timelineService.js`

- **All-supported filters?** → call `/stories/timeline/` directly (server-side ordering preserved).
- **Any unsupported filter?** → call `/stories/search/` (with `q`) or `/stories/feed/`, request up to `FALLBACK_FETCH_PAGE_SIZE = 100` results, re-sort by `getTimelineHistoricalYear(story)`, paginate client-side.

`getTimelineHistoricalYear` is exported and unit-tested per `time_type` so the formula stays in sync with the server's CASE-WHEN in `apps/stories/services.py::get_story_timeline`.

# Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Refactoring
- [ ] Documentation

# Acceptance Criteria / Checklist
- [x] Project builds successfully
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, especially in hard-to-understand parts
- [x] I have performed a self-review of my code
- [x] I have added/updated tests
- [x] New and existing unit tests pass locally with my changes

# Screenshots / Recordings
<!-- N/A — best verified by running the dev server, opening /timeline, and exercising:
  1. Search "galata" → results re-sort by historical year (fallback path).
  2. Open Filters → no Year section, only Location/Distance/Tags. Apply a tag → chip appears.
  3. Tab into the mode pills, ArrowRight cycles selection; Home jumps to All. -->

# Estimated Review Time
- [ ] < 5 min
- [ ] 5-15 min
- [x] > 15 min

---

### Notes for reviewer

- **Why not modify `/stories/timeline/` to accept `q`/`tags`?** That's a backend change and out of scope for this frontend issue; mobile uses the same fallback so the cross-platform behaviour matches.
- **Why a new `hideYearRange` prop on `FilterPanel` instead of a new `TimelineFilterPanel` component?** The two would have been near-clones — `hideYearRange` is one extra prop and one conditional render. Default is `false`, so Feed and Map are untouched.
- **Year isn't a chip.** The time-window selector card visually owns the year filter. Rendering "1875" both as a chip and as a Year-mode card was deemed noise; happy to add chips if reviewers prefer.
- **Photo / EDTF chip drop-out in fallback mode** — see audit table above. Same as mobile; documented as a known cosmetic delta, not a regression.
- **All 992 frontend tests pass** locally; lint and `npm run build` are green.