### PR TITLE
Improve mobile toast UX

### DIFF
--- a/mobile/src/app/navigation/RootNavigator.tsx
+++ b/mobile/src/app/navigation/RootNavigator.tsx
@@ -1183,12 +1183,23 @@ export function RootNavigator() {
           {canGoBack ? (
             <BackButton onPress={handleBack} />
           ) : (
-            <View style={{ flex: 1, flexDirection: 'row', alignItems: 'center', gap: spacing.sm + 2 }}>
+            <Pressable
+              accessibilityRole="button"
+              accessibilityLabel={`${APP_NAME} home`}
+              onPress={() => handleNavigate(ROUTES.FEED)}
+              style={({ pressed }) => ({
+                flex: 1,
+                flexDirection: 'row',
+                alignItems: 'center',
+                gap: spacing.sm + 2,
+                opacity: pressed ? 0.72 : 1,
+              })}
+            >
               <MapPin color={colors.text} size={28} strokeWidth={2.25} />
               <Text style={{ color: colors.text, fontSize: 24, fontWeight: '800' }}>
                 {APP_NAME}
               </Text>
-            </View>
+            </Pressable>
           )}
           {isAuthenticated ? (
             <View style={{ flexDirection: 'row', alignItems: 'center', gap: spacing.sm }}>

--- a/mobile/src/app/navigation/__tests__/RootNavigator.test.tsx
+++ b/mobile/src/app/navigation/__tests__/RootNavigator.test.tsx
@@ -560,6 +560,19 @@ describe('RootNavigator auth flow', () => {
     expect(screen.queryByText('Story map and feed')).toBeNull();
   });
 
+  it('uses the StoryMap brand as a home button to return to feed', async () => {
+    renderNavigator();
+
+    await screen.findByLabelText('Timeline');
+    fireEvent.press(screen.getByLabelText('Timeline'));
+    expect(screen.getByLabelText('Timeline').props.accessibilityState.selected).toBe(true);
+
+    fireEvent.press(screen.getByLabelText('StoryMap home'));
+
+    expect(screen.getByLabelText('Feed').props.accessibilityState.selected).toBe(true);
+    expect(screen.getByLabelText('Timeline').props.accessibilityState.selected).toBe(false);
+  });
+
   it('allows access to protected screens after login and returns to a public route on logout', async () => {
     renderNavigator();
 

--- a/mobile/src/shared/toast/ToastProvider.tsx
+++ b/mobile/src/shared/toast/ToastProvider.tsx
@@ -8,6 +8,11 @@ export function ToastProvider({ children }: PropsWithChildren) {
   const [toasts, setToasts] = useState<ToastItem[]>([]);
   const timersRef = useRef<Record<number, ReturnType<typeof setTimeout>>>({});
 
+  const clearToastTimers = () => {
+    Object.values(timersRef.current).forEach(clearTimeout);
+    timersRef.current = {};
+  };
+
   const removeToast = (id: number) => {
     const timer = timersRef.current[id];
     if (timer) {
@@ -23,7 +28,8 @@ export function ToastProvider({ children }: PropsWithChildren) {
     const variant = options?.variant ?? 'default';
     const duration = options?.duration ?? 3000;
 
-    setToasts((current) => [...current, { id, message, variant }]);
+    clearToastTimers();
+    setToasts([{ id, message, variant }]);
 
     timersRef.current[id] = setTimeout(() => {
       removeToast(id);
@@ -34,8 +40,7 @@ export function ToastProvider({ children }: PropsWithChildren) {
 
   useEffect(() => {
     return () => {
-      Object.values(timersRef.current).forEach(clearTimeout);
-      timersRef.current = {};
+      clearToastTimers();
     };
   }, []);
 

--- a/mobile/src/shared/ui/Toast/Toast.tsx
+++ b/mobile/src/shared/ui/Toast/Toast.tsx
@@ -1,7 +1,11 @@
 import React from 'react';
 import { Pressable, Text, View } from 'react-native';
+import { AlertCircle, CheckCircle, Info, X } from 'lucide-react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useAppTheme } from '../../../core/hooks/useAppTheme';
 import { ToastItem, ToastVariant, useToastContext } from '../../toast/ToastContext';
+
+const BOTTOM_CHROME_CLEARANCE = 112;
 
 function ToastCard({ toast, onDismiss }: { toast: ToastItem; onDismiss: (id: number) => void }) {
   const { colors, spacing, typography } = useAppTheme();
@@ -10,65 +14,91 @@ function ToastCard({ toast, onDismiss }: { toast: ToastItem; onDismiss: (id: num
     {
       accent: string;
       background: string;
+      Icon: typeof Info;
     }
   > = {
     default: {
       accent: colors.primary,
-      background: colors.infoSurface,
+      background: colors.surface,
+      Icon: Info,
     },
     success: {
       accent: colors.success,
       background: colors.successSurface,
+      Icon: CheckCircle,
     },
     error: {
       accent: colors.danger,
       background: colors.dangerSurface,
+      Icon: AlertCircle,
     },
     info: {
       accent: colors.primary,
       background: colors.infoSurface,
+      Icon: Info,
     },
   };
   const styles = variantStyles[toast.variant];
+  const Icon = styles.Icon;
 
   return (
     <View
       style={{
         backgroundColor: styles.background,
-        borderRadius: 14,
+        borderRadius: 8,
         borderWidth: 1,
         borderColor: colors.border,
-        paddingVertical: spacing.sm + 2,
-        paddingHorizontal: spacing.md,
+        paddingVertical: spacing.sm + 4,
+        paddingLeft: spacing.sm + 4,
+        paddingRight: spacing.sm,
         flexDirection: 'row',
         alignItems: 'center',
-        gap: spacing.sm,
+        gap: spacing.sm + 2,
         shadowColor: '#111827',
-        shadowOpacity: 0.08,
-        shadowRadius: 12,
-        shadowOffset: { width: 0, height: 6 },
-        elevation: 3,
+        shadowOpacity: 0.14,
+        shadowRadius: 18,
+        shadowOffset: { width: 0, height: 10 },
+        elevation: 6,
       }}
     >
       <View
         style={{
-          width: 10,
-          height: 10,
-          borderRadius: 5,
-          backgroundColor: styles.accent,
+          width: 30,
+          height: 30,
+          borderRadius: 15,
+          alignItems: 'center',
+          justifyContent: 'center',
+          backgroundColor: colors.background,
         }}
-      />
+      >
+        <Icon color={styles.accent} size={18} strokeWidth={2.4} />
+      </View>
       <Text
         style={{
           flex: 1,
           color: colors.text,
-          fontSize: typography.body,
+          fontSize: typography.body - 1,
+          lineHeight: typography.body + 5,
+          fontWeight: '600',
         }}
       >
         {toast.message}
       </Text>
-      <Pressable onPress={() => onDismiss(toast.id)} hitSlop={8}>
-        <Text style={{ color: colors.muted, fontSize: typography.body }}>x</Text>
+      <Pressable
+        accessibilityRole="button"
+        accessibilityLabel="Dismiss notification"
+        onPress={() => onDismiss(toast.id)}
+        hitSlop={8}
+        style={({ pressed }) => ({
+          width: 30,
+          height: 30,
+          borderRadius: 15,
+          alignItems: 'center',
+          justifyContent: 'center',
+          opacity: pressed ? 0.65 : 1,
+        })}
+      >
+        <X color={colors.muted} size={18} strokeWidth={2.2} />
       </Pressable>
     </View>
   );
@@ -77,6 +107,7 @@ function ToastCard({ toast, onDismiss }: { toast: ToastItem; onDismiss: (id: num
 export function Toaster() {
   const { toasts, removeToast } = useToastContext();
   const { spacing } = useAppTheme();
+  const insets = useSafeAreaInsets();
 
   if (toasts.length === 0) {
     return null;
@@ -84,13 +115,15 @@ export function Toaster() {
 
   return (
     <View
+      testID="toast-container"
       pointerEvents="box-none"
       style={{
         position: 'absolute',
-        top: spacing.lg,
+        bottom: insets.bottom + BOTTOM_CHROME_CLEARANCE,
         left: spacing.md,
         right: spacing.md,
         gap: spacing.sm,
+        zIndex: 1000,
       }}
     >
       {toasts.map((toast) => (

--- a/mobile/src/shared/ui/Toast/Toast.tsx
+++ b/mobile/src/shared/ui/Toast/Toast.tsx
@@ -1,11 +1,12 @@
 import React from 'react';
 import { Pressable, Text, View } from 'react-native';
 import { AlertCircle, CheckCircle, Info, X } from 'lucide-react-native';
-import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { SafeAreaInsetsContext } from 'react-native-safe-area-context';
 import { useAppTheme } from '../../../core/hooks/useAppTheme';
 import { ToastItem, ToastVariant, useToastContext } from '../../toast/ToastContext';
 
 const BOTTOM_CHROME_CLEARANCE = 112;
+const FALLBACK_SAFE_AREA_INSETS = { top: 0, right: 0, bottom: 0, left: 0 };
 
 function ToastCard({ toast, onDismiss }: { toast: ToastItem; onDismiss: (id: number) => void }) {
   const { colors, spacing, typography } = useAppTheme();
@@ -107,7 +108,7 @@ function ToastCard({ toast, onDismiss }: { toast: ToastItem; onDismiss: (id: num
 export function Toaster() {
   const { toasts, removeToast } = useToastContext();
   const { spacing } = useAppTheme();
-  const insets = useSafeAreaInsets();
+  const insets = React.useContext(SafeAreaInsetsContext) ?? FALLBACK_SAFE_AREA_INSETS;
 
   if (toasts.length === 0) {
     return null;

--- a/mobile/src/shared/ui/__tests__/Toast.test.tsx
+++ b/mobile/src/shared/ui/__tests__/Toast.test.tsx
@@ -1,8 +1,24 @@
 import React from 'react';
 import { fireEvent, render, screen } from '@testing-library/react-native';
+import { SafeAreaProvider } from 'react-native-safe-area-context';
 import { ToastProvider } from '../../toast/ToastProvider';
 import { useToast } from '../../hooks/useToast';
 import { Button } from '../Button';
+
+const initialMetrics = {
+  frame: { x: 0, y: 0, width: 390, height: 844 },
+  insets: { top: 44, right: 0, bottom: 34, left: 0 },
+};
+
+function renderToastTrigger() {
+  return render(
+    <SafeAreaProvider initialMetrics={initialMetrics}>
+      <ToastProvider>
+        <ToastTrigger />
+      </ToastProvider>
+    </SafeAreaProvider>,
+  );
+}
 
 function ToastTrigger() {
   const { toast } = useToast();
@@ -18,11 +34,7 @@ function ToastTrigger() {
 
 describe('Toast', () => {
   it('shows a success toast', () => {
-    render(
-      <ToastProvider>
-        <ToastTrigger />
-      </ToastProvider>,
-    );
+    renderToastTrigger();
 
     fireEvent.press(screen.getByText('Success'));
 
@@ -30,16 +42,36 @@ describe('Toast', () => {
   });
 
   it('dismisses a toast', () => {
-    render(
-      <ToastProvider>
-        <ToastTrigger />
-      </ToastProvider>,
-    );
+    renderToastTrigger();
 
     fireEvent.press(screen.getByText('Error'));
     expect(screen.getByText('Save failed!')).toBeTruthy();
 
-    fireEvent.press(screen.getByText('x'));
+    fireEvent.press(screen.getByLabelText('Dismiss notification'));
     expect(screen.queryByText('Save failed!')).toBeNull();
+  });
+
+  it('replaces the current toast instead of stacking several notifications', () => {
+    renderToastTrigger();
+
+    fireEvent.press(screen.getByText('Success'));
+    fireEvent.press(screen.getByText('Error'));
+    fireEvent.press(screen.getByText('Info'));
+
+    expect(screen.queryByText('Story saved!')).toBeNull();
+    expect(screen.queryByText('Save failed!')).toBeNull();
+    expect(screen.getByText('Session expires soon.')).toBeTruthy();
+    expect(screen.getAllByLabelText('Dismiss notification')).toHaveLength(1);
+  });
+
+  it('positions toasts above bottom app chrome', () => {
+    renderToastTrigger();
+
+    fireEvent.press(screen.getByText('Info'));
+
+    expect(screen.getByTestId('toast-container')).toHaveStyle({
+      bottom: 146,
+      top: undefined,
+    });
   });
 });


### PR DESCRIPTION
# 📝 Description
Fixes #607

This PR improves the mobile in-app notification experience and makes the StoryMap brand in the header behave like a home button.

Changes include:
- Move toast notifications to a bottom safe-area-aware position above the bottom app chrome.
- Replace stacked toast behavior with a single active toast, so repeated actions update the current notification instead of covering the screen.
- Refresh the toast UI with variant icons, cleaner spacing, stronger elevation, and an accessible dismiss button.
- Make the StoryMap logo/title in the top header navigate back to the Feed route.
- Add tests for toast replacement, bottom positioning, dismiss behavior, and header home navigation.

# 📊 Type of Change
- [ ]  Bug fix
- [x]  New feature
- [ ]  Refactoring
- [ ]  Documentation

# ✅ Acceptance Criteria / Checklist
- [x] Project builds successfully
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have added/updated tests
- [x] New and existing unit tests pass locally with my changes

# 📸 Screenshots / Recordings
Not attached. UI behavior was covered by component/navigation tests.

# ⏱️ Estimated Review Time
- [ ] < 5 min
- [x] 5-15 min
- [ ] > 15 min
