### PR TITLE
docs: update .env.example and .env.prod.example 

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,34 +8,24 @@ DB_HOST=127.0.0.1
 DB_PORT=3306
 MEDIA_ROOT=/app/media
 
-# ── Email (Resend HTTP API) ───────────────────────────────────────────────────
-# Provider: https://resend.com — create a free account, verify your domain,
-# and generate an API key.
+# ── Email ─────────────────────────────────────────────────────────────────────
+# Local development uses Django's console backend by default.
+# Docker Compose overrides these values and routes mail to Mailpit instead.
 #
-# Production uses ResendEmailBackend (HTTPS port 443) — not SMTP — because
-# cloud hosts (DigitalOcean, AWS, etc.) block outbound SMTP ports 465/587.
-#
-# For local development, EMAIL_BACKEND is overridden to console in development.py
-# so RESEND_API_KEY is not required locally.
-#
-# Steps to configure for production:
-#   1. Sign up at resend.com and add/verify your sending domain
-#   2. Create an API key (Resend dashboard → API Keys → Create)
-#   3. Set RESEND_API_KEY to the key (starts with re_...)
-#   4. Set DEFAULT_FROM_EMAIL to an address on your verified domain
-#   5. Set FRONTEND_URL to the deployed frontend base URL
-EMAIL_BACKEND=common.email_backend.ResendEmailBackend
-RESEND_API_KEY=re_your_api_key_here
-DEFAULT_FROM_EMAIL=Local History Story Map <noreply@yourdomain.com>
+# Production Resend configuration lives in .env.prod.example:
+#   EMAIL_BACKEND=common.email_backend.ResendEmailBackend
+#   RESEND_API_KEY=re_...
+EMAIL_BACKEND=django.core.mail.backends.console.EmailBackend
+DEFAULT_FROM_EMAIL=Local History Story Map <noreply@localhost>
 
 # Base URL of the frontend — used to build password reset links in emails.
 # REQUIRED: replace with your actual deployed frontend URL before going to production.
 # Leaving this unset or pointing to localhost produces broken links in reset emails
 # and triggers a startup warning (when DEBUG=False).
-FRONTEND_URL=https://your-frontend-domain.com
+FRONTEND_URL=http://localhost:5173
 
 # ── Nominatim geocoding proxy ─────────────────────────────────────────────────
 # REQUIRED for local development: Nominatim's usage policy requires a real
 # contact address in the User-Agent header. Placeholder/example addresses are
 # hard-blocked with HTTP 403. Set this to your own email address.
-NOMINATIM_CONTACT_EMAIL=kemal.mahmutogullari@gmail.com
+NOMINATIM_CONTACT_EMAIL=your-email@example.com

--- a/.env.example
+++ b/.env.example
@@ -10,7 +10,8 @@ MEDIA_ROOT=/app/media
 
 # ── Email ─────────────────────────────────────────────────────────────────────
 # Local development uses Django's console backend by default.
-# Docker Compose overrides these values and routes mail to Mailpit instead.
+# Docker Compose overrides EMAIL_BACKEND, EMAIL_HOST, EMAIL_PORT, EMAIL_USE_TLS,
+# EMAIL_USE_SSL, and EMAIL_HOST_PASSWORD to route mail to Mailpit instead.
 #
 # Production Resend configuration lives in .env.prod.example:
 #   EMAIL_BACKEND=common.email_backend.ResendEmailBackend

--- a/.env.prod.example
+++ b/.env.prod.example
@@ -24,4 +24,6 @@ SENTRY_DSN=
 EMAIL_BACKEND=common.email_backend.ResendEmailBackend
 RESEND_API_KEY=re_your_api_key_here
 DEFAULT_FROM_EMAIL=Local History Story Map <noreply@yourdomain.com>
+# Base URL of the deployed frontend, used in password reset links.
+FRONTEND_URL=https://yourdomain.com
 NOMINATIM_CONTACT_EMAIL=your-email@yourdomain.com

--- a/README.md
+++ b/README.md
@@ -216,6 +216,7 @@ CORS_ALLOWED_ORIGINS=https://yourdomain.com
 VITE_API_URL=https://yourdomain.com/api
 NGINX_HOST=yourdomain.com
 FRONTEND_URL=https://yourdomain.com
+NOMINATIM_CONTACT_EMAIL=your-email@yourdomain.com
 ```
 
 Generate a secret key:

--- a/README.md
+++ b/README.md
@@ -46,6 +46,13 @@ docker compose up           # subsequent runs
 |---------|-----|
 | API | http://localhost:8000 |
 | Frontend | http://localhost:5173 |
+| Mailpit inbox | http://localhost:8025 |
+
+When running with Docker Compose, registration and email verification messages
+are captured by Mailpit. Open `http://localhost:8025` to view verification
+emails; no real email is sent in local development. If you run the backend
+directly without Docker, the default local email backend prints messages to the
+backend console instead.
 
 ### Stop
 
@@ -208,6 +215,7 @@ ALLOWED_HOSTS=yourdomain.com
 CORS_ALLOWED_ORIGINS=https://yourdomain.com
 VITE_API_URL=https://yourdomain.com/api
 NGINX_HOST=yourdomain.com
+FRONTEND_URL=https://yourdomain.com
 ```
 
 Generate a secret key:

--- a/backend/config/settings/base.py
+++ b/backend/config/settings/base.py
@@ -135,7 +135,7 @@ EMAIL_USE_SSL = env.bool('EMAIL_USE_SSL', default=True)
 DEFAULT_FROM_EMAIL = env('DEFAULT_FROM_EMAIL', default='Local History Story Map <noreply@yourdomain.example>')
 RESEND_API_KEY = env('RESEND_API_KEY', default='')
 
-FRONTEND_URL = env('FRONTEND_URL', default='http://localhost:3000')
+FRONTEND_URL = env('FRONTEND_URL', default='http://localhost:5173')
 
 # Nominatim geocoding proxy
 NOMINATIM_CONTACT_EMAIL = env('NOMINATIM_CONTACT_EMAIL')


### PR DESCRIPTION
# 📝 Description

Fixes #648 

This PR updates the environment example files and README documentation to align local and production email configuration.

The previous `.env.example` contained production-oriented Resend settings, which could be misleading for local development. Since local development uses Django's console email backend by default and Docker Compose routes emails to Mailpit, this PR separates local and production email configuration more clearly.

Changes include:

- Updated `.env.example` to use the local console email backend.
- Moved production Resend-related configuration guidance to `.env.prod.example`.
- Added `FRONTEND_URL` to `.env.prod.example`, since it is required for generating password reset links correctly in production.
- Replaced a real Nominatim contact email in `.env.example` with a placeholder.
- Updated `README.md` to document Mailpit usage for local Docker development.
- Added `FRONTEND_URL` to the production environment variable example in README.



# 📊 Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactoring
- [x] Documentation
- [ ] Other

# ✅ Acceptance Criteria / Checklist

- [x] `.env.example` reflects local development email configuration.
- [x] `.env.prod.example` includes production email-related variables.
- [x] `FRONTEND_URL` is documented for production usage.
- [x] README explains how local email verification messages can be viewed through Mailpit.
- [x] Placeholder/example values are used instead of personal or real emails.
- [x] Changes are documentation/configuration-only and do not affect application logic.
- [x] I have reviewed the updated files for consistency.


# ⏱️ Estimated Review Time

- [x] <5 minutes
- [ ] 5–15 minutes
- [ ] >15 minutes