### PR TITLE
Feat/docker vite site url build arg

### DIFF
--- a/.env.prod.example
+++ b/.env.prod.example
@@ -9,8 +9,9 @@ DB_ROOT_PASSWORD=change-me-root
 DB_HOST=127.0.0.1
 DB_PORT=3306
 MEDIA_ROOT=/app/media
-# Passed as a Docker build arg to nginx — the React bundle will call this URL.
+# Passed as Docker build args to nginx — baked into the React bundle at build time.
 VITE_API_URL=https://yourdomain.com/api
+VITE_SITE_URL=https://yourdomain.com
 # Injected into the nginx config at container startup via envsubst.
 NGINX_HOST=yourdomain.com
 # Optional: set to your Sentry DSN to enable error tracking.
@@ -24,4 +25,5 @@ SENTRY_DSN=
 EMAIL_BACKEND=common.email_backend.ResendEmailBackend
 RESEND_API_KEY=re_your_api_key_here
 DEFAULT_FROM_EMAIL=Local History Story Map <noreply@yourdomain.com>
+# This needs to be set to a valid email address for Nominatim geocoding to work. Otherwise the requests get blocked.
 NOMINATIM_CONTACT_EMAIL=your-email@yourdomain.com

--- a/README.md
+++ b/README.md
@@ -207,6 +207,7 @@ Fill in all values. The fields that must match your domain:
 ALLOWED_HOSTS=yourdomain.com
 CORS_ALLOWED_ORIGINS=https://yourdomain.com
 VITE_API_URL=https://yourdomain.com/api
+VITE_SITE_URL=https://yourdomain.com
 NGINX_HOST=yourdomain.com
 ```
 

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -40,6 +40,7 @@ services:
       dockerfile: nginx/Dockerfile
       args:
         VITE_API_URL: ${VITE_API_URL}
+        VITE_SITE_URL: ${VITE_SITE_URL:-https://storymap.page}
     restart: unless-stopped
     ports:
       - "80:80"

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,0 +1,9 @@
+# Backend API base URL
+# Dev:  http://localhost:8000
+# Prod: https://your-api-domain.com
+VITE_API_URL=http://localhost:8000
+
+# Frontend public URL (used for constructing absolute links, e.g. email verification)
+# Dev:  http://localhost:5173
+# Prod: https://your-frontend-domain.com
+VITE_SITE_URL=http://localhost:5173

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -40,62 +40,136 @@ The dev server starts at `http://localhost:5173` by default.
 | `lint` | `eslint .` | Run ESLint on the codebase |
 | `test` | `vitest` | Run tests in watch mode |
 | `test:run` | `vitest run` | Run tests once (CI mode) |
+| `test:e2e` | `playwright test` | Run E2E tests (headless) |
+| `test:e2e:ui` | `playwright test --ui` | Run E2E tests with Playwright UI |
+| `test:e2e:debug` | `playwright test --debug` | Debug E2E tests step-by-step |
+| `test:e2e:install` | `playwright install --with-deps chromium` | Install Playwright browser (first-time setup) |
 
 ## Environment Variables
 
-Create a `.env` file in the `frontend/` directory. All custom variables must be prefixed with `VITE_`.
+Copy `frontend/.env.example` to `frontend/.env` and fill in the values. All custom variables must be prefixed with `VITE_`.
 
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `VITE_API_URL` | `http://localhost:8000` | Backend API base URL |
-| `VITE_SITE_URL` | `https://storymap.page` | Public site origin used in Schema.org JSON-LD `@id` / `url` fields. Override in staging/dev so structured data doesn't point to production. |
+| `VITE_SITE_URL` | `http://localhost:5173` | Public site origin — used in Schema.org JSON-LD `@id` / `url` fields. Set to your domain in production so structured data is correct. |
+
+## Routes
+
+| Path | Auth | Description |
+|------|------|-------------|
+| `/` | Public | Story feed |
+| `/map` | Public | Interactive map view |
+| `/timeline` | Public | Timeline view |
+| `/login` | Public | Login |
+| `/register` | Public | Registration |
+| `/verify-email` | Public | Email verification |
+| `/forgot-password` | Public | Forgot password |
+| `/reset-password/:token` | Public | Password reset |
+| `/complete-profile` | Authenticated | Post-registration profile completion |
+| `/profile` | Authenticated | Own profile |
+| `/profile/:userId` | Public | Public user profile |
+| `/submit-story` | Authenticated | Submit a new story |
+| `/stories/:id` | Public | Story detail |
+| `/tags/:slug` | Public | Stories by tag |
+| `/notifications/preferences` | Authenticated | Notification preferences |
+| `/admin` | Admin | Admin panel (reports, stories) |
 
 ## Testing
+
+### Unit tests
 
 Tests use **Vitest** with **jsdom** and **React Testing Library**.
 
 ```bash
-# Watch mode
-npm test
-
-# Single run (used in CI)
-npm run test:run
+npm test          # Watch mode
+npm run test:run  # Single run (used in CI)
 ```
 
-Test files live alongside source code in `__tests__/` directories. The global test setup is at `src/test/setup.js`.
+Test files live in `__tests__/` directories colocated with the code they test. The global test setup is at `src/test/setup.js`.
+
+### E2E tests
+
+End-to-end tests use **Playwright** (Chromium). Backend traffic is mocked via `page.route`, so a live Django server is not required.
+
+```bash
+# First-time setup — install the Playwright browser
+npm run test:e2e:install
+
+# Run all E2E specs headlessly
+npm run test:e2e
+
+# Open the Playwright UI for interactive debugging
+npm run test:e2e:ui
+
+# Step through a failing test in debug mode
+npm run test:e2e:debug
+```
+
+E2E specs live in `frontend/e2e/`. The Vite dev server is started automatically by Playwright on port 5173.
 
 ## Folder Structure
 
 ```
 src/
-├── assets/            # Static assets (images, fonts, etc.)
 ├── components/
-│   ├── ui/            # shadcn/ui components (button, card, input, etc.)
-│   ├── AppLayout/     # App shell / layout wrapper
-│   ├── Interactions/  # Story interaction components (like, comment, etc.)
-│   ├── MapPicker/     # Location picker for story submission
-│   ├── MapView/       # Map display component
-│   ├── SearchFilter/  # Search and filter controls
-│   ├── StoryCard/     # Story card component
-│   └── StoryDetailMap/# Map view on story detail page
-├── context/           # React context providers (Auth, Toast)
-├── hooks/             # Custom React hooks (useAuth, useDebounce, etc.)
-├── lib/               # Utility libraries (e.g., cn() helper)
-├── pages/             # Page-level components (routed views)
-├── services/          # API service modules (axios calls)
-├── styles/            # Global CSS and Tailwind config
-├── test/              # Test setup files
-└── utils/             # General utility functions
+│   ├── ui/              # shadcn/ui primitives (button, card, input, etc.)
+│   ├── AdminPanel/      # Admin panel components
+│   ├── AdminRoute.jsx   # Route guard for admin-only pages
+│   ├── AppLayout/       # App shell / nav / layout wrapper
+│   ├── Follow/          # Follow / unfollow UI
+│   ├── Interactions/    # Story interactions (like, comment, bookmark)
+│   ├── MapPicker/       # Location picker for story submission
+│   ├── MapView/         # Interactive map display
+│   ├── Notifications/   # Notification components
+│   ├── Profile/         # Profile page components
+│   ├── ProtectedRoute.jsx # Route guard for authenticated pages
+│   ├── Report/          # Report / flag content components
+│   ├── SearchFilter/    # Search and filter controls
+│   ├── StoryCard/       # Story card used in feed and search
+│   ├── StoryDetailMap/  # Map shown on story detail page
+│   ├── StructuredData/  # Schema.org JSON-LD injection
+│   ├── Tags/            # Tag display components
+│   └── Timeline/        # Timeline view components
+├── context/             # React context providers (AuthContext, ToastContext)
+├── hooks/               # Custom hooks (useAuth, useDebounce, useGeocoding, etc.)
+├── lib/                 # Utility libraries (cn() helper)
+├── pages/               # Page-level components (one per route)
+├── services/            # API service modules (one per backend domain)
+├── styles/              # Global CSS and Tailwind config
+├── test/                # Vitest global setup
+└── utils/               # Pure utility functions (edtf, distance, tags, etc.)
 ```
 
 Path alias `@` is configured to resolve to `src/`, so you can import as `@/components/ui/button`.
+
+## Services
+
+Each file in `src/services/` wraps one backend domain:
+
+| File | Domain |
+|------|--------|
+| `api.js` | Axios instance + token refresh interceptor |
+| `authService.js` | Register, login, logout, token refresh |
+| `userService.js` | User profiles, photo upload |
+| `storyService.js` | Story CRUD, feed, map pins, search |
+| `interactionService.js` | Likes, comments |
+| `bookmarkService.js` | Bookmarks |
+| `followService.js` | Follow / unfollow, followers/following lists |
+| `tagService.js` | Tags |
+| `notificationService.js` | Notifications |
+| `reportService.js` | Content reports |
+| `adminService.js` | Admin actions |
+| `geocodingService.js` | Nominatim geocoding |
+| `deviceLocationService.js` | Browser geolocation |
+| `timelineService.js` | Timeline data |
+| `tokenStore.js` | JWT token storage |
+| `navigationRef.js` | Imperative navigation reference |
 
 ## Adding shadcn/ui Components
 
 ```bash
 npx shadcn@latest add <component>
 ```
-
-For example: `npx shadcn@latest add button`
 
 Components are installed into `src/components/ui/`.

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -7,7 +7,7 @@ RUN npm ci
 COPY frontend/ .
 ARG VITE_API_URL
 ENV VITE_API_URL=$VITE_API_URL
-ARG VITE_SITE_URL
+ARG VITE_SITE_URL=https://storymap.page
 ENV VITE_SITE_URL=$VITE_SITE_URL
 RUN npm run build
 

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -7,6 +7,8 @@ RUN npm ci
 COPY frontend/ .
 ARG VITE_API_URL
 ENV VITE_API_URL=$VITE_API_URL
+ARG VITE_SITE_URL
+ENV VITE_SITE_URL=$VITE_SITE_URL
 RUN npm run build
 
 # Stage 2 — Serve with nginx


### PR DESCRIPTION
# 📝 Description
Fixes #645 

  The frontend has a VITE_SITE_URL environment variable used to construct absolute URLs in Schema.org JSON-LD structured data (story `@id` fields, profile url fields). Before this PR, the variable existed in the frontend source but was never passed through the Docker build pipeline, which meant it silently fell back to a hardcoded "https://storymap.page" in StructuredData/constants.js for every deployment — regardless of what domain the app was actually running on. This PR wires it properly through the build chain and adds a .env.example so new developers know it exists.

##  What VITE_SITE_URL does

  Vite bakes environment variables prefixed with VITE_ into the JavaScript bundle at build time — they are not runtime values. This means the variable must be passed as a Docker ARG during the image build, not injected later at container start.

VITE_SITE_URL is consumed in a single place:

```
// frontend/src/components/StructuredData/constants.js
export const SITE_URL = import.meta.env.VITE_SITE_URL ?? "https://storymap.page";

```
This value is embedded into the Schema.org JSON-LD <script type="application/ld+json"> blocks that are injected into story detail and profile pages. Search engines (Google, Bing) use these to understand the canonical URL of a page. If SITE_URL is wrong, the structured data points to the wrong domain.

###  How it worked before

  The variable was declared in constants.js with a ?? "https://storymap.page" fallback, but docker-compose.prod.yml and nginx/Dockerfile had no knowledge of it. Because Vite replaces import.meta.env.VITE_SITE_URL with the literal string undefined when the variable is absent at build time, the fallback always kicked in. Every production build regardless of deployment domain would embed https://storymap.page in its structured data.

### How it works now

  1. nginx/Dockerfile — declares VITE_SITE_URL as a build ARG and exports it as an ENV so Vite sees it during npm run build
  2. docker-compose.prod.yml — passes ${VITE_SITE_URL:-https://storymap.page} to the build args, reading from the host environment (i.e. .env.prod) with https://storymap.page as the default
  3. .env.prod.example — documents VITE_SITE_URL=https://yourdomain.com so operators know to set it
  4. frontend/.env.example (new file) — documents both VITE_API_URL and VITE_SITE_URL for local development, with sensible dev defaults

###  Will anything break in production?

  No. The Docker Compose default ${VITE_SITE_URL:-https://storymap.page} means that if an existing deployment doesn't set VITE_SITE_URL in its
  .env.prod, the build will behave exactly as before — the fallback is identical to the hardcoded value that was always used. No rebuild is
  required unless an operator wants to set the correct domain (which they should).

  The variable has no effect on authentication, email sending, API calls, or any runtime behaviour — it is only used in the JSON-LD structured
  data injected into story and profile pages.

  Other changes

  - README.md (root) — adds VITE_SITE_URL to the production env vars table and the "fields that must match your domain" checklist
  - frontend/README.md — comprehensive update: correct env var defaults, full route table, expanded folder structure reflecting all current
  component directories, services table listing all 16 service files, and a new E2E testing section covering all Playwright scripts
  - .env.prod.example — adds a clarifying comment on NOMINATIM_CONTACT_EMAIL explaining that Nominatim will block requests if this is not set to
   a real address

###  New features

  - frontend/.env.example — new file documenting both env vars for local dev setup

###  Modified files

  - nginx/Dockerfile — declare and export VITE_SITE_URL as a build arg so Vite bakes it into the bundle
  - docker-compose.prod.yml — pass VITE_SITE_URL to the nginx build args with https://storymap.page as fallback
  - .env.prod.example — document VITE_SITE_URL; clarify NOMINATIM_CONTACT_EMAIL requirement
  - README.md — add VITE_SITE_URL to production setup instructions
  - frontend/README.md — full documentation update: env vars, routes, folder structure, services, E2E test commands

 ### Tests

  - No code logic changed; no new unit tests required
  - Existing StructuredData tests continue to pass — they import SITE_URL directly and are unaffected by the build pipeline change


# 📊 Type of Change
- [ ]  Bug fix
- [x]  New feature
- [ ]  Refactoring
- [ ]  Documentation
 
# ✅ Acceptance Criteria / Checklist
- [x] Project builds successfully
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, especially in hard-to-understand parts
- [x] I have performed a self-review of my code
- [ ] I have added/updated tests
- [x] New and existing unit tests pass locally with my changes

# 📸 Screenshots / Recordings
<!-- If applicable !-->
# ⏱️ Estimated Review Time
- [x] < 5 min
- [ ] 5-15 min
- [ ] > 15 min
