### PR TITLE
fix: include location_name in story timeline response

### DIFF
--- a/backend/apps/stories/serializers.py
+++ b/backend/apps/stories/serializers.py
@@ -467,10 +467,10 @@ class StoryTimelineSerializer(serializers.ModelSerializer):
     Minimal read-only serializer for timeline cards.
 
     Returns only the fields needed to render a story on the timeline: identity,
-    title, all time fields (including EDTF temporal_coverage), coordinates, and
-    a representative photo URL. Feed-specific fields (preview_text,
-    contributor_name, like/save state, status, submitted_at) are intentionally
-    excluded.
+    title, all time fields (including EDTF temporal_coverage), coordinates,
+    location name, and a representative photo URL. Feed-specific fields
+    (preview_text, contributor_name, like/save state, status, submitted_at)
+    are intentionally excluded.
     """
 
     photo_url = serializers.SerializerMethodField()
@@ -490,6 +490,7 @@ class StoryTimelineSerializer(serializers.ModelSerializer):
             'temporal_coverage',
             'location_lat',
             'location_lng',
+            'location_name',
             'photo_url',
         ]
         read_only_fields = fields

--- a/backend/apps/stories/tests/test_views.py
+++ b/backend/apps/stories/tests/test_views.py
@@ -1208,7 +1208,7 @@ class TestStoryTimelineView:
         card = response.data['results'][0]
         for field in ('id', 'title', 'time_type', 'year', 'year_start', 'year_end',
                       'date_value', 'time_value', 'temporal_coverage',
-                      'location_lat', 'location_lng', 'photo_url'):
+                      'location_lat', 'location_lng', 'location_name', 'photo_url'):
             assert field in card, f'Missing field: {field}'
 
     def test_response_card_omits_feed_specific_fields(self, client):


### PR DESCRIPTION
# 📝 Description

Fixes #603

This PR updates the story timeline response to include `location_name` in addition to latitude and longitude.

This change was made based on an additional request from the frontend side. The timeline cards already returned location coordinates, but the frontend also needs the human-readable location name to display timeline stories more clearly in the UI.

Updated changes:
- Added `location_name` to `StoryTimelineSerializer`
- Updated the serializer documentation to reflect that timeline cards now include the location name
- Updated the timeline response test to verify that `location_name` is included in the response

# 📊 Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactoring
- [ ] Documentation

# ✅ Acceptance Criteria / Checklist

- [x] Project builds successfully
- [x] Code follows the project style guidelines
- [x] Self-review performed
- [x] Tests added/updated
- [x] Timeline response now includes `location_name`
- [x] Feed-specific fields are still excluded from the timeline response
- [x] Tests pass locally



# ⏱️ Estimated Review Time

- [x] < 5 min
- [ ] 5–15 min
- [ ] > 15 min