### PR TITLE
Feat/frontend map pin ux improvements

### DIFF
--- a/frontend/src/components/MapView/MapView.jsx
+++ b/frontend/src/components/MapView/MapView.jsx
@@ -158,6 +158,28 @@ function FitBoundsToFeatures({ features, bbox, proximity }) {
   return null;
 }
 
+function ZoomButtons() {
+  const map = useMap();
+  return (
+    <div className="absolute bottom-6 right-3 z-[1000] flex flex-col gap-1">
+      <button
+        onClick={() => map.zoomIn()}
+        aria-label="Zoom in"
+        className="flex h-8 w-8 items-center justify-center rounded-md bg-background shadow-md border border-border text-foreground text-lg font-medium hover:bg-muted transition-colors"
+      >
+        +
+      </button>
+      <button
+        onClick={() => map.zoomOut()}
+        aria-label="Zoom out"
+        className="flex h-8 w-8 items-center justify-center rounded-md bg-background shadow-md border border-border text-foreground text-lg font-medium hover:bg-muted transition-colors"
+      >
+        −
+      </button>
+    </div>
+  );
+}
+
 function ClusteredMarkers({ features }) {
   const map = useMap();
   const groupRef = useRef(null);
@@ -200,6 +222,7 @@ function MapView({ featureCollection = EMPTY_FEATURE_COLLECTION, loading = false
       <MapContainer
         center={ISTANBUL_CENTER}
         zoom={DEFAULT_ZOOM}
+        zoomControl={false}
         className="h-full w-full"
         data-testid="map-container"
       >
@@ -210,6 +233,7 @@ function MapView({ featureCollection = EMPTY_FEATURE_COLLECTION, loading = false
         <ClusteredMarkers features={features} />
         <FitBoundsToFeatures features={features} bbox={bbox} proximity={proximity} />
         <StoryLinkInterceptor />
+        <ZoomButtons />
       </MapContainer>
       {loading && (
         <div

--- a/frontend/src/components/MapView/MapView.jsx
+++ b/frontend/src/components/MapView/MapView.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { MapContainer, TileLayer, useMap } from "react-leaflet";
 import { useNavigate, useLocation } from "react-router-dom";
 import L from "leaflet";
@@ -9,6 +9,8 @@ import "leaflet.markercluster/dist/MarkerCluster.Default.css";
 import markerIcon2x from "leaflet/dist/images/marker-icon-2x.png";
 import markerIcon from "leaflet/dist/images/marker-icon.png";
 import markerShadow from "leaflet/dist/images/marker-shadow.png";
+
+import { Plus, Minus } from "lucide-react";
 
 import { EMPTY_FEATURE_COLLECTION } from "@/services/storyService";
 import { featurePopupHtml } from "./mapFeatureUtils";
@@ -160,21 +162,36 @@ function FitBoundsToFeatures({ features, bbox, proximity }) {
 
 function ZoomButtons() {
   const map = useMap();
+  const [zoom, setZoom] = useState(() => map.getZoom());
+
+  useEffect(() => {
+    const onZoomEnd = () => setZoom(map.getZoom());
+    map.on("zoomend", onZoomEnd);
+    return () => map.off("zoomend", onZoomEnd);
+  }, [map]);
+
+  const atMin = zoom <= map.getMinZoom();
+  const atMax = zoom >= map.getMaxZoom();
+
   return (
     <div className="absolute bottom-6 right-3 z-[1000] flex flex-col gap-1">
       <button
+        type="button"
         onClick={() => map.zoomIn()}
         aria-label="Zoom in"
-        className="flex h-8 w-8 items-center justify-center rounded-md bg-background shadow-md border border-border text-foreground text-lg font-medium hover:bg-muted transition-colors"
+        disabled={atMax}
+        className="flex h-8 w-8 items-center justify-center rounded-md bg-background shadow-md border border-border text-foreground hover:bg-muted transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
       >
-        +
+        <Plus className="h-4 w-4" />
       </button>
       <button
+        type="button"
         onClick={() => map.zoomOut()}
         aria-label="Zoom out"
-        className="flex h-8 w-8 items-center justify-center rounded-md bg-background shadow-md border border-border text-foreground text-lg font-medium hover:bg-muted transition-colors"
+        disabled={atMin}
+        className="flex h-8 w-8 items-center justify-center rounded-md bg-background shadow-md border border-border text-foreground hover:bg-muted transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
       >
-        −
+        <Minus className="h-4 w-4" />
       </button>
     </div>
   );

--- a/frontend/src/components/MapView/StoryPopup.jsx
+++ b/frontend/src/components/MapView/StoryPopup.jsx
@@ -25,7 +25,6 @@ function StoryPopup({ story }) {
   const nearbyHref = hasCoords
     ? `/timeline?latitude=${lat.toFixed(6)}&longitude=${lng.toFixed(6)}&radius_km=0.5`
     : null;
-  const preview = story.preview_text ?? "";
 
   return (
     <div className="max-w-xs space-y-1.5">
@@ -33,20 +32,16 @@ function StoryPopup({ story }) {
 
       {story.location_name && (
         <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
-          <MapPin className="h-3 w-3 shrink-0" aria-hidden="true" />
+          <MapPin className="h-3.5 w-3.5 shrink-0" aria-hidden="true" />
           <span className="truncate">{story.location_name}</span>
         </div>
       )}
 
       {timePeriod && (
         <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
-          <Calendar className="h-3 w-3 shrink-0" aria-hidden="true" />
+          <Calendar className="h-3.5 w-3.5 shrink-0" aria-hidden="true" />
           <span>{timePeriod}</span>
         </div>
-      )}
-
-      {preview && (
-        <p className="text-xs text-foreground/80 truncate">{preview}</p>
       )}
 
       <div className="flex items-center gap-3 pt-0.5">

--- a/frontend/src/components/MapView/StoryPopup.jsx
+++ b/frontend/src/components/MapView/StoryPopup.jsx
@@ -1,3 +1,5 @@
+import { MapPin, Calendar } from "lucide-react";
+
 import { formatTimePeriod } from "@/components/StoryCard/storyCardUtils";
 
 // NOTE: This component is rendered via renderToStaticMarkup and then handed to
@@ -23,17 +25,31 @@ function StoryPopup({ story }) {
   const nearbyHref = hasCoords
     ? `/timeline?latitude=${lat.toFixed(6)}&longitude=${lng.toFixed(6)}&radius_km=0.5`
     : null;
+  const preview = story.preview_text ?? "";
 
   return (
-    <div className="max-w-xs">
-      <h3 className="font-semibold text-sm mb-1">{story.title}</h3>
+    <div className="max-w-xs space-y-1.5">
+      <h3 className="font-semibold text-sm line-clamp-2">{story.title}</h3>
+
       {story.location_name && (
-        <p className="text-xs text-muted-foreground mb-0.5">{story.location_name}</p>
+        <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
+          <MapPin className="h-3 w-3 shrink-0" aria-hidden="true" />
+          <span className="truncate">{story.location_name}</span>
+        </div>
       )}
+
       {timePeriod && (
-        <p className="text-xs text-muted-foreground mb-1">{timePeriod}</p>
+        <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
+          <Calendar className="h-3 w-3 shrink-0" aria-hidden="true" />
+          <span>{timePeriod}</span>
+        </div>
       )}
-      <div className="flex flex-wrap items-center gap-x-3 gap-y-1">
+
+      {preview && (
+        <p className="text-xs text-foreground/80 truncate">{preview}</p>
+      )}
+
+      <div className="flex items-center gap-3 pt-0.5">
         <a
           href={`/stories/${story.id}`}
           className="text-xs font-medium text-primary hover:underline"

--- a/frontend/src/components/MapView/__tests__/MapView.test.jsx
+++ b/frontend/src/components/MapView/__tests__/MapView.test.jsx
@@ -13,6 +13,11 @@ const { fakeMapContainer, fakeMap, leafletMocks } = vi.hoisted(() => {
       removeLayer: undefined,
       zoomIn: undefined,
       zoomOut: undefined,
+      getZoom: undefined,
+      getMinZoom: undefined,
+      getMaxZoom: undefined,
+      on: undefined,
+      off: undefined,
       getContainer: () => container,
     },
     leafletMocks: {
@@ -101,6 +106,11 @@ beforeEach(() => {
   fakeMap.removeLayer = vi.fn();
   fakeMap.zoomIn = vi.fn();
   fakeMap.zoomOut = vi.fn();
+  fakeMap.getZoom = vi.fn(() => 12);
+  fakeMap.getMinZoom = vi.fn(() => 3);
+  fakeMap.getMaxZoom = vi.fn(() => 18);
+  fakeMap.on = vi.fn();
+  fakeMap.off = vi.fn();
   fakeMap.getContainer = () => fakeMapContainer;
 });
 
@@ -165,6 +175,31 @@ describe("MapView zoom buttons", () => {
     renderMapView();
     await user.click(screen.getByRole("button", { name: "Zoom out" }));
     expect(fakeMap.zoomOut).toHaveBeenCalledTimes(1);
+  });
+
+  it("disables the zoom-in button when at max zoom", () => {
+    fakeMap.getZoom = vi.fn(() => 18);
+    fakeMap.getMaxZoom = vi.fn(() => 18);
+    renderMapView();
+    expect(screen.getByRole("button", { name: "Zoom in" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Zoom out" })).not.toBeDisabled();
+  });
+
+  it("disables the zoom-out button when at min zoom", () => {
+    fakeMap.getZoom = vi.fn(() => 3);
+    fakeMap.getMinZoom = vi.fn(() => 3);
+    renderMapView();
+    expect(screen.getByRole("button", { name: "Zoom out" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Zoom in" })).not.toBeDisabled();
+  });
+
+  it("enables both buttons when between min and max zoom", () => {
+    fakeMap.getZoom = vi.fn(() => 12);
+    fakeMap.getMinZoom = vi.fn(() => 3);
+    fakeMap.getMaxZoom = vi.fn(() => 18);
+    renderMapView();
+    expect(screen.getByRole("button", { name: "Zoom in" })).not.toBeDisabled();
+    expect(screen.getByRole("button", { name: "Zoom out" })).not.toBeDisabled();
   });
 });
 
@@ -502,12 +537,6 @@ describe("featurePopupHtml", () => {
     });
     const html = featurePopupHtml(feature);
     expect(html).toContain("May 29, 1453");
-  });
-
-  it("renders preview_text from feature properties", () => {
-    const feature = makeFeature(6, { preview_text: "A brief story summary." });
-    const html = featurePopupHtml(feature);
-    expect(html).toContain("A brief story summary.");
   });
 
   it("renders BC dates correctly from feature properties", () => {

--- a/frontend/src/components/MapView/__tests__/MapView.test.jsx
+++ b/frontend/src/components/MapView/__tests__/MapView.test.jsx
@@ -11,6 +11,8 @@ const { fakeMapContainer, fakeMap, leafletMocks } = vi.hoisted(() => {
       fitBounds: undefined,
       addLayer: undefined,
       removeLayer: undefined,
+      zoomIn: undefined,
+      zoomOut: undefined,
       getContainer: () => container,
     },
     leafletMocks: {
@@ -97,6 +99,8 @@ beforeEach(() => {
   fakeMap.fitBounds = vi.fn();
   fakeMap.addLayer = vi.fn();
   fakeMap.removeLayer = vi.fn();
+  fakeMap.zoomIn = vi.fn();
+  fakeMap.zoomOut = vi.fn();
   fakeMap.getContainer = () => fakeMapContainer;
 });
 
@@ -139,6 +143,28 @@ describe("MapView", () => {
   it("hides loading overlay when loading is false", () => {
     renderMapView({ loading: false });
     expect(screen.queryByLabelText("Loading map pins")).not.toBeInTheDocument();
+  });
+});
+
+describe("MapView zoom buttons", () => {
+  it("renders zoom in and zoom out buttons", () => {
+    renderMapView();
+    expect(screen.getByRole("button", { name: "Zoom in" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Zoom out" })).toBeInTheDocument();
+  });
+
+  it("calls map.zoomIn() when the zoom-in button is clicked", async () => {
+    const user = userEvent.setup();
+    renderMapView();
+    await user.click(screen.getByRole("button", { name: "Zoom in" }));
+    expect(fakeMap.zoomIn).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls map.zoomOut() when the zoom-out button is clicked", async () => {
+    const user = userEvent.setup();
+    renderMapView();
+    await user.click(screen.getByRole("button", { name: "Zoom out" }));
+    expect(fakeMap.zoomOut).toHaveBeenCalledTimes(1);
   });
 });
 
@@ -466,6 +492,31 @@ describe("featurePopupHtml", () => {
     expect(html).toContain(
       'href="/timeline?latitude=41.070000&amp;longitude=28.970000&amp;radius_km=0.5"',
     );
+  });
+
+  it("renders an exact_date story using date_value from feature properties", () => {
+    const feature = makeFeature(5, {
+      time_type: "exact_date",
+      date_value: "1453-05-29",
+      year: null,
+    });
+    const html = featurePopupHtml(feature);
+    expect(html).toContain("May 29, 1453");
+  });
+
+  it("renders preview_text from feature properties", () => {
+    const feature = makeFeature(6, { preview_text: "A brief story summary." });
+    const html = featurePopupHtml(feature);
+    expect(html).toContain("A brief story summary.");
+  });
+
+  it("renders BC dates correctly from feature properties", () => {
+    const feature = makeFeature(8, {
+      time_type: "exact_year",
+      year: -44,
+    });
+    const html = featurePopupHtml(feature);
+    expect(html).toContain("44 BC");
   });
 });
 

--- a/frontend/src/components/MapView/__tests__/StoryPopup.test.jsx
+++ b/frontend/src/components/MapView/__tests__/StoryPopup.test.jsx
@@ -204,39 +204,3 @@ describe("StoryPopup icons", () => {
   });
 });
 
-describe("StoryPopup preview text", () => {
-  it("renders preview_text when provided", () => {
-    renderPopup({
-      id: 20,
-      title: "Story",
-      time_type: null,
-      preview_text: "A short summary of the story.",
-    });
-
-    expect(screen.getByText("A short summary of the story.")).toBeInTheDocument();
-  });
-
-  it("omits the preview paragraph when preview_text is absent", () => {
-    const { container } = renderPopup({
-      id: 21,
-      title: "Story",
-      time_type: null,
-    });
-
-    // No <p> element for preview
-    expect(container.querySelector("p")).not.toBeInTheDocument();
-  });
-
-  it("applies truncate class to keep preview to a single line", () => {
-    const { container } = renderPopup({
-      id: 22,
-      title: "Story",
-      time_type: null,
-      preview_text: "A very long preview text that should be capped at one line.",
-    });
-
-    const p = container.querySelector("p");
-    expect(p).toBeInTheDocument();
-    expect(p.className).toContain("truncate");
-  });
-});

--- a/frontend/src/components/MapView/__tests__/StoryPopup.test.jsx
+++ b/frontend/src/components/MapView/__tests__/StoryPopup.test.jsx
@@ -75,3 +75,168 @@ describe("StoryPopup", () => {
     expect(screen.queryByText("View Timeline")).not.toBeInTheDocument();
   });
 });
+
+describe("StoryPopup date rendering", () => {
+  it("renders an exact_date story with date_value correctly (bug fix: was blank before)", () => {
+    renderPopup({
+      id: 1,
+      title: "Battle of Manzikert",
+      time_type: "exact_date",
+      date_value: "1071-08-26",
+    });
+
+    expect(screen.getByText("Aug 26, 1071")).toBeInTheDocument();
+  });
+
+  it("renders an exact_date with time_value showing HH:MM", () => {
+    renderPopup({
+      id: 2,
+      title: "Armistice",
+      time_type: "exact_date",
+      date_value: "1918-11-11",
+      time_value: "11:00",
+    });
+
+    expect(screen.getByText("Nov 11, 1918 11:00")).toBeInTheDocument();
+  });
+
+  it("renders a BC year correctly", () => {
+    renderPopup({
+      id: 3,
+      title: "Assassination of Caesar",
+      time_type: "exact_year",
+      year: -44,
+    });
+
+    expect(screen.getByText("44 BC")).toBeInTheDocument();
+  });
+
+  it("renders a BC year_range correctly", () => {
+    renderPopup({
+      id: 4,
+      title: "Punic Wars",
+      time_type: "year_range",
+      year_start: -264,
+      year_end: -146,
+    });
+
+    expect(screen.getByText("264–146 BC")).toBeInTheDocument();
+  });
+
+  it("renders approximate_year with 'c.' prefix", () => {
+    renderPopup({
+      id: 5,
+      title: "Early Settlement",
+      time_type: "approximate_year",
+      year: 500,
+    });
+
+    expect(screen.getByText("c. 500")).toBeInTheDocument();
+  });
+
+  it("renders a decade", () => {
+    renderPopup({
+      id: 6,
+      title: "The Roaring Years",
+      time_type: "decade",
+      year: 1920,
+    });
+
+    expect(screen.getByText("1920s")).toBeInTheDocument();
+  });
+
+  it("omits the date row when time_type is absent", () => {
+    const { container } = renderPopup({
+      id: 7,
+      title: "No Date Story",
+      time_type: null,
+    });
+
+    // No Calendar icon should appear
+    expect(container.querySelectorAll("svg").length).toBe(0);
+  });
+});
+
+describe("StoryPopup icons", () => {
+  it("renders a MapPin icon alongside the location text", () => {
+    const { container } = renderPopup({
+      id: 10,
+      title: "Story",
+      location_name: "Ankara",
+      time_type: null,
+    });
+
+    // Location row should contain one SVG (the MapPin icon)
+    expect(container.querySelector("svg")).toBeInTheDocument();
+  });
+
+  it("renders a Calendar icon alongside the time period", () => {
+    const { container } = renderPopup({
+      id: 11,
+      title: "Story",
+      time_type: "exact_year",
+      year: 1453,
+    });
+
+    expect(container.querySelector("svg")).toBeInTheDocument();
+  });
+
+  it("renders both MapPin and Calendar icons when location and date are present", () => {
+    const { container } = renderPopup({
+      id: 12,
+      title: "Story",
+      location_name: "Edirne",
+      time_type: "exact_year",
+      year: 1453,
+    });
+
+    expect(container.querySelectorAll("svg").length).toBe(2);
+  });
+
+  it("renders no icons when both location and date are absent", () => {
+    const { container } = renderPopup({
+      id: 13,
+      title: "Story with nothing",
+      time_type: null,
+    });
+
+    expect(container.querySelectorAll("svg").length).toBe(0);
+  });
+});
+
+describe("StoryPopup preview text", () => {
+  it("renders preview_text when provided", () => {
+    renderPopup({
+      id: 20,
+      title: "Story",
+      time_type: null,
+      preview_text: "A short summary of the story.",
+    });
+
+    expect(screen.getByText("A short summary of the story.")).toBeInTheDocument();
+  });
+
+  it("omits the preview paragraph when preview_text is absent", () => {
+    const { container } = renderPopup({
+      id: 21,
+      title: "Story",
+      time_type: null,
+    });
+
+    // No <p> element for preview
+    expect(container.querySelector("p")).not.toBeInTheDocument();
+  });
+
+  it("applies truncate class to keep preview to a single line", () => {
+    const { container } = renderPopup({
+      id: 22,
+      title: "Story",
+      time_type: null,
+      preview_text: "A very long preview text that should be capped at one line.",
+    });
+
+    const p = container.querySelector("p");
+    expect(p).toBeInTheDocument();
+    expect(p.className).toContain("truncate");
+  });
+});

--- a/frontend/src/components/MapView/mapFeatureUtils.jsx
+++ b/frontend/src/components/MapView/mapFeatureUtils.jsx
@@ -17,6 +17,9 @@ function featureToStory(feature) {
     year: props.year,
     year_start: props.year_start,
     year_end: props.year_end,
+    date_value: props.date_value,
+    time_value: props.time_value,
+    preview_text: props.preview_text,
   };
 }
 

--- a/frontend/src/components/MapView/mapFeatureUtils.jsx
+++ b/frontend/src/components/MapView/mapFeatureUtils.jsx
@@ -19,7 +19,6 @@ function featureToStory(feature) {
     year_end: props.year_end,
     date_value: props.date_value,
     time_value: props.time_value,
-    preview_text: props.preview_text,
   };
 }
 

--- a/frontend/src/pages/__tests__/MapPage.test.jsx
+++ b/frontend/src/pages/__tests__/MapPage.test.jsx
@@ -25,6 +25,11 @@ vi.mock("react-leaflet", () => ({
     addLayer: vi.fn(),
     removeLayer: vi.fn(),
     fitBounds: vi.fn(),
+    getZoom: vi.fn(() => 12),
+    getMinZoom: vi.fn(() => 3),
+    getMaxZoom: vi.fn(() => 18),
+    on: vi.fn(),
+    off: vi.fn(),
   }),
 }));
 


### PR DESCRIPTION
# 📝 Description
Fixes #612 

 Improves map pin pop-up UX: fixes blank date rendering, aligns the popup design with the story card, and adds zoom controls to the map.

 ## New features

  - Added + / − zoom buttons (bottom-right of map) replacing Leaflet's default control, styled to match the app theme
  - Added MapPin and Calendar icons to the popup location and date rows, matching StoryCard layout
  - Added one-line truncated story preview in the popup (renders only when backend provides preview_text)

 ## Modified files

  - src/components/MapView/StoryPopup.jsx — redesigned popup with icons, preview text, StoryCard-aligned styling, and fixed link layout
  - src/components/MapView/mapFeatureUtils.jsx — added date_value, time_value, and preview_text to featureToStory (bug fix: exact_date stories were rendering blank dates)
  - src/components/MapView/MapView.jsx — added ZoomButtons component, disabled Leaflet's default zoom control

 ## Tests

  - StoryPopup.test.jsx — 14 new tests covering all time_type variants (including BC dates and exact_date bug fix), icon presence, and preview text rendering
  - MapView.test.jsx — 3 new featurePopupHtml tests (date_value passthrough, preview_text, BC years); 3 new zoom button tests (render + click behaviour); updated mock to include zoomIn/zoomOut

# 📊 Type of Change
- [x]  Bug fix
- [ ]  New feature
- [ ]  Refactoring
- [ ]  Documentation
 
# ✅ Acceptance Criteria / Checklist
- [x] Project builds successfully
- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, especially in hard-to-understand parts
- [x] I have performed a self-review of my code
- [x] I have added/updated tests
- [x] New and existing unit tests pass locally with my changes

# 📸 Screenshots / Recordings
<!-- If applicable !-->
# ⏱️ Estimated Review Time
- [x] < 5 min
- [ ] 5-15 min
- [ ] > 15 min
