### PR TITLE
fix: prevent duplicate comments in story seeding

### DIFF
--- a/backend/apps/stories/management/commands/seed_data.py
+++ b/backend/apps/stories/management/commands/seed_data.py
@@ -979,9 +979,14 @@ class Command(BaseCommand):
             commenters = random.sample(regular, random.randint(1, min(4, len(regular))))
             is_personal = story.title in _PERSONAL_TITLES
             specific_comments = STORY_COMMENTS.get(story.title)
+            if specific_comments:
+                shuffled = random.sample(specific_comments, min(len(commenters), len(specific_comments)))
+                comment_iter = iter(shuffled + random.sample(specific_comments, max(0, len(commenters) - len(shuffled))))
+            else:
+                comment_iter = None
             for commenter in commenters:
-                if specific_comments:
-                    text = random.choice(specific_comments)
+                if comment_iter is not None:
+                    text = next(comment_iter)
                 elif is_personal:
                     pool = COMMENTS_PERSONAL_TR if random.random() < 0.6 else COMMENTS_PERSONAL_EN
                     text = random.choice(pool)


### PR DESCRIPTION
Fixes #614 

This PR fixes duplicate seeded comments for personal story seed data.

After adding the new personal and emotional seed stories, we noticed that some stories could receive duplicate comment texts. This happened because the previous implementation used `random.choice()` for story-specific comments. Since each personal story in `STORY_COMMENTS` has a small fixed pool of comment options, randomly choosing a comment independently for each commenter could assign the same text to multiple users under the same story.

The purpose of this PR is to make seeded personal story interactions feel more realistic and clean for the final demo by distributing story-specific comments with `random.sample()` instead of repeatedly using `random.choice()`.

Implemented changes:
- Updated `_seed_interactions()` in `seed_data.py`
- Replaced repeated `random.choice()` usage for `STORY_COMMENTS` with sampled comment assignment
- Ensured story-specific comments are shuffled and assigned more uniquely among commenters
- Preserved the existing fallback behavior for personal generic comments and historical/generic comment pools
- Kept existing `get_or_create` behavior unchanged

## Production / Demo Refresh Notes

After this PR is deployed, the demo server comments can be refreshed without deleting stories, images, users, likes, saves, points, or badges.

Only existing comments need to be deleted before re-running the seed command:

```bash
docker compose -f docker-compose.prod.yml run --rm --entrypoint="" web sh \
  -c "python manage.py shell -c \"from apps.interactions.models import Comment; Comment.objects.all().delete(); print('Done')\""
````

Then re-run seed data:

```bash
docker compose -f docker-compose.prod.yml run --rm --entrypoint="" web sh \
  -c "python manage.py seed_data"
```

This refreshes the seeded comments with cleaner distribution while keeping the rest of the seeded demo content intact.

# 📊 Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactoring
- [ ] Documentation

# ✅ Acceptance Criteria / Checklist

- [x] Story-specific comments are no longer selected using repeated `random.choice()`
- [x] Story-specific comments are assigned using `random.sample()`
- [x] Duplicate comment text under the same personal story is reduced/prevented when enough unique comments are available
- [x] Existing personal generic comment behavior is preserved
- [x] Existing historical/generic comment behavior is preserved
- [x] Existing `get_or_create` behavior is preserved
- [x] `python manage.py seed_data` should still run successfully
- [x] `python manage.py seed_data --clear` should still run successfully


# ⏱️ Estimated Review Time

* [x] < 5 min
* [ ] 5–15 min
* [ ] > 15 min

