### PR TITLE
fix(frontend): remove redundant Back button from Timeline

### DIFF
--- a/frontend/src/pages/TimelinePage.jsx
+++ b/frontend/src/pages/TimelinePage.jsx
@@ -1,6 +1,4 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { useLocation, useNavigate } from "react-router-dom";
-import { ArrowLeft } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
 import { ErrorState } from "@/components/ui/error-state";
@@ -42,11 +40,6 @@ function TimelinePage() {
     removeTag,
     clearAll,
   } = useFilterState();
-
-  const routerLocation = useLocation();
-  const navigate = useNavigate();
-  const _from = routerLocation.state?.from;
-  const mapBack = _from === "/map" || _from?.startsWith("/map?") ? _from : null;
 
   const [stories, setStories] = useState([]);
   const [count, setCount] = useState(0);
@@ -246,23 +239,11 @@ function TimelinePage() {
       <div className="mx-auto max-w-3xl px-4 py-8 sm:px-6 lg:px-8">
         <div className="mb-6">
           <div className="flex items-center justify-between gap-4">
-            <div className="flex items-center gap-3">
-              {mapBack && (
-                <Button
-                  variant="ghost"
-                  size="icon"
-                  onClick={() => navigate(mapBack)}
-                  aria-label="Back to map"
-                >
-                  <ArrowLeft className="h-5 w-5" />
-                </Button>
-              )}
-              <div>
-                <h1 className="text-3xl font-bold tracking-tight">Timeline</h1>
-                <p className="mt-1 text-sm text-muted-foreground">
-                  Stories ordered by when they happened.
-                </p>
-              </div>
+            <div>
+              <h1 className="text-3xl font-bold tracking-tight">Timeline</h1>
+              <p className="mt-1 text-sm text-muted-foreground">
+                Stories ordered by when they happened.
+              </p>
             </div>
             <FilterPanel
               key={filterPanelKey}

--- a/frontend/src/pages/__tests__/TimelinePage.test.jsx
+++ b/frontend/src/pages/__tests__/TimelinePage.test.jsx
@@ -223,19 +223,14 @@ describe("TimelinePage", () => {
     expect(args.lngMax).toBe(29);
   });
 
-  describe("back-to-map button", () => {
-    it("shows a back arrow when navigated from /map", async () => {
+  describe("back-to-map button (removed per #624)", () => {
+    it("never renders a back-to-map button, even when navigated from /map", async () => {
       renderPageWithState({ from: "/map?lat_min=40&lat_max=41" });
-      expect(screen.getByRole("button", { name: /back to map/i })).toBeInTheDocument();
-    });
-
-    it("does not show a back arrow when there is no router state", async () => {
-      renderPage();
       expect(screen.queryByRole("button", { name: /back to map/i })).not.toBeInTheDocument();
     });
 
-    it("does not show a back arrow when navigated from a non-map page", async () => {
-      renderPageWithState({ from: "/timeline?year_from=1900" });
+    it("never renders a back-to-map button when there is no router state", async () => {
+      renderPage();
       expect(screen.queryByRole("button", { name: /back to map/i })).not.toBeInTheDocument();
     });
   });


### PR DESCRIPTION
# Description
Fixes #624

Removes the conditional "Back to map" button from the Timeline view per design review. The timeline is a filter state rather than a separate page — users should navigate via the map/feed switcher, which already preserves the active filter. This also aligns the desktop UI with the existing mobile UI, which doesn't render this button.

Changes:
- `frontend/src/pages/TimelinePage.jsx`: removed the `mapBack` button and the now-unused `useLocation`, `useNavigate`, and `ArrowLeft` imports.
- `frontend/src/pages/__tests__/TimelinePage.test.jsx`: inverted the existing back-button tests to assert the button is never rendered (including when navigated from `/map`).

The "View Timeline" link in `StoryPopup` still works — only the button on the receiving end is gone; proximity filter params are still applied as before.

# Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Refactoring
- [ ] Documentation

# Acceptance Criteria / Checklist
- [x] Project builds successfully
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, especially in hard-to-understand parts
- [x] I have performed a self-review of my code
- [x] I have added/updated tests
- [x] New and existing unit tests pass locally with my changes

# Screenshots / Recordings
<!-- N/A — UI removal only -->

# Estimated Review Time
- [x] < 5 min
- [ ] 5-15 min
- [ ] > 15 min