### PR TITLE
Feat/swagger UI api documentation

### DIFF
--- a/backend/apps/gamification/views.py
+++ b/backend/apps/gamification/views.py
@@ -1,5 +1,6 @@
 from django.http import Http404
 
+from drf_spectacular.utils import extend_schema
 from rest_framework.permissions import AllowAny
 from rest_framework.response import Response
 from rest_framework.views import APIView
@@ -26,6 +27,10 @@ class UserPointsView(APIView):
 
     permission_classes = [AllowAny]
 
+    @extend_schema(
+        description='Public. No authentication required.',
+        responses={200: PointSummarySerializer},
+    )
     def get(self, request, user_id):
         data = get_user_points(user_id)
         return Response(PointSummarySerializer(data).data)
@@ -36,6 +41,10 @@ class UserBadgesView(APIView):
 
     permission_classes = [AllowAny]
 
+    @extend_schema(
+        description='Public. No authentication required.',
+        responses={200: UserBadgeSerializer(many=True)},
+    )
     def get(self, request, user_id):
         qs = get_user_badges(user_id)
         paginator = StoryPagination()
@@ -54,6 +63,10 @@ class UserPointHistoryView(APIView):
 
     permission_classes = [IsOwnerOrAdmin]
 
+    @extend_schema(
+        description='Requires authentication (account owner or admin). Point breakdowns are private.',
+        responses={200: PointTransactionSerializer(many=True)},
+    )
     def get(self, request, user_id):
         try:
             target_user = User.objects.get(pk=user_id, is_active=True)
@@ -71,6 +84,10 @@ class BadgeCatalogView(APIView):
 
     permission_classes = [AllowAny]
 
+    @extend_schema(
+        description='Public. No authentication required.',
+        responses={200: BadgeCatalogSerializer(many=True)},
+    )
     def get(self, request):
         qs = get_badge_catalog()
         paginator = StoryPagination()

--- a/backend/apps/geocoding/views.py
+++ b/backend/apps/geocoding/views.py
@@ -1,4 +1,5 @@
 from django.http import JsonResponse
+from drf_spectacular.utils import OpenApiParameter, extend_schema
 from rest_framework.permissions import AllowAny
 from rest_framework.response import Response
 from rest_framework.views import APIView
@@ -11,6 +12,11 @@ class GeocodeView(APIView):
 
     permission_classes = [AllowAny]
 
+    @extend_schema(
+        parameters=[
+            OpenApiParameter('q', str, required=True, description='Place name to resolve to a bounding box via Nominatim'),
+        ]
+    )
     def get(self, request):
         q = request.query_params.get('q', '')
         result = services.geocode_search(q)
@@ -23,6 +29,11 @@ class SuggestionsView(APIView):
 
     permission_classes = [AllowAny]
 
+    @extend_schema(
+        parameters=[
+            OpenApiParameter('q', str, required=True, description='Partial place name for autocomplete suggestions'),
+        ]
+    )
     def get(self, request):
         q = request.query_params.get('q', '')
         result = services.geocode_suggestions(q)
@@ -34,6 +45,12 @@ class ReverseView(APIView):
 
     permission_classes = [AllowAny]
 
+    @extend_schema(
+        parameters=[
+            OpenApiParameter('lat', float, required=True, description='WGS-84 latitude'),
+            OpenApiParameter('lng', float, required=True, description='WGS-84 longitude'),
+        ]
+    )
     def get(self, request):
         lat = request.query_params.get('lat')
         lng = request.query_params.get('lng')

--- a/backend/apps/interactions/admin_views.py
+++ b/backend/apps/interactions/admin_views.py
@@ -1,4 +1,5 @@
 from django.shortcuts import get_object_or_404
+from drf_spectacular.utils import extend_schema
 from rest_framework import status
 from rest_framework.response import Response
 from rest_framework.views import APIView
@@ -13,6 +14,10 @@ class AdminCommentRemovalView(APIView):
 
     permission_classes = [IsAdminUser]
 
+    @extend_schema(
+        description='Requires admin privileges. Hard-deletes the comment.',
+        responses={204: None},
+    )
     def delete(self, request, pk):
         comment = get_object_or_404(Comment, pk=pk)
         delete_comment(comment)

--- a/backend/apps/interactions/views.py
+++ b/backend/apps/interactions/views.py
@@ -1,4 +1,6 @@
 from django.shortcuts import get_object_or_404
+from drf_spectacular.utils import extend_schema, inline_serializer
+from rest_framework import fields as drf_fields
 from rest_framework import status
 from rest_framework.permissions import AllowAny
 from rest_framework.response import Response
@@ -25,6 +27,14 @@ from common.pagination import StoryPagination
 from common.permissions import IsRegisteredUser
 
 
+def _error_response():
+    return inline_serializer('InteractionValidationError', {
+        'success': drf_fields.BooleanField(),
+        'message': drf_fields.CharField(),
+        'errors': drf_fields.DictField(),
+    })
+
+
 class StoryCommentListCreateView(APIView):
     """
     GET  /stories/<story_id>/comments/ — list comments for a published story (public).
@@ -36,6 +46,10 @@ class StoryCommentListCreateView(APIView):
             return [IsRegisteredUser()]
         return [AllowAny()]
 
+    @extend_schema(
+        description='Public. No authentication required.',
+        responses={200: CommentResponseSerializer(many=True)},
+    )
     def get(self, request, story_id):
         qs = get_story_comments(story_id)
         paginator = StoryPagination()
@@ -43,6 +57,17 @@ class StoryCommentListCreateView(APIView):
         serializer = CommentResponseSerializer(page, many=True, context={'request': request})
         return paginator.get_paginated_response(serializer.data)
 
+    @extend_schema(
+        description='Requires authentication (registered user).',
+        request={'application/json': CommentCreateSerializer},
+        responses={
+            201: inline_serializer('CommentCreateResponse', {
+                'message': drf_fields.CharField(),
+                'comment': CommentResponseSerializer(),
+            }),
+            400: _error_response(),
+        },
+    )
     def post(self, request, story_id):
         serializer = CommentCreateSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)
@@ -62,6 +87,10 @@ class CommentDeleteView(APIView):
     # has_permission enforces authentication; has_object_permission enforces ownership.
     permission_classes = [IsCommentAuthorOrAdmin]
 
+    @extend_schema(
+        description='Requires authentication (comment author or admin).',
+        responses={204: None, 403: _error_response(), 404: _error_response()},
+    )
     def delete(self, request, comment_id):
         comment = get_object_or_404(Comment, pk=comment_id)
         self.check_object_permissions(request, comment)
@@ -78,6 +107,16 @@ class StoryLikeView(APIView):
 
     permission_classes = [IsRegisteredUser]
 
+    @extend_schema(
+        description='Requires authentication (registered user). No request body needed.',
+        request=None,
+        responses={
+            201: inline_serializer('LikeCreateResponse', {
+                'message': drf_fields.CharField(),
+                'like': LikeResponseSerializer(),
+            }),
+        },
+    )
     def post(self, request, story_id):
         like = add_like(request.user, story_id)
         return Response(
@@ -88,6 +127,10 @@ class StoryLikeView(APIView):
             status=status.HTTP_201_CREATED,
         )
 
+    @extend_schema(
+        description='Requires authentication (registered user).',
+        responses={204: None},
+    )
     def delete(self, request, story_id):
         remove_like(request.user, story_id)
         return Response(status=status.HTTP_204_NO_CONTENT)
@@ -105,6 +148,16 @@ class StoryBookmarkView(APIView):
 
     permission_classes = [IsRegisteredUser]
 
+    @extend_schema(
+        description='Requires authentication (registered user). No request body needed. Idempotent: returns 200 if already bookmarked.',
+        request=None,
+        responses={
+            201: inline_serializer('BookmarkCreateResponse', {
+                'message': drf_fields.CharField(),
+                'bookmark': BookmarkResponseSerializer(),
+            }),
+        },
+    )
     def post(self, request, story_id):
         bookmark, created = add_bookmark(request.user, story_id)
         http_status = status.HTTP_201_CREATED if created else status.HTTP_200_OK
@@ -116,6 +169,10 @@ class StoryBookmarkView(APIView):
             status=http_status,
         )
 
+    @extend_schema(
+        description='Requires authentication (registered user). Always returns 204 regardless of prior state.',
+        responses={204: None},
+    )
     def delete(self, request, story_id):
         remove_bookmark(request.user, story_id)
         return Response(status=status.HTTP_204_NO_CONTENT)

--- a/backend/apps/media/views.py
+++ b/backend/apps/media/views.py
@@ -1,4 +1,6 @@
 from django.shortcuts import get_object_or_404
+from drf_spectacular.utils import extend_schema, inline_serializer
+from rest_framework import fields as drf_fields
 from rest_framework import status
 from rest_framework.response import Response
 from rest_framework.views import APIView
@@ -9,12 +11,31 @@ from apps.stories.models import Story
 from common.permissions import IsOwnerOrAdmin
 
 
+def _error_response():
+    return inline_serializer('MediaValidationError', {
+        'success': drf_fields.BooleanField(),
+        'message': drf_fields.CharField(),
+        'errors': drf_fields.DictField(),
+    })
+
+
 class StoryImageUploadView(APIView):
     """POST /stories/<story_id>/images/ — upload an image to a story (owner only)."""
 
     # has_permission enforces authentication; has_object_permission enforces ownership.
     permission_classes = [IsOwnerOrAdmin]
 
+    @extend_schema(
+        # Image upload — must use multipart/form-data, not JSON
+        request={'multipart/form-data': ImageUploadSerializer},
+        responses={
+            201: inline_serializer('ImageUploadResponse', {
+                'message': drf_fields.CharField(),
+                'image': MediaItemResponseSerializer(),
+            }),
+            400: _error_response(),
+        },
+    )
     def post(self, request, story_id):
         # Fetch the story; removed stories are treated as non-existent.
         story = get_object_or_404(
@@ -42,6 +63,17 @@ class StoryMediaUploadView(APIView):
 
     permission_classes = [IsOwnerOrAdmin]
 
+    @extend_schema(
+        # Audio/video upload — must use multipart/form-data, not JSON
+        request={'multipart/form-data': MediaFileUploadSerializer},
+        responses={
+            201: inline_serializer('MediaUploadResponse', {
+                'message': drf_fields.CharField(),
+                'media': MediaItemResponseSerializer(),
+            }),
+            400: _error_response(),
+        },
+    )
     def post(self, request, story_id):
         story = get_object_or_404(
             Story.objects.exclude(status=Story.STATUS_REMOVED),

--- a/backend/apps/notifications/views.py
+++ b/backend/apps/notifications/views.py
@@ -1,4 +1,6 @@
 from django.shortcuts import get_object_or_404
+from drf_spectacular.utils import extend_schema, inline_serializer
+from rest_framework import fields as drf_fields
 from rest_framework import status
 from rest_framework.response import Response
 from rest_framework.views import APIView
@@ -20,6 +22,14 @@ from apps.notifications.services import (
 from common.permissions import IsRegisteredUser
 
 
+def _error_response():
+    return inline_serializer('NotificationValidationError', {
+        'success': drf_fields.BooleanField(),
+        'message': drf_fields.CharField(),
+        'errors': drf_fields.DictField(),
+    })
+
+
 class NotificationListView(APIView):
     """
     GET    /notifications/ — return the authenticated user's full notification inbox.
@@ -28,11 +38,21 @@ class NotificationListView(APIView):
 
     permission_classes = [IsRegisteredUser]
 
+    @extend_schema(
+        description='Requires authentication (registered user). Returns the user\'s full notification inbox.',
+        responses={200: inline_serializer('NotificationListResponse', {
+            'notifications': NotificationSerializer(many=True),
+        })},
+    )
     def get(self, request):
         notifications = get_notifications(request.user)
         serializer = NotificationSerializer(notifications, many=True)
         return Response({'notifications': serializer.data})
 
+    @extend_schema(
+        description='Requires authentication (registered user). Clears all notifications.',
+        responses={204: None},
+    )
     def delete(self, request):
         delete_all_notifications(request.user)
         return Response(status=status.HTTP_204_NO_CONTENT)
@@ -43,6 +63,11 @@ class NotificationMarkReadView(APIView):
 
     permission_classes = [IsRegisteredUser]
 
+    @extend_schema(
+        description='Requires authentication (registered user). Toggles is_read flag.',
+        request={'application/json': MarkReadSerializer},
+        responses={200: NotificationSerializer, 400: _error_response(), 404: _error_response()},
+    )
     def patch(self, request, pk):
         notification = get_object_or_404(Notification, pk=pk, recipient=request.user)
         serializer = MarkReadSerializer(data=request.data)
@@ -56,10 +81,21 @@ class NotificationDetailView(APIView):
 
     permission_classes = [IsRegisteredUser]
 
+    @extend_schema(
+        description='Requires authentication (registered user). Deletes the notification.',
+        responses={204: None, 404: _error_response()},
+    )
     def delete(self, request, pk):
         notification = get_object_or_404(Notification, pk=pk, recipient=request.user)
         delete_notification(notification)
         return Response(status=status.HTTP_204_NO_CONTENT)
+
+
+# Reusable schema for preference response so GET and PATCH share the same shape.
+_PREFERENCE_RESPONSE = inline_serializer('NotificationPreferenceResponse', {
+    'notifications_muted': drf_fields.BooleanField(),
+    'preferences': drf_fields.DictField(),
+})
 
 
 class NotificationPreferenceView(APIView):
@@ -76,9 +112,18 @@ class NotificationPreferenceView(APIView):
             'preferences': get_all_preferences(user),
         })
 
+    @extend_schema(
+        description='Requires authentication (registered user). Returns the full notification preference state.',
+        responses={200: _PREFERENCE_RESPONSE},
+    )
     def get(self, request):
         return self._preference_response(request.user)
 
+    @extend_schema(
+        description='Requires authentication (registered user). Updates global mute and/or per-type toggles.',
+        request={'application/json': NotificationPreferencePatchSerializer},
+        responses={200: _PREFERENCE_RESPONSE, 400: _error_response()},
+    )
     def patch(self, request):
         serializer = NotificationPreferencePatchSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)

--- a/backend/apps/reports/admin_views.py
+++ b/backend/apps/reports/admin_views.py
@@ -1,3 +1,5 @@
+from drf_spectacular.utils import OpenApiParameter, extend_schema, extend_schema_view, inline_serializer
+from rest_framework import fields as drf_fields
 from rest_framework import status
 from rest_framework.generics import ListAPIView
 from rest_framework.response import Response
@@ -6,17 +8,33 @@ from rest_framework.views import APIView
 from common.pagination import StoryPagination
 from common.permissions import IsAdminUser
 from apps.reports.models import ReportStatus
-from apps.reports.serializers import ReportListSerializer, ReportResolveSerializer
+from apps.reports.serializers import ReportSerializer, ReportResolveSerializer
 from apps.reports.services import list_reports, resolve_report
 
 _VALID_STATUSES = {s.value for s in ReportStatus}
 
 
+def _error_response():
+    return inline_serializer('ReportModerationValidationError', {
+        'success': drf_fields.BooleanField(),
+        'message': drf_fields.CharField(),
+        'errors': drf_fields.DictField(),
+    })
+
+
+@extend_schema_view(
+    get=extend_schema(
+        description='Requires admin privileges. Returns a paginated list of all reports.',
+        parameters=[
+            OpenApiParameter('status', str, description='Filter by report status (e.g. pending, resolved)'),
+        ],
+    ),
+)
 class AdminReportListView(ListAPIView):
     """Return a paginated list of all reports, optionally filtered by status."""
 
     permission_classes = [IsAdminUser]
-    serializer_class = ReportListSerializer
+    serializer_class = ReportSerializer
     pagination_class = StoryPagination
 
     def get_queryset(self):
@@ -32,6 +50,11 @@ class AdminReportResolveView(APIView):
 
     permission_classes = [IsAdminUser]
 
+    @extend_schema(
+        description='Requires admin privileges. Marks the report as resolved with an optional note.',
+        request={'application/json': ReportResolveSerializer},
+        responses={200: ReportSerializer, 400: _error_response(), 404: _error_response()},
+    )
     def patch(self, request, pk):
         serializer = ReportResolveSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)
@@ -40,4 +63,4 @@ class AdminReportResolveView(APIView):
             admin_user=request.user,
             resolution_note=serializer.validated_data['resolution_note'],
         )
-        return Response(ReportListSerializer(report).data, status=status.HTTP_200_OK)
+        return Response(ReportSerializer(report).data, status=status.HTTP_200_OK)

--- a/backend/apps/reports/serializers.py
+++ b/backend/apps/reports/serializers.py
@@ -47,7 +47,7 @@ class _UserSummarySerializer(serializers.Serializer):
     username = serializers.CharField()
 
 
-class ReportListSerializer(serializers.ModelSerializer):
+class ReportSerializer(serializers.ModelSerializer):
     """Read-only serializer for the admin report list and resolve response."""
 
     reporter = _UserSummarySerializer(read_only=True)

--- a/backend/apps/reports/tests/test_serializers.py
+++ b/backend/apps/reports/tests/test_serializers.py
@@ -10,7 +10,7 @@ from apps.interactions.models import Comment
 from apps.reports.models import Report, ReportReason, ReportStatus
 from apps.reports.serializers import (
     ReportCreateSerializer,
-    ReportListSerializer,
+    ReportSerializer,
     ReportResolveSerializer,
     ReportResponseSerializer,
 )
@@ -206,10 +206,10 @@ class TestReportResponseSerializer:
         assert data['status'] == ReportStatus.PENDING
 
 
-# ── ReportListSerializer ──────────────────────────────────────────────────────
+# ── ReportSerializer ──────────────────────────────────────────────────────
 
 @pytest.mark.django_db
-class TestReportListSerializer:
+class TestReportSerializer:
 
     def setup_method(self):
         self.reporter = _make_user('reporter@example.com', 'reporter')
@@ -228,7 +228,7 @@ class TestReportListSerializer:
             story=self.story,
             reason=ReportReason.SPAM,
         )
-        data = ReportListSerializer(report).data
+        data = ReportSerializer(report).data
 
         assert data['id'] == report.pk
         assert data['target_type'] == 'story'
@@ -246,7 +246,7 @@ class TestReportListSerializer:
             comment=self.comment,
             reason=ReportReason.HARASSMENT,
         )
-        data = ReportListSerializer(report).data
+        data = ReportSerializer(report).data
 
         assert data['target_type'] == 'comment'
         assert data['target_id'] == self.comment.pk
@@ -257,7 +257,7 @@ class TestReportListSerializer:
             story=self.story,
             reason=ReportReason.OTHER,
         )
-        data = ReportListSerializer(report).data
+        data = ReportSerializer(report).data
 
         assert data['reporter'] is None
 
@@ -270,7 +270,7 @@ class TestReportListSerializer:
             resolved_by=self.admin,
             resolved_at=timezone.now(),
         )
-        data = ReportListSerializer(report).data
+        data = ReportSerializer(report).data
 
         assert data['resolved_by']['email'] == self.admin.email
         assert data['resolved_by']['username'] == self.admin.username
@@ -281,7 +281,7 @@ class TestReportListSerializer:
             story=self.story,
             reason=ReportReason.SPAM,
         )
-        data = ReportListSerializer(report).data
+        data = ReportSerializer(report).data
 
         assert data['resolved_by'] is None
 

--- a/backend/apps/reports/views.py
+++ b/backend/apps/reports/views.py
@@ -1,3 +1,5 @@
+from drf_spectacular.utils import extend_schema, inline_serializer
+from rest_framework import fields as drf_fields
 from rest_framework import status
 from rest_framework.response import Response
 from rest_framework.views import APIView
@@ -7,11 +9,24 @@ from apps.reports.services import submit_report
 from common.permissions import IsRegisteredUser
 
 
+def _error_response():
+    return inline_serializer('ReportValidationError', {
+        'success': drf_fields.BooleanField(),
+        'message': drf_fields.CharField(),
+        'errors': drf_fields.DictField(),
+    })
+
+
 class ReportCreateView(APIView):
     """POST /reports/ — submit a report on a story or comment."""
 
     permission_classes = [IsRegisteredUser]
 
+    @extend_schema(
+        description='Requires authentication (registered user). Submit a report on a story or comment.',
+        request={'application/json': ReportCreateSerializer},
+        responses={201: ReportResponseSerializer, 400: _error_response()},
+    )
     def post(self, request):
         serializer = ReportCreateSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)

--- a/backend/apps/stories/admin_views.py
+++ b/backend/apps/stories/admin_views.py
@@ -1,4 +1,6 @@
 from django.shortcuts import get_object_or_404
+from drf_spectacular.utils import extend_schema, inline_serializer
+from rest_framework import fields as drf_fields
 from rest_framework import serializers, status
 from rest_framework.response import Response
 from rest_framework.views import APIView
@@ -12,11 +14,24 @@ class _ModerationReasonSerializer(serializers.Serializer):
     moderation_reason = serializers.CharField(min_length=1)
 
 
+def _error_response():
+    return inline_serializer('StoryModerationValidationError', {
+        'success': drf_fields.BooleanField(),
+        'message': drf_fields.CharField(),
+        'errors': drf_fields.DictField(),
+    })
+
+
 class AdminStoryRemovalView(APIView):
     """DELETE /moderation/stories/{id}/ — soft-remove a story (admin only)."""
 
     permission_classes = [IsAdminUser]
 
+    @extend_schema(
+        description='Requires admin privileges. Soft-removes the story with a moderation reason.',
+        request={'application/json': _ModerationReasonSerializer},
+        responses={204: None, 400: _error_response(), 404: _error_response()},
+    )
     def delete(self, request, pk):
         serializer = _ModerationReasonSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)

--- a/backend/apps/stories/views.py
+++ b/backend/apps/stories/views.py
@@ -1,3 +1,4 @@
+from drf_spectacular.utils import OpenApiParameter, extend_schema
 from rest_framework import generics
 from rest_framework.permissions import AllowAny, IsAuthenticated
 from rest_framework.response import Response
@@ -52,7 +53,23 @@ class StoryFeedView(APIView):
     
     
 
-    #storyfeedview
+    @extend_schema(
+        parameters=[
+            OpenApiParameter('sort_by', str, description="'recent' (default) or 'popular'"),
+            OpenApiParameter('year_from', int, description='Include stories from this year onwards'),
+            OpenApiParameter('year_to', int, description='Include stories up to and including this year'),
+            OpenApiParameter('location', str, description='Case-insensitive substring match on location_name'),
+            OpenApiParameter('tags', str, many=True, description='AND tag filter; repeat for each tag'),
+            OpenApiParameter('latitude', float, description='WGS-84 latitude of the user\'s position'),
+            OpenApiParameter('longitude', float, description='WGS-84 longitude of the user\'s position'),
+            OpenApiParameter('radius_km', float, description='Filter radius in kilometres (requires latitude + longitude)'),
+            OpenApiParameter('lat_min', float, description='Bounding box south edge'),
+            OpenApiParameter('lat_max', float, description='Bounding box north edge'),
+            OpenApiParameter('lng_min', float, description='Bounding box west edge'),
+            OpenApiParameter('lng_max', float, description='Bounding box east edge'),
+        ],
+        responses=StoryFeedSerializer(many=True),
+    )
     def get(self, request):
         query_serializer = FeedQuerySerializer(data=request.query_params)
         query_serializer.is_valid(raise_exception=True)
@@ -106,6 +123,22 @@ class StoryMapView(APIView):
 
     permission_classes = [AllowAny]
 
+    @extend_schema(
+        parameters=[
+            OpenApiParameter('year_from', int, description='Include stories from this year onwards'),
+            OpenApiParameter('year_to', int, description='Include stories up to and including this year'),
+            OpenApiParameter('location', str, description='Case-insensitive substring match on location_name'),
+            OpenApiParameter('tags', str, many=True, description='AND tag filter; repeat for each tag'),
+            OpenApiParameter('latitude', float, description='WGS-84 latitude of the user\'s position'),
+            OpenApiParameter('longitude', float, description='WGS-84 longitude of the user\'s position'),
+            OpenApiParameter('radius_km', float, description='Filter radius in kilometres (requires latitude + longitude)'),
+            OpenApiParameter('lat_min', float, description='Bounding box south edge'),
+            OpenApiParameter('lat_max', float, description='Bounding box north edge'),
+            OpenApiParameter('lng_min', float, description='Bounding box west edge'),
+            OpenApiParameter('lng_max', float, description='Bounding box east edge'),
+        ],
+        responses=StoryMapGeoJSONSerializer(many=True),
+    )
     def get(self, request):
         query_serializer = FeedQuerySerializer(data=request.query_params)
         query_serializer.is_valid(raise_exception=True)
@@ -148,6 +181,24 @@ class StorySearchView(APIView):
 
     permission_classes = [AllowAny]
 
+    @extend_schema(
+        parameters=[
+            OpenApiParameter('q', str, required=True, description='Search query against title and location_name (min 1 char)'),
+            OpenApiParameter('sort_by', str, description="'recent' (default) or 'popular'"),
+            OpenApiParameter('year_from', int, description='Include stories from this year onwards'),
+            OpenApiParameter('year_to', int, description='Include stories up to and including this year'),
+            OpenApiParameter('location', str, description='Case-insensitive substring match on location_name'),
+            OpenApiParameter('tags', str, many=True, description='AND tag filter; repeat for each tag'),
+            OpenApiParameter('latitude', float, description='WGS-84 latitude of the user\'s position'),
+            OpenApiParameter('longitude', float, description='WGS-84 longitude of the user\'s position'),
+            OpenApiParameter('radius_km', float, description='Filter radius in kilometres (requires latitude + longitude)'),
+            OpenApiParameter('lat_min', float, description='Bounding box south edge'),
+            OpenApiParameter('lat_max', float, description='Bounding box north edge'),
+            OpenApiParameter('lng_min', float, description='Bounding box west edge'),
+            OpenApiParameter('lng_max', float, description='Bounding box east edge'),
+        ],
+        responses=StoryFeedSerializer(many=True),
+    )
     def get(self, request):
         query_serializer = SearchQuerySerializer(data=request.query_params)
         query_serializer.is_valid(raise_exception=True)
@@ -232,6 +283,22 @@ class StoryTimelineView(APIView):
 
     permission_classes = [AllowAny]
 
+    @extend_schema(
+        parameters=[
+            OpenApiParameter('year_from', int, description='Include stories whose interval starts at or after this year'),
+            OpenApiParameter('year_to', int, description='Include stories whose interval ends at or before this year'),
+            OpenApiParameter('tags', str, many=True, description='AND tag filter; repeat for each tag'),
+            OpenApiParameter('latitude', float, description='WGS-84 latitude of the user\'s position'),
+            OpenApiParameter('longitude', float, description='WGS-84 longitude of the user\'s position'),
+            OpenApiParameter('radius_km', float, description='Filter radius in kilometres (requires latitude + longitude)'),
+            OpenApiParameter('lat_min', float, description='Bounding box south edge'),
+            OpenApiParameter('lat_max', float, description='Bounding box north edge'),
+            OpenApiParameter('lng_min', float, description='Bounding box west edge'),
+            OpenApiParameter('lng_max', float, description='Bounding box east edge'),
+            OpenApiParameter('has_image', bool, description='If true, only return stories that have an image attached'),
+        ],
+        responses=StoryTimelineSerializer(many=True),
+    )
     def get(self, request):
         query_serializer = TimelineQuerySerializer(data=request.query_params)
         query_serializer.is_valid(raise_exception=True)

--- a/backend/apps/stories/views.py
+++ b/backend/apps/stories/views.py
@@ -1,4 +1,5 @@
-from drf_spectacular.utils import OpenApiParameter, extend_schema
+from drf_spectacular.utils import OpenApiParameter, extend_schema, extend_schema_view, inline_serializer
+from rest_framework import fields as drf_fields
 from rest_framework import generics
 from rest_framework.permissions import AllowAny, IsAuthenticated
 from rest_framework.response import Response
@@ -69,6 +70,7 @@ class StoryFeedView(APIView):
             OpenApiParameter('lng_max', float, description='Bounding box east edge'),
         ],
         responses=StoryFeedSerializer(many=True),
+        description="Public. No authentication required.",
     )
     def get(self, request):
         query_serializer = FeedQuerySerializer(data=request.query_params)
@@ -137,7 +139,16 @@ class StoryMapView(APIView):
             OpenApiParameter('lng_min', float, description='Bounding box west edge'),
             OpenApiParameter('lng_max', float, description='Bounding box east edge'),
         ],
-        responses=StoryMapGeoJSONSerializer(many=True),
+        responses={
+            200: inline_serializer(
+                name='GeoJSONFeatureCollection',
+                fields={
+                    'type': drf_fields.CharField(),
+                    'features': drf_fields.ListField(child=drf_fields.DictField()),
+                },
+            )
+        },
+        description="Public. No authentication required.",
     )
     def get(self, request):
         query_serializer = FeedQuerySerializer(data=request.query_params)
@@ -198,6 +209,7 @@ class StorySearchView(APIView):
             OpenApiParameter('lng_max', float, description='Bounding box east edge'),
         ],
         responses=StoryFeedSerializer(many=True),
+        description="Public. No authentication required.",
     )
     def get(self, request):
         query_serializer = SearchQuerySerializer(data=request.query_params)
@@ -227,6 +239,13 @@ class StorySearchView(APIView):
         return paginator.get_paginated_response(serializer.data)
 
 
+@extend_schema_view(
+    list=extend_schema(description='Public. No authentication required.'),
+    create=extend_schema(
+        description='Requires authentication (registered user).',
+        request={'application/json': StorySerializer},
+    ),
+)
 class StoryListCreateView(generics.ListCreateAPIView):
     serializer_class = StorySerializer
     pagination_class = StoryPagination
@@ -245,6 +264,14 @@ class StoryListCreateView(generics.ListCreateAPIView):
         serializer.save(user=self.request.user)
 
 
+@extend_schema_view(
+    retrieve=extend_schema(description='Public. No authentication required.'),
+    partial_update=extend_schema(
+        description='Requires authentication (story owner or admin).',
+        request={'application/json': StoryDetailSerializer},
+    ),
+    destroy=extend_schema(description='Requires authentication (story owner or admin).'),
+)
 class StoryDetailView(generics.RetrieveUpdateDestroyAPIView):
     queryset = Story.objects.select_related('user').prefetch_related('media_items', 'tags')
     serializer_class = StoryDetailSerializer
@@ -298,6 +325,7 @@ class StoryTimelineView(APIView):
             OpenApiParameter('has_image', bool, description='If true, only return stories that have an image attached'),
         ],
         responses=StoryTimelineSerializer(many=True),
+        description="Public. No authentication required.",
     )
     def get(self, request):
         query_serializer = TimelineQuerySerializer(data=request.query_params)

--- a/backend/apps/tags/admin_views.py
+++ b/backend/apps/tags/admin_views.py
@@ -1,4 +1,5 @@
 from django.shortcuts import get_object_or_404
+from drf_spectacular.utils import extend_schema
 from rest_framework import status
 from rest_framework.response import Response
 from rest_framework.views import APIView
@@ -14,6 +15,10 @@ class AdminTagDeleteView(APIView):
 
     permission_classes = [IsAdminUser]
 
+    @extend_schema(
+        description='Requires admin privileges. Removes the tag and all story associations.',
+        responses={204: None},
+    )
     def delete(self, request, pk):
         tag = get_object_or_404(Tag, pk=pk)
         delete_tag(tag)

--- a/backend/apps/tags/views.py
+++ b/backend/apps/tags/views.py
@@ -1,3 +1,4 @@
+from drf_spectacular.utils import OpenApiParameter, extend_schema, extend_schema_view
 from rest_framework import generics, status
 from rest_framework.permissions import AllowAny
 from rest_framework.response import Response
@@ -10,11 +11,21 @@ from .serializers import TagSerializer
 from .services import create_tag, delete_tag, list_tags
 
 
+@extend_schema_view(
+    list=extend_schema(
+        description='Public. No authentication required.',
+        parameters=[
+            OpenApiParameter('is_predefined', bool, description='Filter by predefined status'),
+            OpenApiParameter('q', str, description='Search tags by name'),
+        ],
+    ),
+    create=extend_schema(
+        description='Requires authentication (registered user). Admins create predefined tags.',
+        request={'application/json': TagSerializer},
+    ),
+)
 class TagListCreateView(generics.ListCreateAPIView):
-    """
-    GET  AllowAny         — list tags; supports ?is_predefined=true/false and ?q=<search>.
-    POST IsRegisteredUser — create tag (idempotent); admin caller gets is_predefined=True.
-    """
+    """List existing tags with GET or create a new one with POST."""
 
     serializer_class = TagSerializer
 
@@ -38,8 +49,9 @@ class TagListCreateView(generics.ListCreateAPIView):
         return Response(TagSerializer(tag).data, status=code)
 
 
+@extend_schema_view(destroy=extend_schema(description='Requires admin privileges.'))
 class TagDetailView(generics.DestroyAPIView):
-    """DELETE IsAdminUser — delete tag by pk."""
+    """Delete a tag by ID."""
 
     permission_classes = [IsAdminUser]
     queryset = Tag.objects.all()

--- a/backend/apps/users/admin_views.py
+++ b/backend/apps/users/admin_views.py
@@ -1,4 +1,5 @@
 from django.shortcuts import get_object_or_404
+from drf_spectacular.utils import extend_schema
 from rest_framework import status
 from rest_framework.response import Response
 from rest_framework.views import APIView
@@ -15,6 +16,11 @@ class AdminUserBanView(APIView):
 
     permission_classes = [IsAdminUser]
 
+    @extend_schema(
+        description='Requires admin privileges. Disables the target user account.',
+        request=None,
+        responses={200: UserBanResponseSerializer},
+    )
     def patch(self, request, pk):
         target = get_object_or_404(User, pk=pk)
         banned = ban_user(target)

--- a/backend/apps/users/views.py
+++ b/backend/apps/users/views.py
@@ -1,3 +1,5 @@
+from drf_spectacular.utils import extend_schema, inline_serializer
+from rest_framework import fields as drf_fields
 from rest_framework import status
 from rest_framework.permissions import AllowAny
 from rest_framework.response import Response
@@ -49,10 +51,30 @@ from common.pagination import StoryPagination
 from common.permissions import IsRegisteredUser
 
 
+def _error_response():
+    """Standard error envelope: {success, message, errors}."""
+    return inline_serializer('ValidationError', {
+        'success': drf_fields.BooleanField(),
+        'message': drf_fields.CharField(),
+        'errors': drf_fields.DictField(),
+    })
+
+
 class RegisterView(APIView):
     # Anyone can register — no prior authentication required
     permission_classes = [AllowAny]
 
+    @extend_schema(
+        request={'application/json': RegisterSerializer},
+        responses={
+            201: inline_serializer('RegisterResponse', {
+                'message': drf_fields.CharField(),
+                'user': UserResponseSerializer(),
+                'email_sent': drf_fields.BooleanField(),
+            }),
+            400: _error_response(),
+        },
+    )
     def post(self, request):
         serializer = RegisterSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)
@@ -78,6 +100,13 @@ class VerifyEmailView(APIView):
     throttle_classes = [ScopedRateThrottle]
     throttle_scope = 'verify_email'
 
+    @extend_schema(
+        request={'application/json': VerifyEmailSerializer},
+        responses={
+            200: inline_serializer('VerifyEmailResponse', {'message': drf_fields.CharField()}),
+            400: _error_response(),
+        },
+    )
     def post(self, request):
         serializer = VerifyEmailSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)
@@ -95,6 +124,13 @@ class ResendVerificationView(APIView):
     throttle_classes = [ScopedRateThrottle]
     throttle_scope = 'verify_email'
 
+    @extend_schema(
+        request={'application/json': ResendVerificationSerializer},
+        responses={
+            200: inline_serializer('ResendVerificationResponse', {'message': drf_fields.CharField()}),
+            400: _error_response(),
+        },
+    )
     def post(self, request):
         serializer = ResendVerificationSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)
@@ -110,6 +146,17 @@ class LoginView(APIView):
     throttle_classes = [ScopedRateThrottle]
     throttle_scope = 'login'
 
+    @extend_schema(
+        request={'application/json': LoginSerializer},
+        responses={
+            200: inline_serializer('TokenResponse', {
+                'access': drf_fields.CharField(),
+                'refresh': drf_fields.CharField(),
+            }),
+            400: _error_response(),
+            401: _error_response(),
+        },
+    )
     def post(self, request):
         serializer = LoginSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)
@@ -124,6 +171,10 @@ class LogoutView(APIView):
     # Must be authenticated so anonymous requests cannot abuse the blacklist endpoint
     permission_classes = [IsRegisteredUser]
 
+    @extend_schema(
+        request={'application/json': LogoutSerializer},
+        responses={204: None, 400: _error_response()},
+    )
     def post(self, request):
         serializer = LogoutSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)
@@ -136,11 +187,16 @@ class CurrentUserView(APIView):
 
     permission_classes = [IsRegisteredUser]
 
+    @extend_schema(responses={200: CurrentUserSerializer})
     def get(self, request):
         user = get_own_profile(request.user)
         serializer = CurrentUserSerializer(user, context={'request': request})
         return Response({'success': True, 'data': serializer.data}, status=status.HTTP_200_OK)
 
+    @extend_schema(
+        request={'application/json': UpdateCurrentUserSerializer},
+        responses={200: CurrentUserSerializer, 400: _error_response()},
+    )
     def patch(self, request):
         serializer = UpdateCurrentUserSerializer(data=request.data, context={'request': request})
         serializer.is_valid(raise_exception=True)
@@ -151,6 +207,10 @@ class CurrentUserView(APIView):
             status=status.HTTP_200_OK,
         )
 
+    @extend_schema(
+        request={'application/json': DeleteAccountSerializer},
+        responses={204: None, 400: _error_response()},
+    )
     def delete(self, request):
         """Hard-deletes (default) or soft-deletes the authenticated user's account."""
         serializer = DeleteAccountSerializer(data=request.data, context={'request': request})
@@ -168,6 +228,17 @@ class ProfilePhotoView(APIView):
 
     permission_classes = [IsRegisteredUser]
 
+    @extend_schema(
+        # File upload — must use multipart/form-data, not JSON
+        request={'multipart/form-data': ProfilePhotoSerializer},
+        responses={
+            200: inline_serializer('PhotoUploadResponse', {
+                'success': drf_fields.BooleanField(),
+                'photo_url': drf_fields.CharField(),
+            }),
+            400: _error_response(),
+        },
+    )
     def post(self, request):
         serializer = ProfilePhotoSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)
@@ -177,6 +248,7 @@ class ProfilePhotoView(APIView):
             status=status.HTTP_200_OK,
         )
 
+    @extend_schema(responses={204: None})
     def delete(self, request):
         delete_profile_photo(request.user)
         return Response(status=status.HTTP_204_NO_CONTENT)
@@ -187,6 +259,7 @@ class UserPublicProfileView(APIView):
 
     permission_classes = [AllowAny]
 
+    @extend_schema(responses={200: PublicUserProfileSerializer, 404: _error_response()})
     def get(self, request, user_id):
         user = get_public_profile(user_id)
         return Response(
@@ -200,12 +273,14 @@ class FollowView(APIView):
 
     permission_classes = [IsRegisteredUser]
 
+    @extend_schema(responses={201: FollowUserSerializer, 404: _error_response()})
     def post(self, request, user_id):
         follow, created = follow_user(request.user, user_id)
         serializer = FollowUserSerializer(follow)
         http_status = status.HTTP_201_CREATED if created else status.HTTP_200_OK
         return Response({'success': True, 'data': serializer.data}, status=http_status)
 
+    @extend_schema(responses={204: None})
     def delete(self, request, user_id):
         unfollow_user(request.user, user_id)
         return Response(status=status.HTTP_204_NO_CONTENT)
@@ -216,6 +291,7 @@ class FollowerListView(APIView):
 
     permission_classes = [AllowAny]
 
+    @extend_schema(responses={200: FollowedUserSerializer(many=True)})
     def get(self, request, user_id):
         qs = get_followers(user_id)
         paginator = StoryPagination()
@@ -229,6 +305,7 @@ class FollowingListView(APIView):
 
     permission_classes = [AllowAny]
 
+    @extend_schema(responses={200: FollowedUserSerializer(many=True)})
     def get(self, request, user_id):
         qs = get_following(user_id)
         paginator = StoryPagination()
@@ -242,6 +319,7 @@ class UserBookmarksView(APIView):
 
     permission_classes = [IsRegisteredUser]
 
+    @extend_schema(responses={200: StoryFeedSerializer(many=True)})
     def get(self, request, user_id):
         qs = annotate_user_interactions(get_user_bookmarks(user_id, request.user), request.user)
         paginator = StoryPagination()
@@ -255,6 +333,7 @@ class UserStoriesView(APIView):
 
     permission_classes = [AllowAny]
 
+    @extend_schema(responses={200: StoryFeedSerializer(many=True)})
     def get(self, request, user_id):
         qs = get_user_published_stories(user_id)
         is_owner = request.user.is_authenticated and request.user.pk == user_id
@@ -275,6 +354,13 @@ class PasswordResetRequestView(APIView):
     throttle_classes = [ScopedRateThrottle]
     throttle_scope = 'password_reset'
 
+    @extend_schema(
+        request={'application/json': PasswordResetRequestSerializer},
+        responses={
+            200: inline_serializer('PasswordResetRequestResponse', {'message': drf_fields.CharField()}),
+            400: _error_response(),
+        },
+    )
     def post(self, request):
         serializer = PasswordResetRequestSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)
@@ -292,6 +378,13 @@ class PasswordResetConfirmView(APIView):
     throttle_classes = [ScopedRateThrottle]
     throttle_scope = 'password_reset'
 
+    @extend_schema(
+        request={'application/json': PasswordResetConfirmSerializer},
+        responses={
+            200: inline_serializer('PasswordResetConfirmResponse', {'message': drf_fields.CharField()}),
+            400: _error_response(),
+        },
+    )
     def post(self, request):
         serializer = PasswordResetConfirmSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)

--- a/backend/config/settings/base.py
+++ b/backend/config/settings/base.py
@@ -194,7 +194,7 @@ SIMPLE_JWT = {
 SPECTACULAR_SETTINGS = {
     'TITLE': 'Story Map API Documentation',
     'DESCRIPTION': """
-API for the Local History Story Map platform.
+API for the Story Map platform.
 
 ## How to authenticate
 

--- a/backend/config/settings/base.py
+++ b/backend/config/settings/base.py
@@ -195,4 +195,6 @@ SPECTACULAR_SETTINGS = {
     'TITLE': 'Local History Story Map API',
     'DESCRIPTION': 'API for the Local History Story Map platform.',
     'VERSION': '1.0.0',
+    'SERVE_INCLUDE_SCHEMA': False,
+    'SORT_OPERATIONS': False,
 }

--- a/backend/config/settings/base.py
+++ b/backend/config/settings/base.py
@@ -192,9 +192,28 @@ SIMPLE_JWT = {
 
 # API documentation
 SPECTACULAR_SETTINGS = {
-    'TITLE': 'Local History Story Map API',
-    'DESCRIPTION': 'API for the Local History Story Map platform.',
+    'TITLE': 'Story Map API Documentation',
+    'DESCRIPTION': """
+API for the Local History Story Map platform.
+
+## How to authenticate
+
+Some endpoints require a JWT access token. To obtain one:
+
+1. Find **POST /auth/login/** below and click **Try it out**.
+2. Enter your `email` and `password`, then click **Execute**.
+3. Copy the `access` value from the response body.
+4. Click the **Authorize** button at the top of this page.
+5. In the **Value** field paste **only the token** (do NOT type "Bearer", Swagger adds it automatically) and click **Authorize**.
+
+Access tokens expire after **15 minutes**. Use **POST /auth/token/refresh/** with your `refresh` token to get a new one.
+""",
     'VERSION': '1.0.0',
     'SERVE_INCLUDE_SCHEMA': False,
     'SORT_OPERATIONS': False,
+    'ENUM_NAME_MAPPING': {
+        'Status6b8Enum': 'StoryStatus',
+    },
+    # Global security enables Swagger UI to send the JWT token on all requests.
+    'SECURITY': [{'jwtAuth': []}],
 }

--- a/backend/config/urls.py
+++ b/backend/config/urls.py
@@ -2,8 +2,12 @@ from django.conf import settings
 from django.contrib import admin
 from django.urls import path, include
 from django.conf.urls.static import static
+from drf_spectacular.views import SpectacularAPIView, SpectacularSwaggerView, SpectacularRedocView
 
 urlpatterns = [
+    path('api/schema/', SpectacularAPIView.as_view(), name='schema'),
+    path('api/docs/', SpectacularSwaggerView.as_view(url_name='schema'), name='swagger-ui'),
+    path('api/redoc/', SpectacularRedocView.as_view(url_name='schema'), name='redoc'),
     path('admin/', admin.site.urls),
     path('auth/', include('apps.users.urls', namespace='users')),
     path('users/', include('apps.users.profile_urls')),


### PR DESCRIPTION
# 📝 Description

Fixes #641

This PR improves the backend API documentation by exposing interactive documentation pages and enriching the generated OpenAPI schema with clearer endpoint descriptions, request/response schemas, query parameters, authentication requirements, and error response formats.

Main changes:
- Added drf-spectacular Swagger UI and ReDoc routes:
  - `GET /api/schema/`
  - `GET /api/docs/`
  - `GET /api/redoc/`
- Updated `SPECTACULAR_SETTINGS` with a clearer title, authentication instructions, JWT security configuration, and enum naming improvements.
- Added `@extend_schema` / `@extend_schema_view` annotations across backend views.
- Documented complex query parameters for feed, map, search, timeline, geocoding, tags, and reports endpoints.
- Added clearer request/response schemas for authentication, users, stories, interactions, media uploads, reports, notifications, gamification, tags, and moderation endpoints.
- Improved multipart/form-data documentation for image, media, and profile photo uploads.
- Renamed `ReportListSerializer` to `ReportSerializer` since it is now used for both report listing and resolve responses.

## Notes

This PR mainly focuses on improving API discoverability and making backend endpoints easier to test from Swagger UI. It does not change the core endpoint behavior, except for the serializer naming cleanup in the reports module.

# 📊 Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactoring


# ✅ Acceptance Criteria / Checklist

- [x] Swagger UI is available at `/api/docs/`.
- [x] ReDoc is available at `/api/redoc/`.
- [x] OpenAPI schema is available at `/api/schema/`.
- [x] JWT authentication instructions are visible in the generated API documentation.
- [x] Swagger UI supports JWT authorization through the global security configuration.
- [x] Public and authenticated endpoints are clearly described.
- [x] Complex query parameters are documented for feed, map, search, timeline, geocoding, tags, and report list endpoints.
- [x] Request body schemas are documented for create/update/login/upload/report/notification endpoints.
- [x] Response schemas are documented for key endpoints.
- [x] Error response envelopes are documented where applicable.
- [x] Multipart upload endpoints are documented as `multipart/form-data`.
- [x] Existing report serializer tests were updated after renaming `ReportListSerializer` to `ReportSerializer`.
- [x] Code follows the existing project structure and style.
- [x] I have reviewed my own code before requesting review.

# 🧪 Testing

- [x] Verified that the project builds successfully.
- [x] Verified that Swagger UI can be opened from `/api/docs/`.
- [x] Verified that ReDoc can be opened from `/api/redoc/`.
- [x] Verified that `/api/schema/` generates the OpenAPI schema.
- [x] Verified that documented query parameters appear correctly in Swagger UI.
- [x] Verified that authentication-related documentation is visible in Swagger UI.
- [x] Updated affected serializer tests after the report serializer rename.

# 📸 Screenshots / Recordings

Swagger UI and ReDoc pages should be checked after deployment:

- `/api/docs/`
- `/api/redoc/`

# ⏱️ Estimated Review Time

- [ ] <5 minutes
- [x] 5–15 minutes
- [ ] >15 minutes

