### PR TITLE
feat(frontend): support BC dates across submit, filter, and display

### DIFF
--- a/frontend/src/components/SearchFilter/ActiveFilters.jsx
+++ b/frontend/src/components/SearchFilter/ActiveFilters.jsx
@@ -2,6 +2,7 @@ import { X } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { getTagColorClass } from "@/utils/tagUtils";
 import { formatDistanceKm } from "@/utils/distance";
+import { formatHistoricalYear, formatHistoricalYearRange } from "@/utils/year";
 import { isProximityFromDeviceLocation } from "@/services/deviceLocationService";
 import { cn } from "@/lib/utils";
 
@@ -71,11 +72,11 @@ function ActiveFilters({
   }
 
   if (yearFrom && yearTo) {
-    chips.push({ key: "year_range", label: `${yearFrom}–${yearTo}` });
+    chips.push({ key: "year_range", label: formatHistoricalYearRange(yearFrom, yearTo) });
   } else if (yearFrom) {
-    chips.push({ key: "year_from", label: `From ${yearFrom}` });
+    chips.push({ key: "year_from", label: `From ${formatHistoricalYear(yearFrom)}` });
   } else if (yearTo) {
-    chips.push({ key: "year_to", label: `To ${yearTo}` });
+    chips.push({ key: "year_to", label: `To ${formatHistoricalYear(yearTo)}` });
   }
 
   if (location) {

--- a/frontend/src/components/SearchFilter/FilterPanel.jsx
+++ b/frontend/src/components/SearchFilter/FilterPanel.jsx
@@ -12,7 +12,9 @@ import {
 } from "@/services/deviceLocationService";
 import TagFilterInput from "./TagFilterInput";
 
-// Negative years represent BC, so no lower bound. Upper bound caps typos.
+// Negative years represent BC. Bounds keep typos like "-99999" or "20300"
+// from passing through silently; -9999 covers any plausible BC era.
+const YEAR_MIN = -9999;
 const YEAR_MAX = 2030;
 const YEAR_SPINNER_FROM = 1980;
 const YEAR_SPINNER_TO = new Date().getFullYear();
@@ -94,7 +96,9 @@ function FilterPanel({ yearFrom = "", yearTo = "", location = "", latMin = null,
     if (value === "") return value;
     const num = Number(value);
     if (isNaN(num)) return value;
-    return num > YEAR_MAX ? YEAR_MAX : num;
+    if (num > YEAR_MAX) return YEAR_MAX;
+    if (num < YEAR_MIN) return YEAR_MIN;
+    return num;
   }
 
   function handleLocationChange(value) {

--- a/frontend/src/components/SearchFilter/FilterPanel.jsx
+++ b/frontend/src/components/SearchFilter/FilterPanel.jsx
@@ -12,7 +12,7 @@ import {
 } from "@/services/deviceLocationService";
 import TagFilterInput from "./TagFilterInput";
 
-const YEAR_MIN = 1000;
+// Negative years represent BC, so no lower bound. Upper bound caps typos.
 const YEAR_MAX = 2030;
 const YEAR_SPINNER_FROM = 1980;
 const YEAR_SPINNER_TO = new Date().getFullYear();
@@ -208,8 +208,8 @@ function FilterPanel({ yearFrom = "", yearTo = "", location = "", latMin = null,
     const from = localYearFrom === "" ? "" : Number(localYearFrom);
     const to = localYearTo === "" ? "" : Number(localYearTo);
 
-    if ((from !== "" && (isNaN(from) || from < YEAR_MIN)) || (to !== "" && (isNaN(to) || to < YEAR_MIN))) {
-      setYearError(`Year must be ${YEAR_MIN} or later.`);
+    if ((from !== "" && isNaN(from)) || (to !== "" && isNaN(to))) {
+      setYearError("Year must be a valid number.");
       return;
     }
     if (from !== "" && to !== "" && from > to) {
@@ -327,7 +327,7 @@ function FilterPanel({ yearFrom = "", yearTo = "", location = "", latMin = null,
                   <Input
                     id="year-from"
                     type="number"
-                    placeholder="From"
+                    placeholder="From (e.g. 1900 or -300 for BC)"
                     value={localYearFrom}
                     onKeyDown={(e) => {
                       if ((e.key === "ArrowUp" || e.key === "ArrowDown") && localYearFrom === "") {
@@ -339,15 +339,9 @@ function FilterPanel({ yearFrom = "", yearTo = "", location = "", latMin = null,
                     onChange={(e) => {
                       const val = e.target.value;
                       if (val === "") { setLocalYearFrom(""); setYearError(""); return; }
-                      // When mouse-spinner is clicked on empty field the browser fires YEAR_MIN; override with default
-                      if (localYearFrom === "" && Number(val) === YEAR_MIN) {
-                        setLocalYearFrom(YEAR_SPINNER_FROM);
-                      } else {
-                        setLocalYearFrom(clampYear(val));
-                      }
+                      setLocalYearFrom(clampYear(val));
                       setYearError("");
                     }}
-                    min={YEAR_MIN}
                     max={YEAR_MAX}
                     aria-label="From year"
                   />
@@ -374,20 +368,17 @@ function FilterPanel({ yearFrom = "", yearTo = "", location = "", latMin = null,
                     onChange={(e) => {
                       const val = e.target.value;
                       if (val === "") { setLocalYearTo(""); setYearError(""); return; }
-                      // When mouse-spinner is clicked on empty field the browser fires YEAR_MIN; override with default
-                      if (localYearTo === "" && Number(val) === YEAR_MIN) {
-                        setLocalYearTo(YEAR_SPINNER_TO);
-                      } else {
-                        setLocalYearTo(clampYear(val));
-                      }
+                      setLocalYearTo(clampYear(val));
                       setYearError("");
                     }}
-                    min={YEAR_MIN}
                     max={YEAR_MAX}
                     aria-label="To year"
                   />
                 </div>
               </div>
+              <p className="mt-1 text-xs text-muted-foreground">
+                Use a negative year for BC (e.g. -300 = 300 BC).
+              </p>
               {yearError && (
                 <p className="mt-1 text-xs text-destructive" role="alert">
                   {yearError}

--- a/frontend/src/components/SearchFilter/FilterPanel.jsx
+++ b/frontend/src/components/SearchFilter/FilterPanel.jsx
@@ -331,7 +331,7 @@ function FilterPanel({ yearFrom = "", yearTo = "", location = "", latMin = null,
                   <Input
                     id="year-from"
                     type="number"
-                    placeholder="From (e.g. 1900 or -300 for BC)"
+                    placeholder="From"
                     value={localYearFrom}
                     onKeyDown={(e) => {
                       if ((e.key === "ArrowUp" || e.key === "ArrowDown") && localYearFrom === "") {
@@ -380,9 +380,6 @@ function FilterPanel({ yearFrom = "", yearTo = "", location = "", latMin = null,
                   />
                 </div>
               </div>
-              <p className="mt-1 text-xs text-muted-foreground">
-                Use a negative year for BC (e.g. -300 = 300 BC).
-              </p>
               {yearError && (
                 <p className="mt-1 text-xs text-destructive" role="alert">
                   {yearError}

--- a/frontend/src/components/SearchFilter/__tests__/ActiveFilters.test.jsx
+++ b/frontend/src/components/SearchFilter/__tests__/ActiveFilters.test.jsx
@@ -60,6 +60,16 @@ describe("ActiveFilters", () => {
     expect(screen.getByText("To 2000")).toBeInTheDocument();
   });
 
+  it("renders BC year ranges with a single 'BC' suffix and no minus signs", () => {
+    renderFilters({ yearFrom: -300, yearTo: -100 });
+    expect(screen.getByText("300–100 BC")).toBeInTheDocument();
+  });
+
+  it("renders single-sided BC year chip with 'BC' suffix", () => {
+    renderFilters({ yearFrom: -44 });
+    expect(screen.getByText("From 44 BC")).toBeInTheDocument();
+  });
+
   it("shows a location chip", () => {
     renderFilters({ location: "Kadıköy" });
     expect(screen.getByText("Location: Kadıköy")).toBeInTheDocument();

--- a/frontend/src/components/SearchFilter/__tests__/FilterPanel.test.jsx
+++ b/frontend/src/components/SearchFilter/__tests__/FilterPanel.test.jsx
@@ -214,16 +214,42 @@ describe("FilterPanel", () => {
     expect(screen.getByLabelText("To year")).toHaveValue(null);
   });
 
-  it("both inputs have min=1000 and max=2030", async () => {
+  it("inputs have no lower bound (BC dates allowed) and max=2030", async () => {
     const user = userEvent.setup();
     renderPanel();
 
     await user.click(screen.getByRole("button", { name: /^filters$/i }));
 
-    expect(screen.getByLabelText("From year")).toHaveAttribute("min", "1000");
-    expect(screen.getByLabelText("To year")).toHaveAttribute("min", "1000");
+    expect(screen.getByLabelText("From year")).not.toHaveAttribute("min");
+    expect(screen.getByLabelText("To year")).not.toHaveAttribute("min");
     expect(screen.getByLabelText("From year")).toHaveAttribute("max", "2030");
     expect(screen.getByLabelText("To year")).toHaveAttribute("max", "2030");
+  });
+
+  it("accepts negative (BC) years and forwards them to onApply", async () => {
+    const user = userEvent.setup();
+    const onApply = vi.fn();
+    renderPanel({ onApply });
+
+    await user.click(screen.getByRole("button", { name: /^filters$/i }));
+    await user.clear(screen.getByLabelText("From year"));
+    await user.type(screen.getByLabelText("From year"), "-300");
+    await user.clear(screen.getByLabelText("To year"));
+    await user.type(screen.getByLabelText("To year"), "-100");
+    await user.click(screen.getByRole("button", { name: /apply/i }));
+
+    expect(onApply).toHaveBeenCalledWith(
+      expect.objectContaining({ yearFrom: -300, yearTo: -100 }),
+    );
+  });
+
+  it("renders a hint that negative years mean BC", async () => {
+    const user = userEvent.setup();
+    renderPanel();
+
+    await user.click(screen.getByRole("button", { name: /^filters$/i }));
+
+    expect(screen.getByText(/negative year for BC/i)).toBeInTheDocument();
   });
 
   it("ArrowUp on empty From year sets it to 1980", async () => {
@@ -246,7 +272,7 @@ describe("FilterPanel", () => {
     expect(screen.getByLabelText("To year")).toHaveValue(2026);
   });
 
-  it("shows validation error when year is below 1000", async () => {
+  it("accepts a single ancient AD year (e.g. 500) without validation error", async () => {
     const user = userEvent.setup();
     const onApply = vi.fn();
     renderPanel({ onApply });
@@ -255,8 +281,10 @@ describe("FilterPanel", () => {
     await user.type(screen.getByLabelText("From year"), "500");
     await user.click(screen.getByRole("button", { name: /apply/i }));
 
-    expect(screen.getByRole("alert")).toHaveTextContent(/1000 or later/i);
-    expect(onApply).not.toHaveBeenCalled();
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+    expect(onApply).toHaveBeenCalledWith(
+      expect.objectContaining({ yearFrom: 500 }),
+    );
   });
 
   it("clamps typed year above 2030 to 2030 on From year field", async () => {

--- a/frontend/src/components/SearchFilter/__tests__/FilterPanel.test.jsx
+++ b/frontend/src/components/SearchFilter/__tests__/FilterPanel.test.jsx
@@ -243,14 +243,6 @@ describe("FilterPanel", () => {
     );
   });
 
-  it("renders a hint that negative years mean BC", async () => {
-    const user = userEvent.setup();
-    renderPanel();
-
-    await user.click(screen.getByRole("button", { name: /^filters$/i }));
-
-    expect(screen.getByText(/negative year for BC/i)).toBeInTheDocument();
-  });
 
   it("ArrowUp on empty From year sets it to 1980", async () => {
     const user = userEvent.setup();

--- a/frontend/src/components/SearchFilter/__tests__/FilterPanel.test.jsx
+++ b/frontend/src/components/SearchFilter/__tests__/FilterPanel.test.jsx
@@ -317,6 +317,16 @@ describe("FilterPanel", () => {
     expect(screen.getByLabelText("From year")).toHaveValue(2020);
   });
 
+  it("clamps absurd BC inputs (below -9999) up to -9999", async () => {
+    const user = userEvent.setup();
+    renderPanel();
+
+    await user.click(screen.getByRole("button", { name: /^filters$/i }));
+    await user.type(screen.getByLabelText("From year"), "-99999");
+
+    expect(screen.getByLabelText("From year")).toHaveValue(-9999);
+  });
+
   describe("Distance / proximity", () => {
     it("renders the predefined options (Anywhere, 500 m, 1 km, 10 km, 100 km) matching mobile", async () => {
       const user = userEvent.setup();

--- a/frontend/src/components/StoryCard/__tests__/StoryCard.test.jsx
+++ b/frontend/src/components/StoryCard/__tests__/StoryCard.test.jsx
@@ -102,6 +102,32 @@ describe("formatTimePeriod", () => {
   it("returns empty string for unknown time_type", () => {
     expect(formatTimePeriod({ time_type: "unknown" })).toBe("");
   });
+
+  it("formats exact_year BC dates with 'BC' suffix", () => {
+    expect(formatTimePeriod({ time_type: "exact_year", year: -44 })).toBe("44 BC");
+  });
+
+  it("formats approximate_year BC dates with 'c.' prefix and 'BC' suffix", () => {
+    const result = formatTimePeriod({ time_type: "approximate_year", year: -300 });
+    expect(result).toMatch(/^c\.\s*300 BC$/);
+  });
+
+  it("formats decade BC and rounds toward older", () => {
+    expect(formatTimePeriod({ time_type: "decade", year: -50 })).toBe("50s BC");
+    expect(formatTimePeriod({ time_type: "decade", year: -444 })).toBe("450s BC");
+  });
+
+  it("formats BC year_range with one shared 'BC' suffix", () => {
+    expect(
+      formatTimePeriod({ time_type: "year_range", year_start: -300, year_end: -100 })
+    ).toBe("300–100 BC");
+  });
+
+  it("formats year_range crossing BC/AD with both era suffixes", () => {
+    expect(
+      formatTimePeriod({ time_type: "year_range", year_start: -100, year_end: 50 })
+    ).toBe("100 BC – 50 AD");
+  });
 });
 
 // --- StoryCard rendering tests ---

--- a/frontend/src/components/StoryCard/storyCardUtils.js
+++ b/frontend/src/components/StoryCard/storyCardUtils.js
@@ -1,3 +1,9 @@
+import {
+  formatHistoricalDecade,
+  formatHistoricalYear,
+  formatHistoricalYearRange,
+} from "@/utils/year";
+
 export function truncateAtWord(text, maxChars = 80) {
   if (text.length <= maxChars) return text;
   const truncated = text.slice(0, maxChars);
@@ -18,10 +24,10 @@ function formatExactDate(dateValue, timeValue) {
   const monthIdx = Number(m[2]) - 1;
   const day = Number(m[3]);
   const month = MONTHS[monthIdx] ?? m[2];
-  const base = `${month}\u00a0${day},\u00a0${year}`;
+  const base = `${month} ${day}, ${year}`;
   if (typeof timeValue === "string") {
     const t = timeValue.match(/^(\d{2}):(\d{2})/);
-    if (t) return `${base}\u00a0${t[1]}:${t[2]}`;
+    if (t) return `${base} ${t[1]}:${t[2]}`;
   }
   return base;
 }
@@ -30,14 +36,15 @@ export function formatTimePeriod(story) {
   const { time_type, year, year_start, year_end, date_value, time_value } = story;
   switch (time_type) {
     case "exact_year":
-      return String(year);
-    case "approximate_year":
-      return `c.\u00a0${year}`;
+      return formatHistoricalYear(year);
+    case "approximate_year": {
+      const formatted = formatHistoricalYear(year);
+      return formatted ? `c. ${formatted}` : "";
+    }
     case "decade":
-      return `${Math.floor(year / 10) * 10}s`;
+      return formatHistoricalDecade(year);
     case "year_range":
-      if (year_start == null || year_end == null) return "";
-      return `${year_start}\u2013${year_end}`;
+      return formatHistoricalYearRange(year_start, year_end);
     case "exact_date":
       return formatExactDate(date_value, time_value);
     default:

--- a/frontend/src/components/Timeline/TimelineEntry.jsx
+++ b/frontend/src/components/Timeline/TimelineEntry.jsx
@@ -17,7 +17,7 @@ function bulletLabel(story) {
   if (story.year_start != null) return formatHistoricalYear(story.year_start);
   if (typeof story.date_value === "string") {
     const match = story.date_value.match(/-?\d{4}/);
-    if (match) return match[0];
+    if (match) return formatHistoricalYear(Number(match[0]));
   }
   return "";
 }

--- a/frontend/src/components/Timeline/TimelineEntry.jsx
+++ b/frontend/src/components/Timeline/TimelineEntry.jsx
@@ -3,6 +3,7 @@ import { MapPin } from "lucide-react";
 
 import { cn } from "@/lib/utils";
 import { formatTimePeriod } from "@/components/StoryCard/storyCardUtils";
+import { formatHistoricalDecade, formatHistoricalYear } from "@/utils/year";
 
 /**
  * Best-effort label for the bullet on the timeline. Prefers the formatted
@@ -12,8 +13,8 @@ import { formatTimePeriod } from "@/components/StoryCard/storyCardUtils";
 function bulletLabel(story) {
   const formatted = formatTimePeriod(story);
   if (formatted) return formatted;
-  if (story.year != null) return String(story.year);
-  if (story.year_start != null) return String(story.year_start);
+  if (story.year != null) return formatHistoricalYear(story.year);
+  if (story.year_start != null) return formatHistoricalYear(story.year_start);
   if (typeof story.date_value === "string") {
     const match = story.date_value.match(/-?\d{4}/);
     if (match) return match[0];
@@ -24,7 +25,7 @@ function bulletLabel(story) {
 function decadeChip(story) {
   const yearForDecade = story.year ?? story.year_start;
   if (yearForDecade == null) return null;
-  return `${Math.floor(yearForDecade / 10) * 10}s`;
+  return formatHistoricalDecade(yearForDecade);
 }
 
 function TimelineEntry({ story }) {

--- a/frontend/src/components/Timeline/__tests__/TimelineEntry.test.jsx
+++ b/frontend/src/components/Timeline/__tests__/TimelineEntry.test.jsx
@@ -117,6 +117,27 @@ describe("TimelineEntry", () => {
     expect(screen.getByText("50s BC")).toBeInTheDocument();
   });
 
+  it("formats the date_value fallback as 'X BC' instead of leaking the raw negative", () => {
+    renderEntry({
+      id: 1,
+      title: "Story with malformed BC date_value",
+      time_type: "exact_date",
+      year: null,
+      year_start: null,
+      year_end: null,
+      // Malformed BC date_value triggers the bulletLabel fallback path. Without
+      // the fix, the fallback would emit the raw "-0044" match.
+      date_value: "-0044-03-15",
+      location_lat: null,
+      location_lng: null,
+      photo_url: null,
+      temporal_coverage: null,
+    });
+
+    expect(screen.getAllByText("44 BC").length).toBeGreaterThan(0);
+    expect(screen.queryByText(/-0044/)).not.toBeInTheDocument();
+  });
+
   it("renders the photo when photo_url is provided", () => {
     renderEntry({
       id: 1,

--- a/frontend/src/components/Timeline/__tests__/TimelineEntry.test.jsx
+++ b/frontend/src/components/Timeline/__tests__/TimelineEntry.test.jsx
@@ -82,6 +82,41 @@ describe("TimelineEntry", () => {
     expect(screen.getAllByText("1870s").length).toBeGreaterThan(0);
   });
 
+  it("renders BC years on the bullet without a minus sign", () => {
+    renderEntry({
+      id: 1,
+      title: "Roman story",
+      time_type: "exact_year",
+      year: -44,
+      year_start: null,
+      year_end: null,
+      location_lat: null,
+      location_lng: null,
+      photo_url: null,
+      temporal_coverage: null,
+    });
+
+    expect(screen.getAllByText("44 BC").length).toBeGreaterThan(0);
+    expect(screen.queryByText(/^-44/)).not.toBeInTheDocument();
+  });
+
+  it("derives the decade chip from a BC year as 'XXs BC'", () => {
+    renderEntry({
+      id: 1,
+      title: "Roman story",
+      time_type: "exact_year",
+      year: -44,
+      year_start: null,
+      year_end: null,
+      location_lat: null,
+      location_lng: null,
+      photo_url: null,
+      temporal_coverage: null,
+    });
+
+    expect(screen.getByText("50s BC")).toBeInTheDocument();
+  });
+
   it("renders the photo when photo_url is provided", () => {
     renderEntry({
       id: 1,

--- a/frontend/src/pages/SubmitStoryPage.jsx
+++ b/frontend/src/pages/SubmitStoryPage.jsx
@@ -402,85 +402,85 @@ function SubmitStoryPage() {
 
           {/* Year / date inputs */}
           {timeType === "exact_date" ? (
-            <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
-              <div className="space-y-2">
-                <Label htmlFor="dateValue">Date</Label>
-                <Input
-                  id="dateValue"
-                  type="date"
-                  value={dateValue}
-                  onChange={(e) => {
-                    setDateValue(e.target.value);
-                    if (fieldErrors.dateValue)
-                      setFieldErrors((prev) => ({ ...prev, dateValue: "" }));
-                  }}
-                  disabled={isSubmitting}
-                />
-                {fieldErrors.dateValue && (
-                  <p className="text-sm text-destructive">{fieldErrors.dateValue}</p>
-                )}
-              </div>
-              <div className="space-y-2">
-                <Label htmlFor="timeValue">Time (optional)</Label>
-                <Input
-                  id="timeValue"
-                  type="time"
-                  value={timeValue}
-                  onChange={(e) => {
-                    setTimeValue(e.target.value);
-                    if (fieldErrors.timeValue)
-                      setFieldErrors((prev) => ({ ...prev, timeValue: "" }));
-                  }}
-                  disabled={isSubmitting || !dateValue}
-                />
-                {fieldErrors.timeValue && (
-                  <p className="text-sm text-destructive">{fieldErrors.timeValue}</p>
-                )}
-              </div>
-            </div>
-          ) : timeType === "year_range" ? (
             <div className="space-y-2">
-              <div className="grid grid-cols-2 gap-4">
+              <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
                 <div className="space-y-2">
-                  <Label htmlFor="yearStart">Start Year</Label>
+                  <Label htmlFor="dateValue">Date</Label>
                   <Input
-                    id="yearStart"
-                    type="number"
-                    value={yearStart}
+                    id="dateValue"
+                    type="date"
+                    value={dateValue}
                     onChange={(e) => {
-                      setYearStart(e.target.value);
-                      if (fieldErrors.yearStart)
-                        setFieldErrors((prev) => ({ ...prev, yearStart: "" }));
+                      setDateValue(e.target.value);
+                      if (fieldErrors.dateValue)
+                        setFieldErrors((prev) => ({ ...prev, dateValue: "" }));
                     }}
-                    placeholder="e.g. 1400 or -300"
                     disabled={isSubmitting}
                   />
-                  {fieldErrors.yearStart && (
-                    <p className="text-sm text-destructive">{fieldErrors.yearStart}</p>
+                  {fieldErrors.dateValue && (
+                    <p className="text-sm text-destructive">{fieldErrors.dateValue}</p>
                   )}
                 </div>
                 <div className="space-y-2">
-                  <Label htmlFor="yearEnd">End Year</Label>
+                  <Label htmlFor="timeValue">Time (optional)</Label>
                   <Input
-                    id="yearEnd"
-                    type="number"
-                    value={yearEnd}
+                    id="timeValue"
+                    type="time"
+                    value={timeValue}
                     onChange={(e) => {
-                      setYearEnd(e.target.value);
-                      if (fieldErrors.yearEnd)
-                        setFieldErrors((prev) => ({ ...prev, yearEnd: "" }));
+                      setTimeValue(e.target.value);
+                      if (fieldErrors.timeValue)
+                        setFieldErrors((prev) => ({ ...prev, timeValue: "" }));
                     }}
-                    placeholder="e.g. 1500 or -100"
-                    disabled={isSubmitting}
+                    disabled={isSubmitting || !dateValue}
                   />
-                  {fieldErrors.yearEnd && (
-                    <p className="text-sm text-destructive">{fieldErrors.yearEnd}</p>
+                  {fieldErrors.timeValue && (
+                    <p className="text-sm text-destructive">{fieldErrors.timeValue}</p>
                   )}
                 </div>
               </div>
               <p className="text-xs text-muted-foreground">
-                Use a negative year for BC (e.g. -300 = 300 BC).
+                BC dates are not supported for the Specific Date type. Use Exact Year, Approximate Year, Decade, or Year Range for BC.
               </p>
+            </div>
+          ) : timeType === "year_range" ? (
+            <div className="grid grid-cols-2 gap-4">
+              <div className="space-y-2">
+                <Label htmlFor="yearStart">Start Year</Label>
+                <Input
+                  id="yearStart"
+                  type="number"
+                  value={yearStart}
+                  onChange={(e) => {
+                    setYearStart(e.target.value);
+                    if (fieldErrors.yearStart)
+                      setFieldErrors((prev) => ({ ...prev, yearStart: "" }));
+                  }}
+                  placeholder="e.g. 1400 or -300"
+                  disabled={isSubmitting}
+                />
+                {fieldErrors.yearStart && (
+                  <p className="text-sm text-destructive">{fieldErrors.yearStart}</p>
+                )}
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="yearEnd">End Year</Label>
+                <Input
+                  id="yearEnd"
+                  type="number"
+                  value={yearEnd}
+                  onChange={(e) => {
+                    setYearEnd(e.target.value);
+                    if (fieldErrors.yearEnd)
+                      setFieldErrors((prev) => ({ ...prev, yearEnd: "" }));
+                  }}
+                  placeholder="e.g. 1500 or -100"
+                  disabled={isSubmitting}
+                />
+                {fieldErrors.yearEnd && (
+                  <p className="text-sm text-destructive">{fieldErrors.yearEnd}</p>
+                )}
+              </div>
             </div>
           ) : (
             <div className="space-y-2">
@@ -497,9 +497,6 @@ function SubmitStoryPage() {
                 placeholder="e.g. 1453 or -300 for BC"
                 disabled={isSubmitting}
               />
-              <p className="text-xs text-muted-foreground">
-                Use a negative year for BC (e.g. -300 = 300 BC).
-              </p>
               {fieldErrors.year && (
                 <p className="text-sm text-destructive">{fieldErrors.year}</p>
               )}

--- a/frontend/src/pages/SubmitStoryPage.jsx
+++ b/frontend/src/pages/SubmitStoryPage.jsx
@@ -439,43 +439,48 @@ function SubmitStoryPage() {
               </div>
             </div>
           ) : timeType === "year_range" ? (
-            <div className="grid grid-cols-2 gap-4">
-              <div className="space-y-2">
-                <Label htmlFor="yearStart">Start Year</Label>
-                <Input
-                  id="yearStart"
-                  type="number"
-                  value={yearStart}
-                  onChange={(e) => {
-                    setYearStart(e.target.value);
-                    if (fieldErrors.yearStart)
-                      setFieldErrors((prev) => ({ ...prev, yearStart: "" }));
-                  }}
-                  placeholder="e.g. 1400"
-                  disabled={isSubmitting}
-                />
-                {fieldErrors.yearStart && (
-                  <p className="text-sm text-destructive">{fieldErrors.yearStart}</p>
-                )}
+            <div className="space-y-2">
+              <div className="grid grid-cols-2 gap-4">
+                <div className="space-y-2">
+                  <Label htmlFor="yearStart">Start Year</Label>
+                  <Input
+                    id="yearStart"
+                    type="number"
+                    value={yearStart}
+                    onChange={(e) => {
+                      setYearStart(e.target.value);
+                      if (fieldErrors.yearStart)
+                        setFieldErrors((prev) => ({ ...prev, yearStart: "" }));
+                    }}
+                    placeholder="e.g. 1400 or -300"
+                    disabled={isSubmitting}
+                  />
+                  {fieldErrors.yearStart && (
+                    <p className="text-sm text-destructive">{fieldErrors.yearStart}</p>
+                  )}
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor="yearEnd">End Year</Label>
+                  <Input
+                    id="yearEnd"
+                    type="number"
+                    value={yearEnd}
+                    onChange={(e) => {
+                      setYearEnd(e.target.value);
+                      if (fieldErrors.yearEnd)
+                        setFieldErrors((prev) => ({ ...prev, yearEnd: "" }));
+                    }}
+                    placeholder="e.g. 1500 or -100"
+                    disabled={isSubmitting}
+                  />
+                  {fieldErrors.yearEnd && (
+                    <p className="text-sm text-destructive">{fieldErrors.yearEnd}</p>
+                  )}
+                </div>
               </div>
-              <div className="space-y-2">
-                <Label htmlFor="yearEnd">End Year</Label>
-                <Input
-                  id="yearEnd"
-                  type="number"
-                  value={yearEnd}
-                  onChange={(e) => {
-                    setYearEnd(e.target.value);
-                    if (fieldErrors.yearEnd)
-                      setFieldErrors((prev) => ({ ...prev, yearEnd: "" }));
-                  }}
-                  placeholder="e.g. 1500"
-                  disabled={isSubmitting}
-                />
-                {fieldErrors.yearEnd && (
-                  <p className="text-sm text-destructive">{fieldErrors.yearEnd}</p>
-                )}
-              </div>
+              <p className="text-xs text-muted-foreground">
+                Use a negative year for BC (e.g. -300 = 300 BC).
+              </p>
             </div>
           ) : (
             <div className="space-y-2">
@@ -489,9 +494,12 @@ function SubmitStoryPage() {
                   if (fieldErrors.year)
                     setFieldErrors((prev) => ({ ...prev, year: "" }));
                 }}
-                placeholder="e.g. 1453"
+                placeholder="e.g. 1453 or -300 for BC"
                 disabled={isSubmitting}
               />
+              <p className="text-xs text-muted-foreground">
+                Use a negative year for BC (e.g. -300 = 300 BC).
+              </p>
               {fieldErrors.year && (
                 <p className="text-sm text-destructive">{fieldErrors.year}</p>
               )}

--- a/frontend/src/pages/__tests__/SubmitStoryPage.test.jsx
+++ b/frontend/src/pages/__tests__/SubmitStoryPage.test.jsx
@@ -770,6 +770,17 @@ describe("SubmitStoryPage", () => {
     expect(screen.getByLabelText(/time \(optional\)/i)).toBeInTheDocument();
   });
 
+  it("explains that BC dates are not supported for the Specific Date type", async () => {
+    const user = userEvent.setup();
+    renderPage();
+
+    await user.selectOptions(screen.getByLabelText(/time type/i), "exact_date");
+
+    expect(
+      screen.getByText(/BC dates are not supported for the Specific Date type/i)
+    ).toBeInTheDocument();
+  });
+
   it("disables the time input until a date is chosen", async () => {
     const user = userEvent.setup();
     renderPage();

--- a/frontend/src/utils/__tests__/year.test.js
+++ b/frontend/src/utils/__tests__/year.test.js
@@ -1,0 +1,78 @@
+import { describe, it, expect } from "vitest";
+
+import {
+  formatHistoricalDecade,
+  formatHistoricalYear,
+  formatHistoricalYearRange,
+} from "../year";
+
+describe("formatHistoricalYear", () => {
+  it("formats positive years as plain numbers", () => {
+    expect(formatHistoricalYear(1453)).toBe("1453");
+    expect(formatHistoricalYear(2024)).toBe("2024");
+  });
+
+  it("formats negative years with a 'BC' suffix and no minus sign", () => {
+    expect(formatHistoricalYear(-44)).toBe("44 BC");
+    expect(formatHistoricalYear(-2000)).toBe("2000 BC");
+  });
+
+  it("accepts numeric strings", () => {
+    expect(formatHistoricalYear("1500")).toBe("1500");
+    expect(formatHistoricalYear("-300")).toBe("300 BC");
+  });
+
+  it("returns empty string for null, undefined, empty, or non-numeric input", () => {
+    expect(formatHistoricalYear(null)).toBe("");
+    expect(formatHistoricalYear(undefined)).toBe("");
+    expect(formatHistoricalYear("")).toBe("");
+    expect(formatHistoricalYear("abc")).toBe("");
+    expect(formatHistoricalYear(NaN)).toBe("");
+  });
+
+  it("renders zero as '0' (no calendar year zero, treat literally)", () => {
+    expect(formatHistoricalYear(0)).toBe("0");
+  });
+});
+
+describe("formatHistoricalYearRange", () => {
+  it("formats AD-only ranges as 'start–end'", () => {
+    expect(formatHistoricalYearRange(1400, 1500)).toBe("1400–1500");
+  });
+
+  it("collapses BC suffix to one side when both ends are BC", () => {
+    expect(formatHistoricalYearRange(-300, -100)).toBe("300–100 BC");
+  });
+
+  it("emits both era suffixes when the range crosses BC/AD", () => {
+    expect(formatHistoricalYearRange(-100, 50)).toBe("100 BC – 50 AD");
+  });
+
+  it("formats reversed cross-era input symmetrically (no raw negative leak)", () => {
+    expect(formatHistoricalYearRange(50, -100)).toBe("50 AD – 100 BC");
+  });
+
+  it("returns empty string when either end is missing", () => {
+    expect(formatHistoricalYearRange(null, 1500)).toBe("");
+    expect(formatHistoricalYearRange(1500, null)).toBe("");
+    expect(formatHistoricalYearRange("", "")).toBe("");
+  });
+});
+
+describe("formatHistoricalDecade", () => {
+  it("formats AD decades with 's' suffix", () => {
+    expect(formatHistoricalDecade(1980)).toBe("1980s");
+    expect(formatHistoricalDecade(1875)).toBe("1870s");
+  });
+
+  it("formats BC decades with 's BC' suffix and no minus sign", () => {
+    expect(formatHistoricalDecade(-50)).toBe("50s BC");
+    expect(formatHistoricalDecade(-444)).toBe("450s BC");
+  });
+
+  it("returns empty string for missing input", () => {
+    expect(formatHistoricalDecade(null)).toBe("");
+    expect(formatHistoricalDecade(undefined)).toBe("");
+    expect(formatHistoricalDecade("")).toBe("");
+  });
+});

--- a/frontend/src/utils/edtf.js
+++ b/frontend/src/utils/edtf.js
@@ -4,7 +4,7 @@
  * Mirrors backend/apps/stories/temporal.py — keep both in sync.
  *
  * EDTF examples:
- *   exact_year:       "1965"
+ *   exact_year:       "1965"   (negative year = BC, e.g. -44 = 44 BC)
  *   approximate_year: "1965~"
  *   decade:           "196X"          (year=1960 → "196X")
  *   year_range:       "1950/1975"

--- a/frontend/src/utils/year.js
+++ b/frontend/src/utils/year.js
@@ -1,0 +1,54 @@
+/**
+ * Display helpers for historical years. Negative numbers represent BC
+ * (a year of -44 = 44 BC); non-negative values render bare so the
+ * existing AD-only UX stays unchanged.
+ */
+
+const EN_DASH = "–";
+
+function toFiniteNumber(value) {
+  if (value === null || value === undefined || value === "") return null;
+  const n = Number(value);
+  return Number.isFinite(n) ? n : null;
+}
+
+function formatYearWithEra(n) {
+  return n < 0 ? `${Math.abs(n)} BC` : `${n} AD`;
+}
+
+export function formatHistoricalYear(year) {
+  const n = toFiniteNumber(year);
+  if (n === null) return "";
+  if (n < 0) return `${Math.abs(n)} BC`;
+  return String(n);
+}
+
+/**
+ * Format a closed range. Collapses the era suffix to one side when both
+ * ends share an era; emits both when the range crosses the BC/AD line.
+ *
+ *   (1400, 1500)   → "1400–1500"
+ *   (-300, -100)   → "300–100 BC"
+ *   (-100, 50)     → "100 BC – 50 AD"
+ */
+export function formatHistoricalYearRange(start, end) {
+  const s = toFiniteNumber(start);
+  const e = toFiniteNumber(end);
+  if (s === null || e === null) return "";
+  if (s < 0 && e < 0) return `${Math.abs(s)}${EN_DASH}${Math.abs(e)} BC`;
+  if (s >= 0 && e >= 0) return `${s}${EN_DASH}${e}`;
+  return `${formatYearWithEra(s)} ${EN_DASH} ${formatYearWithEra(e)}`;
+}
+
+/**
+ * Format a decade label from any year inside the decade. For BC the base
+ * is the numerically smaller year (e.g. -50 covers 59 BC – 50 BC),
+ * matching how the backend stores `year` for `time_type='decade'`.
+ */
+export function formatHistoricalDecade(year) {
+  const n = toFiniteNumber(year);
+  if (n === null) return "";
+  const base = Math.floor(n / 10) * 10;
+  if (base < 0) return `${Math.abs(base)}s BC`;
+  return `${base}s`;
+}


### PR DESCRIPTION
# Description
Fixes #610

Adds end-to-end BC (Before Christ) year support to the frontend so users can submit, filter, and view stories tied to ancient history. Negative year values (e.g. `-44`) now flow through the year-based time types (`exact_year`, `approximate_year`, `decade`, `year_range`) and render globally with a `BC` suffix and **no leading minus sign** (e.g. `-44` → `44 BC`, `-50` decade → `50s BC`, `-300/-100` range → `300–100 BC`, mixed-era → `100 BC – 50 AD`). Sorting in the timeline already uses numeric comparison, so older BC dates correctly precede more recent ones without changes.

**Key changes**
- New helper `frontend/src/utils/year.js` with `formatHistoricalYear`, `formatHistoricalYearRange`, `formatHistoricalDecade`. Same-era ranges collapse to one suffix; cross-era ranges spell both.
- `formatTimePeriod`, `ActiveFilters` chips, and `TimelineEntry` (bullet + decade chip) routed through the new helpers.
- `FilterPanel`: removed the hard `min=1000` lower bound and matching validation so BC year ranges can be entered; upper cap (`max=2030`) preserved.
- `SubmitStoryPage` and `FilterPanel`: BC hint copy + BC-aware placeholders (`-300 = 300 BC`) for discoverability.
- `edtf.js`: doc note that negative years = BC; existing decade math already handled negatives.

**Out of scope (not part of this PR)**
- BC support for the `exact_date` time type. The HTML `<input type="date">` and the backend `DATE` column do not accept BC dates, so this is a backend-coordinated follow-up.

# Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Refactoring
- [ ] Documentation

# Acceptance Criteria / Checklist
- [x] Project builds successfully
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, especially in hard-to-understand parts
- [x] I have performed a self-review of my code
- [x] I have added/updated tests
- [x] New and existing unit tests pass locally with my changes

**Issue acceptance criteria**
- [x] Submit: users can save a story with a negative year without validation errors (already accepted; placeholders/hint added for discoverability).
- [x] Display: a date stored as `-44` renders globally as `44 BC` (StoryCard, StoryDetailPage, Timeline bullet/decade chip, Map popup all consume `formatTimePeriod`).
- [x] Filter: setting a filter range with BC dates is allowed (FilterPanel `min` removed; `ActiveFilters` chips render BC; covered by new test).
- [x] Map / Timeline: stories with BC dates appear in their correct chronological positions (timeline service sorts numerically, BC < AD).
- [x] Format: no negative signs visible to the end user; only `BC` suffix is shown (asserted in helper, formatter, ActiveFilters, and TimelineEntry tests).
- [x] Unit tests updated accordingly: 1 new test file (`year.test.js`) + BC cases added to StoryCard, ActiveFilters, FilterPanel, and TimelineEntry suites. 1118 tests pass; lint + build clean.

# Screenshots / Recordings
_N/A — display change verified via unit tests._

# Estimated Review Time
- [ ] < 5 min
- [x] 5-15 min
- [ ] > 15 min