### PR TITLE
fix(frontend): UI overflow & layout regression in profile & feed (#650)

### DIFF
--- a/frontend/src/components/Profile/EditProfileForm.jsx
+++ b/frontend/src/components/Profile/EditProfileForm.jsx
@@ -280,7 +280,7 @@ function EditProfileForm({ initialProfile, onSave, onCancel }) {
       </div>
 
       {/* Actions */}
-      <div className="flex justify-end gap-2 pt-2">
+      <div className="flex flex-wrap justify-end gap-2 pt-2">
         <Button
           type="button"
           variant="outline"

--- a/frontend/src/pages/FeedPage.jsx
+++ b/frontend/src/pages/FeedPage.jsx
@@ -70,8 +70,8 @@ function FeedPage() {
     <main className="min-h-screen bg-background">
       <div className="mx-auto max-w-7xl px-4 py-8 sm:px-6 lg:px-8">
         {/* Header */}
-        <div className="mb-6 flex items-center justify-between gap-4">
-          <div>
+        <div className="mb-6 flex flex-wrap items-center justify-between gap-4">
+          <div className="min-w-0">
             <h1 className="text-3xl font-bold tracking-tight">Story Feed</h1>
             <p className="mt-1 text-sm text-muted-foreground">
               Explore local history stories from communities around the world.
@@ -81,7 +81,7 @@ function FeedPage() {
           <div
             role="group"
             aria-label="Sort order"
-            className="flex overflow-hidden rounded-md border border-input text-sm font-medium"
+            className="flex shrink-0 overflow-hidden rounded-md border border-input text-sm font-medium"
           >
             <button
               aria-pressed={sortBy === "recent"}

--- a/frontend/src/pages/ProfilePage.jsx
+++ b/frontend/src/pages/ProfilePage.jsx
@@ -150,8 +150,8 @@ function ProfilePage() {
               </div>
             )
           ) : (
-            <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
-              <div className="flex items-start gap-4">
+            <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+              <div className="flex min-w-0 items-start gap-4">
                 {/* Photo — own profile: show regardless of is_photo_public */}
                 <div className="relative flex h-16 w-16 shrink-0 items-center justify-center overflow-hidden rounded-full bg-muted">
                   {(isOwnProfile ? ownProfileData?.profile?.profile_photo : profile.profile_photo) ? (

--- a/frontend/src/pages/__tests__/FeedPage.test.jsx
+++ b/frontend/src/pages/__tests__/FeedPage.test.jsx
@@ -254,6 +254,18 @@ describe("FeedPage", () => {
     expect(popularBtn).toHaveAttribute("aria-pressed", "false");
   });
 
+  it("wraps the sort toggle below the title on narrow viewports", () => {
+    // Regression guard for #650: prevents the Most Recent/Most Popular
+    // toggle from being clipped at the right edge on mobile widths.
+    getStories.mockReturnValue(new Promise(() => {}));
+    renderPage();
+
+    const sortGroup = screen.getByRole("group", { name: /sort order/i });
+    const header = sortGroup.parentElement;
+    expect(header).toHaveClass("flex-wrap");
+    expect(sortGroup).toHaveClass("shrink-0");
+  });
+
   it("clicking 'Most Popular' fetches with sort_by=popular", async () => {
     const user = userEvent.setup();
     getStories.mockResolvedValue(makeResponse());

--- a/frontend/src/pages/__tests__/ProfilePage.test.jsx
+++ b/frontend/src/pages/__tests__/ProfilePage.test.jsx
@@ -505,6 +505,27 @@ describe("ProfilePage", () => {
     });
   });
 
+  describe("action button row layout", () => {
+    // Regression guard for #650: with 4 own-profile actions (Notifications,
+    // Edit Profile, Reset Password, Delete Profile), the row must stay
+    // stacked under the user info until lg viewports and the buttons must
+    // be allowed to wrap so they never clip the surrounding card.
+    it("keeps the header column-stacked below lg and lets buttons wrap", async () => {
+      useAuth.mockReturnValue({ user: { id: 1 }, isAuthenticated: true });
+      getProfile.mockResolvedValue(mockProfileData);
+      renderPage();
+
+      const editBtn = await screen.findByRole("button", { name: /Edit Profile/i });
+      const buttonRow = editBtn.parentElement;
+      expect(buttonRow).toHaveClass("flex-wrap");
+
+      const headerRow = buttonRow.parentElement;
+      expect(headerRow).toHaveClass("flex-col");
+      expect(headerRow).toHaveClass("lg:flex-row");
+      expect(headerRow).not.toHaveClass("sm:flex-row");
+    });
+  });
+
   describe("public profile fields", () => {
     beforeEach(() => {
       // View as a different user so own-profile logic doesn't interfere


### PR DESCRIPTION
# 📝 Description
Fixes #650

Two layout regressions in the frontend caused button rows to clip on intermediate / mobile viewports. This PR makes both rows wrap before they can overflow their parent containers.

**Profile page** — the own-profile actions (Notifications, Edit Profile, Reset Password, Delete Profile) sat in a `sm:flex-row` row alongside the user info card. From ~640 px–1024 px the four buttons no longer fit next to the user info and were clipped by the surrounding card. The breakpoint is now bumped to `lg:`, so the action row stacks under the user info on tablet widths and lays out side-by-side only when there is genuinely enough room. The user-info column also gets `min-w-0` so long names wrap instead of pushing the buttons out.

**Feed page** — the *Most Recent* / *Most Popular* toggle was in a non-wrapping flex header, so its right edge was sliced off on standard mobile widths (320–430 px). The header now uses `flex-wrap` and the toggle gets `shrink-0` so it drops to its own row, fully visible, instead of being cut off.

**EditProfileForm** — the Cancel / Save changes action row gains a defensive `flex-wrap` so it can never clip if button labels change in the future.

# 📊 Type of Change
- [x]  Bug fix
- [ ]  New feature
- [ ]  Refactoring
- [ ]  Documentation
 
# ✅ Acceptance Criteria / Checklist
- [x] Project builds successfully
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, especially in hard-to-understand parts
- [x] I have performed a self-review of my code
- [x] I have added/updated tests
- [x] New and existing unit tests pass locally with my changes

Per-issue acceptance criteria from #650:
- [x] Profile page buttons stay within the surrounding card at all viewport widths between 320 px and 1440 px (verified with the `lg:` breakpoint switch + `flex-wrap` on the button row).
- [x] Buttons stack vertically before they can overflow the container (`flex-col` → `lg:flex-row`).
- [x] Feed page *Most Popular / Most Recent* toggle is fully visible on standard mobile widths (320 px–430 px) — the toggle wraps to its own line with `flex-wrap`.
- [x] Existing desktop and ultra-small-mobile behavior preserved — no other layout classes were changed; full Vitest suite passes (1141/1141), lint and prod build clean.

# 📸 Screenshots / Recordings
<!-- Reproduction is per the steps in #650. Verified locally at 320, 375, 640, 768, 1024, and 1440 px. -->

# ⏱️ Estimated Review Time
- [x] < 5 min
- [ ] 5-15 min
- [ ] > 15 min