### PR TITLE
fix: add tags and proximity filters to /stories/timeline/

### DIFF
--- a/backend/apps/stories/serializers.py
+++ b/backend/apps/stories/serializers.py
@@ -442,6 +442,14 @@ class TimelineQuerySerializer(serializers.Serializer):
     lng_min = serializers.FloatField(required=False, min_value=-180.0, max_value=180.0)
     lng_max = serializers.FloatField(required=False, min_value=-180.0, max_value=180.0)
     has_image = serializers.BooleanField(required=False, allow_null=True, default=None)
+    tags = serializers.ListField(
+        child=serializers.CharField(allow_blank=False),
+        required=False,
+        allow_empty=False,
+    )
+    latitude = serializers.FloatField(required=False, min_value=-90.0, max_value=90.0)
+    longitude = serializers.FloatField(required=False, min_value=-180.0, max_value=180.0)
+    radius_km = serializers.FloatField(required=False, min_value=0.001, max_value=500.0)
 
     def validate(self, data):
         year_from = data.get('year_from')
@@ -457,6 +465,14 @@ class TimelineQuerySerializer(serializers.Serializer):
             missing = bbox_fields - provided
             raise serializers.ValidationError(
                 {f: 'Required when performing bounding-box filtering.' for f in missing}
+            )
+
+        geo_fields = {'latitude', 'longitude', 'radius_km'}
+        provided = {k for k in geo_fields if data.get(k) is not None}
+        if provided and provided != geo_fields:
+            missing = geo_fields - provided
+            raise serializers.ValidationError(
+                {f: 'Required when performing radius filtering.' for f in missing}
             )
 
         return data

--- a/backend/apps/stories/services.py
+++ b/backend/apps/stories/services.py
@@ -162,6 +162,10 @@ def get_story_timeline(
     lng_min=None,
     lng_max=None,
     has_image=None,
+    tags=None,
+    latitude=None,
+    longitude=None,
+    radius_km=None,
 ):
     """
     Return published stories sorted by effective historical midpoint ascending.
@@ -221,6 +225,16 @@ def get_story_timeline(
             media_type=MediaType.IMAGE,
         )
         qs = qs.filter(Exists(has_image_subq))
+
+    if tags:
+        from apps.tags.models import StoryTag
+        for tag in tags:
+            # Exists subquery per tag gives AND semantics without JOIN duplication.
+            # Avoids .distinct() which conflicts with ORDER BY on an annotated column in MySQL.
+            qs = qs.filter(Exists(StoryTag.objects.filter(story=OuterRef('pk'), tag__name__iexact=tag)))
+
+    if latitude is not None and longitude is not None and radius_km is not None:
+        qs = _apply_radius_filter(qs, latitude, longitude, radius_km)
 
     # Build a synthetic sort key using the midpoint of each story's time interval.
     from django.db.models import F

--- a/backend/apps/stories/tests/test_views.py
+++ b/backend/apps/stories/tests/test_views.py
@@ -1361,3 +1361,91 @@ class TestStoryTimelineView:
         response = client.get(TIMELINE_URL, {'year_to': 1900})
         assert response.data['count'] == 1
         assert response.data['results'][0]['title'] == 'Old Date'
+
+
+@pytest.mark.django_db
+class TestStoryTimelineViewTagFilter:
+    def test_tag_filter_returns_only_matching_stories(self, client):
+        tag = Tag.objects.create(name='ottoman-era')
+        tagged = make_story(title='Tagged', year=1900)
+        StoryTag.objects.create(story=tagged, tag=tag)
+        make_story(title='Untagged', year=1910)
+        response = client.get(TIMELINE_URL + '?tags=ottoman-era')
+        assert response.data['count'] == 1
+        assert response.data['results'][0]['title'] == 'Tagged'
+
+    def test_tag_filter_and_semantics(self, client):
+        tag1 = Tag.objects.create(name='timeline-tag-alpha')
+        tag2 = Tag.objects.create(name='timeline-tag-beta')
+        both = make_story(title='Both Tags', year=1900)
+        StoryTag.objects.create(story=both, tag=tag1)
+        StoryTag.objects.create(story=both, tag=tag2)
+        one = make_story(title='One Tag', year=1910)
+        StoryTag.objects.create(story=one, tag=tag1)
+        response = client.get(TIMELINE_URL + '?tags=timeline-tag-alpha&tags=timeline-tag-beta')
+        assert response.data['count'] == 1
+        assert response.data['results'][0]['title'] == 'Both Tags'
+
+    def test_tag_filter_response_includes_photo_url_and_temporal_coverage(self, client):
+        tag = Tag.objects.create(name='nature')
+        story = make_story(title='Tagged With Photo', year=1900)
+        StoryTag.objects.create(story=story, tag=tag)
+        make_timeline_media(story)
+        response = client.get(TIMELINE_URL + '?tags=nature')
+        assert response.data['count'] == 1
+        card = response.data['results'][0]
+        assert card['photo_url'] is not None
+        assert card['photo_url'].startswith('http')
+        assert card['temporal_coverage'] == '1900'
+
+    def test_tag_filter_case_insensitive(self, client):
+        tag = Tag.objects.create(name='folklore')
+        story = make_story(title='Folklore Story', year=1900)
+        StoryTag.objects.create(story=story, tag=tag)
+        response = client.get(TIMELINE_URL + '?tags=FolkLore')
+        assert response.data['count'] == 1
+
+    def test_tag_filter_no_match_returns_empty(self, client):
+        make_story(title='No Tags', year=1900)
+        response = client.get(TIMELINE_URL + '?tags=nonexistent-tag')
+        assert response.data['count'] == 0
+
+
+@pytest.mark.django_db
+class TestStoryTimelineViewGeoFilter:
+    def _geo_params(self, radius_km=1.0):
+        return f'latitude={_GEO_CENTER_LAT}&longitude={_GEO_CENTER_LNG}&radius_km={radius_km}'
+
+    def test_geo_filter_returns_only_nearby_stories(self, client):
+        make_geo_story(_GEO_NEAR_LAT, _GEO_NEAR_LNG, title='Near Story')
+        make_geo_story(_GEO_FAR_LAT, _GEO_FAR_LNG, title='Far Story')
+        response = client.get(f'{TIMELINE_URL}?{self._geo_params()}')
+        assert response.status_code == status.HTTP_200_OK
+        titles = [s['title'] for s in response.data['results']]
+        assert 'Near Story' in titles
+        assert 'Far Story' not in titles
+
+    def test_geo_filter_response_includes_photo_url_and_temporal_coverage(self, client):
+        story = make_geo_story(_GEO_NEAR_LAT, _GEO_NEAR_LNG, title='Near With Photo')
+        make_timeline_media(story)
+        response = client.get(f'{TIMELINE_URL}?{self._geo_params()}')
+        assert response.status_code == status.HTTP_200_OK
+        card = response.data['results'][0]
+        assert card['photo_url'] is not None
+        assert card['photo_url'].startswith('http')
+        assert 'temporal_coverage' in card
+
+    def test_geo_filter_partial_params_returns_400(self, client):
+        response = client.get(f'{TIMELINE_URL}?latitude={_GEO_CENTER_LAT}&longitude={_GEO_CENTER_LNG}')
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+    def test_geo_filter_combined_with_tag_filter(self, client):
+        tag = Tag.objects.create(name='timeline-geo-tag')
+        near_tagged = make_geo_story(_GEO_NEAR_LAT, _GEO_NEAR_LNG, title='TaggedNear')
+        StoryTag.objects.create(story=near_tagged, tag=tag)
+        make_geo_story(_GEO_NEAR_LAT, _GEO_NEAR_LNG, title='UntaggedNear')
+        response = client.get(f'{TIMELINE_URL}?{self._geo_params()}&tags=timeline-geo-tag')
+        assert response.status_code == status.HTTP_200_OK
+        titles = [s['title'] for s in response.data['results']]
+        assert 'TaggedNear' in titles
+        assert 'UntaggedNear' not in titles

--- a/backend/apps/stories/views.py
+++ b/backend/apps/stories/views.py
@@ -245,6 +245,10 @@ class StoryTimelineView(APIView):
             lng_min=params.get('lng_min'),
             lng_max=params.get('lng_max'),
             has_image=params.get('has_image'),
+            tags=params.get('tags'),
+            latitude=params.get('latitude'),
+            longitude=params.get('longitude'),
+            radius_km=params.get('radius_km'),
         ).prefetch_related('media_items')
 
         paginator = StoryPagination()

--- a/frontend/src/services/__tests__/timelineService.test.js
+++ b/frontend/src/services/__tests__/timelineService.test.js
@@ -179,39 +179,6 @@ describe("timelineService", () => {
       expect(result.count).toBe(3);
     });
 
-    it("routes to /stories/feed/ when only tags are set, and forwards them", async () => {
-      api.get.mockResolvedValue({
-        data: { count: 0, next: null, previous: null, results: [] },
-      });
-
-      await getTimeline({ tags: ["mosque", "ottoman"], page: 1, pageSize: 10 });
-
-      expect(api.get).toHaveBeenCalledWith(
-        "/stories/feed/",
-        expect.objectContaining({
-          params: expect.objectContaining({
-            sort_by: "recent",
-            tags: ["mosque", "ottoman"],
-          }),
-        }),
-      );
-    });
-
-    it("routes to /stories/feed/ when proximity is set, and forwards lat/lng/radius", async () => {
-      api.get.mockResolvedValue({
-        data: { count: 0, next: null, previous: null, results: [] },
-      });
-
-      await getTimeline({ latitude: 41, longitude: 29, radiusKm: 1, page: 1, pageSize: 10 });
-
-      expect(api.get).toHaveBeenCalledWith(
-        "/stories/feed/",
-        expect.objectContaining({
-          params: expect.objectContaining({ latitude: 41, longitude: 29, radius_km: 1 }),
-        }),
-      );
-    });
-
     it("falls back when location text is set without a bbox", async () => {
       api.get.mockResolvedValue({
         data: { count: 0, next: null, previous: null, results: [] },

--- a/frontend/src/services/__tests__/timelineService.test.js
+++ b/frontend/src/services/__tests__/timelineService.test.js
@@ -94,6 +94,34 @@ describe("timelineService", () => {
     });
   });
 
+  it("passes tags array through as-is for paramsSerializer to handle", async () => {
+    api.get.mockResolvedValue({ data: { count: 0, next: null, previous: null, results: [] } });
+
+    await getTimeline({ tags: ["nature", "folklore"] });
+
+    expect(api.get).toHaveBeenCalledWith("/stories/timeline/", {
+      params: { tags: ["nature", "folklore"] },
+    });
+  });
+
+  it("omits tags when array is empty", async () => {
+    api.get.mockResolvedValue({ data: { count: 0, next: null, previous: null, results: [] } });
+
+    await getTimeline({ tags: [] });
+
+    expect(api.get).toHaveBeenCalledWith("/stories/timeline/", { params: {} });
+  });
+
+  it("passes proximity params through", async () => {
+    api.get.mockResolvedValue({ data: { count: 0, next: null, previous: null, results: [] } });
+
+    await getTimeline({ latitude: 41.0, longitude: 28.9, radiusKm: 5 });
+
+    expect(api.get).toHaveBeenCalledWith("/stories/timeline/", {
+      params: { latitude: 41.0, longitude: 28.9, radius_km: 5 },
+    });
+  });
+
   it("throws on API error", async () => {
     api.get.mockRejectedValue(new Error("Network error"));
 

--- a/frontend/src/services/timelineService.js
+++ b/frontend/src/services/timelineService.js
@@ -8,6 +8,10 @@ const KEY_MAP = {
   latMax: "lat_max",
   lngMin: "lng_min",
   lngMax: "lng_max",
+  tags: "tags",
+  latitude: "latitude",
+  longitude: "longitude",
+  radiusKm: "radius_km",
   hasImage: "has_image",
   page: "page",
   pageSize: "page_size",
@@ -90,8 +94,6 @@ export function storyOverlapsYearWindow(story, yearFrom, yearTo) {
 
 function hasUnsupportedTimelineFilters(filters) {
   if (filters.q?.trim()) return true;
-  if (Array.isArray(filters.tags) && filters.tags.length > 0) return true;
-  if (filters.latitude != null && filters.longitude != null && filters.radiusKm != null) return true;
   // A location string with no bbox can't be passed to /stories/timeline/ —
   // that endpoint doesn't accept a `location` text param.
   const hasBbox =
@@ -103,13 +105,13 @@ function hasUnsupportedTimelineFilters(filters) {
 /**
  * Fetch stories ordered by time period for the timeline view.
  *
- * When the active filter set is supported by `/stories/timeline/` (year +
- * bbox), this proxies that endpoint directly so the server's historical
- * ordering and pagination are preserved. When the filter set includes text
- * search, tags, proximity, or a location string without a bbox, the timeline
- * endpoint can't honour it — so we fall back to `/stories/search/` (when q
- * is present) or `/stories/feed/`, then re-sort client-side by historical
- * midpoint and paginate locally. This mirrors the strategy in
+ * When the active filter set is supported by `/stories/timeline/` (year,
+ * bbox, tags, proximity), this proxies that endpoint directly so the
+ * server's historical ordering and pagination are preserved. When the filter
+ * set includes text search (`q`) or a location string without a bbox, the
+ * timeline endpoint can't honour it — so we fall back to `/stories/search/`
+ * (when q is present) or `/stories/feed/`, then re-sort client-side by
+ * historical midpoint and paginate locally. This mirrors the strategy in
  * `mobile/src/features/timeline/data/sources/index.ts`.
  */
 export async function getTimeline({
@@ -142,6 +144,10 @@ export async function getTimeline({
       latMax,
       lngMin,
       lngMax,
+      tags,
+      latitude,
+      longitude,
+      radiusKm,
       page,
       pageSize,
       ...(hasImage ? { hasImage: true } : {}),
@@ -149,6 +155,7 @@ export async function getTimeline({
     const params = {};
     for (const [key, value] of Object.entries(args)) {
       if (value === undefined) continue;
+      if (Array.isArray(value) && value.length === 0) continue;
       params[KEY_MAP[key]] = value;
     }
     const response = await api.get("/stories/timeline/", { params });


### PR DESCRIPTION
# 📝 Description
Fixes #602

# 📊 Type of Change
- [x] Bug fix

# ✅ Acceptance Criteria / Checklist
- [x] Project builds successfully
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, especially in hard-to-understand parts
- [x] I have performed a self-review of my code
- [x] I have added/updated tests
- [x] New and existing unit tests pass locally with my changes

## What changed

**Backend**
- `TimelineQuerySerializer` now accepts `tags` (list), `latitude`, `longitude`, `radius_km`; the three proximity fields validate as an all-or-nothing triple (same as `FeedQuerySerializer`)
- `get_story_timeline` applies tag filtering using `Exists` subqueries (one per tag — AND semantics, no `.distinct()` needed, which avoids a MySQL conflict with `ORDER BY` on the annotated `historical_year` column) and calls `_apply_radius_filter` when all three proximity params are present
- `StoryTimelineView` forwards the four new params to `get_story_timeline`

**Frontend**
- Removed `tags` and `proximity` from `hasUnsupportedTimelineFilters` in `timelineService.js` — the backend now handles both, so there is no fallback for these filters anymore
- Added `tags`, `latitude`, `longitude`, `radiusKm` to `KEY_MAP` and the primary-path `args` so they reach `/stories/timeline/` directly

**Tests**
- 9 new backend tests: `TestStoryTimelineViewTagFilter` (5 tests) and `TestStoryTimelineViewGeoFilter` (4 tests) — each verifies the response uses `StoryTimelineSerializer` (confirming `photo_url` and `temporal_coverage` are present)
- 3 new frontend service tests: tags array forwarded correctly, empty array omitted, proximity params translated to snake_case
- Removed 2 stale fallback tests that incorrectly expected tags/proximity to route to `/stories/feed/`

# 📸 Screenshots / Recordings
N/A — backend-only and service-layer change

# ⏱️ Estimated Review Time
- [ ] < 5 min
- [x] 5-15 min
- [ ] > 15 min