### PR TITLE
fix: mobile remove duplicate mobile map filter summary

### DIFF
--- a/mobile/src/features/map/presentation/screens/MapScreen.tsx
+++ b/mobile/src/features/map/presentation/screens/MapScreen.tsx
@@ -222,25 +222,6 @@ export function MapScreen({
     setStatusIndicatorMode('filters');
   }, [activeFilters, hasActiveFilters]);
 
-  const activeFilterSummary = useMemo(() => {
-    const parts = [];
-
-    if (state.filters.q) {
-      parts.push(`Search: ${state.filters.q}`);
-    }
-    if (state.filters.location) {
-      parts.push(`Place: ${state.filters.location}`);
-    }
-    if (state.filters.yearFrom || state.filters.yearTo) {
-      parts.push(`Years: ${state.filters.yearFrom ?? 'Any'}-${state.filters.yearTo ?? 'Any'}`);
-    }
-    if (state.filters.tags?.length) {
-      parts.push(`Tag: ${state.filters.tags.join(', ')}`);
-    }
-
-    return parts;
-  }, [state.filters]);
-
   const totalStoryCount = useMemo(
     () => state.markers.reduce((sum, marker) => sum + marker.count, 0),
     [state.markers],
@@ -323,7 +304,6 @@ export function MapScreen({
   return (
     <View style={{ gap: spacing.md }}>
       {showSearchControls ? <StorySearchControls helperText="Search by title or place." scope={searchScope} /> : null}
-      {activeFilterSummary.length ? <Text style={{ color: colors.muted }}>{activeFilterSummary.join('  |  ')}</Text> : null}
 
       <View
         testID="map-card-container"

--- a/mobile/src/features/map/presentation/screens/__tests__/MapScreen.test.tsx
+++ b/mobile/src/features/map/presentation/screens/__tests__/MapScreen.test.tsx
@@ -318,6 +318,28 @@ describe('MapScreen', () => {
     expect(screen.getByText('Select a story marker to preview.')).toBeTruthy();
   });
 
+  it('does not repeat active filters above the map', async () => {
+    renderScreen(
+      <MapScreen
+        initialFilters={{
+          q: 'hidden query',
+          location: 'Hidden Place',
+          yearFrom: 1900,
+          yearTo: 1950,
+          tags: ['History'],
+        }}
+        getMarkerGroups={async () => markerGroups}
+        showSearchControls={false}
+      />,
+    );
+
+    expect(await screen.findByTestId('story-map')).toBeTruthy();
+    expect(screen.queryByText('Search: hidden query')).toBeNull();
+    expect(screen.queryByText('Place: Hidden Place')).toBeNull();
+    expect(screen.queryByText('Years: 1900-1950')).toBeNull();
+    expect(screen.queryByText('History')).toBeNull();
+  });
+
   it('clusters nearby pins while zoomed out and separates them after zooming in', async () => {
     renderScreen(<MapScreen getMarkerGroups={async () => zoomClusterMarkerGroups} />);
 


### PR DESCRIPTION
# 📝 Description
Fixes #597

Removes the duplicate active filter summary text rendered above the mobile map. The same filter state is already represented by the search/filter UI, so the extra summary created repeated information and unnecessary visual clutter.

This also adds a regression test that renders the map with active search, location, year, and tag filters and verifies those filter summary labels are not repeated above the map.

# 📊 Type of Change
- [x]  Bug fix
- [ ]  New feature
- [ ]  Refactoring
- [ ]  Documentation
 
# ✅ Acceptance Criteria / Checklist
- [ ] Project builds successfully
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, especially in hard-to-understand parts
- [x] I have performed a self-review of my code
- [x] I have added/updated tests
- [x] New and existing unit tests pass locally with my changes

Validation:
- `npm test -- --runTestsByPath src/features/map/presentation/screens/__tests__/MapScreen.test.tsx --runInBand` passed: 40 tests
- `npm run typecheck` passed

# 📸 Screenshots / Recordings
N/A

# ⏱️ Estimated Review Time
- [ ] < 5 min
- [x] 5-15 min
- [ ] > 15 min
