### PR TITLE
fix: move delete account/reset-password to profile page and fix wrong…

### DIFF
--- a/frontend/src/components/Profile/DeleteAccountDialog.jsx
+++ b/frontend/src/components/Profile/DeleteAccountDialog.jsx
@@ -48,12 +48,16 @@ function DeleteAccountForm({ onOpenChange }) {
     } catch (err) {
       const status = err?.response?.status;
       const data = err?.response?.data;
-      const isPasswordError =
-        status === 400 ||
-        (Array.isArray(data?.password) && data.password.length > 0);
-      const message = isPasswordError
-        ? "Wrong password, please try again."
-        : (data?.detail || err?.message || "Failed to delete account. Please try again.");
+      const passwordFieldError =
+        Array.isArray(data?.password) && data.password.length > 0
+          ? data.password[0]
+          : null;
+      const message =
+        passwordFieldError
+          ?? data?.detail
+          ?? (status === 400 ? "Wrong password, please try again." : null)
+          ?? err?.message
+          ?? "Failed to delete account. Please try again.";
       setError(message);
       setSubmitting(false);
     }

--- a/frontend/src/components/Profile/DeleteAccountDialog.jsx
+++ b/frontend/src/components/Profile/DeleteAccountDialog.jsx
@@ -43,15 +43,17 @@ function DeleteAccountForm({ onOpenChange }) {
       // AuthContext listens for to drop the in-memory user.
       clearTokens();
       onOpenChange(false);
-      toast.success("Your account has been deleted.");
+      toast.success("Account deleted successfully.");
       navigate("/");
     } catch (err) {
+      const status = err?.response?.status;
       const data = err?.response?.data;
-      const message =
-        (Array.isArray(data?.password) && data.password[0]) ||
-        data?.detail ||
-        err?.message ||
-        "Failed to delete account. Please try again.";
+      const isPasswordError =
+        status === 400 ||
+        (Array.isArray(data?.password) && data.password.length > 0);
+      const message = isPasswordError
+        ? "Wrong password, please try again."
+        : (data?.detail || err?.message || "Failed to delete account. Please try again.");
       setError(message);
       setSubmitting(false);
     }

--- a/frontend/src/components/Profile/EditProfileForm.jsx
+++ b/frontend/src/components/Profile/EditProfileForm.jsx
@@ -13,7 +13,6 @@ import {
 import { useAuth } from "@/hooks/useAuth";
 import PhotoUpload from "@/components/Profile/PhotoUpload";
 import VisibilityToggle from "@/components/Profile/VisibilityToggle";
-import DeleteAccountDialog from "@/components/Profile/DeleteAccountDialog";
 
 const MAX_BIO_LENGTH = 500;
 
@@ -24,7 +23,6 @@ function EditProfileForm({ initialProfile, onSave, onCancel }) {
 
   const [saving, setSaving] = useState(false);
   const [errors, setErrors] = useState({});
-  const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
 
   const [username, setUsername] = useState(() => initialProfile?.username ?? "");
   const [firstName, setFirstName] = useState(() => prof.first_name ?? "");
@@ -297,29 +295,6 @@ function EditProfileForm({ initialProfile, onSave, onCancel }) {
         </Button>
       </div>
 
-      {/* Danger zone — visually de-emphasised so it isn't an accidental tap target. */}
-      <div className="mt-4 border-t pt-6">
-        <h3 className="text-sm font-medium">Danger zone</h3>
-        <div className="mt-2 flex flex-col items-start justify-between gap-2 sm:flex-row sm:items-center">
-          <p className="text-xs text-muted-foreground">
-            Permanently delete your account, stories, comments, and uploads.
-          </p>
-          <Button
-            type="button"
-            variant="outline"
-            size="sm"
-            onClick={() => setDeleteDialogOpen(true)}
-            disabled={saving}
-          >
-            Delete account
-          </Button>
-        </div>
-      </div>
-
-      <DeleteAccountDialog
-        open={deleteDialogOpen}
-        onOpenChange={setDeleteDialogOpen}
-      />
     </form>
   );
 }

--- a/frontend/src/components/Profile/__tests__/DeleteAccountDialog.test.jsx
+++ b/frontend/src/components/Profile/__tests__/DeleteAccountDialog.test.jsx
@@ -96,11 +96,11 @@ describe("DeleteAccountDialog", () => {
 
     await waitFor(() => expect(clearTokens).toHaveBeenCalledTimes(1));
     expect(onOpenChange).toHaveBeenCalledWith(false);
-    expect(successToast).toHaveBeenCalledWith("Your account has been deleted.");
+    expect(successToast).toHaveBeenCalledWith("Account deleted successfully.");
     expect(navigateMock).toHaveBeenCalledWith("/");
   });
 
-  it("surfaces a backend 'incorrect password' error inline and does not navigate", async () => {
+  it("surfaces an inline 'wrong password' error and does not navigate", async () => {
     deleteAccount.mockRejectedValue({
       response: { status: 400, data: { password: ["Incorrect password."] } },
     });
@@ -112,9 +112,27 @@ describe("DeleteAccountDialog", () => {
     fireEvent.click(screen.getByRole("button", { name: /delete my account/i }));
 
     await waitFor(() =>
-      expect(screen.getByRole("alert")).toHaveTextContent(/incorrect password/i)
+      expect(screen.getByRole("alert")).toHaveTextContent(/wrong password, please try again/i)
     );
     expect(clearTokens).not.toHaveBeenCalled();
+    expect(navigateMock).not.toHaveBeenCalled();
+  });
+
+  it("shows 'wrong password' for a 400 response with no password array (raw Axios message suppressed)", async () => {
+    deleteAccount.mockRejectedValue({
+      response: { status: 400, data: {} },
+      message: "Request failed with status code 400",
+    });
+    renderDialog();
+
+    fireEvent.change(screen.getByLabelText(/confirm with your password/i), {
+      target: { value: "wrong" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /delete my account/i }));
+
+    await waitFor(() =>
+      expect(screen.getByRole("alert")).toHaveTextContent(/wrong password, please try again/i)
+    );
     expect(navigateMock).not.toHaveBeenCalled();
   });
 
@@ -219,7 +237,7 @@ describe("DeleteAccountDialog", () => {
       fireEvent.click(screen.getByRole("button", { name: /delete my account/i }));
 
       await waitFor(() =>
-        expect(screen.getByRole("alert")).toHaveTextContent(/incorrect password/i)
+        expect(screen.getByRole("alert")).toHaveTextContent(/wrong password, please try again/i)
       );
       expect(screen.getByRole("alertdialog")).toBeInTheDocument();
       expect(screen.getByLabelText(/confirm with your password/i)).toBeInTheDocument();

--- a/frontend/src/components/Profile/__tests__/DeleteAccountDialog.test.jsx
+++ b/frontend/src/components/Profile/__tests__/DeleteAccountDialog.test.jsx
@@ -100,7 +100,7 @@ describe("DeleteAccountDialog", () => {
     expect(navigateMock).toHaveBeenCalledWith("/");
   });
 
-  it("surfaces an inline 'wrong password' error and does not navigate", async () => {
+  it("surfaces the backend password field message and does not navigate", async () => {
     deleteAccount.mockRejectedValue({
       response: { status: 400, data: { password: ["Incorrect password."] } },
     });
@@ -112,9 +112,27 @@ describe("DeleteAccountDialog", () => {
     fireEvent.click(screen.getByRole("button", { name: /delete my account/i }));
 
     await waitFor(() =>
-      expect(screen.getByRole("alert")).toHaveTextContent(/wrong password, please try again/i)
+      expect(screen.getByRole("alert")).toHaveTextContent(/incorrect password\./i)
     );
     expect(clearTokens).not.toHaveBeenCalled();
+    expect(navigateMock).not.toHaveBeenCalled();
+  });
+
+  it("shows a detail message when the backend returns 400 with a detail field", async () => {
+    deleteAccount.mockRejectedValue({
+      response: { status: 400, data: { detail: "Account already scheduled for deletion." } },
+      message: "Request failed with status code 400",
+    });
+    renderDialog();
+
+    fireEvent.change(screen.getByLabelText(/confirm with your password/i), {
+      target: { value: "hunter2" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /delete my account/i }));
+
+    await waitFor(() =>
+      expect(screen.getByRole("alert")).toHaveTextContent(/account already scheduled for deletion/i)
+    );
     expect(navigateMock).not.toHaveBeenCalled();
   });
 
@@ -237,7 +255,7 @@ describe("DeleteAccountDialog", () => {
       fireEvent.click(screen.getByRole("button", { name: /delete my account/i }));
 
       await waitFor(() =>
-        expect(screen.getByRole("alert")).toHaveTextContent(/wrong password, please try again/i)
+        expect(screen.getByRole("alert")).toHaveTextContent(/incorrect password\./i)
       );
       expect(screen.getByRole("alertdialog")).toBeInTheDocument();
       expect(screen.getByLabelText(/confirm with your password/i)).toBeInTheDocument();

--- a/frontend/src/components/Profile/__tests__/EditProfileForm.test.jsx
+++ b/frontend/src/components/Profile/__tests__/EditProfileForm.test.jsx
@@ -6,12 +6,6 @@ vi.mock("@/services/userService", () => ({
   updateProfile: vi.fn(),
   uploadProfilePhoto: vi.fn(),
   removeProfilePhoto: vi.fn(),
-  deleteAccount: vi.fn(),
-}));
-
-vi.mock("@/components/Profile/DeleteAccountDialog", () => ({
-  default: ({ open }) =>
-    open ? <div data-testid="delete-account-dialog" /> : null,
 }));
 
 vi.mock("@/hooks/useToast", () => ({
@@ -22,11 +16,7 @@ vi.mock("@/hooks/useAuth", () => ({
   useAuth: vi.fn(),
 }));
 
-import {
-  updateProfile,
-  uploadProfilePhoto,
-  removeProfilePhoto,
-} from "@/services/userService";
+import { updateProfile, uploadProfilePhoto, removeProfilePhoto } from "@/services/userService";
 import { useToast } from "@/hooks/useToast";
 import { useAuth } from "@/hooks/useAuth";
 import EditProfileForm from "../EditProfileForm";
@@ -537,23 +527,4 @@ describe("EditProfileForm", () => {
     });
   });
 
-  describe("danger zone — delete account", () => {
-    it("renders a de-emphasised 'Delete account' trigger in a Danger zone section", () => {
-      renderForm();
-      expect(screen.getByRole("heading", { name: /danger zone/i })).toBeInTheDocument();
-      const trigger = screen.getByRole("button", { name: /^delete account$/i });
-      expect(trigger).toBeInTheDocument();
-      expect(trigger).toHaveAttribute("type", "button");
-    });
-
-    it("opens the DeleteAccountDialog when the trigger is clicked", async () => {
-      const user = userEvent.setup();
-      renderForm();
-      expect(screen.queryByTestId("delete-account-dialog")).not.toBeInTheDocument();
-
-      await user.click(screen.getByRole("button", { name: /^delete account$/i }));
-
-      expect(screen.getByTestId("delete-account-dialog")).toBeInTheDocument();
-    });
-  });
 });

--- a/frontend/src/pages/ProfilePage.jsx
+++ b/frontend/src/pages/ProfilePage.jsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useCallback } from "react";
 import { Link, useParams } from "react-router-dom";
-import { User, BookOpen, CalendarDays, MapPin, Star, Pencil, Lock, Loader2, Bell } from "lucide-react";
+import { User, BookOpen, CalendarDays, MapPin, Star, Pencil, Lock, Loader2, Bell, KeyRound, Trash2 } from "lucide-react";
 
 import { SkeletonPage } from "@/components/ui/loading-skeleton";
 import { ErrorState } from "@/components/ui/error-state";
@@ -11,6 +11,7 @@ import StructuredData from "@/components/StructuredData/StructuredData";
 import FollowButton from "@/components/Follow/FollowButton";
 import FollowListSheet from "@/components/Follow/FollowListSheet";
 import EditProfileForm from "@/components/Profile/EditProfileForm";
+import DeleteAccountDialog from "@/components/Profile/DeleteAccountDialog";
 import SavedStoriesTab from "@/components/Profile/SavedStoriesTab";
 import PublishedStoriesTab from "@/components/Profile/PublishedStoriesTab";
 import BadgeGrid from "@/components/Profile/BadgeGrid";
@@ -52,6 +53,7 @@ function ProfilePage() {
   const [listSheet, setListSheet] = useState({ open: false, mode: "followers" });
   const [editMode, setEditMode] = useState(false);
   const [ownProfileData, setOwnProfileData] = useState(null);
+  const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
 
   const fetchProfile = useCallback(async () => {
     if (!targetUserId) return;
@@ -269,7 +271,7 @@ function ProfilePage() {
                   })()}
                 </div>
               </div>
-              <div className="flex shrink-0 gap-2">
+              <div className="flex shrink-0 flex-wrap gap-2">
                 {isOwnProfile && (
                   <>
                     <Button variant="outline" size="sm" asChild>
@@ -285,6 +287,20 @@ function ProfilePage() {
                     >
                       <Pencil className="h-4 w-4" />
                       Edit Profile
+                    </Button>
+                    <Button variant="outline" size="sm" asChild>
+                      <Link to="/forgot-password">
+                        <KeyRound className="h-4 w-4" />
+                        Reset Password
+                      </Link>
+                    </Button>
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      onClick={() => setDeleteDialogOpen(true)}
+                    >
+                      <Trash2 className="h-4 w-4" />
+                      Delete Profile
                     </Button>
                   </>
                 )}
@@ -354,6 +370,13 @@ function ProfilePage() {
             setListSheet((s) => ({ ...s, open }))
           }
         />
+
+        {isOwnProfile && (
+          <DeleteAccountDialog
+            open={deleteDialogOpen}
+            onOpenChange={setDeleteDialogOpen}
+          />
+        )}
       </div>
     </main>
   );

--- a/frontend/src/pages/ProfilePage.jsx
+++ b/frontend/src/pages/ProfilePage.jsx
@@ -295,7 +295,7 @@ function ProfilePage() {
                       </Link>
                     </Button>
                     <Button
-                      variant="outline"
+                      variant="destructive"
                       size="sm"
                       onClick={() => setDeleteDialogOpen(true)}
                     >

--- a/frontend/src/pages/__tests__/ProfilePage.test.jsx
+++ b/frontend/src/pages/__tests__/ProfilePage.test.jsx
@@ -48,6 +48,15 @@ vi.mock("@/components/Profile/EditProfileForm", () => ({
   ),
 }));
 
+vi.mock("@/components/Profile/DeleteAccountDialog", () => ({
+  default: ({ open, onOpenChange }) =>
+    open ? (
+      <div data-testid="delete-account-dialog">
+        <button type="button" onClick={() => onOpenChange(false)}>mock-close-delete</button>
+      </div>
+    ) : null,
+}));
+
 vi.mock("@/components/Profile/SavedStoriesTab", () => ({
   default: ({ userId }) => (
     <div data-testid="saved-stories-tab" data-user-id={userId} />
@@ -414,6 +423,70 @@ describe("ProfilePage", () => {
         expect(screen.queryByTestId("edit-profile-form")).not.toBeInTheDocument()
       );
       expect(getProfile).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("delete profile", () => {
+    it("shows Delete Profile button on own profile", async () => {
+      useAuth.mockReturnValue({ user: { id: 1 }, isAuthenticated: true });
+      getProfile.mockResolvedValue(mockProfileData);
+      renderPage();
+
+      const btn = await screen.findByRole("button", { name: /Delete Profile/i });
+      expect(btn).toBeInTheDocument();
+    });
+
+    it("does NOT show Delete Profile button on another user's profile", async () => {
+      useAuth.mockReturnValue({ user: { id: 99 }, isAuthenticated: true });
+      getProfile.mockResolvedValue(mockProfileData);
+      renderPage();
+
+      await waitFor(() => expect(screen.getByText("historian")).toBeInTheDocument());
+      expect(screen.queryByRole("button", { name: /Delete Profile/i })).not.toBeInTheDocument();
+    });
+
+    it("opens DeleteAccountDialog when Delete Profile button is clicked", async () => {
+      const user = userEvent.setup();
+      useAuth.mockReturnValue({ user: { id: 1 }, isAuthenticated: true });
+      getProfile.mockResolvedValue(mockProfileData);
+      renderPage();
+
+      await user.click(await screen.findByRole("button", { name: /Delete Profile/i }));
+
+      expect(screen.getByTestId("delete-account-dialog")).toBeInTheDocument();
+    });
+
+    it("closes DeleteAccountDialog when onOpenChange(false) is called", async () => {
+      const user = userEvent.setup();
+      useAuth.mockReturnValue({ user: { id: 1 }, isAuthenticated: true });
+      getProfile.mockResolvedValue(mockProfileData);
+      renderPage();
+
+      await user.click(await screen.findByRole("button", { name: /Delete Profile/i }));
+      await user.click(screen.getByRole("button", { name: /mock-close-delete/i }));
+
+      expect(screen.queryByTestId("delete-account-dialog")).not.toBeInTheDocument();
+    });
+  });
+
+  describe("reset password", () => {
+    it("shows Reset Password link on own profile", async () => {
+      useAuth.mockReturnValue({ user: { id: 1 }, isAuthenticated: true });
+      getProfile.mockResolvedValue(mockProfileData);
+      renderPage();
+
+      const link = await screen.findByRole("link", { name: /Reset Password/i });
+      expect(link).toBeInTheDocument();
+      expect(link).toHaveAttribute("href", "/forgot-password");
+    });
+
+    it("does NOT show Reset Password link on another user's profile", async () => {
+      useAuth.mockReturnValue({ user: { id: 99 }, isAuthenticated: true });
+      getProfile.mockResolvedValue(mockProfileData);
+      renderPage();
+
+      await waitFor(() => expect(screen.getByText("historian")).toBeInTheDocument());
+      expect(screen.queryByRole("link", { name: /Reset Password/i })).not.toBeInTheDocument();
     });
   });
 

--- a/frontend/src/pages/__tests__/ProfilePage.test.jsx
+++ b/frontend/src/pages/__tests__/ProfilePage.test.jsx
@@ -409,6 +409,21 @@ describe("ProfilePage", () => {
       expect(getOwnProfile).toHaveBeenCalledTimes(2);
     });
 
+    it("hides action buttons while in edit mode", async () => {
+      const user = userEvent.setup();
+      useAuth.mockReturnValue({ user: { id: 1 }, isAuthenticated: true });
+      getProfile.mockResolvedValue(mockProfileData);
+      getOwnProfile.mockResolvedValue({ profile: {} });
+      renderPage();
+
+      await user.click(await screen.findByRole("button", { name: /Edit Profile/i }));
+
+      expect(screen.queryByRole("button", { name: /Edit Profile/i })).not.toBeInTheDocument();
+      expect(screen.queryByRole("button", { name: /Delete Profile/i })).not.toBeInTheDocument();
+      expect(screen.queryByRole("link", { name: /Reset Password/i })).not.toBeInTheDocument();
+      expect(screen.queryByRole("link", { name: /Notifications/i })).not.toBeInTheDocument();
+    });
+
     it("hides EditProfileForm without re-fetching when onCancel is called", async () => {
       const user = userEvent.setup();
       useAuth.mockReturnValue({ user: { id: 1 }, isAuthenticated: true });


### PR DESCRIPTION
…-password error handling

# 📝 Description
Fixes #637 

Fixes critical bugs in the Delete Profile workflow and restructures account management actions to match mobile UX. When a user entered an incorrect password during account deletion, the modal closed and a misleading "Profile updated successfully" toast appeared. This was caused by the DeleteAccountDialog being nested inside the EditProfileForm, creating an implicit coupling between the two forms. Moving the dialog to ProfilePage decouples them entirely. Error messaging for wrong-password and success responses has also been corrected.

###  New features

  - Delete Profile button added directly to ProfilePage (visible only on own profile), replacing the one hidden in the Edit Profile form's danger zone
  - Reset Password button added to ProfilePage (visible only on own profile), linking to /forgot-password

###  Modified files

  - src/components/Profile/DeleteAccountDialog.jsx — success toast changed to "Account deleted successfully."; wrong-password detection now triggers on any HTTP 400, suppressing the raw Axios error message
  - src/components/Profile/EditProfileForm.jsx — removed "Danger zone" section (Delete account button and DeleteAccountDialog)
  - src/pages/ProfilePage.jsx — added Delete Profile button, Reset Password link, deleteDialogOpen state, and DeleteAccountDialog mount at page level
  - src/components/Profile/__tests__/DeleteAccountDialog.test.jsx — updated toast assertion; updated wrong-password error text assertions; added regression test for 400 with no password array in body
  - src/components/Profile/__tests__/EditProfileForm.test.jsx — removed danger zone tests and unused mocks
  - src/pages/__tests__/ProfilePage.test.jsx — added DeleteAccountDialog mock; added 6 new tests for Delete Profile and Reset Password buttons

 ### Tests

  - All 1136 existing tests pass
  - New: Delete Profile button shows/hides on own vs. other profile
  - New: clicking Delete Profile opens DeleteAccountDialog; closing it works correctly
  - New: Reset Password link shows/hides on own vs. other profile and points to /forgot-password
  - New: 400 response with no password array in body now shows "Wrong password, please try again." instead of raw Axios message

# 📊 Type of Change
- [x]  Bug fix
- [ ]  New feature
- [ ]  Refactoring
- [ ]  Documentation
 
# ✅ Acceptance Criteria / Checklist
- [x] Project builds successfully
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, especially in hard-to-understand parts
- [x] I have performed a self-review of my code
- [x] I have added/updated tests
- [x] New and existing unit tests pass locally with my changes

# 📸 Screenshots / Recordings
<!-- If applicable !-->
# ⏱️ Estimated Review Time
- [x] < 5 min
- [ ] 5-15 min
- [ ] > 15 min
