### PR TITLE
fix(mobile): keep timeline story pins separate from map clusters

### DIFF
--- a/mobile/src/app/navigation/RootNavigator.tsx
+++ b/mobile/src/app/navigation/RootNavigator.tsx
@@ -731,7 +731,7 @@ export function RootNavigator() {
   };
 
   const handleViewTimelineNearPin = useCallback(
-    (target: { latitude: number; longitude: number; label?: string }) => {
+    (target: { latitude: number; longitude: number; label?: string; storyId?: string }) => {
       updateFilters(
         {
           query: '',
@@ -744,6 +744,7 @@ export function RootNavigator() {
           },
           proximitySource: 'map_pin',
           proximityLabel: target.label,
+          proximityStoryId: target.storyId,
           timeFrom: '',
           timeTo: '',
           tags: [],

--- a/mobile/src/app/navigation/__tests__/RootNavigator.test.tsx
+++ b/mobile/src/app/navigation/__tests__/RootNavigator.test.tsx
@@ -1079,7 +1079,7 @@ describe('RootNavigator auth flow', () => {
         'GET /stories/feed/?page_size=100&sort_by=recent&latitude=41.02&longitude=28.96&radius_km=0.5&page=1',
       );
     });
-    expect(screen.getByLabelText('Remove Distance: 500 m from Harbor Memory red location pin')).toBeTruthy();
+    expect(screen.getByLabelText('Remove Distance: 500 m from red location pin')).toBeTruthy();
 
     fireEvent.press(await screen.findByLabelText('Open timeline story: Harbor Memory'));
 

--- a/mobile/src/features/map/presentation/components/MapCard.tsx
+++ b/mobile/src/features/map/presentation/components/MapCard.tsx
@@ -17,7 +17,7 @@ interface MapCardProps {
   userLocation?: { latitude: number; longitude: number };
   onSelectMarker: (markerId: string) => void;
   onOpenStory: (storyId: string) => void;
-  onViewTimeline?: (target: { latitude: number; longitude: number; label?: string }) => void;
+  onViewTimeline?: (target: { latitude: number; longitude: number; label?: string; storyId?: string }) => void;
   onRegionChangeComplete?: (region: Region) => void;
   onPreviewLayout?: (event: LayoutChangeEvent) => void;
   onMapTouchChange?: (isTouchingMap: boolean) => void;
@@ -26,6 +26,7 @@ interface MapCardProps {
 const PREVIEW_MAX_LENGTH = 140;
 const MAP_GESTURE_SUPPRESSION_MS = 1200;
 const passivePreviewTextProps = { pointerEvents: 'none' as const };
+type MapMarkerVisualRole = 'timeline' | 'selected';
 export function MapCard({
   region,
   markers,
@@ -47,15 +48,21 @@ export function MapCard({
   const selectedMarker = selectedMarkerId ? markers.find((marker) => marker.id === selectedMarkerId) : undefined;
   const mapMarkers = useMemo(
     () =>
-      markers.map((marker) => ({
-        id: marker.id,
-        latitude: marker.latitude,
-        longitude: marker.longitude,
-        selected: marker.id === (highlightedMarkerId ?? selectedMarkerId),
-        label: marker.isCluster && marker.id !== highlightedMarkerId && marker.id !== selectedMarkerId
-          ? String(marker.count)
-          : undefined,
-      })),
+      markers.map((marker) => {
+        const visualRole: MapMarkerVisualRole | undefined =
+          marker.id === highlightedMarkerId ? 'timeline' : marker.id === selectedMarkerId ? 'selected' : undefined;
+
+        return {
+          id: marker.id,
+          latitude: marker.latitude,
+          longitude: marker.longitude,
+          selected: Boolean(visualRole),
+          visualRole,
+          label: marker.isCluster && marker.id !== highlightedMarkerId && marker.id !== selectedMarkerId
+            ? String(marker.count)
+            : undefined,
+        };
+      }),
     [highlightedMarkerId, markers, selectedMarkerId],
   );
   const clearMapTouchReleaseTimer = useCallback(() => {
@@ -210,19 +217,6 @@ export function MapCard({
           </Text>
         ) : selectedMarker.isCluster ? (
           <>
-            <Button
-              variant="outline"
-              accessibilityLabel={`View timeline near ${selectedMarker.count} nearby stories`}
-              onPress={() =>
-                onViewTimeline?.({
-                  latitude: selectedMarker.latitude,
-                  longitude: selectedMarker.longitude,
-                  label: `${selectedMarker.count} nearby stories`,
-                })
-              }
-            >
-              View Group Timeline
-            </Button>
             <ScrollView
               style={{ maxHeight: 240 }}
               contentContainerStyle={{ gap: spacing.sm }}
@@ -261,6 +255,7 @@ export function MapCard({
                           latitude: story.latitude,
                           longitude: story.longitude,
                           label: story.title,
+                          storyId: story.id,
                         })
                       }
                     >
@@ -295,6 +290,7 @@ export function MapCard({
                     latitude: selectedMarker.stories[0].latitude,
                     longitude: selectedMarker.stories[0].longitude,
                     label: selectedMarker.stories[0].title,
+                    storyId: selectedMarker.stories[0].id,
                   })
                 }
               >

--- a/mobile/src/features/map/presentation/screens/MapScreen.tsx
+++ b/mobile/src/features/map/presentation/screens/MapScreen.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { LayoutChangeEvent, Text, View } from 'react-native';
 import { Region } from 'react-native-maps';
 import { useAppTheme } from '../../../../core/hooks/useAppTheme';
+import { StoryMapPin } from '../../../stories/domain/entities';
 import { StoryFilters } from '../../../stories/domain/repositories';
 import { MapMarkerGroup } from '../../domain/entities';
 import { mapService } from '../../application/services';
@@ -21,7 +22,7 @@ interface MapScreenProps {
   onOpenStory?: (storyId: string) => void;
   getMarkerGroups?: (filters?: StoryFilters) => Promise<MapMarkerGroup[]>;
   onMarkerPreviewRequested?: (targetY: number) => void;
-  onViewTimeline?: (target: { latitude: number; longitude: number; label?: string }) => void;
+  onViewTimeline?: (target: { latitude: number; longitude: number; label?: string; storyId?: string }) => void;
   showSearchControls?: boolean;
   onRegisterRefresh?: (handler: (() => Promise<void>) | null) => void;
   onMapTouchChange?: (isTouchingMap: boolean) => void;
@@ -48,6 +49,16 @@ const CLUSTER_RADIUS_REGION_FRACTION = 0.1;
 const MIN_CLUSTER_RADIUS_DEGREES = 0.0008;
 const MIN_CLUSTER_ZOOM_DELTA = 0.00001;
 type StatusIndicatorMode = 'hidden' | 'filters' | 'area';
+interface MapPinTimelineTarget {
+  latitude: number;
+  longitude: number;
+  label?: string;
+  storyId?: string;
+}
+interface PinnedStoryMarker {
+  id: string;
+  story: StoryMapPin;
+}
 
 export function MapScreen({
   initialFilters = EMPTY_FILTERS,
@@ -239,23 +250,22 @@ export function MapScreen({
     filters.proximityRadiusKm && filters.proximityCoordinates && filters.proximitySource !== 'map_pin'
       ? filters.proximityCoordinates
       : undefined;
-  const mapPinFilterMarkerId = useMemo(
-    () => getMapPinFilterMarkerId(state.markers, filters),
-    [filters, state.markers],
+  const mapPinTimelineTarget = useMemo(() => getMapPinTimelineTarget(filters), [filters]);
+  const pinnedStoryMarkers = useMemo(
+    () => getPinnedStoryMarkers(state.markers, state.selectedMarkerId, mapPinTimelineTarget),
+    [mapPinTimelineTarget, state.markers, state.selectedMarkerId],
   );
   const displayMarkers = useMemo(
-    () => clusterMarkersForRegion(state.markers, mapRegion, expandedMarkerIds),
-    [expandedMarkerIds, mapRegion, state.markers],
+    () => clusterMarkersForRegion(state.markers, mapRegion, expandedMarkerIds, pinnedStoryMarkers),
+    [expandedMarkerIds, mapRegion, pinnedStoryMarkers, state.markers],
   );
   const displayedSelectedMarkerId = useMemo(
     () => getDisplayedMarkerId(state.selectedMarkerId, displayMarkers, state.markers),
     [displayMarkers, state.markers, state.selectedMarkerId],
   );
   const displayedHighlightedMarkerId = useMemo(
-    () =>
-      getDisplayedMarkerId(mapPinFilterMarkerId, displayMarkers, state.markers) ??
-      getDisplayedMapPinCoordinateMarkerId(displayMarkers, filters),
-    [displayMarkers, filters, mapPinFilterMarkerId, state.markers],
+    () => getDisplayedMapPinTimelineMarkerId(displayMarkers, mapPinTimelineTarget),
+    [displayMarkers, mapPinTimelineTarget],
   );
   const statusStoryCount = useMemo(() => {
     if (statusIndicatorMode !== 'area' || !hasInteractedWithArea || !visibleRegion) {
@@ -456,11 +466,17 @@ function clusterMarkersForRegion(
   markers: MapMarkerGroup[],
   region: Region,
   expandedMarkerIds: Set<string>,
+  pinnedStoryMarkers: PinnedStoryMarker[] = [],
 ): MapMarkerGroup[] {
-  const clusterableMarkers = expandDistinctStoryMarkers(markers, expandedMarkerIds);
+  const pinnedStoryIds = new Set(pinnedStoryMarkers.map((marker) => marker.story.id));
+  const pinnedMarkers = pinnedStoryMarkers.map(createPinnedStoryMarker);
+  const clusterableMarkers = expandDistinctStoryMarkers(
+    pinnedStoryIds.size ? removeStoriesFromMarkers(markers, pinnedStoryIds) : markers,
+    expandedMarkerIds,
+  );
 
   if (clusterableMarkers.length < 2) {
-    return clusterableMarkers;
+    return pinnedMarkers.length ? [...clusterableMarkers, ...pinnedMarkers] : clusterableMarkers;
   }
 
   const clusterRadius = Math.max(
@@ -484,7 +500,7 @@ function clusterMarkersForRegion(
     clusters.push([marker]);
   });
 
-  return clusters.map((cluster) => {
+  const clusteredMarkers = clusters.map((cluster) => {
     if (cluster.length === 1) {
       return cluster[0];
     }
@@ -505,6 +521,136 @@ function clusterMarkersForRegion(
       count,
       isCluster: true,
     };
+  });
+
+  return pinnedMarkers.length ? [...clusteredMarkers, ...pinnedMarkers] : clusteredMarkers;
+}
+
+function getPinnedStoryMarkers(
+  markers: MapMarkerGroup[],
+  selectedMarkerId: string | undefined,
+  mapPinTimelineTarget?: MapPinTimelineTarget,
+) {
+  const pinnedByStoryId = new Map<string, PinnedStoryMarker>();
+  const selectedPinnedStory = selectedMarkerId
+    ? findSelectedPinnedStoryMarker(markers, selectedMarkerId)
+    : undefined;
+
+  if (selectedPinnedStory) {
+    pinnedByStoryId.set(selectedPinnedStory.story.id, selectedPinnedStory);
+  }
+
+  const mapPinStory = mapPinTimelineTarget ? findMapPinTimelineStory(markers, mapPinTimelineTarget) : undefined;
+
+  if (mapPinStory) {
+    pinnedByStoryId.set(mapPinStory.id, {
+      id: getPinnedStoryMarkerId(mapPinStory.id),
+      story: mapPinStory,
+    });
+  }
+
+  return Array.from(pinnedByStoryId.values());
+}
+
+function findSelectedPinnedStoryMarker(
+  markers: MapMarkerGroup[],
+  selectedMarkerId: string,
+): PinnedStoryMarker | undefined {
+  const sourceMarker = markers.find((marker) => marker.id === selectedMarkerId);
+
+  if (sourceMarker && !sourceMarker.isCluster && sourceMarker.stories.length === 1) {
+    return {
+      id: sourceMarker.id,
+      story: sourceMarker.stories[0],
+    };
+  }
+
+  for (const marker of markers) {
+    const story = marker.stories.find((candidate) => selectedMarkerId === `${marker.id}:story:${candidate.id}`);
+
+    if (story) {
+      return {
+        id: selectedMarkerId,
+        story,
+      };
+    }
+  }
+
+  return undefined;
+}
+
+function findMapPinTimelineStory(markers: MapMarkerGroup[], target: MapPinTimelineTarget) {
+  const stories = markers.flatMap((marker) => marker.stories);
+  const matchingStoryById = target.storyId
+    ? stories.find((story) => story.id === target.storyId)
+    : undefined;
+
+  if (matchingStoryById) {
+    return matchingStoryById;
+  }
+
+  const matchingStoryByLabel = target.label
+    ? stories.find((story) => story.title === target.label && storyMatchesCoordinates(story, target))
+    : undefined;
+
+  if (matchingStoryByLabel) {
+    return matchingStoryByLabel;
+  }
+
+  return stories.find((story) => storyMatchesCoordinates(story, target));
+}
+
+function storyMatchesCoordinates(story: StoryMapPin, target: Pick<MapPinTimelineTarget, 'latitude' | 'longitude'>) {
+  return coordinatesEqual(story.latitude, target.latitude) && coordinatesEqual(story.longitude, target.longitude);
+}
+
+function createPinnedStoryMarker({ id, story }: PinnedStoryMarker): MapMarkerGroup {
+  return {
+    id,
+    latitude: story.latitude,
+    longitude: story.longitude,
+    stories: [story],
+    count: 1,
+    isCluster: false,
+  };
+}
+
+function getPinnedStoryMarkerId(storyId: string) {
+  return `map-pin-story:${storyId}`;
+}
+
+function removeStoriesFromMarkers(markers: MapMarkerGroup[], storyIds: Set<string>): MapMarkerGroup[] {
+  return markers.flatMap((marker) => {
+    const stories = marker.stories.filter((story) => !storyIds.has(story.id));
+
+    if (!stories.length) {
+      return [];
+    }
+
+    if (stories.length === marker.stories.length) {
+      return [marker];
+    }
+
+    const latitude =
+      stories.length === 1
+        ? stories[0].latitude
+        : stories.reduce((sum, story) => sum + story.latitude, 0) / stories.length;
+    const longitude =
+      stories.length === 1
+        ? stories[0].longitude
+        : stories.reduce((sum, story) => sum + story.longitude, 0) / stories.length;
+
+    return [
+      {
+        ...marker,
+        id: `${marker.id}:without:${Array.from(storyIds).sort().join(':')}`,
+        latitude,
+        longitude,
+        stories,
+        count: stories.length,
+        isCluster: stories.length > 1,
+      },
+    ];
   });
 }
 
@@ -612,34 +758,47 @@ function getMapPinFilterKey(filters: SearchFiltersState) {
     return null;
   }
 
-  return `${filters.proximityCoordinates.latitude}:${filters.proximityCoordinates.longitude}:${filters.proximityRadiusKm ?? ''}`;
+  return [
+    filters.proximityCoordinates.latitude,
+    filters.proximityCoordinates.longitude,
+    filters.proximityRadiusKm ?? '',
+    filters.proximityStoryId ?? '',
+    filters.proximityLabel ?? '',
+  ].join(':');
 }
 
-function getMapPinFilterMarkerId(markers: MapMarkerGroup[], filters: SearchFiltersState) {
+function getMapPinTimelineTarget(filters: SearchFiltersState): MapPinTimelineTarget | undefined {
   if (filters.proximitySource !== 'map_pin' || !filters.proximityCoordinates) {
     return undefined;
   }
 
-  const { latitude, longitude } = filters.proximityCoordinates;
-  const matchingMarker = markers.find(
-    (marker) =>
-      (coordinatesEqual(marker.latitude, latitude) && coordinatesEqual(marker.longitude, longitude)) ||
-      marker.stories.some((story) => coordinatesEqual(story.latitude, latitude) && coordinatesEqual(story.longitude, longitude)),
-  );
-
-  return matchingMarker?.id;
+  return {
+    latitude: filters.proximityCoordinates.latitude,
+    longitude: filters.proximityCoordinates.longitude,
+    label: filters.proximityLabel,
+    storyId: filters.proximityStoryId,
+  };
 }
 
-function getDisplayedMapPinCoordinateMarkerId(markers: MapMarkerGroup[], filters: SearchFiltersState) {
-  if (filters.proximitySource !== 'map_pin' || !filters.proximityCoordinates) {
+function getDisplayedMapPinTimelineMarkerId(
+  markers: MapMarkerGroup[],
+  target: MapPinTimelineTarget | undefined,
+) {
+  if (!target) {
     return undefined;
   }
 
-  const { latitude, longitude } = filters.proximityCoordinates;
+  const targetStoryId = target.storyId;
+  const matchingPinnedStory = targetStoryId
+    ? markers.find((marker) => marker.id === getPinnedStoryMarkerId(targetStoryId))
+    : undefined;
+
+  if (matchingPinnedStory) {
+    return matchingPinnedStory.id;
+  }
+
   const matchingMarker = markers.find(
-    (marker) =>
-      (coordinatesEqual(marker.latitude, latitude) && coordinatesEqual(marker.longitude, longitude)) ||
-      marker.stories.some((story) => coordinatesEqual(story.latitude, latitude) && coordinatesEqual(story.longitude, longitude)),
+    (marker) => marker.stories.some((story) => storyMatchesCoordinates(story, target)),
   );
 
   return matchingMarker?.id;

--- a/mobile/src/features/map/presentation/screens/__tests__/MapScreen.test.tsx
+++ b/mobile/src/features/map/presentation/screens/__tests__/MapScreen.test.tsx
@@ -33,7 +33,7 @@ jest.mock('../../../../../shared/components/WebMapView', () => {
         latitudeDelta: number;
         longitudeDelta: number;
       };
-      markers?: Array<{ id: string; selected?: boolean; label?: string }>;
+      markers?: Array<{ id: string; selected?: boolean; visualRole?: 'timeline' | 'selected'; label?: string }>;
       userLocation?: {
         latitude: number;
         longitude: number;
@@ -79,6 +79,17 @@ jest.mock('../../../../../shared/components/WebMapView', () => {
             })
           }
         />
+        <Pressable
+          testID="map-region-wide"
+          onPress={() =>
+            onRegionChangeComplete?.({
+              latitude: 41.02,
+              longitude: 28.97,
+              latitudeDelta: 1,
+              longitudeDelta: 1,
+            })
+          }
+        />
         {markers.map((marker) => (
           <Pressable
             key={marker.id}
@@ -86,6 +97,7 @@ jest.mock('../../../../../shared/components/WebMapView', () => {
             testID="story-marker"
             accessibilityLabel={`marker:${marker.id}:${marker.label ?? ''}`}
             accessibilityState={{ selected: Boolean(marker.selected) }}
+            accessibilityValue={{ text: marker.visualRole ?? 'default' }}
           />
         ))}
       </View>
@@ -398,6 +410,7 @@ describe('MapScreen', () => {
       latitude: 41.0284,
       longitude: 28.9647,
       label: 'The Day the Harbor Fell Silent',
+      storyId: 'story-001',
     });
   });
 
@@ -414,7 +427,7 @@ describe('MapScreen', () => {
     renderScreen(<MapScreen getMarkerGroups={async () => markerGroups} />);
 
     await waitFor(() => {
-      expect(screen.getAllByTestId('story-marker')[0].props.accessibilityState.selected).toBe(true);
+      expect(screen.getByLabelText('marker:map-pin-story:story-001:').props.accessibilityState.selected).toBe(true);
     });
 
     fireEvent.press(screen.getByLabelText('Remove Distance: 500 m from red location pin'));
@@ -424,14 +437,40 @@ describe('MapScreen', () => {
     });
   });
 
+  it('shows separate pins for the timeline filter and current selected story', async () => {
+    await storage.set(storageKeys.mapSearchFilters, {
+      proximityRadiusKm: 0.5,
+      proximityCoordinates: {
+        latitude: 41,
+        longitude: 29,
+      },
+      proximitySource: 'map_pin',
+      proximityLabel: 'First Nearby Memory',
+      proximityStoryId: 'story-near-1',
+    });
+
+    renderScreen(<MapScreen getMarkerGroups={async () => zoomClusterMarkerGroups} />);
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('marker:map-pin-story:story-near-1:').props.accessibilityValue.text).toBe('timeline');
+    });
+
+    fireEvent.press(screen.getByLabelText('marker:far-1:'));
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('marker:far-1:').props.accessibilityValue.text).toBe('selected');
+    });
+    expect(screen.getByLabelText('marker:map-pin-story:story-near-1:').props.accessibilityValue.text).toBe('timeline');
+  });
+
   it('hides the selected marker preview when the same marker is pressed again', async () => {
     renderScreen(<MapScreen getMarkerGroups={async () => markerGroups} />);
 
     await screen.findByText('Select a story marker to preview.');
-    fireEvent.press(screen.getAllByTestId('story-marker')[0]);
+    fireEvent.press(screen.getByLabelText('marker:41.02:28.96:'));
     expect(await screen.findByText('The Day the Harbor Fell Silent')).toBeTruthy();
 
-    fireEvent.press(screen.getAllByTestId('story-marker')[0]);
+    fireEvent.press(screen.getByLabelText('marker:41.02:28.96:'));
 
     await waitFor(() => {
       expect(screen.queryByText('The Day the Harbor Fell Silent')).toBeNull();
@@ -458,6 +497,25 @@ describe('MapScreen', () => {
     });
   });
 
+  it('keeps a selected red story pin fixed when zooming out into nearby stories', async () => {
+    renderScreen(<MapScreen getMarkerGroups={async () => markerGroups} />);
+
+    await screen.findByText('Select a story marker to preview.');
+    fireEvent.press(screen.getByLabelText('marker:41.02:28.96:'));
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('marker:41.02:28.96:').props.accessibilityState.selected).toBe(true);
+    });
+
+    fireEvent.press(screen.getByTestId('map-region-wide'));
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('marker:41.02:28.96:').props.accessibilityState.selected).toBe(true);
+    });
+    expect(screen.getByLabelText('marker:41.01:28.97:2')).toBeTruthy();
+    expect(screen.queryByLabelText(/^marker:zoom-cluster:.*:3$/)).toBeNull();
+  });
+
   it('shows nearby stories when a clustered marker is pressed', async () => {
     renderScreen(<MapScreen getMarkerGroups={async () => markerGroups} />);
 
@@ -471,33 +529,18 @@ describe('MapScreen', () => {
     expect(screen.getByText('Voices of the Ferry Pier')).toBeTruthy();
   });
 
-  it('shows a selected grouped marker as a red pin while the group timeline action is visible', async () => {
+  it('does not offer a group timeline action for a selected grouped marker', async () => {
     renderScreen(<MapScreen getMarkerGroups={async () => markerGroups} />);
 
     await screen.findByText('Select a story marker to preview.');
     fireEvent.press(screen.getByLabelText('marker:41.01:28.97:2'));
 
     await waitFor(() => {
-      expect(screen.getByLabelText('View timeline near 2 nearby stories')).toBeTruthy();
+      expect(screen.getByText('2 nearby stories')).toBeTruthy();
     });
+    expect(screen.queryByLabelText('View timeline near 2 nearby stories')).toBeNull();
     expect(screen.getByLabelText('marker:41.01:28.97:').props.accessibilityState.selected).toBe(true);
     expect(screen.queryByLabelText('marker:41.01:28.97:2')).toBeNull();
-  });
-
-  it('offers a timeline action for a clustered marker', async () => {
-    const onViewTimeline = jest.fn();
-
-    renderScreen(<MapScreen getMarkerGroups={async () => markerGroups} onViewTimeline={onViewTimeline} />);
-
-    await screen.findByText('Select a story marker to preview.');
-    fireEvent.press(screen.getAllByTestId('story-marker')[1]);
-    fireEvent.press(await screen.findByLabelText('View timeline near 2 nearby stories'));
-
-    expect(onViewTimeline).toHaveBeenCalledWith({
-      latitude: 41.01,
-      longitude: 28.97,
-      label: '2 nearby stories',
-    });
   });
 
   it('offers story-specific timeline actions inside a clustered marker', async () => {
@@ -513,10 +556,65 @@ describe('MapScreen', () => {
       latitude: 41.0249,
       longitude: 28.9548,
       label: 'Lanterns Above the Hill Market',
+      storyId: 'story-002',
     });
   });
 
-  it('highlights the grouped marker when a map-pin timeline filter targets a story inside it', async () => {
+  it('shows a red story pin apart from cluster pins when zoomed out', async () => {
+    await storage.set(storageKeys.mapSearchFilters, {
+      proximityRadiusKm: 0.5,
+      proximityCoordinates: {
+        latitude: 41.01,
+        longitude: 28.97,
+      },
+      proximitySource: 'map_pin',
+      proximityLabel: 'Backend Group One',
+      proximityStoryId: 'backend-story-1',
+    });
+
+    renderScreen(<MapScreen getMarkerGroups={async () => backendGroupedDistinctMarkerGroups} />);
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('marker:map-pin-story:backend-story-1:').props.accessibilityState.selected).toBe(true);
+    });
+    expect(screen.getByLabelText('marker:backend-group:without:backend-story-1:2')).toBeTruthy();
+  });
+
+  it('keeps the red story pin out of grouping after zoom changes', async () => {
+    await storage.set(storageKeys.mapSearchFilters, {
+      proximityRadiusKm: 0.5,
+      proximityCoordinates: {
+        latitude: 41.01,
+        longitude: 28.97,
+      },
+      proximitySource: 'map_pin',
+      proximityLabel: 'Backend Group One',
+      proximityStoryId: 'backend-story-1',
+    });
+
+    renderScreen(<MapScreen getMarkerGroups={async () => backendGroupedDistinctMarkerGroups} />);
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('marker:map-pin-story:backend-story-1:').props.accessibilityState.selected).toBe(true);
+    });
+    expect(screen.getByLabelText('marker:backend-group:without:backend-story-1:2')).toBeTruthy();
+
+    fireEvent.press(screen.getByTestId('map-region-empty'));
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('marker:map-pin-story:backend-story-1:').props.accessibilityState.selected).toBe(true);
+    });
+    expect(screen.getByLabelText('marker:backend-group:without:backend-story-1:2')).toBeTruthy();
+
+    fireEvent.press(screen.getByTestId('map-region-change'));
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('marker:map-pin-story:backend-story-1:').props.accessibilityState.selected).toBe(true);
+    });
+    expect(screen.getByLabelText('marker:backend-group:without:backend-story-1:2')).toBeTruthy();
+  });
+
+  it('falls back to the story title when highlighting a map-pin timeline filter', async () => {
     await storage.set(storageKeys.mapSearchFilters, {
       proximityRadiusKm: 0.5,
       proximityCoordinates: {
@@ -530,30 +628,28 @@ describe('MapScreen', () => {
     renderScreen(<MapScreen getMarkerGroups={async () => markerGroups} />);
 
     await waitFor(() => {
-      expect(screen.getByTestId('story-marker').props.accessibilityState.selected).toBe(true);
+      expect(screen.getByLabelText('marker:map-pin-story:story-002:').props.accessibilityState.selected).toBe(true);
     });
   });
 
-  it('shows a red pin instead of a cluster bubble for an active group timeline filter', async () => {
-    await storage.set(storageKeys.mapSearchFilters, {
-      proximityRadiusKm: 0.5,
-      proximityCoordinates: {
-        latitude: 41.01,
-        longitude: 28.97,
-      },
-      proximitySource: 'map_pin',
-      proximityLabel: '2 nearby stories',
-    });
+  it('switches the red marker to the story selected from a clustered marker timeline action', async () => {
+    const onViewTimeline = jest.fn();
 
-    renderScreen(<MapScreen getMarkerGroups={async () => markerGroups} />);
+    renderScreen(<MapScreen getMarkerGroups={async () => markerGroups} onViewTimeline={onViewTimeline} />);
 
-    await waitFor(() => {
-      expect(screen.getByLabelText(/^marker:zoom-cluster:.*:$/).props.accessibilityState.selected).toBe(true);
+    await screen.findByText('Select a story marker to preview.');
+    fireEvent.press(screen.getAllByTestId('story-marker')[1]);
+    fireEvent.press(await screen.findByLabelText('View timeline near Voices of the Ferry Pier'));
+
+    expect(onViewTimeline).toHaveBeenCalledWith({
+      latitude: 41.016,
+      longitude: 28.98,
+      label: 'Voices of the Ferry Pier',
+      storyId: 'story-003',
     });
-    expect(screen.queryByLabelText(/^marker:.*:2$/)).toBeNull();
   });
 
-  it('keeps a client-side group timeline target red when only the displayed cluster coordinate matches', async () => {
+  it('does not highlight a client-side group timeline coordinate after group timelines are removed', async () => {
     await storage.set(storageKeys.mapSearchFilters, {
       proximityRadiusKm: 0.5,
       proximityCoordinates: {
@@ -566,10 +662,8 @@ describe('MapScreen', () => {
 
     renderScreen(<MapScreen getMarkerGroups={async () => markerGroups} />);
 
-    await waitFor(() => {
-      expect(screen.getByLabelText(/^marker:zoom-cluster:.*:$/).props.accessibilityState.selected).toBe(true);
-    });
-    expect(screen.queryByLabelText(/^marker:zoom-cluster:.*:2$/)).toBeNull();
+    await screen.findByText('Select a story marker to preview.');
+    expect(screen.queryByLabelText(/^marker:zoom-cluster:.*:$/)).toBeNull();
   });
 
   it('requests scrolling to the preview when a marker is pressed', async () => {

--- a/mobile/src/features/search/presentation/components/StorySearchControls.tsx
+++ b/mobile/src/features/search/presentation/components/StorySearchControls.tsx
@@ -25,7 +25,7 @@ function buildChips(filters: ReturnType<typeof useSearchFilters>['filters']): Fi
 
     chips.push({
       key: 'proximityRadiusKm',
-      label: `Distance: ${formatDistance(filters.proximityRadiusKm)} from ${filters.proximityLabel ?? ''}`.trim(),
+      label: `Distance: ${formatDistance(filters.proximityRadiusKm)} from`,
       visual: isMapPinFilter ? 'redPin' : 'bluePin',
       visualAccessibilityLabel: isMapPinFilter ? 'red location pin' : 'current location blue pin',
     });

--- a/mobile/src/features/search/presentation/context/SearchFiltersContext.tsx
+++ b/mobile/src/features/search/presentation/context/SearchFiltersContext.tsx
@@ -21,6 +21,7 @@ export interface SearchFiltersState {
   proximityCoordinates?: ProximityCoordinates;
   proximitySource?: ProximitySource;
   proximityLabel?: string;
+  proximityStoryId?: string;
   timeFrom: string;
   timeTo: string;
   tags: string[];
@@ -45,6 +46,7 @@ const initialFilters: SearchFiltersState = {
   proximityCoordinates: undefined,
   proximitySource: undefined,
   proximityLabel: undefined,
+  proximityStoryId: undefined,
   timeFrom: '',
   timeTo: '',
   tags: [],
@@ -60,6 +62,13 @@ const storageKeyByScope: Record<SearchFilterScope, string> = {
   feed: storageKeys.feedSearchFilters,
   map: storageKeys.mapSearchFilters,
   main: storageKeys.mainSearchFilters,
+};
+const clearedProximityFilters = {
+  proximityRadiusKm: undefined,
+  proximityCoordinates: undefined,
+  proximitySource: undefined,
+  proximityLabel: undefined,
+  proximityStoryId: undefined,
 };
 
 const SearchFiltersContext = createContext<SearchFiltersContextValue | undefined>(undefined);
@@ -156,10 +165,7 @@ export function SearchFiltersProvider({ children }: PropsWithChildren) {
             ...currentFilters,
             [key]: key === 'tags' ? [] : '',
             ...(key === 'location' ? { locationBounds: undefined } : {}),
-            ...(key === 'proximityRadiusKm' ? { proximityRadiusKm: undefined, proximityCoordinates: undefined, proximitySource: undefined, proximityLabel: undefined } : {}),
-            ...(key === 'proximityCoordinates' ? { proximityRadiusKm: undefined, proximityCoordinates: undefined, proximitySource: undefined, proximityLabel: undefined } : {}),
-            ...(key === 'proximitySource' ? { proximityRadiusKm: undefined, proximityCoordinates: undefined, proximitySource: undefined, proximityLabel: undefined } : {}),
-            ...(key === 'proximityLabel' ? { proximityRadiusKm: undefined, proximityCoordinates: undefined, proximitySource: undefined, proximityLabel: undefined } : {}),
+            ...(isProximityFilterKey(key) ? clearedProximityFilters : {}),
           }),
           { refresh: true },
         );
@@ -240,6 +246,7 @@ function normalizeStoredFilters(filters?: Partial<SearchFiltersState> | null): S
     proximityCoordinates: normalizeProximityCoordinates(filters?.proximityCoordinates),
     proximitySource: normalizeProximitySource(filters?.proximitySource),
     proximityLabel: normalizeOptionalString(filters?.proximityLabel),
+    proximityStoryId: normalizeOptionalString(filters?.proximityStoryId),
     timeFrom: filters?.timeFrom ?? '',
     timeTo: filters?.timeTo ?? '',
     tags: normalizeTags(filters?.tags),
@@ -254,6 +261,16 @@ function normalizeTags(tags?: string[] | null): string[] {
   return tags
     .map((tag) => tag.trim())
     .filter((tag, index, values): tag is string => tag.length > 0 && values.indexOf(tag) === index);
+}
+
+function isProximityFilterKey(key: keyof SearchFiltersState) {
+  return (
+    key === 'proximityRadiusKm' ||
+    key === 'proximityCoordinates' ||
+    key === 'proximitySource' ||
+    key === 'proximityLabel' ||
+    key === 'proximityStoryId'
+  );
 }
 
 function normalizeProximityRadius(radius?: number | null): ProximityRadiusKm | undefined {

--- a/mobile/src/shared/components/WebMapView.tsx
+++ b/mobile/src/shared/components/WebMapView.tsx
@@ -7,6 +7,7 @@ type MarkerItem = {
   latitude: number;
   longitude: number;
   selected?: boolean;
+  visualRole?: 'timeline' | 'selected';
   label?: string;
 };
 
@@ -46,7 +47,7 @@ type MapUpdatePayload = {
   transitionDurationMs?: number;
 };
 
-const MAP_HTML_VERSION = 'colored-cluster-markers-v1';
+const MAP_HTML_VERSION = 'colored-cluster-markers-v2';
 
 const mapHtml = ({
   region,
@@ -127,6 +128,13 @@ const mapHtml = ({
         box-shadow: 0 4px 12px rgba(220, 38, 38, 0.32);
       }
 
+      .marker-pin-current {
+        background: #059669;
+        box-shadow:
+          0 0 0 5px rgba(5, 150, 105, 0.18),
+          0 4px 12px rgba(5, 150, 105, 0.34);
+      }
+
       .marker-cluster {
         position: relative;
         width: 38px;
@@ -145,6 +153,12 @@ const mapHtml = ({
         border-color: #ffffff;
         box-shadow:
           0 0 0 4px rgba(220, 38, 38, 0.18),
+          0 5px 16px rgba(15, 23, 42, 0.3);
+      }
+
+      .marker.cluster.current-selected .marker-cluster {
+        box-shadow:
+          0 0 0 4px rgba(5, 150, 105, 0.22),
           0 5px 16px rgba(15, 23, 42, 0.3);
       }
 
@@ -328,16 +342,18 @@ const mapHtml = ({
       const createStoryMarker = (marker) => {
         const element = document.createElement('div');
         const isCluster = Boolean(marker.label);
+        const visualRole = marker.visualRole || (marker.selected ? 'timeline' : null);
         element.className = [
           'marker',
           isCluster ? 'cluster' : '',
-          marker.selected ? 'selected' : '',
+          visualRole ? 'selected' : '',
+          visualRole === 'selected' ? 'current-selected' : '',
         ].filter(Boolean).join(' ');
         const markerBody = document.createElement('div');
         markerBody.className = isCluster
           ? 'marker-cluster ' + getClusterSizeClass(marker.label)
-          : marker.selected
-            ? 'marker-pin'
+          : visualRole
+            ? ['marker-pin', visualRole === 'selected' ? 'marker-pin-current' : ''].filter(Boolean).join(' ')
             : 'marker-dot';
         element.appendChild(markerBody);
 
@@ -355,7 +371,7 @@ const mapHtml = ({
           );
         });
 
-        return new maplibregl.Marker({ element, anchor: marker.selected && !isCluster ? 'bottom' : 'center' })
+        return new maplibregl.Marker({ element, anchor: visualRole && !isCluster ? 'bottom' : 'center' })
           .setLngLat([marker.longitude, marker.latitude])
           .addTo(map);
       };
@@ -682,6 +698,7 @@ function markersEqual(left: MarkerItem[], right: MarkerItem[]) {
       marker.latitude === nextMarker.latitude &&
       marker.longitude === nextMarker.longitude &&
       marker.selected === nextMarker.selected &&
+      marker.visualRole === nextMarker.visualRole &&
       marker.label === nextMarker.label
     );
   });


### PR DESCRIPTION
# 📝 Description
Fixes #592

This PR fixes the mobile map behavior where a story selected from a grouped marker timeline flow could be swallowed by clustering and lose its exact red timeline pin. The root cause was that the map-pin timeline filter only carried coordinates/labels, so grouped markers and reclustering could represent the target as a cluster instead of the individual story.

The fix carries the story id through the mobile timeline action and persisted proximity filters, extracts the active timeline story into its own pinned marker before clustering, and keeps that red timeline pin visually distinct from the currently selected marker. It also removes the group-level timeline action so timeline navigation is story-specific, updates the distance chip copy, and expands regression tests around zooming, backend grouped markers, and fallback story matching.

# 📊 Type of Change
- [x]  Bug fix
- [ ]  New feature
- [ ]  Refactoring
- [ ]  Documentation
 
# ✅ Acceptance Criteria / Checklist
- [ ] Project builds successfully
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, especially in hard-to-understand parts
- [x] I have performed a self-review of my code
- [x] I have added/updated tests
- [x] New and existing unit tests pass locally with my changes

# 📸 Screenshots / Recordings
N/A

# ⏱️ Estimated Review Time
- [ ] < 5 min
- [ ] 5-15 min
- [x] > 15 min

# ✅ Validation
- `npm test -- --runTestsByPath src/features/map/presentation/screens/__tests__/MapScreen.test.tsx src/app/navigation/__tests__/RootNavigator.test.tsx --runInBand`
  - Passed: 2 test suites, 62 tests
  - Note: existing `VirtualizedList` act warnings appeared in `RootNavigator.test.tsx` output, but the suite passed.