### PR TITLE
Fix/ timeline filtering for BC dates

### DIFF
--- a/backend/apps/stories/services.py
+++ b/backend/apps/stories/services.py
@@ -188,6 +188,11 @@ def get_story_timeline(
     qs = Story.objects.filter(status=Story.STATUS_PUBLISHED)
 
     if year_from is not None:
+        date_q = (
+            # MySQL YEAR() only handles non-negative years; skip for BC boundaries
+            Q(time_type=Story.TIME_DATE, date_value__year__gte=year_from)
+            if year_from >= 0 else Q()
+        )
         qs = qs.filter(
             # decade: interval ends at year+9; include if year+9 >= year_from ↔ year >= year_from-9
             Q(time_type=Story.TIME_DECADE, year__gte=year_from - 9) |
@@ -195,18 +200,22 @@ def get_story_timeline(
             Q(time_type__in=[Story.TIME_EXACT, Story.TIME_APPROXIMATE], year__gte=year_from) |
             # year_range: interval ends at year_end; include if year_end >= year_from
             Q(time_type=Story.TIME_RANGE, year_end__gte=year_from) |
-            # exact_date: compare by calendar year extracted from date_value
-            Q(time_type=Story.TIME_DATE, date_value__year__gte=year_from)
+            date_q
         )
 
     if year_to is not None:
         # All non-range time types start at year; year_range starts at year_start.
         # Decade starts at year too (same as exact/approx), so no special case needed here.
         # exact_date has no year field — its date_value year is compared directly.
+        # MySQL YEAR() only handles non-negative years; skip for BC boundaries.
+        date_q = (
+            Q(time_type=Story.TIME_DATE, date_value__year__lte=year_to)
+            if year_to >= 0 else Q()
+        )
         qs = qs.filter(
             Q(year__lte=year_to) |
             Q(year_start__lte=year_to) |
-            Q(time_type=Story.TIME_DATE, date_value__year__lte=year_to)
+            date_q
         )
 
     if lat_min is not None:

--- a/backend/apps/stories/services.py
+++ b/backend/apps/stories/services.py
@@ -189,9 +189,10 @@ def get_story_timeline(
 
     if year_from is not None:
         date_q = (
-            # MySQL YEAR() only handles non-negative years; skip for BC boundaries
+            # MySQL YEAR() only handles non-negative years; for BC boundaries
+            # include all exact-date stories (date_value is always a positive year).
             Q(time_type=Story.TIME_DATE, date_value__year__gte=year_from)
-            if year_from >= 0 else Q()
+            if year_from >= 0 else Q(time_type=Story.TIME_DATE)
         )
         qs = qs.filter(
             # decade: interval ends at year+9; include if year+9 >= year_from ↔ year >= year_from-9


### PR DESCRIPTION
# 📝 Description

Fixes #617 

This PR fixes a timeline filtering bug for `exact_date` stories when the requested year boundary is in BC / negative years.

Previously, `date_value__year__gte` and `date_value__year__lte` filters were always applied for `exact_date` timeline entries. However, MySQL `YEAR()` extraction only works reliably for non-negative calendar years. When `year_from` or `year_to` was negative, applying this filter could cause incorrect behavior or prevent filtering from working as expected.

With this change:

- `exact_date` filtering through `date_value__year` is only applied when the boundary year is non-negative.
- For BC boundaries, the MySQL `YEAR()` filter is skipped safely.
- Existing filtering behavior for decade, exact year, approximate year, and year range stories is preserved.



---

# 📊 Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactoring
- [ ] Documentation

---

# ✅ Acceptance Criteria / Checklist

- [x] Timeline filtering does not apply MySQL `YEAR()` extraction for BC / negative year boundaries.
- [x] `year_from` filtering still works for decade, exact year, approximate year, and year range stories.
- [x] `year_to` filtering still works for supported timeline story types.
- [x] `exact_date` filtering is preserved for non-negative years.
- [x] Existing timeline behavior is not changed outside this edge case.
- [x] Code follows the existing service-layer structure in `stories/services.py`.
- [x] I have self-reviewed the changes.



---

# ⏱️ Estimated Review Time

- [x] <5 minutes
- [ ] 5–15 minutes
- [ ] >15 minutes