### PR TITLE
Feat/frontend admin panel

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,7 +1,13 @@
 import { BrowserRouter, Routes, Route } from "react-router-dom";
 
 import ProtectedRoute from "@/components/ProtectedRoute";
+import AdminRoute from "@/components/AdminRoute";
 import AppLayout from "@/components/AppLayout/AppLayout";
+import AdminLayout from "@/components/AdminPanel/AdminLayout";
+import AdminReportsPage from "@/pages/admin/AdminReportsPage";
+import AdminStoriesPage from "@/pages/admin/AdminStoriesPage";
+import AdminUsersPage from "@/pages/admin/AdminUsersPage";
+import AdminTagsPage from "@/pages/admin/AdminTagsPage";
 import { AuthProvider } from "@/context/AuthContext";
 import { ToastProvider } from "@/context/ToastContext";
 import { Toaster } from "@/components/ui/toaster";
@@ -71,6 +77,20 @@ function App() {
               <Route path="/profile/:userId" element={<ProfilePage />} />
               <Route path="/stories/:id" element={<StoryDetailPage />} />
               <Route path="/tags/:slug" element={<TagPage />} />
+              <Route
+                path="/admin"
+                element={(
+                  <AdminRoute>
+                    <AdminLayout />
+                  </AdminRoute>
+                )}
+              >
+                <Route index element={<AdminReportsPage />} />
+                <Route path="reports" element={<AdminReportsPage />} />
+                <Route path="stories" element={<AdminStoriesPage />} />
+                <Route path="users" element={<AdminUsersPage />} />
+                <Route path="tags" element={<AdminTagsPage />} />
+              </Route>
               <Route path="*" element={<NotFoundPage />} />
             </Route>
           </Routes>

--- a/frontend/src/components/AdminPanel/AdminLayout.jsx
+++ b/frontend/src/components/AdminPanel/AdminLayout.jsx
@@ -1,0 +1,52 @@
+import { NavLink, Outlet } from "react-router-dom";
+import { Flag, FileText, Users, Tag as TagIcon, Shield } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+
+const sections = [
+  { to: "/admin/reports", label: "Reports", icon: Flag },
+  { to: "/admin/stories", label: "Stories", icon: FileText },
+  { to: "/admin/users", label: "Users", icon: Users },
+  { to: "/admin/tags", label: "Tags", icon: TagIcon },
+];
+
+function AdminLayout() {
+  return (
+    <div className="container mx-auto max-w-7xl px-4 py-6">
+      <div className="mb-6 flex items-center gap-2">
+        <Shield className="h-6 w-6 text-primary" aria-hidden="true" />
+        <h1 className="text-2xl font-semibold">Admin Panel</h1>
+      </div>
+
+      <div className="grid gap-6 md:grid-cols-[200px_1fr]">
+        <aside aria-label="Admin sections">
+          <nav className="flex flex-row gap-1 overflow-x-auto md:flex-col">
+            {sections.map((s) => (
+              <NavLink
+                key={s.to}
+                to={s.to}
+                className={({ isActive }) =>
+                  cn(
+                    "flex items-center gap-2 rounded-md px-3 py-2 text-sm font-medium transition-colors whitespace-nowrap",
+                    isActive
+                      ? "bg-primary text-primary-foreground"
+                      : "text-muted-foreground hover:bg-muted hover:text-foreground"
+                  )
+                }
+              >
+                <s.icon className="h-4 w-4" aria-hidden="true" />
+                {s.label}
+              </NavLink>
+            ))}
+          </nav>
+        </aside>
+
+        <main className="min-w-0">
+          <Outlet />
+        </main>
+      </div>
+    </div>
+  );
+}
+
+export default AdminLayout;

--- a/frontend/src/components/AdminPanel/ConfirmDialog.jsx
+++ b/frontend/src/components/AdminPanel/ConfirmDialog.jsx
@@ -1,0 +1,57 @@
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+
+/**
+ * Confirmation dialog for destructive admin actions.
+ * Children are rendered inside the body — used to slot in reason/note inputs.
+ */
+function ConfirmDialog({
+  open,
+  onOpenChange,
+  title,
+  description,
+  confirmLabel = "Confirm",
+  cancelLabel = "Cancel",
+  onConfirm,
+  confirming = false,
+  destructive = true,
+  children,
+  confirmDisabled = false,
+}) {
+  return (
+    <AlertDialog open={open} onOpenChange={onOpenChange}>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>{title}</AlertDialogTitle>
+          {description && (
+            <AlertDialogDescription>{description}</AlertDialogDescription>
+          )}
+        </AlertDialogHeader>
+        {children && <div className="space-y-2">{children}</div>}
+        <AlertDialogFooter>
+          <AlertDialogCancel disabled={confirming}>{cancelLabel}</AlertDialogCancel>
+          <AlertDialogAction
+            variant={destructive ? "destructive" : "default"}
+            disabled={confirming || confirmDisabled}
+            onClick={(e) => {
+              e.preventDefault();
+              onConfirm();
+            }}
+          >
+            {confirming ? "Working…" : confirmLabel}
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}
+
+export default ConfirmDialog;

--- a/frontend/src/components/AdminPanel/Pagination.jsx
+++ b/frontend/src/components/AdminPanel/Pagination.jsx
@@ -1,0 +1,38 @@
+import { Button } from "@/components/ui/button";
+
+/**
+ * Simple paginator for DRF-style { count, next, previous } responses.
+ * Page numbers are 1-based. Renders nothing when there is only one page.
+ */
+function Pagination({ page, count, pageSize, onPageChange, disabled = false }) {
+  const totalPages = count > 0 ? Math.ceil(count / pageSize) : 1;
+  if (totalPages <= 1) return null;
+
+  return (
+    <div className="mt-4 flex items-center justify-between gap-2">
+      <span className="text-sm text-muted-foreground">
+        Page {page} of {totalPages} ({count} total)
+      </span>
+      <div className="flex gap-2">
+        <Button
+          variant="outline"
+          size="sm"
+          disabled={disabled || page <= 1}
+          onClick={() => onPageChange(page - 1)}
+        >
+          Previous
+        </Button>
+        <Button
+          variant="outline"
+          size="sm"
+          disabled={disabled || page >= totalPages}
+          onClick={() => onPageChange(page + 1)}
+        >
+          Next
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+export default Pagination;

--- a/frontend/src/components/AdminRoute.jsx
+++ b/frontend/src/components/AdminRoute.jsx
@@ -1,0 +1,33 @@
+import { Navigate, useLocation } from "react-router-dom";
+
+import { useAuth } from "@/hooks/useAuth";
+
+/**
+ * Restricts a route to authenticated admin users.
+ *  - Unauthenticated → redirect to /login.
+ *  - Authenticated non-admin → render a simple "Not authorized" page.
+ *  - Admin → render children.
+ */
+function AdminRoute({ children }) {
+  const { user, isAuthenticated } = useAuth();
+  const location = useLocation();
+
+  if (!isAuthenticated) {
+    return <Navigate to="/login" replace state={{ from: location }} />;
+  }
+
+  if (user?.role !== "admin") {
+    return (
+      <div className="container mx-auto max-w-xl px-4 py-16 text-center">
+        <h1 className="text-2xl font-semibold">Not authorized</h1>
+        <p className="mt-2 text-muted-foreground">
+          You do not have permission to access the admin panel.
+        </p>
+      </div>
+    );
+  }
+
+  return children;
+}
+
+export default AdminRoute;

--- a/frontend/src/components/AppLayout/AppLayout.jsx
+++ b/frontend/src/components/AppLayout/AppLayout.jsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import { Link, Outlet, useLocation, useNavigate } from "react-router-dom";
-import { Menu, MapPin, LogOut, User, Plus } from "lucide-react";
+import { Menu, MapPin, LogOut, User, Plus, Shield } from "lucide-react";
 
 import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
@@ -52,8 +52,12 @@ function AppLayout() {
     navigate("/");
   };
 
+  const isAdmin = user?.role === "admin";
+  const baseLinks = isAdmin
+    ? [...publicLinks, { to: "/admin", label: "Admin", icon: Shield }]
+    : publicLinks;
   const isFilterPage = location.pathname === "/" || location.pathname === "/map";
-  const links = publicLinks.map((link) =>
+  const links = baseLinks.map((link) =>
     link.preserveSearch && isFilterPage && location.search
       ? { ...link, basePath: link.to, to: `${link.to}${location.search}` }
       : link

--- a/frontend/src/components/__tests__/AdminRoute.test.jsx
+++ b/frontend/src/components/__tests__/AdminRoute.test.jsx
@@ -1,0 +1,56 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+
+vi.mock("@/hooks/useAuth", () => ({ useAuth: vi.fn() }));
+
+import { useAuth } from "@/hooks/useAuth";
+import AdminRoute from "../AdminRoute";
+
+function renderAt(path = "/admin") {
+  return render(
+    <MemoryRouter initialEntries={[path]}>
+      <Routes>
+        <Route path="/login" element={<div>LOGIN PAGE</div>} />
+        <Route
+          path="/admin"
+          element={(
+            <AdminRoute>
+              <div>ADMIN CONTENT</div>
+            </AdminRoute>
+          )}
+        />
+      </Routes>
+    </MemoryRouter>
+  );
+}
+
+describe("AdminRoute", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("redirects unauthenticated users to /login", () => {
+    useAuth.mockReturnValue({ user: null, isAuthenticated: false });
+    renderAt("/admin");
+    expect(screen.getByText("LOGIN PAGE")).toBeInTheDocument();
+    expect(screen.queryByText("ADMIN CONTENT")).not.toBeInTheDocument();
+  });
+
+  it("shows Not authorized for authenticated non-admin users", () => {
+    useAuth.mockReturnValue({
+      user: { id: 1, role: "user" },
+      isAuthenticated: true,
+    });
+    renderAt("/admin");
+    expect(screen.getByRole("heading", { name: /not authorized/i })).toBeInTheDocument();
+    expect(screen.queryByText("ADMIN CONTENT")).not.toBeInTheDocument();
+  });
+
+  it("renders children for admin users", () => {
+    useAuth.mockReturnValue({
+      user: { id: 1, role: "admin" },
+      isAuthenticated: true,
+    });
+    renderAt("/admin");
+    expect(screen.getByText("ADMIN CONTENT")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/__tests__/AdminReportsPage.test.jsx
+++ b/frontend/src/pages/__tests__/AdminReportsPage.test.jsx
@@ -1,0 +1,107 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter } from "react-router-dom";
+
+vi.mock("@/services/adminService", () => ({
+  listReports: vi.fn(),
+  resolveReportWithAction: vi.fn(),
+}));
+vi.mock("@/services/storyService", () => ({
+  getStoryById: vi.fn(),
+}));
+
+import { listReports, resolveReportWithAction } from "@/services/adminService";
+import { getStoryById } from "@/services/storyService";
+import AdminReportsPage from "../admin/AdminReportsPage";
+
+function makeReport(overrides = {}) {
+  return {
+    id: 1,
+    reporter: { id: 2, username: "alice" },
+    target_type: "story",
+    target_id: 10,
+    reason: "spam",
+    description: "",
+    status: "pending",
+    created_at: "2026-05-01T00:00:00Z",
+    resolved_at: null,
+    ...overrides,
+  };
+}
+
+function renderPage() {
+  return render(
+    <MemoryRouter>
+      <AdminReportsPage />
+    </MemoryRouter>
+  );
+}
+
+describe("AdminReportsPage", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("shows the loading spinner then the report rows", async () => {
+    listReports.mockResolvedValue({ count: 1, results: [makeReport()] });
+    renderPage();
+    expect(screen.getByTestId("reports-loading")).toBeInTheDocument();
+    expect(await screen.findByText(/alice/)).toBeInTheDocument();
+    expect(screen.getByText(/story #10/)).toBeInTheDocument();
+  });
+
+  it("filters by status when the dropdown changes", async () => {
+    listReports.mockResolvedValue({ count: 0, results: [] });
+    renderPage();
+    await waitFor(() => expect(listReports).toHaveBeenCalledTimes(1));
+    await userEvent.selectOptions(screen.getByLabelText(/status/i), "resolved");
+    await waitFor(() =>
+      expect(listReports).toHaveBeenLastCalledWith({
+        status: "resolved",
+        page: 1,
+        pageSize: 20,
+      })
+    );
+  });
+
+  it("opens the resolve modal and submits with the selected outcome", async () => {
+    listReports.mockResolvedValue({ count: 1, results: [makeReport()] });
+    resolveReportWithAction.mockResolvedValue({});
+    renderPage();
+    await screen.findByText(/alice/);
+
+    await userEvent.click(screen.getByRole("button", { name: /resolve/i }));
+    const dialog = await screen.findByRole("alertdialog");
+
+    await userEvent.type(within(dialog).getByLabelText(/note/i), "looked legitimate");
+    await userEvent.click(within(dialog).getByRole("button", { name: /^resolve$/i }));
+
+    await waitFor(() =>
+      expect(resolveReportWithAction).toHaveBeenCalledWith({
+        report: expect.objectContaining({ id: 1 }),
+        action: "no_action",
+        note: "looked legitimate",
+        targetUserId: null,
+      })
+    );
+  });
+
+  it("looks up the story author when banning via a story report", async () => {
+    listReports.mockResolvedValue({ count: 1, results: [makeReport()] });
+    getStoryById.mockResolvedValue({ id: 10, user: { id: 77, username: "bob" } });
+    resolveReportWithAction.mockResolvedValue({});
+    renderPage();
+    await screen.findByText(/alice/);
+
+    await userEvent.click(screen.getByRole("button", { name: /resolve/i }));
+    const dialog = await screen.findByRole("alertdialog");
+    await userEvent.click(within(dialog).getByLabelText(/ban user/i));
+    await userEvent.click(within(dialog).getByRole("button", { name: /^resolve$/i }));
+
+    await waitFor(() => expect(getStoryById).toHaveBeenCalledWith(10));
+    await waitFor(() =>
+      expect(resolveReportWithAction).toHaveBeenCalledWith(
+        expect.objectContaining({ action: "ban_user", targetUserId: 77 })
+      )
+    );
+  });
+});

--- a/frontend/src/pages/__tests__/AdminStoriesPage.test.jsx
+++ b/frontend/src/pages/__tests__/AdminStoriesPage.test.jsx
@@ -1,0 +1,67 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter } from "react-router-dom";
+
+vi.mock("@/services/storyService", () => ({ getStories: vi.fn() }));
+vi.mock("@/services/adminService", () => ({ removeStory: vi.fn() }));
+
+import { getStories } from "@/services/storyService";
+import { removeStory } from "@/services/adminService";
+import AdminStoriesPage from "../admin/AdminStoriesPage";
+
+function renderPage() {
+  return render(
+    <MemoryRouter>
+      <AdminStoriesPage />
+    </MemoryRouter>
+  );
+}
+
+describe("AdminStoriesPage", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("loads stories on mount and shows them", async () => {
+    getStories.mockResolvedValue({
+      count: 1,
+      results: [{ id: 1, title: "First Story", location_name: "Istanbul", user: { username: "ada" } }],
+    });
+    renderPage();
+    expect(await screen.findByText("First Story")).toBeInTheDocument();
+    expect(screen.getByText("ada")).toBeInTheDocument();
+  });
+
+  it("submits the search query and refetches", async () => {
+    getStories.mockResolvedValue({ count: 0, results: [] });
+    renderPage();
+    await waitFor(() => expect(getStories).toHaveBeenCalledTimes(1));
+
+    await userEvent.type(screen.getByLabelText(/search stories/i), "ottoman");
+    await userEvent.click(screen.getByRole("button", { name: /search/i }));
+
+    await waitFor(() =>
+      expect(getStories).toHaveBeenLastCalledWith({ q: "ottoman", page: 1, pageSize: 12 })
+    );
+  });
+
+  it("requires a reason and removes the story after confirmation", async () => {
+    getStories.mockResolvedValue({
+      count: 1,
+      results: [{ id: 5, title: "Bad Story", location_name: "X", user: { username: "u" } }],
+    });
+    removeStory.mockResolvedValue();
+    renderPage();
+    await screen.findByText("Bad Story");
+
+    await userEvent.click(screen.getByRole("button", { name: /remove/i }));
+    const dialog = await screen.findByRole("alertdialog");
+
+    const confirm = within(dialog).getByRole("button", { name: /^remove$/i });
+    expect(confirm).toBeDisabled();
+
+    await userEvent.type(within(dialog).getByLabelText(/reason/i), "violates policy");
+    await userEvent.click(confirm);
+
+    await waitFor(() => expect(removeStory).toHaveBeenCalledWith(5, "violates policy"));
+  });
+});

--- a/frontend/src/pages/__tests__/AdminTagsPage.test.jsx
+++ b/frontend/src/pages/__tests__/AdminTagsPage.test.jsx
@@ -1,0 +1,58 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter } from "react-router-dom";
+
+vi.mock("@/services/tagService", () => ({ searchTags: vi.fn() }));
+vi.mock("@/services/adminService", () => ({ deleteTag: vi.fn() }));
+
+import { searchTags } from "@/services/tagService";
+import { deleteTag } from "@/services/adminService";
+import AdminTagsPage from "../admin/AdminTagsPage";
+
+function renderPage() {
+  return render(
+    <MemoryRouter>
+      <AdminTagsPage />
+    </MemoryRouter>
+  );
+}
+
+describe("AdminTagsPage", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("renders tags with their story counts", async () => {
+    searchTags.mockResolvedValue([
+      { id: 1, name: "war", is_predefined: true, story_count: 5 },
+      { id: 2, name: "peace", is_predefined: false, story_count: 0 },
+    ]);
+    renderPage();
+    expect(await screen.findByText("war")).toBeInTheDocument();
+    expect(screen.getByText("peace")).toBeInTheDocument();
+    expect(screen.getByText("5")).toBeInTheDocument();
+  });
+
+  it("filters via search input", async () => {
+    searchTags.mockResolvedValue([]);
+    renderPage();
+    await waitFor(() => expect(searchTags).toHaveBeenCalledTimes(1));
+
+    await userEvent.type(screen.getByLabelText(/search tags/i), "ottoman");
+    await userEvent.click(screen.getByRole("button", { name: /search/i }));
+
+    await waitFor(() => expect(searchTags).toHaveBeenLastCalledWith("ottoman"));
+  });
+
+  it("removes a tag after confirmation", async () => {
+    searchTags.mockResolvedValue([{ id: 9, name: "obsolete", is_predefined: false, story_count: 0 }]);
+    deleteTag.mockResolvedValue();
+    renderPage();
+    await screen.findByText("obsolete");
+
+    await userEvent.click(screen.getByRole("button", { name: /^remove$/i }));
+    const dialog = await screen.findByRole("alertdialog");
+    await userEvent.click(within(dialog).getByRole("button", { name: /^remove$/i }));
+
+    await waitFor(() => expect(deleteTag).toHaveBeenCalledWith(9));
+  });
+});

--- a/frontend/src/pages/__tests__/AdminUsersPage.test.jsx
+++ b/frontend/src/pages/__tests__/AdminUsersPage.test.jsx
@@ -1,0 +1,59 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter } from "react-router-dom";
+
+vi.mock("@/services/userService", () => ({ getPublicProfile: vi.fn() }));
+vi.mock("@/services/adminService", () => ({ banUser: vi.fn() }));
+
+import { getPublicProfile } from "@/services/userService";
+import { banUser } from "@/services/adminService";
+import AdminUsersPage from "../admin/AdminUsersPage";
+
+function renderPage() {
+  return render(
+    <MemoryRouter>
+      <AdminUsersPage />
+    </MemoryRouter>
+  );
+}
+
+describe("AdminUsersPage", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("looks up a user by ID and renders their info", async () => {
+    getPublicProfile.mockResolvedValue({ id: 12, username: "carol", is_active: true });
+    renderPage();
+    await userEvent.type(screen.getByLabelText(/user id/i), "12");
+    await userEvent.click(screen.getByRole("button", { name: /look up/i }));
+    expect(await screen.findByText(/carol/)).toBeInTheDocument();
+    expect(screen.getByText(/active/i)).toBeInTheDocument();
+  });
+
+  it("shows an error when the user is not found", async () => {
+    getPublicProfile.mockRejectedValue({ response: { status: 404 } });
+    renderPage();
+    await userEvent.type(screen.getByLabelText(/user id/i), "999");
+    await userEvent.click(screen.getByRole("button", { name: /look up/i }));
+    expect(await screen.findByText(/user not found/i)).toBeInTheDocument();
+  });
+
+  it("bans a user after confirmation", async () => {
+    getPublicProfile.mockResolvedValue({ id: 7, username: "dave", is_active: true });
+    banUser.mockResolvedValue({ id: 7, is_active: false });
+    renderPage();
+
+    await userEvent.type(screen.getByLabelText(/user id/i), "7");
+    await userEvent.click(screen.getByRole("button", { name: /look up/i }));
+    await screen.findByText(/dave/);
+
+    await userEvent.click(screen.getByRole("button", { name: /ban user/i }));
+    const dialog = await screen.findByRole("alertdialog");
+    await userEvent.click(within(dialog).getByRole("button", { name: /^ban$/i }));
+
+    await waitFor(() => expect(banUser).toHaveBeenCalledWith(7));
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: /already banned/i })).toBeDisabled()
+    );
+  });
+});

--- a/frontend/src/pages/__tests__/AdminUsersPage.test.jsx
+++ b/frontend/src/pages/__tests__/AdminUsersPage.test.jsx
@@ -22,7 +22,7 @@ describe("AdminUsersPage", () => {
   beforeEach(() => vi.clearAllMocks());
 
   it("looks up a user by ID and renders their info", async () => {
-    getPublicProfile.mockResolvedValue({ id: 12, username: "carol", is_active: true });
+    getPublicProfile.mockResolvedValue({ id: 12, username: "carol" });
     renderPage();
     await userEvent.type(screen.getByLabelText(/user id/i), "12");
     await userEvent.click(screen.getByRole("button", { name: /look up/i }));
@@ -39,7 +39,7 @@ describe("AdminUsersPage", () => {
   });
 
   it("bans a user after confirmation", async () => {
-    getPublicProfile.mockResolvedValue({ id: 7, username: "dave", is_active: true });
+    getPublicProfile.mockResolvedValue({ id: 7, username: "dave" });
     banUser.mockResolvedValue({ id: 7, is_active: false });
     renderPage();
 

--- a/frontend/src/pages/admin/AdminReportsPage.jsx
+++ b/frontend/src/pages/admin/AdminReportsPage.jsx
@@ -1,0 +1,224 @@
+import { useCallback, useEffect, useState } from "react";
+
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { LoadingSpinner } from "@/components/ui/loading-spinner";
+import { ErrorState } from "@/components/ui/error-state";
+import { EmptyState } from "@/components/ui/empty-state";
+import ConfirmDialog from "@/components/AdminPanel/ConfirmDialog";
+import Pagination from "@/components/AdminPanel/Pagination";
+import { listReports, resolveReportWithAction } from "@/services/adminService";
+import { getStoryById } from "@/services/storyService";
+
+const PAGE_SIZE = 20;
+const STATUS_FILTERS = [
+  { value: "", label: "All" },
+  { value: "pending", label: "Pending" },
+  { value: "resolved", label: "Resolved" },
+  { value: "dismissed", label: "Dismissed" },
+];
+const OUTCOMES = [
+  { value: "no_action", label: "No action" },
+  { value: "remove_content", label: "Remove content" },
+  { value: "ban_user", label: "Ban user" },
+];
+
+function formatDate(iso) {
+  if (!iso) return "—";
+  const d = new Date(iso);
+  return Number.isNaN(d.getTime()) ? "—" : d.toLocaleString();
+}
+
+function AdminReportsPage() {
+  const [statusFilter, setStatusFilter] = useState("");
+  const [page, setPage] = useState(1);
+  const [data, setData] = useState({ count: 0, results: [] });
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  const [activeReport, setActiveReport] = useState(null);
+  const [outcome, setOutcome] = useState("no_action");
+  const [note, setNote] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [actionError, setActionError] = useState(null);
+
+  const fetchReports = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await listReports({ status: statusFilter || undefined, page, pageSize: PAGE_SIZE });
+      setData(res);
+    } catch (err) {
+      setError(err?.response?.data?.detail || "Failed to load reports.");
+    } finally {
+      setLoading(false);
+    }
+  }, [statusFilter, page]);
+
+  useEffect(() => {
+    fetchReports();
+  }, [fetchReports]);
+
+  const openResolve = (report) => {
+    setActiveReport(report);
+    setOutcome("no_action");
+    setNote("");
+    setActionError(null);
+  };
+
+  const submitResolve = async () => {
+    if (!activeReport) return;
+    setSubmitting(true);
+    setActionError(null);
+    try {
+      let targetUserId = null;
+      if (outcome === "ban_user" && activeReport.target_type === "story") {
+        // The list payload doesn't include the story author, so look it up.
+        const story = await getStoryById(activeReport.target_id);
+        targetUserId = story?.user?.id ?? story?.user_id ?? null;
+        if (!targetUserId) {
+          throw new Error("Could not resolve target user for ban.");
+        }
+      }
+      await resolveReportWithAction({ report: activeReport, action: outcome, note, targetUserId });
+      setActiveReport(null);
+      await fetchReports();
+    } catch (err) {
+      setActionError(err?.response?.data?.detail || err.message || "Action failed.");
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <section>
+      <div className="mb-4 flex flex-wrap items-center justify-between gap-3">
+        <h2 className="text-xl font-semibold">Reports</h2>
+        <div className="flex items-center gap-2">
+          <Label htmlFor="report-status-filter" className="text-sm">Status:</Label>
+          <select
+            id="report-status-filter"
+            value={statusFilter}
+            onChange={(e) => { setPage(1); setStatusFilter(e.target.value); }}
+            className="h-9 rounded-md border bg-background px-2 text-sm"
+          >
+            {STATUS_FILTERS.map((opt) => (
+              <option key={opt.value || "all"} value={opt.value}>{opt.label}</option>
+            ))}
+          </select>
+        </div>
+      </div>
+
+      {loading ? (
+        <div className="flex justify-center py-12" data-testid="reports-loading">
+          <LoadingSpinner />
+        </div>
+      ) : error ? (
+        <ErrorState title="Could not load reports" message={error} onRetry={fetchReports} />
+      ) : data.results.length === 0 ? (
+        <EmptyState title="No reports" message="No reports match this filter." />
+      ) : (
+        <div className="overflow-x-auto rounded-md border">
+          <table className="w-full text-sm">
+            <thead className="bg-muted">
+              <tr>
+                <th className="px-3 py-2 text-left">Reporter</th>
+                <th className="px-3 py-2 text-left">Target</th>
+                <th className="px-3 py-2 text-left">Reason</th>
+                <th className="px-3 py-2 text-left">Status</th>
+                <th className="px-3 py-2 text-left">Date</th>
+                <th className="px-3 py-2 text-right">Action</th>
+              </tr>
+            </thead>
+            <tbody>
+              {data.results.map((r) => (
+                <tr key={r.id} className="border-t">
+                  <td className="px-3 py-2">{r.reporter?.username || "—"}</td>
+                  <td className="px-3 py-2">{r.target_type} #{r.target_id}</td>
+                  <td className="px-3 py-2">{r.reason}</td>
+                  <td className="px-3 py-2 capitalize">{r.status}</td>
+                  <td className="px-3 py-2">{formatDate(r.created_at)}</td>
+                  <td className="px-3 py-2 text-right">
+                    {r.status === "pending" ? (
+                      <Button size="sm" onClick={() => openResolve(r)}>Resolve</Button>
+                    ) : (
+                      <span className="text-xs text-muted-foreground">{formatDate(r.resolved_at)}</span>
+                    )}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      <Pagination
+        page={page}
+        count={data.count}
+        pageSize={PAGE_SIZE}
+        onPageChange={setPage}
+        disabled={loading}
+      />
+
+      <ConfirmDialog
+        open={Boolean(activeReport)}
+        onOpenChange={(open) => { if (!open) setActiveReport(null); }}
+        title="Resolve report"
+        description={
+          activeReport
+            ? `Resolve report on ${activeReport.target_type} #${activeReport.target_id}.`
+            : ""
+        }
+        confirmLabel="Resolve"
+        confirming={submitting}
+        destructive={outcome !== "no_action"}
+        confirmDisabled={
+          outcome === "ban_user" && activeReport?.target_type === "comment"
+        }
+        onConfirm={submitResolve}
+      >
+        <div className="space-y-3 text-left">
+          <div className="space-y-1">
+            <Label>Outcome</Label>
+            <div className="flex flex-wrap gap-2">
+              {OUTCOMES.map((o) => (
+                <label
+                  key={o.value}
+                  className="flex cursor-pointer items-center gap-1 rounded-md border px-3 py-1 text-sm has-[:checked]:border-primary has-[:checked]:bg-primary/10"
+                >
+                  <input
+                    type="radio"
+                    name="outcome"
+                    value={o.value}
+                    checked={outcome === o.value}
+                    onChange={() => setOutcome(o.value)}
+                    className="sr-only"
+                  />
+                  {o.label}
+                </label>
+              ))}
+            </div>
+          </div>
+          <div className="space-y-1">
+            <Label htmlFor="resolution-note">Note</Label>
+            <Input
+              id="resolution-note"
+              value={note}
+              onChange={(e) => setNote(e.target.value)}
+              placeholder="Optional resolution note"
+            />
+          </div>
+          {outcome === "ban_user" && activeReport?.target_type === "comment" && (
+            <p className="text-xs text-destructive">
+              Banning via comment reports is not supported yet.
+            </p>
+          )}
+          {actionError && <p className="text-sm text-destructive">{actionError}</p>}
+        </div>
+      </ConfirmDialog>
+    </section>
+  );
+}
+
+export default AdminReportsPage;

--- a/frontend/src/pages/admin/AdminReportsPage.jsx
+++ b/frontend/src/pages/admin/AdminReportsPage.jsx
@@ -163,7 +163,7 @@ function AdminReportsPage() {
 
       <ConfirmDialog
         open={Boolean(activeReport)}
-        onOpenChange={(open) => { if (!open) setActiveReport(null); }}
+        onOpenChange={(open) => { if (!open && !submitting) setActiveReport(null); }}
         title="Resolve report"
         description={
           activeReport

--- a/frontend/src/pages/admin/AdminStoriesPage.jsx
+++ b/frontend/src/pages/admin/AdminStoriesPage.jsx
@@ -1,0 +1,169 @@
+import { useCallback, useEffect, useState } from "react";
+import { Link } from "react-router-dom";
+
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { LoadingSpinner } from "@/components/ui/loading-spinner";
+import { ErrorState } from "@/components/ui/error-state";
+import { EmptyState } from "@/components/ui/empty-state";
+import ConfirmDialog from "@/components/AdminPanel/ConfirmDialog";
+import Pagination from "@/components/AdminPanel/Pagination";
+import { getStories } from "@/services/storyService";
+import { removeStory } from "@/services/adminService";
+
+const PAGE_SIZE = 12;
+
+function AdminStoriesPage() {
+  const [searchInput, setSearchInput] = useState("");
+  const [query, setQuery] = useState("");
+  const [page, setPage] = useState(1);
+  const [data, setData] = useState({ count: 0, results: [] });
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  const [target, setTarget] = useState(null);
+  const [reason, setReason] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [actionError, setActionError] = useState(null);
+
+  const fetchStories = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await getStories({ q: query || undefined, page, pageSize: PAGE_SIZE });
+      setData(res);
+    } catch (err) {
+      setError(err?.response?.data?.detail || "Failed to load stories.");
+    } finally {
+      setLoading(false);
+    }
+  }, [query, page]);
+
+  useEffect(() => {
+    fetchStories();
+  }, [fetchStories]);
+
+  const submitSearch = (e) => {
+    e.preventDefault();
+    setPage(1);
+    setQuery(searchInput.trim());
+  };
+
+  const openRemove = (story) => {
+    setTarget(story);
+    setReason("");
+    setActionError(null);
+  };
+
+  const submitRemove = async () => {
+    if (!target) return;
+    if (!reason.trim()) {
+      setActionError("Reason is required.");
+      return;
+    }
+    setSubmitting(true);
+    setActionError(null);
+    try {
+      await removeStory(target.id, reason.trim());
+      setTarget(null);
+      await fetchStories();
+    } catch (err) {
+      setActionError(err?.response?.data?.detail || "Removal failed.");
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <section>
+      <div className="mb-4 flex flex-wrap items-center justify-between gap-3">
+        <h2 className="text-xl font-semibold">Stories</h2>
+        <form onSubmit={submitSearch} className="flex gap-2" role="search">
+          <Input
+            type="search"
+            value={searchInput}
+            onChange={(e) => setSearchInput(e.target.value)}
+            placeholder="Search title or location"
+            aria-label="Search stories"
+            className="w-64"
+          />
+          <Button type="submit" variant="outline">Search</Button>
+        </form>
+      </div>
+
+      {loading ? (
+        <div className="flex justify-center py-12" data-testid="stories-loading">
+          <LoadingSpinner />
+        </div>
+      ) : error ? (
+        <ErrorState title="Could not load stories" message={error} onRetry={fetchStories} />
+      ) : data.results.length === 0 ? (
+        <EmptyState title="No stories" message="No stories match this search." />
+      ) : (
+        <div className="overflow-x-auto rounded-md border">
+          <table className="w-full text-sm">
+            <thead className="bg-muted">
+              <tr>
+                <th className="px-3 py-2 text-left">Title</th>
+                <th className="px-3 py-2 text-left">Location</th>
+                <th className="px-3 py-2 text-left">Author</th>
+                <th className="px-3 py-2 text-right">Action</th>
+              </tr>
+            </thead>
+            <tbody>
+              {data.results.map((s) => (
+                <tr key={s.id} className="border-t">
+                  <td className="px-3 py-2">
+                    <Link to={`/stories/${s.id}`} className="hover:underline">
+                      {s.title}
+                    </Link>
+                  </td>
+                  <td className="px-3 py-2">{s.location_name || "—"}</td>
+                  <td className="px-3 py-2">{s.user?.username || s.author?.username || "—"}</td>
+                  <td className="px-3 py-2 text-right">
+                    <Button variant="destructive" size="sm" onClick={() => openRemove(s)}>
+                      Remove
+                    </Button>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      <Pagination
+        page={page}
+        count={data.count}
+        pageSize={PAGE_SIZE}
+        onPageChange={setPage}
+        disabled={loading}
+      />
+
+      <ConfirmDialog
+        open={Boolean(target)}
+        onOpenChange={(open) => { if (!open) setTarget(null); }}
+        title="Remove story"
+        description={target ? `This will remove "${target.title}". This action is logged.` : ""}
+        confirmLabel="Remove"
+        confirming={submitting}
+        confirmDisabled={!reason.trim()}
+        onConfirm={submitRemove}
+      >
+        <div className="space-y-2 text-left">
+          <Label htmlFor="story-removal-reason">Reason (required)</Label>
+          <Input
+            id="story-removal-reason"
+            value={reason}
+            onChange={(e) => setReason(e.target.value)}
+            placeholder="Why is this story being removed?"
+          />
+          {actionError && <p className="text-sm text-destructive">{actionError}</p>}
+        </div>
+      </ConfirmDialog>
+    </section>
+  );
+}
+
+export default AdminStoriesPage;

--- a/frontend/src/pages/admin/AdminStoriesPage.jsx
+++ b/frontend/src/pages/admin/AdminStoriesPage.jsx
@@ -143,7 +143,7 @@ function AdminStoriesPage() {
 
       <ConfirmDialog
         open={Boolean(target)}
-        onOpenChange={(open) => { if (!open) setTarget(null); }}
+        onOpenChange={(open) => { if (!open && !submitting) setTarget(null); }}
         title="Remove story"
         description={target ? `This will remove "${target.title}". This action is logged.` : ""}
         confirmLabel="Remove"

--- a/frontend/src/pages/admin/AdminTagsPage.jsx
+++ b/frontend/src/pages/admin/AdminTagsPage.jsx
@@ -1,0 +1,152 @@
+import { useCallback, useEffect, useState } from "react";
+
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { LoadingSpinner } from "@/components/ui/loading-spinner";
+import { ErrorState } from "@/components/ui/error-state";
+import { EmptyState } from "@/components/ui/empty-state";
+import ConfirmDialog from "@/components/AdminPanel/ConfirmDialog";
+import Pagination from "@/components/AdminPanel/Pagination";
+import { searchTags } from "@/services/tagService";
+import { deleteTag } from "@/services/adminService";
+
+const PAGE_SIZE = 20;
+
+function AdminTagsPage() {
+  const [searchInput, setSearchInput] = useState("");
+  const [query, setQuery] = useState("");
+  const [page, setPage] = useState(1);
+  const [tags, setTags] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  const [target, setTarget] = useState(null);
+  const [submitting, setSubmitting] = useState(false);
+  const [actionError, setActionError] = useState(null);
+
+  const fetchTags = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const all = await searchTags(query || undefined);
+      setTags(all);
+    } catch (err) {
+      setError(err?.response?.data?.detail || "Failed to load tags.");
+    } finally {
+      setLoading(false);
+    }
+  }, [query]);
+
+  useEffect(() => {
+    fetchTags();
+  }, [fetchTags]);
+
+  const submitSearch = (e) => {
+    e.preventDefault();
+    setPage(1);
+    setQuery(searchInput.trim());
+  };
+
+  const openRemove = (tag) => {
+    setTarget(tag);
+    setActionError(null);
+  };
+
+  const submitRemove = async () => {
+    if (!target) return;
+    setSubmitting(true);
+    setActionError(null);
+    try {
+      await deleteTag(target.id);
+      setTarget(null);
+      await fetchTags();
+    } catch (err) {
+      setActionError(err?.response?.data?.detail || "Tag removal failed.");
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const start = (page - 1) * PAGE_SIZE;
+  const visibleTags = tags.slice(start, start + PAGE_SIZE);
+
+  return (
+    <section>
+      <div className="mb-4 flex flex-wrap items-center justify-between gap-3">
+        <h2 className="text-xl font-semibold">Tags</h2>
+        <form onSubmit={submitSearch} className="flex gap-2" role="search">
+          <Input
+            type="search"
+            value={searchInput}
+            onChange={(e) => setSearchInput(e.target.value)}
+            placeholder="Search tag name"
+            aria-label="Search tags"
+            className="w-64"
+          />
+          <Button type="submit" variant="outline">Search</Button>
+        </form>
+      </div>
+
+      {loading ? (
+        <div className="flex justify-center py-12" data-testid="tags-loading">
+          <LoadingSpinner />
+        </div>
+      ) : error ? (
+        <ErrorState title="Could not load tags" message={error} onRetry={fetchTags} />
+      ) : visibleTags.length === 0 ? (
+        <EmptyState title="No tags" message="No tags match this search." />
+      ) : (
+        <div className="overflow-x-auto rounded-md border">
+          <table className="w-full text-sm">
+            <thead className="bg-muted">
+              <tr>
+                <th className="px-3 py-2 text-left">Name</th>
+                <th className="px-3 py-2 text-left">Predefined</th>
+                <th className="px-3 py-2 text-left">Stories</th>
+                <th className="px-3 py-2 text-right">Action</th>
+              </tr>
+            </thead>
+            <tbody>
+              {visibleTags.map((t) => (
+                <tr key={t.id} className="border-t">
+                  <td className="px-3 py-2">{t.name}</td>
+                  <td className="px-3 py-2">{t.is_predefined ? "Yes" : "No"}</td>
+                  <td className="px-3 py-2">{t.story_count ?? 0}</td>
+                  <td className="px-3 py-2 text-right">
+                    <Button variant="destructive" size="sm" onClick={() => openRemove(t)}>
+                      Remove
+                    </Button>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      <Pagination
+        page={page}
+        count={tags.length}
+        pageSize={PAGE_SIZE}
+        onPageChange={setPage}
+        disabled={loading}
+      />
+
+      <ConfirmDialog
+        open={Boolean(target)}
+        onOpenChange={(open) => { if (!open) setTarget(null); }}
+        title="Remove tag"
+        description={
+          target ? `Remove the tag "${target.name}"? It will be detached from ${target.story_count ?? 0} stories.` : ""
+        }
+        confirmLabel="Remove"
+        confirming={submitting}
+        onConfirm={submitRemove}
+      >
+        {actionError && <p className="text-sm text-destructive">{actionError}</p>}
+      </ConfirmDialog>
+    </section>
+  );
+}
+
+export default AdminTagsPage;

--- a/frontend/src/pages/admin/AdminTagsPage.jsx
+++ b/frontend/src/pages/admin/AdminTagsPage.jsx
@@ -126,7 +126,7 @@ function AdminTagsPage() {
 
       <Pagination
         page={page}
-        count={tags.length}
+        count={tags.count ?? tags.length}
         pageSize={PAGE_SIZE}
         onPageChange={setPage}
         disabled={loading}

--- a/frontend/src/pages/admin/AdminUsersPage.jsx
+++ b/frontend/src/pages/admin/AdminUsersPage.jsx
@@ -1,0 +1,144 @@
+import { useState } from "react";
+
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { LoadingSpinner } from "@/components/ui/loading-spinner";
+import ConfirmDialog from "@/components/AdminPanel/ConfirmDialog";
+import { getPublicProfile } from "@/services/userService";
+import { banUser } from "@/services/adminService";
+
+/**
+ * No backend endpoint lists users for admins, so this page works as a
+ * single-result lookup by user ID. Once the backend exposes a paginated
+ * search/list endpoint we can switch to a true paginated table.
+ */
+function AdminUsersPage() {
+  const [idInput, setIdInput] = useState("");
+  const [profile, setProfile] = useState(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(null);
+
+  const [confirming, setConfirming] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
+  const [actionError, setActionError] = useState(null);
+
+  const lookup = async (e) => {
+    e.preventDefault();
+    const id = Number(idInput);
+    if (!Number.isInteger(id) || id <= 0) {
+      setError("Enter a positive numeric user ID.");
+      setProfile(null);
+      return;
+    }
+    setLoading(true);
+    setError(null);
+    setProfile(null);
+    try {
+      const data = await getPublicProfile(id);
+      setProfile({ ...data, _lookupId: id });
+    } catch (err) {
+      setError(err?.response?.status === 404 ? "User not found." : "Failed to load user.");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const submitBan = async () => {
+    if (!profile) return;
+    setSubmitting(true);
+    setActionError(null);
+    try {
+      const res = await banUser(profile.id ?? profile._lookupId);
+      setProfile((prev) => (prev ? { ...prev, is_active: res.is_active } : prev));
+      setConfirming(false);
+    } catch (err) {
+      setActionError(err?.response?.data?.detail || "Ban failed.");
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const isBanned = profile && profile.is_active === false;
+
+  return (
+    <section>
+      <div className="mb-4">
+        <h2 className="text-xl font-semibold">Users</h2>
+        <p className="mt-1 text-sm text-muted-foreground">
+          Look up a user by ID and ban their account.
+        </p>
+      </div>
+
+      <form onSubmit={lookup} className="flex flex-wrap items-end gap-2" role="search">
+        <div className="flex flex-col gap-1">
+          <Label htmlFor="user-id-input">User ID</Label>
+          <Input
+            id="user-id-input"
+            type="number"
+            min="1"
+            value={idInput}
+            onChange={(e) => setIdInput(e.target.value)}
+            placeholder="e.g. 42"
+            className="w-40"
+          />
+        </div>
+        <Button type="submit" variant="outline">Look up</Button>
+      </form>
+
+      <div className="mt-6">
+        {loading && (
+          <div className="flex justify-center py-8" data-testid="users-loading">
+            <LoadingSpinner />
+          </div>
+        )}
+        {error && <p className="text-sm text-destructive">{error}</p>}
+        {profile && !loading && (
+          <div className="rounded-md border p-4">
+            <div className="flex flex-wrap items-center justify-between gap-3">
+              <div>
+                <div className="font-medium">{profile.username || "Unknown"}</div>
+                <div className="text-sm text-muted-foreground">
+                  ID #{profile.id ?? profile._lookupId}
+                  {profile.email ? ` · ${profile.email}` : ""}
+                </div>
+                <div className="mt-1 text-sm">
+                  Status: {isBanned ? (
+                    <span className="font-medium text-destructive">Banned</span>
+                  ) : (
+                    <span className="font-medium text-green-600">Active</span>
+                  )}
+                </div>
+              </div>
+              <Button
+                variant="destructive"
+                disabled={isBanned}
+                onClick={() => { setActionError(null); setConfirming(true); }}
+              >
+                {isBanned ? "Already banned" : "Ban user"}
+              </Button>
+            </div>
+          </div>
+        )}
+      </div>
+
+      <ConfirmDialog
+        open={confirming}
+        onOpenChange={setConfirming}
+        title="Ban user"
+        description={
+          profile
+            ? `Ban ${profile.username || `user #${profile.id ?? profile._lookupId}`}? This disables their account.`
+            : ""
+        }
+        confirmLabel="Ban"
+        confirming={submitting}
+        onConfirm={submitBan}
+      >
+        {actionError && <p className="text-sm text-destructive">{actionError}</p>}
+      </ConfirmDialog>
+    </section>
+  );
+}
+
+export default AdminUsersPage;

--- a/frontend/src/pages/admin/AdminUsersPage.jsx
+++ b/frontend/src/pages/admin/AdminUsersPage.jsx
@@ -100,7 +100,6 @@ function AdminUsersPage() {
                 <div className="font-medium">{profile.username || "Unknown"}</div>
                 <div className="text-sm text-muted-foreground">
                   ID #{profile.id ?? profile._lookupId}
-                  {profile.email ? ` · ${profile.email}` : ""}
                 </div>
                 <div className="mt-1 text-sm">
                   Status: {isBanned ? (

--- a/frontend/src/services/__tests__/adminService.test.js
+++ b/frontend/src/services/__tests__/adminService.test.js
@@ -1,0 +1,128 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("../api", () => ({
+  default: {
+    get: vi.fn(),
+    post: vi.fn(),
+    patch: vi.fn(),
+    delete: vi.fn(),
+  },
+}));
+
+import api from "../api";
+import {
+  listReports,
+  resolveReport,
+  removeStory,
+  removeComment,
+  banUser,
+  deleteTag,
+  resolveReportWithAction,
+} from "../adminService";
+
+describe("adminService", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("listReports", () => {
+    it("calls the moderation reports endpoint with status and pagination", async () => {
+      api.get.mockResolvedValue({ data: { count: 0, results: [] } });
+      await listReports({ status: "pending", page: 2, pageSize: 10 });
+      expect(api.get).toHaveBeenCalledWith("/moderation/reports/", {
+        params: { status: "pending", page: 2, page_size: 10 },
+      });
+    });
+
+    it("omits status when not provided", async () => {
+      api.get.mockResolvedValue({ data: { count: 0, results: [] } });
+      await listReports();
+      expect(api.get).toHaveBeenCalledWith("/moderation/reports/", {
+        params: { page: 1, page_size: 20 },
+      });
+    });
+  });
+
+  it("resolveReport PATCHes with note", async () => {
+    api.patch.mockResolvedValue({ data: { id: 1 } });
+    await resolveReport(1, "ok");
+    expect(api.patch).toHaveBeenCalledWith("/moderation/reports/1/resolve/", {
+      resolution_note: "ok",
+    });
+  });
+
+  it("removeStory DELETEs with reason in body", async () => {
+    api.delete.mockResolvedValue({});
+    await removeStory(7, "spam");
+    expect(api.delete).toHaveBeenCalledWith("/moderation/stories/7/", {
+      data: { moderation_reason: "spam" },
+    });
+  });
+
+  it("removeComment DELETEs the comment", async () => {
+    api.delete.mockResolvedValue({});
+    await removeComment(3);
+    expect(api.delete).toHaveBeenCalledWith("/moderation/comments/3/");
+  });
+
+  it("banUser PATCHes the ban endpoint", async () => {
+    api.patch.mockResolvedValue({ data: { id: 5, is_active: false } });
+    const r = await banUser(5);
+    expect(api.patch).toHaveBeenCalledWith("/moderation/users/5/ban/");
+    expect(r).toEqual({ id: 5, is_active: false });
+  });
+
+  it("deleteTag DELETEs the tag", async () => {
+    api.delete.mockResolvedValue({});
+    await deleteTag(9);
+    expect(api.delete).toHaveBeenCalledWith("/moderation/tags/9/");
+  });
+
+  describe("resolveReportWithAction", () => {
+    const baseReport = { id: 1, target_type: "story", target_id: 10 };
+
+    it("no_action only resolves the report", async () => {
+      api.patch.mockResolvedValue({ data: {} });
+      await resolveReportWithAction({ report: baseReport, action: "no_action", note: "n" });
+      expect(api.delete).not.toHaveBeenCalled();
+      expect(api.patch).toHaveBeenCalledTimes(1);
+      expect(api.patch).toHaveBeenCalledWith("/moderation/reports/1/resolve/", { resolution_note: "n" });
+    });
+
+    it("remove_content removes the story then resolves", async () => {
+      api.delete.mockResolvedValue({});
+      api.patch.mockResolvedValue({ data: {} });
+      await resolveReportWithAction({ report: baseReport, action: "remove_content", note: "bad" });
+      expect(api.delete).toHaveBeenCalledWith("/moderation/stories/10/", {
+        data: { moderation_reason: "bad" },
+      });
+      expect(api.patch).toHaveBeenCalledWith("/moderation/reports/1/resolve/", { resolution_note: "bad" });
+    });
+
+    it("remove_content on a comment deletes the comment and skips resolve (CASCADE deletes the report)", async () => {
+      api.delete.mockResolvedValue({});
+      api.patch.mockResolvedValue({ data: {} });
+      await resolveReportWithAction({
+        report: { id: 2, target_type: "comment", target_id: 33 },
+        action: "remove_content",
+        note: "n",
+      });
+      expect(api.delete).toHaveBeenCalledWith("/moderation/comments/33/");
+      expect(api.patch).not.toHaveBeenCalled();
+    });
+
+    it("ban_user calls the ban endpoint with the supplied target user id", async () => {
+      api.patch.mockResolvedValue({ data: {} });
+      await resolveReportWithAction({
+        report: baseReport,
+        action: "ban_user",
+        note: "abuse",
+        targetUserId: 99,
+      });
+      expect(api.patch).toHaveBeenNthCalledWith(1, "/moderation/users/99/ban/");
+      expect(api.patch).toHaveBeenNthCalledWith(2, "/moderation/reports/1/resolve/", {
+        resolution_note: "abuse",
+      });
+    });
+  });
+});

--- a/frontend/src/services/adminService.js
+++ b/frontend/src/services/adminService.js
@@ -1,0 +1,67 @@
+import api from "./api";
+
+const PAGE_SIZE = 20;
+
+/** GET /moderation/reports/?status=&page= — paginated, IsAdminUser. */
+export async function listReports({ status, page = 1, pageSize = PAGE_SIZE } = {}) {
+  const params = { page, page_size: pageSize };
+  if (status) params.status = status;
+  const response = await api.get("/moderation/reports/", { params });
+  return response.data; // { count, next, previous, results }
+}
+
+/** PATCH /moderation/reports/<id>/resolve/ — resolution_note string. */
+export async function resolveReport(reportId, resolutionNote = "") {
+  const response = await api.patch(`/moderation/reports/${reportId}/resolve/`, {
+    resolution_note: resolutionNote,
+  });
+  return response.data;
+}
+
+/** DELETE /moderation/stories/<id>/ — body { moderation_reason }. */
+export async function removeStory(storyId, moderationReason) {
+  await api.delete(`/moderation/stories/${storyId}/`, {
+    data: { moderation_reason: moderationReason },
+  });
+}
+
+/** DELETE /moderation/comments/<id>/ — hard-delete a comment. */
+export async function removeComment(commentId) {
+  await api.delete(`/moderation/comments/${commentId}/`);
+}
+
+/** PATCH /moderation/users/<id>/ban/ — disables a user account. */
+export async function banUser(userId) {
+  const response = await api.patch(`/moderation/users/${userId}/ban/`);
+  return response.data; // { id, email, username, role, is_active }
+}
+
+/** DELETE /moderation/tags/<id>/ — remove tag and all associations. */
+export async function deleteTag(tagId) {
+  await api.delete(`/moderation/tags/${tagId}/`);
+}
+
+/**
+ * Resolve a report and optionally apply a side action.
+ *
+ * Outcomes:
+ *  - "no_action": just record the note + mark resolved.
+ *  - "remove_content": delete story/comment, then resolve.
+ *  - "ban_user": ban the targetUserId (caller-supplied), then resolve.
+ */
+export async function resolveReportWithAction({ report, action, note, targetUserId }) {
+  if (action === "remove_content") {
+    if (report.target_type === "story") {
+      await removeStory(report.target_id, note || "Removed via admin moderation.");
+    } else if (report.target_type === "comment") {
+      // Report.comment FK is ON DELETE CASCADE in the backend, so deleting
+      // the comment also removes the report row. A follow-up resolve PATCH
+      // would 404 — skip it.
+      await removeComment(report.target_id);
+      return null;
+    }
+  } else if (action === "ban_user" && targetUserId) {
+    await banUser(targetUserId);
+  }
+  return resolveReport(report.id, note);
+}

--- a/frontend/src/services/adminService.js
+++ b/frontend/src/services/adminService.js
@@ -18,7 +18,7 @@ export async function resolveReport(reportId, resolutionNote = "") {
   return response.data;
 }
 
-/** DELETE /moderation/stories/<id>/ — body { moderation_reason }. */
+/** DELETE /moderation/stories/<id>/ — body { moderation_reason }. Soft-delete: sets status=REMOVED, content is preserved server-side. */
 export async function removeStory(storyId, moderationReason) {
   await api.delete(`/moderation/stories/${storyId}/`, {
     data: { moderation_reason: moderationReason },


### PR DESCRIPTION
# 📝 Description
Fixes #211 
Adds an admin moderation panel at /admin, gated by user.role === "admin". Sidebar navigation routes to four sections (Reports, Stories, Users, Tags), each with paginated lists, filtering/search, and confirmation modals on every destructive action. The "Admin" link in the header only renders for admin users; non-admins hitting /admin see a "Not authorized" page; unauthenticated users get redirected to /login.

  All moderation calls go through a new adminService that wraps the /moderation/* endpoints. Comment-report removal is handled correctly given the cascade on Report.comment — the resolve PATCH is skipped because the cascade already removes the report row.

  Two backend gaps surfaced during the build are listed below as follow-ups; the panel still works without them, just with a degraded Users page.

 ## New features

  - /admin panel with sidebar (Reports, Stories, Users, Tags) and admin-only nav link in the header
  - Reports table with status filter and resolve modal supporting outcomes: no action / remove content / ban user (story author looked up automatically)
  - Stories search + remove with required reason
  - Users lookup (by ID, until a backend list endpoint exists) + ban with confirmation
  - Tags list with story count and remove with confirmation
  - Confirmation modals on every destructive action; pagination on every list view; loading/error/empty states

 ## Modified files

  - src/App.jsx — new admin routes
  - src/components/AppLayout/AppLayout.jsx — role-gated admin link
  - src/services/adminService.js (new) — listReports, resolveReport, removeStory, removeComment, banUser, deleteTag, resolveReportWithAction
  - src/components/AdminRoute.jsx (new) — role-based route guard
  - src/components/AdminPanel/{AdminLayout,Pagination,ConfirmDialog}.jsx (new)
  - src/pages/admin/{AdminReportsPage,AdminStoriesPage,AdminUsersPage,AdminTagsPage}.jsx (new)

 ## Tests

  - adminService.test.js — 11 tests covering all CRUD wrappers and the resolve-with-action flow (including the comment-cascade case)
  - AdminRoute.test.jsx — unauthenticated redirect, non-admin "Not authorized", admin pass-through
  - AdminReportsPage.test.jsx — load, status filter, resolve with note, story-author lookup for ban
  - AdminStoriesPage.test.jsx — load, search, reason-required confirmation, remove flow
  - AdminUsersPage.test.jsx — lookup, 404 handling, ban with confirmation
  - AdminTagsPage.test.jsx — load, search filter, remove confirmation
  - All checks pass: npm run lint, npm run test:run (1070/1070), npm run build

##  Backend follow-ups (not blockers)

  - No /moderation/users/ list endpoint, so the Users page is single-result lookup by ID
  - No unban endpoint, so the ban toggle is one-way
  - GET /users/<id>/ returns 404 for is_active=False, hiding banned users from both the admin lookup and viewers reaching them via story author links


# 📊 Type of Change
- [ ]  Bug fix
- [x]  New feature
- [ ]  Refactoring
- [ ]  Documentation
 
# ✅ Acceptance Criteria / Checklist
- [x] Project builds successfully
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, especially in hard-to-understand parts
- [x] I have performed a self-review of my code
- [x] I have added/updated tests
- [x] New and existing unit tests pass locally with my changes

# 📸 Screenshots / Recordings
<img width="1440" height="900" alt="Screenshot 2026-05-09 at 14 44 15" src="https://github.com/user-attachments/assets/c17e55a0-99a1-4cd8-bb5d-1b90693b151a" />
<img width="1440" height="900" alt="Screenshot 2026-05-09 at 14 47 45" src="https://github.com/user-attachments/assets/931f860f-ceea-4304-b45a-b57acc57f340" />
<img width="1440" height="900" alt="Screenshot 2026-05-09 at 14 47 40" src="https://github.com/user-attachments/assets/ed6999ce-6af7-4c0c-ad4c-17f88c339723" />
<img width="1440" height="900" alt="Screenshot 2026-05-09 at 14 47 34" src="https://github.com/user-attachments/assets/da567bb0-9cbe-420d-a033-963527cea626" />

<!-- If applicable !-->
# ⏱️ Estimated Review Time
- [ ] < 5 min
- [ ] 5-15 min
- [x] > 15 min
