### PR TITLE
Fix/frontend timeline ux improvements

### DIFF
--- a/frontend/src/components/AppLayout/AppLayout.jsx
+++ b/frontend/src/components/AppLayout/AppLayout.jsx
@@ -56,7 +56,7 @@ function AppLayout() {
   const baseLinks = isAdmin
     ? [...publicLinks, { to: "/admin", label: "Admin", icon: Shield }]
     : publicLinks;
-  const isFilterPage = location.pathname === "/" || location.pathname === "/map";
+  const isFilterPage = location.pathname === "/" || location.pathname === "/map" || location.pathname === "/timeline";
   const links = baseLinks.map((link) =>
     link.preserveSearch && isFilterPage && location.search
       ? { ...link, basePath: link.to, to: `${link.to}${location.search}` }

--- a/frontend/src/components/AppLayout/__tests__/AppLayout.test.jsx
+++ b/frontend/src/components/AppLayout/__tests__/AppLayout.test.jsx
@@ -25,6 +25,7 @@ function renderWithRouter(initialRoute = "/") {
         <Route element={<AppLayout />}>
           <Route path="/" element={<div>Feed Content</div>} />
           <Route path="/map" element={<div>Map Content</div>} />
+          <Route path="/timeline" element={<div>Timeline Content</div>} />
           <Route path="/login" element={<div>Login Content</div>} />
           <Route path="/register" element={<div>Register Content</div>} />
           <Route path="/profile" element={<div>Profile Content</div>} />
@@ -131,6 +132,29 @@ describe("AppLayout", () => {
     renderWithRouter("/map?q=galata&year_from=1980");
 
     const feedLinks = screen.getAllByRole("link", { name: /^feed$/i });
+    expect(feedLinks[0]).toHaveAttribute("href", "/?q=galata&year_from=1980");
+  });
+
+  it("Timeline link carries current search params when on the Feed page", () => {
+    renderWithRouter("/?q=galata&year_from=1980");
+
+    const timelineLinks = screen.getAllByRole("link", { name: /^timeline$/i });
+    expect(timelineLinks[0]).toHaveAttribute("href", "/timeline?q=galata&year_from=1980");
+  });
+
+  it("Timeline link carries current search params when on the Map page", () => {
+    renderWithRouter("/map?tags=ottoman-era");
+
+    const timelineLinks = screen.getAllByRole("link", { name: /^timeline$/i });
+    expect(timelineLinks[0]).toHaveAttribute("href", "/timeline?tags=ottoman-era");
+  });
+
+  it("Map and Feed links carry current search params when on the Timeline page", () => {
+    renderWithRouter("/timeline?q=galata&year_from=1980");
+
+    const mapLinks = screen.getAllByRole("link", { name: /^map$/i });
+    const feedLinks = screen.getAllByRole("link", { name: /^feed$/i });
+    expect(mapLinks[0]).toHaveAttribute("href", "/map?q=galata&year_from=1980");
     expect(feedLinks[0]).toHaveAttribute("href", "/?q=galata&year_from=1980");
   });
 

--- a/frontend/src/components/Timeline/TimelineEntry.jsx
+++ b/frontend/src/components/Timeline/TimelineEntry.jsx
@@ -21,15 +21,8 @@ function bulletLabel(story) {
   return "";
 }
 
-function decadeChip(story) {
-  const yearForDecade = story.year ?? story.year_start;
-  if (yearForDecade == null) return null;
-  return `${Math.floor(yearForDecade / 10) * 10}s`;
-}
-
 function TimelineEntry({ story }) {
   const label = bulletLabel(story);
-  const decade = story.time_type === "decade" ? null : decadeChip(story);
   const hasCoords =
     story.location_lat != null && story.location_lng != null;
   const locationName =
@@ -78,23 +71,13 @@ function TimelineEntry({ story }) {
             {story.title}
           </h3>
 
-          <div className="flex flex-wrap gap-1.5">
-            {label && (
+          {label && (
+            <div className="flex flex-wrap gap-1.5">
               <span className="inline-flex items-center rounded-full bg-muted px-2 py-0.5 text-xs text-muted-foreground">
                 {label}
               </span>
-            )}
-            {decade && decade !== label && (
-              <span className="inline-flex items-center rounded-full bg-muted px-2 py-0.5 text-xs text-muted-foreground">
-                {decade}
-              </span>
-            )}
-            {story.temporal_coverage && (
-              <span className="inline-flex items-center rounded-full bg-muted px-2 py-0.5 text-xs text-muted-foreground">
-                {story.temporal_coverage}
-              </span>
-            )}
-          </div>
+            </div>
+          )}
 
           {locationText && (
             <div className="flex items-center gap-1.5 text-xs text-muted-foreground">

--- a/frontend/src/components/Timeline/TimelineEntry.jsx
+++ b/frontend/src/components/Timeline/TimelineEntry.jsx
@@ -71,14 +71,6 @@ function TimelineEntry({ story }) {
             {story.title}
           </h3>
 
-          {label && (
-            <div className="flex flex-wrap gap-1.5">
-              <span className="inline-flex items-center rounded-full bg-muted px-2 py-0.5 text-xs text-muted-foreground">
-                {label}
-              </span>
-            </div>
-          )}
-
           {locationText && (
             <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
               <MapPin className="h-3.5 w-3.5 shrink-0" aria-hidden="true" />

--- a/frontend/src/components/Timeline/__tests__/TimelineEntry.test.jsx
+++ b/frontend/src/components/Timeline/__tests__/TimelineEntry.test.jsx
@@ -82,6 +82,44 @@ describe("TimelineEntry", () => {
     expect(screen.getAllByText("1870s").length).toBeGreaterThan(0);
   });
 
+  it("renders only the formatTimePeriod label chip — no decade chip for non-decade stories", () => {
+    renderEntry({
+      id: 1,
+      title: "T",
+      time_type: "exact_year",
+      year: 1920,
+      year_start: null,
+      year_end: null,
+      location_lat: null,
+      location_lng: null,
+      photo_url: null,
+      temporal_coverage: "1920",
+    });
+
+    // "1920" appears as the bullet label and as one chip — nothing else
+    const chips = screen.getAllByText("1920");
+    // bullet + one chip = 2 occurrences at most; the decade "1920s" must not appear
+    expect(chips.length).toBeLessThanOrEqual(2);
+    expect(screen.queryByText("1920s")).not.toBeInTheDocument();
+  });
+
+  it("does not render a temporal_coverage chip even when the field is present", () => {
+    renderEntry({
+      id: 1,
+      title: "T",
+      time_type: "approx_year",
+      year: 1920,
+      year_start: null,
+      year_end: null,
+      location_lat: null,
+      location_lng: null,
+      photo_url: null,
+      temporal_coverage: "~1920",
+    });
+
+    expect(screen.queryByText("~1920")).not.toBeInTheDocument();
+  });
+
   it("renders the photo when photo_url is provided", () => {
     renderEntry({
       id: 1,

--- a/frontend/src/components/Timeline/__tests__/TimelineEntry.test.jsx
+++ b/frontend/src/components/Timeline/__tests__/TimelineEntry.test.jsx
@@ -96,10 +96,9 @@ describe("TimelineEntry", () => {
       temporal_coverage: "1920",
     });
 
-    // "1920" appears as the bullet label and as one chip — nothing else
+    // "1920" appears only as the bullet — the in-card chip is removed
     const chips = screen.getAllByText("1920");
-    // bullet + one chip = 2 occurrences at most; the decade "1920s" must not appear
-    expect(chips.length).toBeLessThanOrEqual(2);
+    expect(chips.length).toBe(1);
     expect(screen.queryByText("1920s")).not.toBeInTheDocument();
   });
 

--- a/frontend/src/pages/TimelinePage.jsx
+++ b/frontend/src/pages/TimelinePage.jsx
@@ -4,7 +4,6 @@ import { Button } from "@/components/ui/button";
 import { ErrorState } from "@/components/ui/error-state";
 import { LoadingSpinner } from "@/components/ui/loading-spinner";
 import TimelineView from "@/components/Timeline/TimelineView";
-import SearchBar from "@/components/SearchFilter/SearchBar";
 import FilterPanel from "@/components/SearchFilter/FilterPanel";
 import ActiveFilters from "@/components/SearchFilter/ActiveFilters";
 import { useFilterState } from "@/hooks/useFilterState";
@@ -23,7 +22,6 @@ function countActiveFilters({ yearFrom, yearTo, location, hasProximity, tags, ha
 
 function TimelinePage() {
   const {
-    q,
     yearFrom,
     yearTo,
     location,
@@ -65,7 +63,6 @@ function TimelinePage() {
         const data = await getTimeline({
           yearFrom: yearFrom === "" ? undefined : yearFrom,
           yearTo: yearTo === "" ? undefined : yearTo,
-          q,
           location,
           tags,
           latMin: latMin ?? undefined,
@@ -101,7 +98,6 @@ function TimelinePage() {
     [
       yearFrom,
       yearTo,
-      q,
       location,
       tags,
       latMin,
@@ -127,13 +123,6 @@ function TimelinePage() {
   function handleRetry() {
     fetchPage(1, { append: false });
   }
-
-  const handleSearchChange = useCallback(
-    (value) => {
-      setFilters({ q: value }, { replace: true });
-    },
-    [setFilters],
-  );
 
   function handleFilterApply({
     yearFrom: yf,
@@ -249,20 +238,12 @@ function TimelinePage() {
     <main className="min-h-screen bg-background">
       <div className="mx-auto max-w-3xl px-4 py-8 sm:px-6 lg:px-8">
         <div className="mb-6">
-          <h1 className="text-3xl font-bold tracking-tight">Timeline</h1>
-          <p className="mt-1 text-sm text-muted-foreground">
-            Stories ordered by when they happened.
-          </p>
-        </div>
-
-        <div className="mb-6 space-y-2">
-          <div className="flex items-center gap-2">
-            <div className="min-w-0 flex-1">
-              <SearchBar
-                defaultValue={q}
-                onSearch={handleSearchChange}
-                placeholder="Search by title or place…"
-              />
+          <div className="flex items-center justify-between gap-4">
+            <div>
+              <h1 className="text-3xl font-bold tracking-tight">Timeline</h1>
+              <p className="mt-1 text-sm text-muted-foreground">
+                Stories ordered by when they happened.
+              </p>
             </div>
             <FilterPanel
               key={filterPanelKey}
@@ -284,7 +265,6 @@ function TimelinePage() {
             />
           </div>
           <ActiveFilters
-            q={q}
             yearFrom={yearFrom}
             yearTo={yearTo}
             location={location}

--- a/frontend/src/pages/TimelinePage.jsx
+++ b/frontend/src/pages/TimelinePage.jsx
@@ -1,4 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useLocation, useNavigate } from "react-router-dom";
+import { ArrowLeft } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
 import { ErrorState } from "@/components/ui/error-state";
@@ -40,6 +42,10 @@ function TimelinePage() {
     removeTag,
     clearAll,
   } = useFilterState();
+
+  const routerLocation = useLocation();
+  const navigate = useNavigate();
+  const mapBack = routerLocation.state?.from?.startsWith("/map") ? routerLocation.state.from : null;
 
   const [stories, setStories] = useState([]);
   const [count, setCount] = useState(0);
@@ -239,11 +245,23 @@ function TimelinePage() {
       <div className="mx-auto max-w-3xl px-4 py-8 sm:px-6 lg:px-8">
         <div className="mb-6">
           <div className="flex items-center justify-between gap-4">
-            <div>
-              <h1 className="text-3xl font-bold tracking-tight">Timeline</h1>
-              <p className="mt-1 text-sm text-muted-foreground">
-                Stories ordered by when they happened.
-              </p>
+            <div className="flex items-center gap-3">
+              {mapBack && (
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  onClick={() => navigate(mapBack)}
+                  aria-label="Back to map"
+                >
+                  <ArrowLeft className="h-5 w-5" />
+                </Button>
+              )}
+              <div>
+                <h1 className="text-3xl font-bold tracking-tight">Timeline</h1>
+                <p className="mt-1 text-sm text-muted-foreground">
+                  Stories ordered by when they happened.
+                </p>
+              </div>
             </div>
             <FilterPanel
               key={filterPanelKey}

--- a/frontend/src/pages/TimelinePage.jsx
+++ b/frontend/src/pages/TimelinePage.jsx
@@ -45,7 +45,8 @@ function TimelinePage() {
 
   const routerLocation = useLocation();
   const navigate = useNavigate();
-  const mapBack = routerLocation.state?.from?.startsWith("/map") ? routerLocation.state.from : null;
+  const _from = routerLocation.state?.from;
+  const mapBack = _from === "/map" || _from?.startsWith("/map?") ? _from : null;
 
   const [stories, setStories] = useState([]);
   const [count, setCount] = useState(0);

--- a/frontend/src/pages/__tests__/TimelinePage.test.jsx
+++ b/frontend/src/pages/__tests__/TimelinePage.test.jsx
@@ -40,6 +40,14 @@ function renderPage(initialEntries = ["/timeline"]) {
   );
 }
 
+function renderPageWithState(state) {
+  return render(
+    <MemoryRouter initialEntries={[{ pathname: "/timeline", state }]}>
+      <TimelinePage />
+    </MemoryRouter>,
+  );
+}
+
 describe("TimelinePage", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -213,5 +221,22 @@ describe("TimelinePage", () => {
     expect(args.latMax).toBe(41);
     expect(args.lngMin).toBe(28);
     expect(args.lngMax).toBe(29);
+  });
+
+  describe("back-to-map button", () => {
+    it("shows a back arrow when navigated from /map", async () => {
+      renderPageWithState({ from: "/map?lat_min=40&lat_max=41" });
+      expect(screen.getByRole("button", { name: /back to map/i })).toBeInTheDocument();
+    });
+
+    it("does not show a back arrow when there is no router state", async () => {
+      renderPage();
+      expect(screen.queryByRole("button", { name: /back to map/i })).not.toBeInTheDocument();
+    });
+
+    it("does not show a back arrow when navigated from a non-map page", async () => {
+      renderPageWithState({ from: "/timeline?year_from=1900" });
+      expect(screen.queryByRole("button", { name: /back to map/i })).not.toBeInTheDocument();
+    });
   });
 });

--- a/frontend/src/pages/__tests__/TimelinePage.test.jsx
+++ b/frontend/src/pages/__tests__/TimelinePage.test.jsx
@@ -61,10 +61,10 @@ describe("TimelinePage", () => {
     ).not.toBeInTheDocument();
   });
 
-  it("renders the shared SearchBar + Filters button + ActiveFilters pattern", async () => {
+  it("renders the Filters button but no search bar input", async () => {
     renderPage();
-    expect(screen.getByPlaceholderText(/search by title or place/i)).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /^filters$/i })).toBeInTheDocument();
+    expect(screen.queryByPlaceholderText(/search by title or place/i)).not.toBeInTheDocument();
   });
 
   it("fetches with no year params on first render (no URL filters)", async () => {
@@ -92,19 +92,10 @@ describe("TimelinePage", () => {
     expect(getTimeline.mock.calls[0][0].hasImage).toBe(true);
   });
 
-  it("forwards q from the URL on mount and reacts to typed input (debounced)", async () => {
-    const user = userEvent.setup();
+  it("does not pass q to getTimeline even when q is present in the URL", async () => {
     renderPage(["/timeline?q=hagia"]);
     await waitFor(() => expect(getTimeline).toHaveBeenCalled());
-    expect(getTimeline.mock.calls[0][0].q).toBe("hagia");
-
-    await user.clear(screen.getByPlaceholderText(/search by title or place/i));
-    await user.type(screen.getByPlaceholderText(/search by title or place/i), "galata");
-
-    await waitFor(() => {
-      const matched = getTimeline.mock.calls.some(([a]) => a?.q === "galata");
-      expect(matched).toBe(true);
-    });
+    expect(getTimeline.mock.calls[0][0].q).toBeUndefined();
   });
 
   it("forwards URL filters (location, tags, proximity) to getTimeline", async () => {
@@ -120,18 +111,18 @@ describe("TimelinePage", () => {
     expect(args.radiusKm).toBe(1);
   });
 
-  it("renders dismissible chips for q / year_range / location / tags / has_image", async () => {
+  it("renders dismissible chips for year_range / location / tags / has_image (no q chip)", async () => {
     renderPage([
-      "/timeline?q=war&year_from=1850&year_to=1900&location=Galata&tags=ottoman&has_image=true",
+      "/timeline?year_from=1850&year_to=1900&location=Galata&tags=ottoman&has_image=true",
     ]);
     await waitFor(() => expect(getTimeline).toHaveBeenCalled());
 
     expect(screen.getByLabelText(/active filters/i)).toBeInTheDocument();
-    expect(screen.getByText('"war"')).toBeInTheDocument();
     expect(screen.getByText("1850–1900")).toBeInTheDocument();
     expect(screen.getByText(/location: galata/i)).toBeInTheDocument();
     expect(screen.getByText("ottoman")).toBeInTheDocument();
     expect(screen.getByText(/^has image$/i)).toBeInTheDocument();
+    expect(screen.queryByText(/"war"/)).not.toBeInTheDocument();
   });
 
   it("removing the year-range chip clears year_from / year_to and refetches", async () => {

--- a/frontend/src/services/__tests__/timelineService.test.js
+++ b/frontend/src/services/__tests__/timelineService.test.js
@@ -7,11 +7,7 @@ vi.mock("../api", () => ({
 }));
 
 import api from "../api";
-import {
-  getTimeline,
-  getTimelineHistoricalYear,
-  storyOverlapsYearWindow,
-} from "../timelineService";
+import { getTimeline } from "../timelineService";
 
 function story(overrides = {}) {
   return {
@@ -309,88 +305,4 @@ describe("timelineService", () => {
     });
   });
 
-  describe("storyOverlapsYearWindow", () => {
-    it("returns true when both bounds are null (no filter)", () => {
-      expect(storyOverlapsYearWindow(story({ time_type: "exact_year", year: 1875 }), null, null)).toBe(
-        true,
-      );
-    });
-
-    it("exact_year — point in [yearFrom, yearTo]", () => {
-      const s = story({ time_type: "exact_year", year: 1875 });
-      expect(storyOverlapsYearWindow(s, 1870, 1880)).toBe(true);
-      expect(storyOverlapsYearWindow(s, 1880, 1890)).toBe(false);
-      expect(storyOverlapsYearWindow(s, 1860, 1870)).toBe(false);
-    });
-
-    it("decade — interval [Y, Y+9] overlaps window (the bug we're fixing)", () => {
-      const s = story({ time_type: "decade", year: 1870 });
-      // Window 1875-1885 overlaps 1870-1879 → INCLUDED
-      expect(storyOverlapsYearWindow(s, 1875, 1885)).toBe(true);
-      // Window 1865-1872 overlaps 1870-1879 → INCLUDED
-      expect(storyOverlapsYearWindow(s, 1865, 1872)).toBe(true);
-      // Window entirely after the decade → EXCLUDED
-      expect(storyOverlapsYearWindow(s, 1880, 1890)).toBe(false);
-      // Window entirely before the decade → EXCLUDED
-      expect(storyOverlapsYearWindow(s, 1850, 1869)).toBe(false);
-    });
-
-    it("year_range — interval [year_start, year_end] overlaps window", () => {
-      const s = story({ time_type: "year_range", year_start: 1850, year_end: 1900 });
-      expect(storyOverlapsYearWindow(s, 1875, 1885)).toBe(true);
-      expect(storyOverlapsYearWindow(s, 1820, 1860)).toBe(true);
-      expect(storyOverlapsYearWindow(s, 1910, 1920)).toBe(false);
-      expect(storyOverlapsYearWindow(s, 1800, 1849)).toBe(false);
-    });
-
-    it("exact_date — year extracted from date_value", () => {
-      const s = story({ time_type: "exact_date", date_value: "1923-10-29" });
-      expect(storyOverlapsYearWindow(s, 1920, 1925)).toBe(true);
-      expect(storyOverlapsYearWindow(s, 1924, 1930)).toBe(false);
-    });
-
-    it("one-sided window — only yearFrom or only yearTo", () => {
-      const s = story({ time_type: "exact_year", year: 1875 });
-      expect(storyOverlapsYearWindow(s, 1870, null)).toBe(true);
-      expect(storyOverlapsYearWindow(s, 1880, null)).toBe(false);
-      expect(storyOverlapsYearWindow(s, null, 1880)).toBe(true);
-      expect(storyOverlapsYearWindow(s, null, 1870)).toBe(false);
-    });
-
-    it("excludes stories with no usable time info when a window is set", () => {
-      expect(storyOverlapsYearWindow(story({ time_type: "exact_year", year: null }), 1870, 1880)).toBe(
-        false,
-      );
-      expect(storyOverlapsYearWindow(null, 1870, 1880)).toBe(false);
-    });
-  });
-
-  describe("getTimelineHistoricalYear", () => {
-    it("returns year for exact_year stories", () => {
-      expect(getTimelineHistoricalYear(story({ time_type: "exact_year", year: 1875 }))).toBe(1875);
-    });
-
-    it("returns midpoint for year_range stories", () => {
-      expect(
-        getTimelineHistoricalYear(story({ time_type: "year_range", year_start: 1850, year_end: 1900 })),
-      ).toBe(1875);
-    });
-
-    it("returns year + 5 for decade stories", () => {
-      expect(getTimelineHistoricalYear(story({ time_type: "decade", year: 1870 }))).toBe(1875);
-    });
-
-    it("extracts the year from exact_date stories", () => {
-      expect(
-        getTimelineHistoricalYear(story({ time_type: "exact_date", date_value: "1923-10-29" })),
-      ).toBe(1923);
-    });
-
-    it("returns MAX_SAFE_INTEGER for stories with no usable time info (so they sink)", () => {
-      expect(getTimelineHistoricalYear(story({ time_type: "exact_year", year: null }))).toBe(
-        Number.MAX_SAFE_INTEGER,
-      );
-      expect(getTimelineHistoricalYear(null)).toBe(Number.MAX_SAFE_INTEGER);
-    });
-  });
 });

--- a/frontend/src/services/__tests__/timelineService.test.js
+++ b/frontend/src/services/__tests__/timelineService.test.js
@@ -145,26 +145,26 @@ describe("timelineService", () => {
       expect(params).not.toHaveProperty("has_image");
     });
 
-    it("does NOT forward has_image to the fallback endpoint (search/feed reject it)", async () => {
+    it("forwards has_image=true to /stories/timeline/ even on the fallback path", async () => {
       api.get.mockResolvedValue({ data: { count: 0, next: null, previous: null, results: [] } });
-      // q triggers the fallback path; has_image must not leak through.
+      // q triggers the fallback path; has_image must still reach the timeline endpoint.
       await getTimeline({ q: "galata", hasImage: true });
       const params = api.get.mock.calls[0][1].params;
-      expect(params).not.toHaveProperty("has_image");
+      expect(params).toHaveProperty("has_image", true);
     });
   });
 
   describe("fallback path (filters not supported by /stories/timeline/)", () => {
-    it("routes to /stories/search/ when q is set, sorted by historical year", async () => {
+    it("routes to /stories/timeline/ when q is set and applies q as client-side filter", async () => {
       api.get.mockResolvedValue({
         data: {
           count: 3,
           next: null,
           previous: null,
           results: [
-            story({ id: "later", year: 2000 }),
-            story({ id: "earlier", year: 1900 }),
-            story({ id: "middle", year: 1950 }),
+            story({ id: "match-title", year: 1900, title: "Galata Tower story" }),
+            story({ id: "match-location", year: 1950, title: "Other", location_name: "Galata" }),
+            story({ id: "no-match", year: 2000, title: "Unrelated" }),
           ],
         },
       });
@@ -172,24 +172,34 @@ describe("timelineService", () => {
       const result = await getTimeline({ q: "Galata", page: 1, pageSize: 10 });
 
       expect(api.get).toHaveBeenCalledWith(
-        "/stories/search/",
-        expect.objectContaining({ params: expect.objectContaining({ q: "Galata" }) }),
+        "/stories/timeline/",
+        expect.objectContaining({ params: expect.not.objectContaining({ q: expect.anything() }) }),
       );
-      expect(result.results.map((s) => s.id)).toEqual(["earlier", "middle", "later"]);
-      expect(result.count).toBe(3);
+      expect(result.results.map((s) => s.id)).toEqual(["match-title", "match-location"]);
+      expect(result.count).toBe(2);
     });
 
-    it("falls back when location text is set without a bbox", async () => {
+    it("routes to /stories/timeline/ when location text is set without a bbox and filters client-side", async () => {
       api.get.mockResolvedValue({
-        data: { count: 0, next: null, previous: null, results: [] },
+        data: {
+          count: 2,
+          next: null,
+          previous: null,
+          results: [
+            story({ id: "in-galata", year: 1900, location_name: "Galata District" }),
+            story({ id: "elsewhere", year: 1950, location_name: "Kadikoy" }),
+          ],
+        },
       });
 
-      await getTimeline({ location: "Galata", page: 1, pageSize: 10 });
+      const result = await getTimeline({ location: "Galata", page: 1, pageSize: 10 });
 
       expect(api.get).toHaveBeenCalledWith(
-        "/stories/feed/",
-        expect.objectContaining({ params: expect.objectContaining({ location: "Galata" }) }),
+        "/stories/timeline/",
+        expect.objectContaining({ params: expect.not.objectContaining({ location: expect.anything() }) }),
       );
+      expect(result.results.map((s) => s.id)).toEqual(["in-galata"]);
+      expect(result.count).toBe(1);
     });
 
     it("does NOT fall back when location string has a matching bbox", async () => {
@@ -216,13 +226,13 @@ describe("timelineService", () => {
     it("client-paginates the fallback results", async () => {
       const all = [];
       for (let i = 0; i < 25; i++) {
-        all.push(story({ id: `s${i}`, year: 1900 + i }));
+        all.push(story({ id: `s${i}`, year: 1900 + i, location_name: "Galata" }));
       }
       api.get.mockResolvedValue({
         data: { count: 25, next: null, previous: null, results: all },
       });
 
-      const page2 = await getTimeline({ q: "x", page: 2, pageSize: 10 });
+      const page2 = await getTimeline({ location: "Galata", page: 2, pageSize: 10 });
 
       expect(page2.count).toBe(25);
       expect(page2.results).toHaveLength(10);
@@ -230,12 +240,12 @@ describe("timelineService", () => {
       expect(page2.next).toBe("client-next-page");
       expect(page2.previous).toBe("client-previous-page");
 
-      const page3 = await getTimeline({ q: "x", page: 3, pageSize: 10 });
+      const page3 = await getTimeline({ location: "Galata", page: 3, pageSize: 10 });
       expect(page3.results).toHaveLength(5);
       expect(page3.next).toBeNull();
     });
 
-    it("requests at most page_size=100 from the fallback endpoint (documenting the cap)", async () => {
+    it("requests at most page_size=100 from /stories/timeline/ in the fallback (documenting the cap)", async () => {
       api.get.mockResolvedValue({
         data: { count: 0, next: null, previous: null, results: [] },
       });
@@ -245,92 +255,57 @@ describe("timelineService", () => {
       const params = api.get.mock.calls[0][1].params;
       // The fallback always asks for the cap regardless of the caller's
       // requested pageSize — the slice happens client-side. Stories beyond
-      // the 100th in the underlying endpoint's order are not reachable.
+      // the 100th in the timeline's historical order are not reachable.
       expect(params.page_size).toBe(100);
     });
 
     it("count reflects only stories within the fallback fetch window (cap is observable)", async () => {
-      // Simulate a corpus where the underlying endpoint has 100 results to
-      // hand back (max page size). The timeline view's `count` will read 100,
-      // not the true backend count of any larger result set.
-      const stories = Array.from({ length: 100 }, (_, i) => story({ id: `s${i}`, year: 1900 + i }));
+      // Simulate a corpus where the timeline endpoint hands back 100 results.
+      // The view's `count` will read 100, not the true backend total.
+      const stories = Array.from({ length: 100 }, (_, i) =>
+        story({ id: `s${i}`, year: 1900 + i, title: "Galata story" }),
+      );
       api.get.mockResolvedValue({
         data: { count: 999, next: "url-to-page-2", previous: null, results: stories },
       });
 
-      const result = await getTimeline({ q: "x", page: 1, pageSize: 10 });
+      const result = await getTimeline({ q: "Galata", page: 1, pageSize: 10 });
       expect(result.count).toBe(100);
     });
   });
 
   describe("fallback path year semantics (matches /stories/timeline/ behaviour)", () => {
-    it("does NOT forward year_from/year_to to the fallback endpoint", async () => {
+    it("forwards year_from/year_to to /stories/timeline/ in the fallback", async () => {
       api.get.mockResolvedValue({
         data: { count: 0, next: null, previous: null, results: [] },
       });
 
       await getTimeline({ q: "Galata", yearFrom: 1870, yearTo: 1880, page: 1, pageSize: 10 });
 
-      // Feed/search use simpler year semantics; we filter client-side instead.
+      // The timeline endpoint handles interval-overlap year semantics, so we
+      // forward year params and let the server filter correctly.
       const calledWith = api.get.mock.calls[0][1];
-      expect(calledWith.params).not.toHaveProperty("year_from");
-      expect(calledWith.params).not.toHaveProperty("year_to");
+      expect(calledWith.params).toHaveProperty("year_from", 1870);
+      expect(calledWith.params).toHaveProperty("year_to", 1880);
     });
 
-    it("includes a decade story whose interval overlaps the year window (semantic parity with /stories/timeline/)", async () => {
+    it("server-side year filtering is trusted — results returned by the endpoint are not re-filtered", async () => {
+      // The timeline endpoint already applies interval-overlap semantics for
+      // decade and exact_date stories. The frontend trusts whatever it returns.
       api.get.mockResolvedValue({
         data: {
-          count: 1,
+          count: 2,
           next: null,
           previous: null,
           results: [
-            // Decade 1870 = represents 1870-1879. /stories/feed/ would have
-            // dropped it for year_from=1875 because year (1870) < 1875. But
-            // /stories/timeline/ includes it via interval overlap. After this
-            // fix, the fallback path also includes it.
-            story({ id: "d", time_type: "decade", year: 1870 }),
+            story({ id: "d", time_type: "decade", year: 1870, title: "Galata story" }),
+            story({ id: "ed", time_type: "exact_date", date_value: "1923-10-29", title: "Galata story" }),
           ],
         },
       });
 
-      const result = await getTimeline({ q: "x", yearFrom: 1875, yearTo: 1885, page: 1, pageSize: 10 });
-      expect(result.results.map((s) => s.id)).toEqual(["d"]);
-    });
-
-    it("includes an exact_date story whose year falls in the window", async () => {
-      api.get.mockResolvedValue({
-        data: {
-          count: 1,
-          next: null,
-          previous: null,
-          results: [
-            // /stories/feed/ would drop this — year is null on exact_date —
-            // but /stories/timeline/ matches via date_value__year. Parity.
-            story({ id: "ed", time_type: "exact_date", date_value: "1923-10-29" }),
-          ],
-        },
-      });
-
-      const result = await getTimeline({ q: "x", yearFrom: 1920, yearTo: 1925, page: 1, pageSize: 10 });
-      expect(result.results.map((s) => s.id)).toEqual(["ed"]);
-    });
-
-    it("excludes stories whose interval falls outside the year window", async () => {
-      api.get.mockResolvedValue({
-        data: {
-          count: 3,
-          next: null,
-          previous: null,
-          results: [
-            story({ id: "before", time_type: "exact_year", year: 1850 }),
-            story({ id: "in", time_type: "exact_year", year: 1875 }),
-            story({ id: "after", time_type: "exact_year", year: 1950 }),
-          ],
-        },
-      });
-
-      const result = await getTimeline({ q: "x", yearFrom: 1870, yearTo: 1880, page: 1, pageSize: 10 });
-      expect(result.results.map((s) => s.id)).toEqual(["in"]);
+      const result = await getTimeline({ q: "Galata", yearFrom: 1875, yearTo: 1885, page: 1, pageSize: 10 });
+      expect(result.results.map((s) => s.id)).toEqual(["d", "ed"]);
     });
   });
 

--- a/frontend/src/services/timelineService.js
+++ b/frontend/src/services/timelineService.js
@@ -1,5 +1,4 @@
 import api from "./api";
-import { getStories } from "./storyService";
 
 const KEY_MAP = {
   yearFrom: "year_from",
@@ -21,15 +20,12 @@ const KEY_MAP = {
 // max_page_size and the cap mobile uses for the same fallback path).
 //
 // Known limitation: when an unsupported filter combination forces the
-// fallback (q / tags / proximity / free-text location), the client fetches
-// at most this many stories from /stories/search/ or /stories/feed/, sorts
-// them by historical year, and paginates the slice. Stories that match the
-// filter set but rank beyond the 100th in the underlying endpoint's order
-// (recent-first by default, or relevance for q) are NOT reachable via the
-// timeline view, and the `count` returned reflects only what was fetched —
-// not the true backend count. Same trade-off mobile makes; lifting it would
-// require a backend change to expose timeline-specific filtering across the
-// full result set.
+// fallback (q / free-text location), the client fetches at most this many
+// stories from /stories/timeline/, applies q and location text client-side,
+// and paginates the slice. Stories that match the text filter but rank beyond
+// the 100th in the timeline's historical order are not reachable via the
+// timeline view, and `count` reflects only what was fetched — not the true
+// backend count. Same trade-off mobile makes.
 const FALLBACK_FETCH_PAGE_SIZE = 100;
 
 /**
@@ -106,13 +102,14 @@ function hasUnsupportedTimelineFilters(filters) {
  * Fetch stories ordered by time period for the timeline view.
  *
  * When the active filter set is supported by `/stories/timeline/` (year,
- * bbox, tags, proximity), this proxies that endpoint directly so the
- * server's historical ordering and pagination are preserved. When the filter
- * set includes text search (`q`) or a location string without a bbox, the
- * timeline endpoint can't honour it — so we fall back to `/stories/search/`
- * (when q is present) or `/stories/feed/`, then re-sort client-side by
- * historical midpoint and paginate locally. This mirrors the strategy in
- * `mobile/src/features/timeline/data/sources/index.ts`.
+ * bbox, tags, proximity, has_image), this proxies that endpoint directly so
+ * the server's historical ordering and pagination are preserved. When the
+ * filter set includes text search (`q`) or a location string without a bbox,
+ * the timeline endpoint can't honour them — so we still call
+ * `/stories/timeline/` for all server-supported params, then apply `q` and
+ * `location` text as client-side substring filters on the fetched results.
+ * This ensures `photo_url` is always present in the response, giving
+ * consistent card rendering regardless of active filters.
  */
 export async function getTimeline({
   yearFrom,
@@ -194,57 +191,61 @@ async function getTimelineViaFallback({
   latitude,
   longitude,
   radiusKm,
+  hasImage,
   page,
   pageSize,
-  // hasImage is deliberately not destructured here — see note below.
 }) {
-  // storyService.getStories already routes between /stories/search/ (with q)
-  // and /stories/feed/, and it builds exactly the bbox/location/proximity/
-  // tags param shape we need. We just borrow it as the underlying fetch.
-  //
-  // year_from/year_to are deliberately NOT forwarded — feed/search apply a
-  // simpler `year__gte`/`year__lte` filter that drops decade and exact_date
-  // stories the timeline endpoint would include via interval overlap. We
-  // re-apply year filtering below with storyOverlapsYearWindow so the fallback
-  // path matches the primary path's semantics.
-  //
-  // has_image is also NOT applied in this branch: /stories/search/ and
-  // /stories/feed/ neither accept the filter param nor expose a per-story
-  // image flag in StoryFeedSerializer, so a client-side filter has nothing
-  // to read. The toggle silently no-ops in fallback mode; would need a
-  // backend addition to apply consistently across both paths.
-  const data = await getStories({
-    q,
-    location,
+  // Always call /stories/timeline/ so results include photo_url, correct
+  // interval-overlap year semantics, and historical sort order.
+  // q and location text (without bbox) are not supported by the timeline
+  // endpoint — apply them as client-side substring filters after the fetch.
+  const args = {
+    yearFrom,
+    yearTo,
     latMin,
     latMax,
     lngMin,
     lngMax,
+    tags,
     latitude,
     longitude,
     radiusKm,
-    tags,
-    page: 1,
     pageSize: FALLBACK_FETCH_PAGE_SIZE,
-  });
-  const allResults = Array.isArray(data?.results) ? data.results : [];
+    ...(hasImage ? { hasImage: true } : {}),
+  };
+  const params = {};
+  for (const [key, value] of Object.entries(args)) {
+    if (value === undefined) continue;
+    if (Array.isArray(value) && value.length === 0) continue;
+    params[KEY_MAP[key]] = value;
+  }
+
+  const response = await api.get("/stories/timeline/", { params });
+  const allResults = Array.isArray(response.data?.results) ? response.data.results : [];
+
+  const qNorm = q?.trim().toLowerCase();
+  const locNorm = location?.trim().toLowerCase();
   const matching =
-    yearFrom == null && yearTo == null
-      ? allResults
-      : allResults.filter((s) => storyOverlapsYearWindow(s, yearFrom, yearTo));
-  // Decorate-sort-undecorate: compute the historical year once per story,
-  // not twice per comparison.
-  const sorted = matching
-    .map((story) => [getTimelineHistoricalYear(story), story])
-    .sort((a, b) => a[0] - b[0])
-    .map(([, story]) => story);
+    qNorm || locNorm
+      ? allResults.filter((s) => {
+          if (qNorm) {
+            if (
+              !s.title?.toLowerCase().includes(qNorm) &&
+              !s.location_name?.toLowerCase().includes(qNorm)
+            )
+              return false;
+          }
+          if (locNorm && !s.location_name?.toLowerCase().includes(locNorm)) return false;
+          return true;
+        })
+      : allResults;
 
   const startIndex = (page - 1) * pageSize;
-  const pageResults = sorted.slice(startIndex, startIndex + pageSize);
-  const hasNext = startIndex + pageSize < sorted.length;
+  const pageResults = matching.slice(startIndex, startIndex + pageSize);
+  const hasNext = startIndex + pageSize < matching.length;
 
   return {
-    count: sorted.length,
+    count: matching.length,
     next: hasNext ? "client-next-page" : null,
     previous: page > 1 ? "client-previous-page" : null,
     results: pageResults,

--- a/frontend/src/services/timelineService.js
+++ b/frontend/src/services/timelineService.js
@@ -28,66 +28,6 @@ const KEY_MAP = {
 // backend count. Same trade-off mobile makes.
 const FALLBACK_FETCH_PAGE_SIZE = 100;
 
-/**
- * Compute the historical-year midpoint for a story so the client can sort
- * fallback-fetched results the same way the timeline endpoint does on the
- * server. Returns Number.MAX_SAFE_INTEGER for stories with no usable time
- * info so they sink to the bottom rather than crash the comparator.
- *
- * Mirrors the server-side CASE expression in
- * `backend/apps/stories/services.py::get_story_timeline`.
- */
-export function getTimelineHistoricalYear(story) {
-  if (!story || typeof story !== "object") return Number.MAX_SAFE_INTEGER;
-  const { time_type, year, year_start, year_end, date_value } = story;
-  if (time_type === "year_range" && Number.isFinite(year_start) && Number.isFinite(year_end)) {
-    return (year_start + year_end) / 2;
-  }
-  if (time_type === "decade" && Number.isFinite(year)) {
-    return year + 5;
-  }
-  if (time_type === "exact_date" && typeof date_value === "string") {
-    const parsedYear = Number.parseInt(date_value.slice(0, 4), 10);
-    return Number.isFinite(parsedYear) ? parsedYear : Number.MAX_SAFE_INTEGER;
-  }
-  if (Number.isFinite(year)) return year;
-  return Number.MAX_SAFE_INTEGER;
-}
-
-function getStoryYearInterval(story) {
-  if (!story || typeof story !== "object") return null;
-  const { time_type, year, year_start, year_end, date_value } = story;
-  if (time_type === "year_range" && Number.isFinite(year_start) && Number.isFinite(year_end)) {
-    return [year_start, year_end];
-  }
-  if (time_type === "decade" && Number.isFinite(year)) {
-    return [year, year + 9];
-  }
-  if (time_type === "exact_date" && typeof date_value === "string") {
-    const parsedYear = Number.parseInt(date_value.slice(0, 4), 10);
-    return Number.isFinite(parsedYear) ? [parsedYear, parsedYear] : null;
-  }
-  if (Number.isFinite(year)) return [year, year];
-  return null;
-}
-
-/**
- * Same interval-overlap year filter the /stories/timeline/ endpoint applies
- * server-side. Re-applied client-side for the fallback path because
- * /stories/feed/ and /stories/search/ use a simpler `year__gte` / `year__lte`
- * check that silently excludes decade and exact_date stories whose intervals
- * the timeline endpoint would include. yearFrom/yearTo of null mean "no bound."
- */
-export function storyOverlapsYearWindow(story, yearFrom, yearTo) {
-  if (yearFrom == null && yearTo == null) return true;
-  const interval = getStoryYearInterval(story);
-  if (!interval) return false;
-  const [start, end] = interval;
-  if (yearFrom != null && end < yearFrom) return false;
-  if (yearTo != null && start > yearTo) return false;
-  return true;
-}
-
 function hasUnsupportedTimelineFilters(filters) {
   if (filters.q?.trim()) return true;
   // A location string with no bbox can't be passed to /stories/timeline/ —


### PR DESCRIPTION
# 📝 Description
Fixes #605 

A set of UX improvements and bug fixes for the timeline page: consistent image rendering regardless of active filters, bidirectional filter persistence across pages, cleaner timeline cards, removal of the search bar that broke chronological ordering, a tighter filter button placement, and a back-to-map shortcut when arriving from a map pin popup.

 ## New features

  - Back-to-map arrow button on /timeline when the page was opened via the map popup's "View Timeline" link — returns to the exact map URL (zoom level, center, and active filters) that was active before navigating away

##  Modified files

  - frontend/src/services/timelineService.js — rewrote getTimelineViaFallback to always call /stories/timeline/ instead of /stories/feed/ or /stories/search/; q and bare location text are now applied as client-side substring filters so photo_url is present in every response; has_image is now forwarded in the fallback path; removed the getStories import
  - frontend/src/components/AppLayout/AppLayout.jsx — added /timeline to isFilterPage so nav links carry the current query string when switching away from the timeline page (filters were already persisted in the feed→timeline direction but not timeline→feed/map)
  - frontend/src/components/Timeline/TimelineEntry.jsx — removed the computed decade chip and temporal_coverage chip; each card now shows exactly one date chip (the formatTimePeriod label); removed the decadeChip helper
  - frontend/src/pages/TimelinePage.jsx — removed SearchBar and all q state (reading, writing, dependency array entry, handleSearchChange); moved FilterPanel inline with the page heading; added back-to-map ArrowLeft button driven by location.state.from

##  Tests

  - timelineService.test.js — updated fallback-path tests: both q and location fallbacks now assert /stories/timeline/ is called (not /stories/search/ or /stories/feed/); added client-side filter assertions; updated has_image and year-param forwarding expectations; removed stale sort and feed-endpoint tests
  - TimelineEntry.test.jsx — added two tests: one asserting no decade chip for exact_year stories, one asserting temporal_coverage is never rendered as a chip
  - TimelinePage.test.jsx — updated search bar assertion to confirm absence; replaced q-forwarding test with a test confirming q is never passed to getTimeline; updated chip test to exclude q; added renderPageWithState helper and three back-to-map button tests (shown from map, absent without state, absent from non-map referrer)
  - AppLayout.test.jsx — added three tests: Timeline link carries search params from Feed, Timeline link carries search params from Map, Map/Feed links carry search params from Timeline


# 📊 Type of Change
- [x]  Bug fix
- [ ]  New feature
- [ ]  Refactoring
- [ ]  Documentation
 
# ✅ Acceptance Criteria / Checklist
- [x] Project builds successfully
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, especially in hard-to-understand parts
- [x] I have performed a self-review of my code
- [x] I have added/updated tests
- [x] New and existing unit tests pass locally with my changes

# 📸 Screenshots / Recordings
<!-- If applicable !-->
# ⏱️ Estimated Review Time
- [ ] < 5 min
- [x] 5-15 min
- [ ] > 15 min
