### PR TITLE
Fix/ Swagger URL prefix for the production 

### DIFF
--- a/backend/config/urls.py
+++ b/backend/config/urls.py
@@ -5,9 +5,10 @@ from django.conf.urls.static import static
 from drf_spectacular.views import SpectacularAPIView, SpectacularSwaggerView, SpectacularRedocView
 
 urlpatterns = [
-    path('api/schema/', SpectacularAPIView.as_view(), name='schema'),
-    path('api/docs/', SpectacularSwaggerView.as_view(url_name='schema'), name='swagger-ui'),
-    path('api/redoc/', SpectacularRedocView.as_view(url_name='schema'), name='redoc'),
+    # No 'api/' prefix here — nginx strips it before forwarding to Django.
+    path('schema/', SpectacularAPIView.as_view(), name='schema'),
+    path('docs/', SpectacularSwaggerView.as_view(url_name='schema'), name='swagger-ui'),
+    path('redoc/', SpectacularRedocView.as_view(url_name='schema'), name='redoc'),
     path('admin/', admin.site.urls),
     path('auth/', include('apps.users.urls', namespace='users')),
     path('users/', include('apps.users.profile_urls')),


### PR DESCRIPTION
# 📝 Description

Fixes #642 

This PR fixes the production documentation URL mismatch for drf-spectacular endpoints when the application is served behind nginx.

Previously, the schema, Swagger UI, and ReDoc routes were defined in Django with an `api/` prefix:

* `api/schema/`
* `api/docs/`
* `api/redoc/`

However, in production nginx already strips `/api/` before forwarding requests to Django. Because of that, Django was receiving `/schema/`, `/docs/`, and `/redoc/`, while the URL configuration expected `/api/schema/`, `/api/docs/`, and `/api/redoc/`. This caused the live API documentation flow to break, especially when Swagger tried to fetch the schema from the wrong path. 

This PR fixes the issue by removing the extra `api/` prefix from the drf-spectacular URL patterns in `backend/config/urls.py`, so the configured routes now match the paths Django actually receives behind nginx:

* `schema/`
* `docs/`
* `redoc/`

With this change:

* production docs remain reachable through the public `/api/...` paths exposed by nginx,
* Django resolves the internal spectacular routes correctly,
* and Swagger/ReDoc can load the schema without the broken `/api/api/...` or `/api/schema/` mismatch. 

This is a small but important production hotfix, since the API documentation pages are part of the final deliverables and must work correctly in the deployed environment.

# 📊 Type of Change

*  [x] Bug fix
*  [ ] New feature
*  [ ] Refactoring
*  [ ] Documentation

# ✅ Acceptance Criteria / Checklist

* [x] Project builds successfully
* [x] My code follows the style guidelines of this project
* [x] I have commented my code, especially in hard-to-understand parts
* [x] I have performed a self-review of my code
* [ ] I have added/updated tests
* [x] New and existing unit tests pass locally with my changes




# ⏱️ Estimated Review Time

* [x] < 5 min
* [ ] 5-15 min
* [ ] > 15 min
