### PR TITLE
fix: align right buttons of the navigation bar correctly

### DIFF
--- a/frontend/src/components/AppLayout/AppLayout.jsx
+++ b/frontend/src/components/AppLayout/AppLayout.jsx
@@ -66,7 +66,7 @@ function AppLayout() {
   return (
     <div className="min-h-screen">
       <header className="sticky top-0 z-40 w-full border-b bg-background">
-        <div className="container flex h-14 items-center px-4">
+        <div className="flex h-14 w-full items-center px-4">
           {/* Logo */}
           <Link to="/" className="mr-6 flex items-center space-x-2">
             <MapPin className="h-5 w-5" />


### PR DESCRIPTION
# 📝 Description
Fixes #632 

Replaced the container wrapper with w-full in frontend/src/components/AppLayout/AppLayout.jsx:69. The header bar now spans full viewport width, so ml-auto pushes the right-side group (notification bell, profile/logout or login/register) to the actual right edge — symmetric with the logo on the left.

# 📊 Type of Change
- [x]  Bug fix
- [ ]  New feature
- [ ]  Refactoring
- [ ]  Documentation
 
# ✅ Acceptance Criteria / Checklist
- [x] Project builds successfully
- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, especially in hard-to-understand parts
- [x] I have performed a self-review of my code
- [ ] I have added/updated tests
- [x] New and existing unit tests pass locally with my changes

# 📸 Screenshots / Recordings
Before: 
<img width="1440" height="818" alt="Screenshot 2026-05-10 at 15 15 08" src="https://github.com/user-attachments/assets/e1a005e8-39c8-412d-bae2-81ede013001e" />
After:
<img width="1440" height="819" alt="Screenshot 2026-05-10 at 15 16 50" src="https://github.com/user-attachments/assets/2455d6d3-b8c0-4c95-8a64-53581896b925" />

<!-- If applicable !-->
# ⏱️ Estimated Review Time
- [x] < 5 min
- [ ] 5-15 min
- [ ] > 15 min
