### PR TITLE
Fix/timeline view update

### DIFF
--- a/mobile/src/app/navigation/RootNavigator.tsx
+++ b/mobile/src/app/navigation/RootNavigator.tsx
@@ -154,6 +154,10 @@ function NotificationBellButton({
   );
 }
 
+function shouldClearTimelineOnlyFilters(route: AppRoute) {
+  return route === ROUTES.FEED || route === ROUTES.MAP;
+}
+
 function BottomNavButton({
   label,
   active,
@@ -566,6 +570,9 @@ export function RootNavigator() {
 
   const handleNavigate = (route: AppRoute) => {
     if (MAIN_PAGER_ROUTES.includes(route)) {
+      if (shouldClearTimelineOnlyFilters(route)) {
+        updateFilters({ hasMedia: undefined }, { refresh: true });
+      }
       scrollMainPagerToRoute(route);
       navigateToSnapshot({ route }, { resetStack: true, preserveCurrent: false });
       return;
@@ -1089,6 +1096,9 @@ export function RootNavigator() {
             const nextRoute = MAIN_PAGER_ROUTES[pageIndex];
 
             if (nextRoute !== currentRoute) {
+              if (shouldClearTimelineOnlyFilters(nextRoute)) {
+                updateFilters({ hasMedia: undefined }, { refresh: true });
+              }
               setCurrentRoute(nextRoute);
             }
           }}
@@ -1220,7 +1230,14 @@ export function RootNavigator() {
             <TopIconButton label="Login" onPress={() => handleNavigate(ROUTES.AUTH)} />
           )}
         </View>
-      {isMainRoute ? <StorySearchControls hideHeading onFiltersApplied={handleMainFiltersApplied} scope="main" /> : null}
+      {isMainRoute ? (
+        <StorySearchControls
+          hideHeading
+          onFiltersApplied={handleMainFiltersApplied}
+          scope="main"
+          showMediaFilter={currentRoute === ROUTES.TIMELINE}
+        />
+      ) : null}
       </View>
       <View style={{ flex: 1, backgroundColor: colors.background }}>{content}</View>
       {isMainRoute ? (

--- a/mobile/src/app/navigation/__tests__/RootNavigator.test.tsx
+++ b/mobile/src/app/navigation/__tests__/RootNavigator.test.tsx
@@ -1007,6 +1007,49 @@ describe('RootNavigator auth flow', () => {
     expect(screen.getByLabelText('Search stories').props.value).toBe('harbor');
   });
 
+  it('clears the timeline-only image filter when navigating to feed or map', async () => {
+    renderNavigator();
+
+    await screen.findByLabelText('Timeline');
+    fireEvent.press(screen.getByLabelText('Timeline'));
+
+    fireEvent.press(screen.getByText('Show filters'));
+    fireEvent.press(screen.getByLabelText('Filter stories with image'));
+    fireEvent.press(screen.getByLabelText('Apply filters'));
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('Remove Media: With image')).toBeTruthy();
+    });
+
+    fireEvent.press(screen.getByLabelText('Feed'));
+
+    await waitFor(() => {
+      expect(screen.queryByLabelText('Remove Media: With image')).toBeNull();
+    });
+
+    const latestFeedRequest = [...apiRequests]
+      .reverse()
+      .find((request) => request.startsWith('GET /stories/feed/') || request.startsWith('GET /stories/search/'));
+
+    expect(latestFeedRequest).toBeDefined();
+    expect(latestFeedRequest).not.toContain('has_image=true');
+
+    fireEvent.press(screen.getByLabelText('Timeline'));
+    fireEvent.press(screen.getByText('Show filters'));
+    fireEvent.press(screen.getByLabelText('Filter stories with image'));
+    fireEvent.press(screen.getByLabelText('Apply filters'));
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('Remove Media: With image')).toBeTruthy();
+    });
+
+    fireEvent.press(screen.getByLabelText('Map'));
+
+    await waitFor(() => {
+      expect(screen.queryByLabelText('Remove Media: With image')).toBeNull();
+    });
+  });
+
   it('keeps the timeline tab active when filters are applied there', async () => {
     (geocodeLocationQuery as jest.Mock).mockResolvedValueOnce(goldenHornBounds);
 

--- a/mobile/src/features/profile/presentation/screens/__tests__/ProfileScreen.test.tsx
+++ b/mobile/src/features/profile/presentation/screens/__tests__/ProfileScreen.test.tsx
@@ -270,7 +270,6 @@ describe('ProfileScreen', () => {
 
     fireEvent.press(screen.getByLabelText('Open badge details: First Story'));
 
-    expect(await screen.findByText('Published one story.')).toBeTruthy();
     expect(screen.getAllByText('Awarded for publishing your first story.').length).toBeGreaterThan(0);
     expect(screen.getByText('Earned on May 1, 2026')).toBeTruthy();
   });

--- a/mobile/src/features/search/presentation/components/StorySearchControls.tsx
+++ b/mobile/src/features/search/presentation/components/StorySearchControls.tsx
@@ -39,6 +39,10 @@ function buildChips(filters: ReturnType<typeof useSearchFilters>['filters']): Fi
     chips.push({ key: 'timeTo', label: `To: ${filters.timeTo.trim()}` });
   }
 
+  if (filters.hasMedia) {
+    chips.push({ key: 'hasMedia', label: 'Media: With image' });
+  }
+
   filters.tags.forEach((tag) => {
     chips.push({ key: `tag:${tag}`, label: `Tag: ${tag}` });
   });
@@ -49,11 +53,13 @@ function buildChips(filters: ReturnType<typeof useSearchFilters>['filters']): Fi
 interface StorySearchControlsProps {
   helperText?: string;
   hideHeading?: boolean;
+  filterPanelExtraContent?: React.ReactNode;
+  showMediaFilter?: boolean;
   onFiltersApplied?: (filters: SearchFiltersState) => void;
   scope: SearchFilterScope;
 }
 
-export function StorySearchControls({ helperText, hideHeading = false, onFiltersApplied, scope }: StorySearchControlsProps) {
+export function StorySearchControls({ helperText, hideHeading = false, filterPanelExtraContent, showMediaFilter = false, onFiltersApplied, scope }: StorySearchControlsProps) {
   const { colors, spacing, typography } = useAppTheme();
   const { height } = useWindowDimensions();
   const { filters, updateFilters, removeFilter, clearFilters, applyFilters } = useSearchFilters(scope);
@@ -73,6 +79,7 @@ export function StorySearchControls({ helperText, hideHeading = false, onFilters
   const [draftProximitySource, setDraftProximitySource] = useState<ProximitySource | undefined>();
   const [draftTimeFrom, setDraftTimeFrom] = useState('');
   const [draftTimeTo, setDraftTimeTo] = useState('');
+  const [draftHasMedia, setDraftHasMedia] = useState<boolean | undefined>();
   const [draftTags, setDraftTags] = useState<string[]>([]);
   const [draftTagQuery, setDraftTagQuery] = useState('');
   const [tagOptions, setTagOptions] = useState<SearchTag[]>([]);
@@ -103,6 +110,7 @@ export function StorySearchControls({ helperText, hideHeading = false, onFilters
     setIsProximityResolving(false);
     setDraftTimeFrom(filters.timeFrom);
     setDraftTimeTo(filters.timeTo);
+    setDraftHasMedia(filters.hasMedia);
     setDraftTags(filters.tags);
     setDraftTagQuery('');
     setTagOptions([]);
@@ -212,6 +220,7 @@ export function StorySearchControls({ helperText, hideHeading = false, onFilters
       proximityStoryId: nextProximitySource === 'map_pin' ? filters.proximityStoryId : undefined,
       timeFrom: draftTimeFrom,
       timeTo: draftTimeTo,
+      hasMedia: draftHasMedia,
       tags: draftTags,
     };
 
@@ -392,10 +401,13 @@ export function StorySearchControls({ helperText, hideHeading = false, onFilters
                 tagQuery={draftTagQuery}
                 tagOptions={tagOptions}
                 isTagsLoading={isTagsLoading}
+                hasMedia={draftHasMedia}
+                showMediaFilter={showMediaFilter}
                 onLocationChange={handleDraftLocationChange}
                 onLocationSuggestionPress={handleLocationSuggestionPress}
                 onTimeFromChange={setDraftTimeFrom}
                 onTimeToChange={setDraftTimeTo}
+                onHasMediaChange={setDraftHasMedia}
                 onTagQueryChange={setDraftTagQuery}
                 onToggleTag={toggleDraftTag}
                 onRemoveTag={(tag) => setDraftTags((currentTags) => currentTags.filter((currentTag) => currentTag !== tag))}
@@ -414,6 +426,7 @@ export function StorySearchControls({ helperText, hideHeading = false, onFilters
                   Boolean(draftProximityRadiusKm && !draftProximityCoordinates)
                 }
                 onTagPickerOpenChange={setIsTagPickerOpen}
+                extraContent={filterPanelExtraContent}
                 onClearAll={() => {
                   setDraftLocation('');
                   setDraftLocationBounds(undefined);
@@ -427,6 +440,7 @@ export function StorySearchControls({ helperText, hideHeading = false, onFilters
                   setIsProximityError(false);
                   setDraftTimeFrom('');
                   setDraftTimeTo('');
+                  setDraftHasMedia(undefined);
                   setDraftTags([]);
                   setDraftTagQuery('');
                   clearFilters();

--- a/mobile/src/features/search/presentation/context/SearchFiltersContext.tsx
+++ b/mobile/src/features/search/presentation/context/SearchFiltersContext.tsx
@@ -24,6 +24,7 @@ export interface SearchFiltersState {
   proximityStoryId?: string;
   timeFrom: string;
   timeTo: string;
+  hasMedia?: boolean;
   tags: string[];
 }
 
@@ -49,6 +50,7 @@ const initialFilters: SearchFiltersState = {
   proximityStoryId: undefined,
   timeFrom: '',
   timeTo: '',
+  hasMedia: undefined,
   tags: [],
 };
 
@@ -163,7 +165,7 @@ export function SearchFiltersProvider({ children }: PropsWithChildren) {
           scope,
           (currentFilters) => ({
             ...currentFilters,
-            [key]: key === 'tags' ? [] : '',
+            [key]: key === 'tags' ? [] : key === 'hasMedia' ? undefined : '',
             ...(key === 'location' ? { locationBounds: undefined } : {}),
             ...(isProximityFilterKey(key) ? clearedProximityFilters : {}),
           }),
@@ -225,6 +227,7 @@ export function toSearchParams(filters: SearchFiltersState): StoryFilters {
     locationBounds: filters.locationBounds,
     yearFrom,
     yearTo,
+    hasMedia: filters.hasMedia,
     tags: filters.tags.length ? filters.tags : undefined,
   };
 
@@ -249,6 +252,7 @@ function normalizeStoredFilters(filters?: Partial<SearchFiltersState> | null): S
     proximityStoryId: normalizeOptionalString(filters?.proximityStoryId),
     timeFrom: filters?.timeFrom ?? '',
     timeTo: filters?.timeTo ?? '',
+    hasMedia: filters?.hasMedia === true ? true : undefined,
     tags: normalizeTags(filters?.tags),
   };
 }

--- a/mobile/src/features/search/presentation/context/__tests__/SearchFiltersContext.test.ts
+++ b/mobile/src/features/search/presentation/context/__tests__/SearchFiltersContext.test.ts
@@ -17,6 +17,7 @@ describe('toSearchParams', () => {
       locationBounds: undefined,
       yearFrom: undefined,
       yearTo: undefined,
+      hasMedia: undefined,
       tags: undefined,
     });
   });
@@ -44,6 +45,29 @@ describe('toSearchParams', () => {
       locationBounds,
       yearFrom: undefined,
       yearTo: undefined,
+      hasMedia: undefined,
+      tags: undefined,
+    });
+  });
+
+  it('maps the with image filter to story search params', () => {
+    expect(
+      toSearchParams({
+        query: '',
+        location: '',
+        locationBounds: undefined,
+        timeFrom: '',
+        timeTo: '',
+        hasMedia: true,
+        tags: [],
+      }),
+    ).toEqual({
+      q: undefined,
+      location: undefined,
+      locationBounds: undefined,
+      yearFrom: undefined,
+      yearTo: undefined,
+      hasMedia: true,
       tags: undefined,
     });
   });

--- a/mobile/src/features/timeline/data/mappers/__tests__/timelineMappers.test.ts
+++ b/mobile/src/features/timeline/data/mappers/__tests__/timelineMappers.test.ts
@@ -25,7 +25,7 @@ describe('timeline mappers', () => {
         time_type: 'approximate_year',
         year: 1870,
       }).timePeriod,
-    ).toBe('c. 1870');
+    ).toBe('1870');
   });
 
   it('maps decade, range, and exact date periods', () => {

--- a/mobile/src/features/timeline/data/mappers/index.ts
+++ b/mobile/src/features/timeline/data/mappers/index.ts
@@ -142,7 +142,7 @@ function formatTimePeriod(record: TimelineApiRecord) {
     case 'exact_year':
       return year !== undefined ? formatHistoricalYear(year) : '';
     case 'approximate_year':
-      return year !== undefined ? `c. ${formatHistoricalYear(year)}` : '';
+      return year !== undefined ? formatHistoricalYear(year) : '';
     case 'decade':
       return year !== undefined ? formatDecade(year) : '';
     case 'year_range':

--- a/mobile/src/features/timeline/presentation/components/TimelineCard.tsx
+++ b/mobile/src/features/timeline/presentation/components/TimelineCard.tsx
@@ -11,14 +11,16 @@ interface TimelineCardProps {
 
 function getBadgeLabel(story: TimelineEntity) {
   if (story.historicalYear !== undefined) {
-    return formatHistoricalYear(story.historicalYear);
+    return formatTimelineBadgeYear(story.historicalYear);
   }
 
   return story.timePeriod || 'Time';
 }
 
-function formatHistoricalYear(year: number) {
-  return year < 0 ? `${Math.abs(year)} BC` : String(year);
+function formatTimelineBadgeYear(year: number) {
+  const decade = Math.floor(Math.abs(year) / 10) * 10;
+
+  return year < 0 ? `${decade}s BC` : `${decade}s`;
 }
 
 export function TimelineCard({ story, onPress, isLast = false }: TimelineCardProps) {
@@ -82,24 +84,6 @@ export function TimelineCard({ story, onPress, isLast = false }: TimelineCardPro
           />
         ) : null}
         <View style={{ padding: spacing.md, gap: spacing.sm }}>
-          <View style={{ flexDirection: 'row', flexWrap: 'wrap', gap: spacing.sm }}>
-            {story.timePeriod ? (
-              <View
-                style={{
-                  alignSelf: 'flex-start',
-                  paddingHorizontal: spacing.sm,
-                  paddingVertical: spacing.xs,
-                  borderRadius: 999,
-                  backgroundColor: colors.background,
-                }}
-              >
-                <Text style={{ color: colors.text, fontSize: typography.caption, fontWeight: '700' }}>
-                  {story.timePeriod}
-                </Text>
-              </View>
-            ) : null}
-          </View>
-
           <Text style={{ color: colors.text, fontSize: typography.subtitle, fontWeight: '800', lineHeight: 24 }}>
             {story.title}
           </Text>

--- a/mobile/src/features/timeline/presentation/components/TimelineCard.tsx
+++ b/mobile/src/features/timeline/presentation/components/TimelineCard.tsx
@@ -10,11 +10,15 @@ interface TimelineCardProps {
 }
 
 function getBadgeLabel(story: TimelineEntity) {
-  if (story.historicalYear !== undefined) {
+  if (story.timePeriod) {
+    return story.timePeriod;
+  }
+
+  if (story.timeType === 'decade' && story.historicalYear !== undefined) {
     return formatTimelineBadgeYear(story.historicalYear);
   }
 
-  return story.timePeriod || 'Time';
+  return story.historicalYear !== undefined ? String(story.historicalYear) : 'Time';
 }
 
 function formatTimelineBadgeYear(year: number) {
@@ -37,7 +41,7 @@ export function TimelineCard({ story, onPress, isLast = false }: TimelineCardPro
         opacity: pressed ? 0.86 : 1,
       })}
     >
-      <View style={{ width: 76, alignItems: 'center' }}>
+      <View style={{ width: 112, alignItems: 'center' }}>
         <View
           style={{
             position: 'absolute',
@@ -50,6 +54,7 @@ export function TimelineCard({ story, onPress, isLast = false }: TimelineCardPro
         <View
           style={{
             minWidth: 72,
+            maxWidth: 108,
             paddingHorizontal: spacing.sm,
             paddingVertical: spacing.xs + 2,
             borderRadius: 999,
@@ -59,7 +64,18 @@ export function TimelineCard({ story, onPress, isLast = false }: TimelineCardPro
             alignItems: 'center',
           }}
         >
-          <Text numberOfLines={1} style={{ color: colors.text, fontSize: typography.caption, fontWeight: '800' }}>
+          <Text
+            adjustsFontSizeToFit
+            minimumFontScale={0.65}
+            numberOfLines={1}
+            style={{
+              color: colors.text,
+              fontSize: typography.caption,
+              fontWeight: '800',
+              textAlign: 'center',
+              width: '100%',
+            }}
+          >
             {getBadgeLabel(story)}
           </Text>
         </View>

--- a/mobile/src/features/timeline/presentation/screens/TimelineScreen.tsx
+++ b/mobile/src/features/timeline/presentation/screens/TimelineScreen.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { FlatList, Pressable, Text, View } from 'react-native';
+import { FlatList, Text, View } from 'react-native';
 import { useAppTheme } from '../../../../core/hooks/useAppTheme';
 import { EmptyState, ErrorState, Loader, SkeletonCard } from '../../../../shared';
 import { useDebounce } from '../../../../shared/hooks/useDebounce';
@@ -39,7 +39,6 @@ interface PeriodDescriptor {
 }
 
 const EMPTY_FILTERS: StoryFilters = {};
-type TimelineImageFilter = 'all' | 'with_image';
 
 export function TimelineScreen({
   initialFilters = EMPTY_FILTERS,
@@ -54,8 +53,8 @@ export function TimelineScreen({
   const [useImmediateQuery, setUseImmediateQuery] = useState(false);
   const [periodSelection, setPeriodSelection] = useState<TimelinePeriodSelection>(EMPTY_TIMELINE_PERIOD_SELECTION);
   const [appliedPeriodSelection, setAppliedPeriodSelection] = useState<TimelinePeriodSelection>(EMPTY_TIMELINE_PERIOD_SELECTION);
-  const [imageFilter, setImageFilter] = useState<TimelineImageFilter>(() => getInitialImageFilter(initialFilters));
   const periodDescriptor = useMemo(() => describePeriodSelection(appliedPeriodSelection), [appliedPeriodSelection]);
+  const draftPeriodDescriptor = useMemo(() => describePeriodSelection(periodSelection), [periodSelection]);
   const [state, setState] = useState<TimelineUiState>(() => createInitialTimelineUiState(initialFilters));
   const stateRef = useRef(state);
   const hasRequestedNextPage = useRef(false);
@@ -90,9 +89,8 @@ export function TimelineScreen({
     () => ({
       ...initialFilters,
       ...toSearchParams({ ...filters, query: useImmediateQuery ? filters.query : debouncedQuery }),
-      hasMedia: getHasMediaFilter(imageFilter),
     }),
-    [debouncedQuery, filters, imageFilter, initialFilters, useImmediateQuery],
+    [debouncedQuery, filters, initialFilters, useImmediateQuery],
   );
 
   const hasActiveFilters = Boolean(
@@ -188,20 +186,14 @@ export function TimelineScreen({
   };
 
   const handlePeriodSelectionChange = (nextSelection: TimelinePeriodSelection) => {
-    setPeriodSelection((currentSelection) => {
-      if (nextSelection.mode !== currentSelection.mode) {
-        if (nextSelection.mode === 'all') {
-          setAppliedPeriodSelection(nextSelection);
-        } else if (Object.keys(periodDescriptor.request).length > 0) {
-          setAppliedPeriodSelection(EMPTY_TIMELINE_PERIOD_SELECTION);
-        }
-      }
-
-      return nextSelection;
-    });
+    setPeriodSelection(nextSelection);
   };
 
   const handlePeriodSelectionSubmit = () => {
+    setAppliedPeriodSelection(periodSelection);
+  };
+
+  const handleFiltersApplied = () => {
     setAppliedPeriodSelection(periodSelection);
   };
 
@@ -224,20 +216,22 @@ export function TimelineScreen({
         </Text>
       </View>
 
-      {showSearchControls ? <StorySearchControls helperText="Search by title or place." scope={searchScope} /> : null}
-
-      <TimelinePeriodSelector
-        value={periodSelection}
-        onChange={handlePeriodSelectionChange}
-        onSubmit={handlePeriodSelectionSubmit}
-        error={periodDescriptor.error}
-        headerAccessory={
-          <TimelineImageFilterToggle
-            isActive={imageFilter === 'with_image'}
-            onPress={() => setImageFilter((current) => (current === 'with_image' ? 'all' : 'with_image'))}
-          />
-        }
-      />
+      {showSearchControls ? (
+        <StorySearchControls
+          helperText="Search by title or place."
+          scope={searchScope}
+          showMediaFilter
+          onFiltersApplied={handleFiltersApplied}
+          filterPanelExtraContent={
+            <TimelinePeriodSelector
+              value={periodSelection}
+              onChange={handlePeriodSelectionChange}
+              onSubmit={handlePeriodSelectionSubmit}
+              error={draftPeriodDescriptor.error}
+            />
+          }
+        />
+      ) : null}
 
       <View
         style={{
@@ -491,8 +485,9 @@ function toSearchState(filters: StoryFilters): SearchFiltersState {
       filters.radiusKm !== undefined && filters.latitude !== undefined && filters.longitude !== undefined
         ? 'current_location'
         : undefined,
-    timeFrom: filters.yearFrom ? String(filters.yearFrom) : '',
-    timeTo: filters.yearTo ? String(filters.yearTo) : '',
+    timeFrom: filters.yearFrom !== undefined ? String(filters.yearFrom) : '',
+    timeTo: filters.yearTo !== undefined ? String(filters.yearTo) : '',
+    hasMedia: filters.hasMedia,
     tags: filters.tags ?? [],
   };
 }
@@ -505,6 +500,7 @@ function hasAnySearchFilters(filters: SearchFiltersState) {
       filters.proximityRadiusKm ||
       filters.timeFrom.trim() ||
       filters.timeTo.trim() ||
+      filters.hasMedia ||
       filters.tags.length,
   );
 }
@@ -519,48 +515,7 @@ function areSearchStatesEqual(left: SearchFiltersState, right: SearchFiltersStat
     left.proximitySource === right.proximitySource &&
     left.timeFrom === right.timeFrom &&
     left.timeTo === right.timeTo &&
+    left.hasMedia === right.hasMedia &&
     JSON.stringify(left.tags) === JSON.stringify(right.tags)
-  );
-}
-
-function getInitialImageFilter(filters: StoryFilters): TimelineImageFilter {
-  if (filters.hasMedia === true) {
-    return 'with_image';
-  }
-
-  return 'all';
-}
-
-function getHasMediaFilter(value: TimelineImageFilter) {
-  if (value === 'with_image') {
-    return true;
-  }
-
-  return undefined;
-}
-
-function TimelineImageFilterToggle({ isActive, onPress }: { isActive: boolean; onPress: () => void }) {
-  const { colors, spacing, typography } = useAppTheme();
-
-  return (
-    <Pressable
-      accessibilityRole="button"
-      accessibilityLabel="Timeline image filter With image"
-      accessibilityState={{ selected: isActive }}
-      onPress={onPress}
-      style={({ pressed }) => ({
-        paddingHorizontal: spacing.sm + 2,
-        paddingVertical: spacing.xs + 2,
-        borderRadius: 999,
-        borderWidth: 1,
-        borderColor: isActive ? colors.text : colors.border,
-        backgroundColor: isActive ? colors.text : colors.background,
-        opacity: pressed ? 0.8 : 1,
-      })}
-    >
-      <Text style={{ color: isActive ? colors.background : colors.text, fontSize: typography.caption + 1, fontWeight: '800' }}>
-        With image
-      </Text>
-    </Pressable>
   );
 }

--- a/mobile/src/features/timeline/presentation/screens/__tests__/TimelineScreen.test.tsx
+++ b/mobile/src/features/timeline/presentation/screens/__tests__/TimelineScreen.test.tsx
@@ -79,13 +79,13 @@ describe('TimelineScreen', () => {
     expect(await screen.findByText('Timeline Story 1')).toBeTruthy();
     expect(screen.getByText('Location 1')).toBeTruthy();
     expect(screen.queryByText('Choose a time window')).toBeNull();
-    expect(screen.getAllByText('1950s').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('1950').length).toBeGreaterThan(0);
     fireEvent.press(screen.getByLabelText('Open timeline story: Timeline Story 1'));
 
     expect(onOpenStory).toHaveBeenCalledWith('1');
   });
 
-  it('uses the left timeline badge for period labels and hides card year chips', async () => {
+  it('uses the story time period in the left timeline badge and hides card year chips', async () => {
     renderScreen(
       <TimelineScreen
         getTimeline={async () =>
@@ -107,6 +107,35 @@ describe('TimelineScreen', () => {
     expect(await screen.findByText('1900s')).toBeTruthy();
     expect(screen.queryByText('190X')).toBeNull();
     expect(screen.queryByText('1905')).toBeNull();
+  });
+
+  it('preserves exact date and range labels in the left timeline badge', async () => {
+    renderScreen(
+      <TimelineScreen
+        getTimeline={async () =>
+          makeTimelinePage({
+            items: [
+              makeStory('range', {
+                timeType: 'year_range',
+                timePeriod: '1914-1918',
+                historicalYear: 1916,
+              }),
+              makeStory('date', {
+                timeType: 'exact_date',
+                timePeriod: '1923-10-29 09:30',
+                historicalYear: 1923,
+              }),
+            ],
+          })
+        }
+        showSearchControls={false}
+      />,
+    );
+
+    expect(await screen.findByText('1914-1918')).toBeTruthy();
+    expect(screen.getByText('1923-10-29 09:30')).toBeTruthy();
+    expect(screen.queryByText('1910s')).toBeNull();
+    expect(screen.queryByText('1920s')).toBeNull();
   });
 
   it('applies decade selection after Done is pressed', async () => {

--- a/mobile/src/features/timeline/presentation/screens/__tests__/TimelineScreen.test.tsx
+++ b/mobile/src/features/timeline/presentation/screens/__tests__/TimelineScreen.test.tsx
@@ -53,6 +53,10 @@ describe('TimelineScreen', () => {
     return render(<SearchFiltersProvider>{ui}</SearchFiltersProvider>);
   }
 
+  function openFilters() {
+    fireEvent.press(screen.getByText('Show filters'));
+  }
+
   it('shows loading skeletons while fetching timeline stories', async () => {
     const pendingPromise = new Promise<TimelinePageEntity>(() => undefined);
 
@@ -74,13 +78,14 @@ describe('TimelineScreen', () => {
 
     expect(await screen.findByText('Timeline Story 1')).toBeTruthy();
     expect(screen.getByText('Location 1')).toBeTruthy();
-    expect(screen.getByText('Choose a time window')).toBeTruthy();
+    expect(screen.queryByText('Choose a time window')).toBeNull();
+    expect(screen.getAllByText('1950s').length).toBeGreaterThan(0);
     fireEvent.press(screen.getByLabelText('Open timeline story: Timeline Story 1'));
 
     expect(onOpenStory).toHaveBeenCalledWith('1');
   });
 
-  it('shows one time chip when timeline coverage has an alternate notation', async () => {
+  it('uses the left timeline badge for period labels and hides card year chips', async () => {
     renderScreen(
       <TimelineScreen
         getTimeline={async () =>
@@ -101,16 +106,18 @@ describe('TimelineScreen', () => {
 
     expect(await screen.findByText('1900s')).toBeTruthy();
     expect(screen.queryByText('190X')).toBeNull();
+    expect(screen.queryByText('1905')).toBeNull();
   });
 
   it('applies decade selection after Done is pressed', async () => {
     const getTimeline = jest.fn<Promise<TimelinePageEntity>, [any]>().mockResolvedValue(makeTimelinePage());
 
-    renderScreen(<TimelineScreen getTimeline={getTimeline} showSearchControls={false} />);
+    renderScreen(<TimelineScreen getTimeline={getTimeline} />);
 
     await screen.findByText('Timeline Story 1');
     const callCountAfterInitialLoad = getTimeline.mock.calls.length;
 
+    openFilters();
     fireEvent.press(screen.getByLabelText('Timeline mode Decade'));
     const callCountAfterModeSwitch = getTimeline.mock.calls.length;
     expect(callCountAfterModeSwitch).toBe(callCountAfterInitialLoad);
@@ -148,10 +155,11 @@ describe('TimelineScreen', () => {
   it('accepts short and negative historical decade years', async () => {
     const getTimeline = jest.fn<Promise<TimelinePageEntity>, [any]>().mockResolvedValue(makeTimelinePage());
 
-    renderScreen(<TimelineScreen getTimeline={getTimeline} showSearchControls={false} />);
+    renderScreen(<TimelineScreen getTimeline={getTimeline} />);
 
     await screen.findByText('Timeline Story 1');
 
+    openFilters();
     fireEvent.press(screen.getByLabelText('Timeline mode Decade'));
     fireEvent.changeText(screen.getByLabelText('Timeline decade'), '445');
     fireEvent(screen.getByLabelText('Timeline decade'), 'submitEditing');
@@ -184,10 +192,11 @@ describe('TimelineScreen', () => {
       .mockResolvedValueOnce(makeTimelinePage({ items: [], totalCount: 0 }))
       .mockImplementation(() => new Promise<TimelinePageEntity>(() => undefined));
 
-    renderScreen(<TimelineScreen getTimeline={getTimeline} showSearchControls={false} />);
+    renderScreen(<TimelineScreen getTimeline={getTimeline} />);
 
     await screen.findByText('Timeline is empty');
 
+    openFilters();
     fireEvent.press(screen.getByLabelText('Timeline mode Decade'));
     fireEvent.changeText(screen.getByLabelText('Timeline decade'), '1');
 
@@ -198,11 +207,12 @@ describe('TimelineScreen', () => {
   it('keeps range typing local until both years are provided', async () => {
     const getTimeline = jest.fn<Promise<TimelinePageEntity>, [any]>().mockResolvedValue(makeTimelinePage());
 
-    renderScreen(<TimelineScreen getTimeline={getTimeline} showSearchControls={false} />);
+    renderScreen(<TimelineScreen getTimeline={getTimeline} />);
 
     await screen.findByText('Timeline Story 1');
     const callCountAfterInitialLoad = getTimeline.mock.calls.length;
 
+    openFilters();
     fireEvent.press(screen.getByLabelText('Timeline mode Range'));
     const callCountAfterRangeMode = getTimeline.mock.calls.length;
     expect(callCountAfterRangeMode).toBe(callCountAfterInitialLoad);
@@ -229,10 +239,11 @@ describe('TimelineScreen', () => {
   it('clears the previous period mode when switching between controls', async () => {
     const getTimeline = jest.fn<Promise<TimelinePageEntity>, [any]>().mockResolvedValue(makeTimelinePage());
 
-    renderScreen(<TimelineScreen getTimeline={getTimeline} showSearchControls={false} />);
+    renderScreen(<TimelineScreen getTimeline={getTimeline} />);
 
     await screen.findByText('Timeline Story 1');
 
+    openFilters();
     fireEvent.press(screen.getByLabelText('Timeline mode Year'));
     fireEvent.changeText(screen.getByLabelText('Timeline year'), '100');
     fireEvent(screen.getByLabelText('Timeline year'), 'submitEditing');
@@ -248,6 +259,8 @@ describe('TimelineScreen', () => {
 
     fireEvent.press(screen.getByLabelText('Timeline mode Range'));
 
+    fireEvent.press(screen.getByLabelText('Apply filters'));
+
     await waitFor(() => {
       const lastRequest = getTimeline.mock.calls[getTimeline.mock.calls.length - 1][0];
 
@@ -256,6 +269,9 @@ describe('TimelineScreen', () => {
       expect(lastRequest.yearRange).toBeUndefined();
       expect(lastRequest.decade).toBeUndefined();
     });
+    expect(screen.getByText('All time periods')).toBeTruthy();
+
+    openFilters();
     expect(screen.queryByLabelText('Timeline year')).toBeNull();
     expect(screen.getByLabelText('Timeline start year').props.value).toBe('');
     expect(screen.getByLabelText('Timeline end year').props.value).toBe('');
@@ -357,7 +373,9 @@ describe('TimelineScreen', () => {
     renderScreen(<TimelineScreen getTimeline={getTimeline} />);
 
     await screen.findByText('Timeline Story 1');
-    fireEvent.press(screen.getByLabelText('Timeline image filter With image'));
+    openFilters();
+    fireEvent.press(screen.getByLabelText('Filter stories with image'));
+    fireEvent.press(screen.getByLabelText('Apply filters'));
 
     await waitFor(() => {
       expect(getTimeline).toHaveBeenLastCalledWith(
@@ -370,7 +388,9 @@ describe('TimelineScreen', () => {
       );
     });
 
-    fireEvent.press(screen.getByLabelText('Timeline image filter With image'));
+    openFilters();
+    fireEvent.press(screen.getByLabelText('Filter stories with image'));
+    fireEvent.press(screen.getByLabelText('Apply filters'));
 
     await waitFor(() => {
       expect(getTimeline).toHaveBeenLastCalledWith(
@@ -383,6 +403,7 @@ describe('TimelineScreen', () => {
       );
     });
 
+    expect(screen.queryByLabelText('Timeline image filter With image')).toBeNull();
     expect(screen.queryByLabelText('Timeline image filter All')).toBeNull();
     expect(screen.queryByLabelText('Timeline image filter Without image')).toBeNull();
   });

--- a/mobile/src/shared/components/FilterPanel.tsx
+++ b/mobile/src/shared/components/FilterPanel.tsx
@@ -8,7 +8,7 @@ import { formatTagLabel, TagChip } from './TagChip';
 
 export const DEFAULT_FROM_YEAR = '1980';
 export const DEFAULT_TO_YEAR = '2026';
-export const MIN_YEAR = 1000;
+export const MIN_YEAR = -9999;
 export const MAX_YEAR = 2030;
 export type ProximityRadiusOption = 0.5 | 1 | 10 | 100;
 export interface LocationFilterSuggestion {
@@ -38,11 +38,11 @@ function normalizeYearInput(value: string) {
     return value;
   }
 
-  if (!/^\d*$/.test(value)) {
+  if (!/^-?\d*$/.test(value)) {
     return null;
   }
 
-  if (value.length > 4) {
+  if (value.replace('-', '').length > 5) {
     return null;
   }
 
@@ -71,11 +71,14 @@ interface FilterPanelProps {
   tagQuery?: string;
   tagOptions?: SearchTag[];
   isTagsLoading?: boolean;
+  hasMedia?: boolean;
+  showMediaFilter?: boolean;
   onLocationChange: (value: string) => void;
   locationSuggestions?: LocationFilterSuggestion[];
   onLocationSuggestionPress?: (suggestion: LocationFilterSuggestion) => void;
   onTimeFromChange: (value: string) => void;
   onTimeToChange: (value: string) => void;
+  onHasMediaChange?: (value?: boolean) => void;
   onTagQueryChange?: (value: string) => void;
   onToggleTag?: (value: string) => void;
   onRemoveTag?: (value: string) => void;
@@ -90,6 +93,7 @@ interface FilterPanelProps {
   locationStatusText?: string;
   isApplyDisabled?: boolean;
   onTagPickerOpenChange?: (isOpen: boolean) => void;
+  extraContent?: React.ReactNode;
 }
 
 export function FilterPanel({
@@ -100,11 +104,14 @@ export function FilterPanel({
   tagQuery = '',
   tagOptions = [],
   isTagsLoading = false,
+  hasMedia,
+  showMediaFilter = false,
   onLocationChange,
   locationSuggestions = [],
   onLocationSuggestionPress,
   onTimeFromChange,
   onTimeToChange,
+  onHasMediaChange,
   onTagQueryChange,
   onToggleTag,
   onRemoveTag,
@@ -119,6 +126,7 @@ export function FilterPanel({
   locationStatusText,
   isApplyDisabled = false,
   onTagPickerOpenChange,
+  extraContent,
 }: FilterPanelProps) {
   const { colors, spacing, typography } = useAppTheme();
   const [isTagPickerOpen, setIsTagPickerOpen] = useState(false);
@@ -469,7 +477,7 @@ export function FilterPanel({
             onChangeText={handleTimeFromChange}
             onBlur={() => onTimeFromChange(clampYearValue(timeFrom))}
             placeholder={DEFAULT_FROM_YEAR}
-            keyboardType="number-pad"
+            keyboardType="numbers-and-punctuation"
             accessibilityLabel="Start year"
             trailingElement={
               <View style={{ flexDirection: 'row', alignItems: 'center', paddingRight: spacing.xs }}>
@@ -509,7 +517,7 @@ export function FilterPanel({
             onChangeText={handleTimeToChange}
             onBlur={() => onTimeToChange(clampYearValue(timeTo))}
             placeholder={DEFAULT_TO_YEAR}
-            keyboardType="number-pad"
+            keyboardType="numbers-and-punctuation"
             accessibilityLabel="End year"
             trailingElement={
               <View style={{ flexDirection: 'row', alignItems: 'center', paddingRight: spacing.xs }}>
@@ -549,6 +557,34 @@ export function FilterPanel({
           Start year cannot be later than end year.
         </Text>
       ) : null}
+
+      {showMediaFilter ? (
+        <View style={{ gap: spacing.sm }}>
+          <Text style={{ color: colors.text, fontWeight: '600' }}>Media</Text>
+          <Pressable
+            accessibilityRole="button"
+            accessibilityLabel="Filter stories with image"
+            accessibilityState={{ selected: hasMedia === true }}
+            onPress={() => onHasMediaChange?.(hasMedia === true ? undefined : true)}
+            style={({ pressed }) => ({
+              alignSelf: 'flex-start',
+              paddingHorizontal: spacing.md,
+              paddingVertical: spacing.sm,
+              borderRadius: 999,
+              borderWidth: 1,
+              borderColor: hasMedia === true ? colors.primary : colors.border,
+              backgroundColor: hasMedia === true ? colors.infoSurface : colors.surface,
+              opacity: pressed ? 0.75 : 1,
+            })}
+          >
+            <Text style={{ color: hasMedia === true ? colors.primary : colors.text, fontWeight: '700' }}>
+              With image
+            </Text>
+          </Pressable>
+        </View>
+      ) : null}
+
+      {extraContent}
 
       <View style={{ flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center' }}>
         <Pressable accessibilityRole="button" onPress={onClearAll}>

--- a/mobile/src/shared/components/__tests__/FilterPanel.test.tsx
+++ b/mobile/src/shared/components/__tests__/FilterPanel.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { fireEvent, render, screen } from '@testing-library/react-native';
-import { DEFAULT_FROM_YEAR, DEFAULT_TO_YEAR, FilterPanel, MAX_YEAR } from '../FilterPanel';
+import { DEFAULT_FROM_YEAR, DEFAULT_TO_YEAR, FilterPanel, MAX_YEAR, MIN_YEAR } from '../FilterPanel';
 
 describe('FilterPanel', () => {
   it('forwards location and valid year filter updates', () => {
@@ -48,7 +48,7 @@ describe('FilterPanel', () => {
     expect(screen.getByLabelText('End year').props.placeholder).toBe(DEFAULT_TO_YEAR);
   });
 
-  it('accepts only positive four-digit-or-shorter numeric years', () => {
+  it('accepts signed five-digit-or-shorter numeric years for BC ranges', () => {
     const onTimeFromChange = jest.fn();
     const onTimeToChange = jest.fn();
 
@@ -68,15 +68,15 @@ describe('FilterPanel', () => {
     fireEvent.changeText(screen.getByLabelText('End year'), '9999');
     fireEvent.changeText(screen.getByLabelText('Start year'), '-200');
     fireEvent.changeText(screen.getByLabelText('Start year'), 'fvbnj');
-    fireEvent.changeText(screen.getByLabelText('Start year'), '99999');
-    fireEvent.changeText(screen.getByLabelText('End year'), '10000');
+    fireEvent.changeText(screen.getByLabelText('Start year'), '999999');
+    fireEvent.changeText(screen.getByLabelText('End year'), '-100000');
 
     expect(onTimeFromChange).toHaveBeenCalledWith('200');
     expect(onTimeToChange).toHaveBeenCalledWith('9999');
-    expect(onTimeFromChange).not.toHaveBeenCalledWith('-200');
+    expect(onTimeFromChange).toHaveBeenCalledWith('-200');
     expect(onTimeFromChange).not.toHaveBeenCalledWith('fvbnj');
-    expect(onTimeFromChange).not.toHaveBeenCalledWith('99999');
-    expect(onTimeToChange).not.toHaveBeenCalledWith('10000');
+    expect(onTimeFromChange).not.toHaveBeenCalledWith('999999');
+    expect(onTimeToChange).not.toHaveBeenCalledWith('-100000');
   });
 
   it('clamps manual year entries to the supported bounds on blur', () => {
@@ -87,7 +87,7 @@ describe('FilterPanel', () => {
       <FilterPanel
         location=""
         timeFrom="2050"
-        timeTo="0999"
+        timeTo="-12000"
         onLocationChange={jest.fn()}
         onTimeFromChange={onTimeFromChange}
         onTimeToChange={onTimeToChange}
@@ -99,7 +99,49 @@ describe('FilterPanel', () => {
     fireEvent(screen.getByLabelText('End year'), 'blur');
 
     expect(onTimeFromChange).toHaveBeenCalledWith(String(MAX_YEAR));
-    expect(onTimeToChange).toHaveBeenCalledWith('1000');
+    expect(onTimeToChange).toHaveBeenCalledWith(String(MIN_YEAR));
+  });
+
+  it('toggles the with image filter', () => {
+    const onHasMediaChange = jest.fn();
+
+    const { rerender } = render(
+      <FilterPanel
+        location=""
+        timeFrom=""
+        timeTo=""
+        hasMedia={undefined}
+        showMediaFilter
+        onLocationChange={jest.fn()}
+        onTimeFromChange={jest.fn()}
+        onTimeToChange={jest.fn()}
+        onHasMediaChange={onHasMediaChange}
+        onClearAll={jest.fn()}
+      />,
+    );
+
+    fireEvent.press(screen.getByLabelText('Filter stories with image'));
+
+    expect(onHasMediaChange).toHaveBeenCalledWith(true);
+
+    rerender(
+      <FilterPanel
+        location=""
+        timeFrom=""
+        timeTo=""
+        hasMedia
+        showMediaFilter
+        onLocationChange={jest.fn()}
+        onTimeFromChange={jest.fn()}
+        onTimeToChange={jest.fn()}
+        onHasMediaChange={onHasMediaChange}
+        onClearAll={jest.fn()}
+      />,
+    );
+
+    fireEvent.press(screen.getByLabelText('Filter stories with image'));
+
+    expect(onHasMediaChange).toHaveBeenCalledWith(undefined);
   });
 
   it('disables increment once the maximum year is reached', () => {


### PR DESCRIPTION
# 📝 Description
Fixes #622

Implements mobile timeline filter improvements:
- Moves timeline time-window controls into the filter flow
- Moves the `With image` option into filters
- Clears the `With image` filter when navigating to Feed or Map
- Removes visible year info from timeline cards
- Shows the left timeline year label as decade text, e.g. `205` -> `200s`
- Allows negative year input for BC year ranges

# 📊 Type of Change
- [ ]  Bug fix
- [x]  New feature
- [ ]  Refactoring
- [ ]  Documentation
 
# ✅ Acceptance Criteria / Checklist
- [x] Project builds successfully
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, especially in hard-to-understand parts
- [x] I have performed a self-review of my code
- [x] I have added/updated tests
- [x] New and existing unit tests pass locally with my changes

# 📸 Screenshots / Recordings
<!-- If applicable !-->

# ⏱️ Estimated Review Time
- [ ] < 5 min
- [x] 5-15 min
- [ ] > 15 min
